### PR TITLE
Fix nondeterministic CI test isolation

### DIFF
--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -161,7 +161,7 @@
     "platform:audit": "bun ../components/scripts/check-platform-features.ts --source-root src/lib --baseline scripts/platform-viewport-baseline.json --strict",
     "publish:release": "bun ../components/scripts/publish-release.ts --package-root .",
     "test": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 src/lib scripts",
-    "test:coverage": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 src/lib scripts --coverage --coverage-reporter=lcov && bun ../components/scripts/check-coverage-ratchet.ts --package-root .",
+    "test:coverage": "TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte src/lib scripts --coverage --coverage-reporter=lcov && bun ../components/scripts/check-coverage-ratchet.ts --package-root .",
     "tokens:audit": "bun ../components/scripts/check-component-css-token-usage.ts --source-root src/lib --baseline scripts/token-usage-baseline.json --strict",
     "typecheck": "tsc --noEmit -p tsconfig.json && bunx svelte-check --workspace src/lib --tsconfig ../../tsconfig.json --threshold warning",
     "validate": "bun run lint && bun run typecheck && bun run test:coverage && bun run platform:audit && bun run colors:audit && bun run tokens:audit && bun run components:check && bun run build",

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -154,4 +154,9 @@ describe('Chat package ownership boundary', () => {
       'default',
     ]);
   });
+
+  test('keeps coverage in one process so repeated Svelte modules merge deterministically', () => {
+    expect(chatManifest.scripts?.['test:coverage']).toContain('--coverage-reporter=lcov');
+    expect(chatManifest.scripts?.['test:coverage']).not.toContain('--parallel');
+  });
 });

--- a/packages/chat/src/lib/test/register-global-cleanup.ts
+++ b/packages/chat/src/lib/test/register-global-cleanup.ts
@@ -7,9 +7,9 @@
  * Why this exists: `@testing-library/svelte` v5's own auto-cleanup registers via
  * a framework's native afterEach hook (Vitest/Jest globals), which Bun's test
  * runner does not provide, so it silently never registers under `bun:test`.
- * Every `render()` call across the suite then accumulates its mounted tree in
- * the one process-wide happy-dom `Window` (`--parallel=1` shares a single
- * global), which is the direct cause of multi-gigabyte RSS over a full run.
+ * Every `render()` call within a runner process then accumulates its mounted
+ * tree in that process's happy-dom `Window`, which is the direct cause of
+ * multi-gigabyte RSS over a full run.
  *
  * Called once from `scripts/preload.ts`, which runs before any test file's
  * imports resolve — so this hook is registered before the first `describe`/

--- a/packages/commentary/src/editor/attach.test.ts
+++ b/packages/commentary/src/editor/attach.test.ts
@@ -1,11 +1,13 @@
 /// <reference lib="dom" />
-import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { createEditorAttachment } from './attach.js';
+import * as editorRuntime from './editor.js';
 import type { EditorConfig, EditorState } from './types.js';
 
 let resolveCreatedEditor: ((state: EditorState) => void) | undefined;
 let rejectCreatedEditor: ((error: unknown) => void) | undefined;
 
-const createEditorMock = mock((_element: HTMLElement, _configuration: EditorConfig) => {
+const createEditorMock = mock((_element: HTMLElement, _configuration?: EditorConfig) => {
   return new Promise<EditorState>((resolve, reject) => {
     resolveCreatedEditor = resolve;
     rejectCreatedEditor = reject;
@@ -13,13 +15,6 @@ const createEditorMock = mock((_element: HTMLElement, _configuration: EditorConf
 });
 
 const destroyEditorMock = mock((_state: EditorState) => {});
-
-mock.module('./editor.js', () => ({
-  createEditor: createEditorMock,
-  destroyEditor: destroyEditorMock,
-}));
-
-const { createEditorAttachment } = await import('./attach.js');
 
 function createEditorState(): EditorState {
   return {
@@ -71,6 +66,12 @@ describe('createEditorAttachment', () => {
     rejectCreatedEditor = undefined;
     createEditorMock.mockClear();
     destroyEditorMock.mockClear();
+    spyOn(editorRuntime, 'createEditor').mockImplementation(createEditorMock);
+    spyOn(editorRuntime, 'destroyEditor').mockImplementation(destroyEditorMock);
+  });
+
+  afterEach(() => {
+    mock.restore();
   });
 
   test('destroys the editor when initialization resolves after detach', async () => {

--- a/packages/commentary/src/editor/ssr-import.test.ts
+++ b/packages/commentary/src/editor/ssr-import.test.ts
@@ -61,19 +61,21 @@ describe('@cinder/commentary editor SSR import safety', () => {
 
   it('keeps process-global module mocks out of the shared test process', async () => {
     const violations: string[] = [];
-    const sourceRoot = resolve(import.meta.dirname, '..');
+    // Commentary's bare `bun test` discovers both src/ and scripts/, so scan
+    // the package root rather than only the editor's source tree.
+    const packageRoot = resolve(import.meta.dirname, '..', '..');
     const moduleMockPattern = new RegExp(['mock', 'module'].join('\\.'), 'g');
     const glob = new Bun.Glob('**/*.test.ts');
 
     for await (const filePath of glob.scan({
       absolute: true,
-      cwd: sourceRoot,
+      cwd: packageRoot,
       onlyFiles: true,
     })) {
       const source = await Bun.file(filePath).text();
       for (const match of source.matchAll(moduleMockPattern)) {
         const lineNumber = source.slice(0, match.index).split('\n').length;
-        violations.push(`${relative(sourceRoot, filePath)}:${lineNumber}`);
+        violations.push(`${relative(packageRoot, filePath)}:${lineNumber}`);
       }
     }
 

--- a/packages/commentary/src/editor/ssr-import.test.ts
+++ b/packages/commentary/src/editor/ssr-import.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from 'bun:test';
-import { relative } from 'node:path';
+import { relative, resolve } from 'node:path';
 
 // Protected prefix — single source of truth is scripts/ssr-import-boundary.ts.
 // Defined inline (matching markdown-editor.import-boundary.test.ts's
@@ -53,6 +53,27 @@ describe('@cinder/commentary editor SSR import safety', () => {
       for (const match of source.matchAll(RUNTIME_MILKDOWN_IMPORT_PATTERN)) {
         const lineNumber = source.slice(0, match.index).split('\n').length;
         violations.push(`${relative(import.meta.dirname, filePath)}:${lineNumber}`);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps process-global module mocks out of the shared test process', async () => {
+    const violations: string[] = [];
+    const sourceRoot = resolve(import.meta.dirname, '..');
+    const moduleMockPattern = new RegExp(['mock', 'module'].join('\\.'), 'g');
+    const glob = new Bun.Glob('**/*.test.ts');
+
+    for await (const filePath of glob.scan({
+      absolute: true,
+      cwd: sourceRoot,
+      onlyFiles: true,
+    })) {
+      const source = await Bun.file(filePath).text();
+      for (const match of source.matchAll(moduleMockPattern)) {
+        const lineNumber = source.slice(0, match.index).split('\n').length;
+        violations.push(`${relative(sourceRoot, filePath)}:${lineNumber}`);
       }
     }
 


### PR DESCRIPTION
## Summary

- replace Commentary's process-global `mock.module('./editor.js')` override with restorable `spyOn` bindings
- add a Commentary package invariant that rejects process-global module mocks
- run Chat coverage in one process so Bun cannot race isolated-worker LCOV records for the same compiled Svelte modules
- add a Chat package-contract test that prevents isolated-worker coverage from returning

## Root causes

### Commentary module mock leak

`packages/commentary/src/editor/attach.test.ts` replaced the entire `./editor.js` module with a mock that exported only `createEditor` and `destroyEditor`. Bun module mocks persist for the process and are not reset by `mock.restore()`. When that test file was evaluated before `ssr-import.test.ts`, the editor barrel tried to re-export `setEditorReadonly` from the incomplete mocked module and failed during module evaluation. File evaluation order made the same commit fail on push and pass in the later scheduled `main-green` run.

### Chat coverage merge race

The first pull request run exposed a second intermittent CI failure: all 725 Chat tests passed, but the Svelte coverage ratchet varied from 76.47% to 82.33% functions and from 28.85% to 59.47% lines. `--parallel=1` still enables Bun's isolated-worker mode. Multiple workers emitted counters for the same compiled `.svelte` paths, and the merged LCOV report sometimes retained an unexecuted worker's copy of whole components. Removing isolated-worker mode keeps one module graph and produced the same 90.08% function / 77.43% line result in two consecutive runs.

## Validation

- `bun run --filter=@cinder/commentary lint`
- `bun run --filter=@cinder/commentary typecheck`
- `bun run --filter=@cinder/commentary test` (426 pass)
- `TURBO_FORCE=true bunx turbo run test --filter=@lostgradient/markdown --filter=@cinder/commentary --filter=@cinder/playground --filter=@cinder/testing` (8/8 tasks passed)
- `bun run --filter=@lostgradient/chat lint`
- `bun run --filter=@lostgradient/chat typecheck`
- `bun run --filter=@lostgradient/chat test:coverage` (726 pass; runtime 100%/100%; Svelte 90.08% functions / 77.43% lines)
- repeated non-isolated Chat coverage run with identical Svelte totals
- focused package-contract and Commentary regression tests
- Prettier checks and `git diff --check`