### PR TITLE
fix(chat): synchronize non-virtualized scrollToTop state

### DIFF
--- a/.changeset/blue-chats-scroll.md
+++ b/.changeset/blue-chats-scroll.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Keep unread-message accrual synchronized after non-virtualized chats scroll to the top.

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -815,6 +815,42 @@ describe('Chat — atBottom bindable after send', () => {
     const jumpButton = container.querySelector('.chat-jump-button');
     expect(jumpButton).toBeNull();
   });
+
+  test('scrollToTop accrues messages appended before the first scroll event', async () => {
+    const source = await Bun.file(new URL('./container/chat.svelte', import.meta.url)).text();
+    const nonVirtualizedBranch = source.slice(
+      source.indexOf('    } else {\n      // Same canLeaveBottom reasoning'),
+    );
+    expect(nonVirtualizedBranch).toMatch(
+      /const canLeaveBottom[\s\S]*?scrollState\.setAtBottom\(false\);[\s\S]*?updateAtBottomBinding\(false\);/,
+    );
+
+    let conversation = appendAssistantMessage(
+      appendUserMessage(createConversation({ id: 'conversation-scroll-top-unread' }), 'Hello'),
+      'Hi there',
+    );
+    const unreadChanges: number[] = [];
+    const { component, container, rerender } = render(Chat, {
+      props: {
+        id: 'chat-scroll-top-unread',
+        conversation,
+        onunreadindicatorchange: (event: { unreadCount: number }) => {
+          unreadChanges.push(event.unreadCount);
+        },
+      },
+    });
+
+    const timeline = container.querySelector<HTMLElement>('.chat-timeline');
+    expect(timeline).not.toBeNull();
+    Object.defineProperty(timeline!, 'clientHeight', { configurable: true, value: 100 });
+    Object.defineProperty(timeline!, 'scrollHeight', { configurable: true, value: 400 });
+
+    (component as unknown as { scrollToTop: () => void }).scrollToTop();
+
+    conversation = appendAssistantMessage(conversation, 'A message while scrolling');
+    await rerender({ conversation });
+    await waitFor(() => expect(unreadChanges).toContain(1));
+  });
 });
 
 describe('Chat — public wrapper forwards bind:atBottom/unreadCount/newMessageIndicatorVisible', () => {

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -818,11 +818,8 @@ describe('Chat — atBottom bindable after send', () => {
 
   test('scrollToTop accrues messages appended before the first scroll event', async () => {
     const source = await Bun.file(new URL('./container/chat.svelte', import.meta.url)).text();
-    const nonVirtualizedBranch = source.slice(
-      source.indexOf('    } else {\n      // Same canLeaveBottom reasoning'),
-    );
-    expect(nonVirtualizedBranch).toMatch(
-      /const canLeaveBottom[\s\S]*?scrollState\.setAtBottom\(false\);[\s\S]*?updateAtBottomBinding\(false\);/,
+    expect(source).toMatch(
+      /const canLeaveBottom = !!viewport\s*&& viewport\.scrollHeight > viewport\.clientHeight;[\s\S]*?scrollState\.setAtBottom\(false\);[\s\S]*?updateAtBottomBinding\(false\);/,
     );
 
     let conversation = appendAssistantMessage(

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -1526,6 +1526,7 @@
       // Same canLeaveBottom reasoning as the virtualized branch above.
       const canLeaveBottom = !!viewport && viewport.scrollHeight > viewport.clientHeight;
       if (canLeaveBottom) {
+        scrollState.setAtBottom(false);
         updateAtBottomBinding(false);
       }
       scrollState.scrollToTop(viewport);


### PR DESCRIPTION
## Summary

- synchronize internal and bindable atBottom state in non-virtualized scrollToTop()
- cover unread accrual when a message arrives before the first scroll event

Closes #864

## Validation

- bun test --conditions browser --conditions svelte --parallel=1 packages/chat/src/lib/components/chat/chat.test.ts packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
- bunx oxlint --type-aware --tsconfig packages/chat/tsconfig.json packages/chat/src/lib/components/chat/chat.test.ts packages/chat/src/lib/components/chat/container/chat.svelte
- git diff --check