### PR TITLE
fix: expose StatusDot live labels as accessible names

### DIFF
--- a/.changeset/quiet-dots-name.md
+++ b/.changeset/quiet-dots-name.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Expose StatusDot labels as accessible names when live connection indicators hide their visible label.

--- a/packages/components/src/components/status-dot/status-dot.svelte
+++ b/packages/components/src/components/status-dot/status-dot.svelte
@@ -76,6 +76,13 @@
   const needsHiddenLiveLabel = $derived(
     resolvedLive && (!hasVisibleLabel || visibleLabelIsLiveDuplicate),
   );
+  // A live region with its visible label suppressed still needs an author name
+  // so role-based queries and assistive technology can identify the status.
+  const liveAriaLabel = $derived(
+    !hasVisibleLabel && (normalizedLabel !== undefined || normalizedAriaLabel !== undefined)
+      ? resolvedAriaLabel
+      : undefined,
+  );
 </script>
 
 <!--
@@ -97,7 +104,7 @@
   role={resolvedLive ? 'status' : 'img'}
   aria-live={resolvedLive ? 'polite' : undefined}
   aria-atomic={resolvedLive ? 'true' : undefined}
-  aria-label={resolvedLive ? undefined : resolvedAriaLabel}
+  aria-label={resolvedLive ? liveAriaLabel : resolvedAriaLabel}
 >
   <span class="cinder-status-dot__indicator" aria-hidden="true"></span>
   {#if hasVisibleLabel}

--- a/packages/components/src/components/status-dot/status-dot.test.ts
+++ b/packages/components/src/components/status-dot/status-dot.test.ts
@@ -260,16 +260,34 @@ describe('StatusDot connection preset', () => {
     expect(root?.hasAttribute('aria-live')).toBe(false);
   });
 
-  test('showLabel=false keeps hidden text for the live-region connection preset', () => {
+  test('showLabel=false keeps hidden text and an accessible name for the live-region preset', () => {
     const { container } = render(StatusDot, {
       props: { connectionState: 'connected', showLabel: false },
     });
     const root = container.querySelector('.cinder-status-dot');
 
     expect(root?.getAttribute('role')).toBe('status');
-    expect(root?.getAttribute('aria-label')).toBeNull();
+    expect(root?.getAttribute('aria-label')).toBe('Connected');
     expect(root?.textContent).toContain('Connected');
     expect(container.querySelector('.cinder-sr-only')?.textContent).toBe('Connected');
+  });
+
+  test('showLabel=false exposes the provided label as the live-region accessible name', () => {
+    const { container } = render(StatusDot, {
+      props: { connectionState: 'connecting', label: 'streaming', showLabel: false },
+    });
+    const root = container.querySelector('.cinder-status-dot');
+
+    expect(root?.getAttribute('role')).toBe('status');
+    expect(root?.getAttribute('aria-label')).toBe('streaming');
+    expect(within(container).getByRole('status', { name: 'streaming' })).not.toBeNull();
+  });
+
+  test('showLabel=false exposes a consumer aria-label as the live-region accessible name', () => {
+    const { container } = render(StatusDot, {
+      props: { connectionState: 'connected', 'aria-label': 'streaming', showLabel: false },
+    });
+    expect(within(container).getByRole('status', { name: 'streaming' })).not.toBeNull();
   });
 
   test('consumer aria-label is preserved as live-region text', () => {


### PR DESCRIPTION
Closes #868

StatusDot keeps role=status and polite live-region semantics while exposing label or aria-label as the accessible name when showLabel={false}. Added focused rendering and role-query regressions.