### PR TITLE
feat(components): expose curated Shiki loader maps

### DIFF
--- a/.changeset/curated-shiki-registries.md
+++ b/.changeset/curated-shiki-registries.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': minor
+---
+
+Allow `shikiHighlighter` to accept curated `languageLoaders` and `themeLoaders` maps so Vite consumers can ship only the Shiki grammars and themes they use.

--- a/.changeset/curated-shiki-registries.md
+++ b/.changeset/curated-shiki-registries.md
@@ -2,4 +2,4 @@
 '@lostgradient/cinder': minor
 ---
 
-Allow `shikiHighlighter` to accept curated `languageLoaders` and `themeLoaders` maps so Vite consumers can ship only the Shiki grammars and themes they use.
+Add `@lostgradient/cinder/highlighters/shiki/curated`, a curated adapter entrypoint where `shikiHighlighter` accepts `languageLoaders` and `themeLoaders` maps so Vite consumers can ship only the Shiki grammars and themes they use.

--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
         "svelte2tsx": "^0.7.33",
         "ts-morph": "^28.0.0",
         "typescript": "^5.9.0",
+        "vite": "^8.0.9",
         "zod": "4.4.1",
       },
       "peerDependencies": {
@@ -301,6 +302,12 @@
 
     "@csstools/selector-specificity": ["@csstools/selector-specificity@6.0.0", "", { "peerDependencies": { "postcss-selector-parser": "^7.1.1" } }, "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA=="],
 
+    "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
+
+    "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.7.6", "", { "dependencies": { "@floating-ui/core": "^1.7.5", "@floating-ui/utils": "^0.2.11" } }, "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ=="],
@@ -387,6 +394,8 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
+    "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
@@ -394,6 +403,8 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@ocavue/utils": ["@ocavue/utils@1.6.0", "", {}, "sha512-8W3q1hxx9qFdrYgPtbElllG/tqYkO/dMhlRUiqasO0SuDFTj78azSQjhIrBTFWxlBPPsSZN6zXYHmb3RwN2Jtg=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
     "@oxlint-tsgolint/darwin-arm64": ["@oxlint-tsgolint/darwin-arm64@0.17.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-z3XwCDuOAKgk7bO4y5tyH8Zogwr51G56R0XGKC3tlAbrAq8DecoxAd3qhRZqWBMG2Gzl5bWU3Ghu7lrxuLPzYw=="],
 
@@ -447,6 +458,38 @@
 
     "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
 
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.1.5", "", { "os": "android", "cpu": "arm64" }, "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.1.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.1.5", "", { "os": "linux", "cpu": "arm" }, "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.1.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.1.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.1.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.1.5", "", { "os": "none", "cpu": "arm64" }, "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw=="],
+
+    "@rolldown/binding-wasm32-wasi": ["@rolldown/binding-wasm32-wasi@1.1.5", "", { "dependencies": { "@emnapi/core": "1.11.1", "@emnapi/runtime": "1.11.1", "@napi-rs/wasm-runtime": "^1.1.6" }, "cpu": "none" }, "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.1.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
     "@shikijs/core": ["@shikijs/core@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@3.23.0", "", { "dependencies": { "@shikijs/types": "3.23.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.4" } }, "sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA=="],
@@ -490,6 +533,8 @@
     "@turbo/windows-64": ["@turbo/windows-64@2.10.5", "", { "os": "win32", "cpu": "x64" }, "sha512-eL2Iyj4DbMINq1Sr1w0iAi6nAiZOF16KSlRGwCJpVh+IWZeY33MAsLHVOBMj1xoFtncVJXclCVpTPL2nBoYkFg=="],
 
     "@turbo/windows-arm64": ["@turbo/windows-arm64@2.10.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-sog+wP+8YSJrdWZ/rUJg8xghVTrwoG+BrSlDQpnK5fzSgJHn1INRWXbVWRH0d3vX8dBI01E3yxXRre9Dn+OXQA=="],
+
+    "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
@@ -685,6 +730,8 @@
 
     "detect-indent": ["detect-indent@7.0.2", "", {}, "sha512-y+8xyqdGLL+6sh0tVeHcfP/QDd8gUgbasolJJpY7NgeQGSZ739bDtSiaiDgtoicy+mtYB81dKLxO9xRhCyIB3A=="],
 
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
     "detect-newline": ["detect-newline@4.0.1", "", {}, "sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog=="],
 
     "devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
@@ -795,7 +842,7 @@
 
     "fs-extra": ["fs-extra@7.0.1", "", { "dependencies": { "graceful-fs": "^4.1.2", "jsonfile": "^4.0.0", "universalify": "^0.1.0" } }, "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw=="],
 
-    "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -942,6 +989,30 @@
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "libphonenumber-js": ["libphonenumber-js@1.13.3", "", {}, "sha512-xMkdAMqcyG7iN2WZZmGIfWbYxW4orRkny+0/AXIbwL0xll2zkDX0Vzo/BXFa6+7mh2UvJl9MbcTtHk0YXkFtBA=="],
+
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
@@ -1277,6 +1348,8 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
+    "rolldown": ["rolldown@1.1.5", "", { "dependencies": { "@oxc-project/types": "=0.139.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.5", "@rolldown/binding-darwin-arm64": "1.1.5", "@rolldown/binding-darwin-x64": "1.1.5", "@rolldown/binding-freebsd-x64": "1.1.5", "@rolldown/binding-linux-arm-gnueabihf": "1.1.5", "@rolldown/binding-linux-arm64-gnu": "1.1.5", "@rolldown/binding-linux-arm64-musl": "1.1.5", "@rolldown/binding-linux-ppc64-gnu": "1.1.5", "@rolldown/binding-linux-s390x-gnu": "1.1.5", "@rolldown/binding-linux-x64-gnu": "1.1.5", "@rolldown/binding-linux-x64-musl": "1.1.5", "@rolldown/binding-openharmony-arm64": "1.1.5", "@rolldown/binding-wasm32-wasi": "1.1.5", "@rolldown/binding-win32-arm64-msvc": "1.1.5", "@rolldown/binding-win32-x64-msvc": "1.1.5" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA=="],
+
     "rope-sequence": ["rope-sequence@1.3.4", "", {}, "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="],
 
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
@@ -1389,6 +1462,8 @@
 
     "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "turbo": ["turbo@2.10.5", "", { "optionalDependencies": { "@turbo/darwin-64": "2.10.5", "@turbo/darwin-arm64": "2.10.5", "@turbo/linux-64": "2.10.5", "@turbo/linux-arm64": "2.10.5", "@turbo/windows-64": "2.10.5", "@turbo/windows-arm64": "2.10.5" }, "bin": { "turbo": "bin/turbo" } }, "sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
@@ -1428,6 +1503,8 @@
     "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "vite": ["vite@8.1.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.5", "postcss": "^8.5.17", "rolldown": "~1.1.5", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw=="],
 
     "vue": ["vue@3.5.33", "", { "dependencies": { "@vue/compiler-dom": "3.5.33", "@vue/compiler-sfc": "3.5.33", "@vue/runtime-dom": "3.5.33", "@vue/server-renderer": "3.5.33", "@vue/shared": "3.5.33" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-1AgChhx5w3ALgT4oK3acm2Es/7jyZhWSVUfs3rOBlGQC0rjEDkS7G4lWlJJGGNQD+BV3reCwbQrOe1mPNwKHBQ=="],
 
@@ -1525,6 +1602,8 @@
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
     "postcss-html/postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
@@ -1546,6 +1625,12 @@
     "table/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
+
+    "vite/postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
+
+    "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
@@ -1584,6 +1669,8 @@
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "stylelint/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,7 +80,7 @@
         "@types/qrcode": "^1.5.6",
         "chalk": "^5.6.2",
         "change-case": "^5.4.4",
-        "esbuild": "^0.25.0",
+        "esbuild": "^0.27.0",
         "happy-dom": "^15.11.7",
         "js-yaml": "^4.1.0",
         "oxlint": "^1.56.0",
@@ -309,57 +309,57 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
-    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
 
-    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
 
-    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
 
-    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
@@ -835,7 +835,7 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
-    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
+    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -1158,7 +1158,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@3.3.12", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ=="],
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -1234,7 +1234,7 @@
 
     "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
 
-    "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
+    "postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
 
     "postcss-html": ["postcss-html@1.8.1", "", { "dependencies": { "htmlparser2": "^8.0.0", "js-tokens": "^9.0.0", "postcss": "^8.5.0", "postcss-safe-parser": "^6.0.0" } }, "sha512-OLF6P7qctfAWayOhLpcVnTGqVeJzu2W3WpIYelfz2+JV5oGxfkcEvweN9U4XpeqE0P98dcD9ssusGwlF0TK0uQ=="],
 
@@ -1628,8 +1628,6 @@
 
     "vite/picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
-    "vite/postcss": ["postcss@8.5.22", "", { "dependencies": { "nanoid": "^3.3.16", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ=="],
-
     "vite/tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
     "whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
@@ -1669,8 +1667,6 @@
     "string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "stylelint/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
-    "vite/postcss/nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "@types/qrcode": "^1.5.6",
         "chalk": "^5.6.2",
         "change-case": "^5.4.4",
+        "esbuild": "^0.25.0",
         "happy-dom": "^15.11.7",
         "js-yaml": "^4.1.0",
         "oxlint": "^1.56.0",
@@ -307,6 +308,58 @@
     "@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.25.12", "", { "os": "android", "cpu": "arm64" }, "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.25.12", "", { "os": "android", "cpu": "x64" }, "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.25.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.25.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.25.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.25.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.25.12", "", { "os": "linux", "cpu": "arm" }, "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.25.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.25.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.25.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.25.12", "", { "os": "linux", "cpu": "none" }, "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.25.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.25.12", "", { "os": "linux", "cpu": "x64" }, "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.25.12", "", { "os": "none", "cpu": "x64" }, "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.25.12", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.25.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.25.12", "", { "os": "none", "cpu": "arm64" }, "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.25.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.25.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.25.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 
@@ -781,6 +834,8 @@
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
     "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -255,6 +255,7 @@ const allowedNonComponentExportKeys = new Set([
   './styles/guard',
   './icons',
   './highlighters/shiki',
+  './highlighters/shiki/curated',
   // Upstream re-export root barrels. These (and their `/subpath` children,
   // skipped below) are not component exports; node-consumer validates them.
   './markdown',

--- a/packages/components/fixtures/shiki-curated-vite/index.html
+++ b/packages/components/fixtures/shiki-curated-vite/index.html
@@ -1,0 +1,1 @@
+<script type="module" src="/src/main.ts"></script>

--- a/packages/components/fixtures/shiki-curated-vite/package.json
+++ b/packages/components/fixtures/shiki-curated-vite/package.json
@@ -1,5 +1,9 @@
 {
   "name": "cinder-shiki-curated-vite",
   "private": true,
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "@shikijs/langs": "3.23.0",
+    "@shikijs/themes": "3.23.0"
+  }
 }

--- a/packages/components/fixtures/shiki-curated-vite/package.json
+++ b/packages/components/fixtures/shiki-curated-vite/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "cinder-shiki-curated-vite",
+  "private": true,
+  "type": "module"
+}

--- a/packages/components/fixtures/shiki-curated-vite/src/main.ts
+++ b/packages/components/fixtures/shiki-curated-vite/src/main.ts
@@ -1,4 +1,4 @@
-import { shikiHighlighter } from '../../../src/highlighters/shiki/index.ts';
+import { shikiHighlighter } from '@lostgradient/cinder/highlighters/shiki/curated';
 export const highlighter = shikiHighlighter({
   languageLoaders: { typescript: () => import('@shikijs/langs/typescript') },
   themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },

--- a/packages/components/fixtures/shiki-curated-vite/src/main.ts
+++ b/packages/components/fixtures/shiki-curated-vite/src/main.ts
@@ -1,0 +1,8 @@
+import { shikiHighlighter } from '../../../src/highlighters/shiki/index.ts';
+export const highlighter = shikiHighlighter({
+  languageLoaders: { typescript: () => import('@shikijs/langs/typescript') },
+  themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
+  theme: 'github-light',
+});
+
+void highlighter('const answer = 42;', 'typescript');

--- a/packages/components/fixtures/shiki-curated-vite/vite.config.ts
+++ b/packages/components/fixtures/shiki-curated-vite/vite.config.ts
@@ -1,1 +1,1 @@
-export default { build: { target: 'es2022', chunkSizeWarningLimit: 700 } };
+export default { build: { target: 'es2022' } };

--- a/packages/components/fixtures/shiki-curated-vite/vite.config.ts
+++ b/packages/components/fixtures/shiki-curated-vite/vite.config.ts
@@ -1,1 +1,1 @@
-export default { build: { target: 'es2022' } };
+export default { build: { target: 'es2022', chunkSizeWarningLimit: 700 } };

--- a/packages/components/fixtures/shiki-curated-vite/vite.config.ts
+++ b/packages/components/fixtures/shiki-curated-vite/vite.config.ts
@@ -1,1 +1,13 @@
-export default { build: { target: 'es2022' } };
+import { resolve } from 'node:path';
+
+export default {
+  resolve: {
+    alias: {
+      '@lostgradient/cinder/highlighters/shiki/curated': resolve(
+        import.meta.dirname,
+        '../../src/highlighters/shiki/index.ts',
+      ),
+    },
+  },
+  build: { target: 'es2022' },
+};

--- a/packages/components/fixtures/shiki-curated-vite/vite.config.ts
+++ b/packages/components/fixtures/shiki-curated-vite/vite.config.ts
@@ -1,0 +1,1 @@
+export default { build: { target: 'es2022' } };

--- a/packages/components/fixtures/shiki-curated-vite/vite.config.ts
+++ b/packages/components/fixtures/shiki-curated-vite/vite.config.ts
@@ -1,13 +1,1 @@
-import { resolve } from 'node:path';
-
-export default {
-  resolve: {
-    alias: {
-      '@lostgradient/cinder/highlighters/shiki/curated': resolve(
-        import.meta.dirname,
-        '../../src/highlighters/shiki/index.ts',
-      ),
-    },
-  },
-  build: { target: 'es2022' },
-};
+export default { build: { target: 'es2022' } };

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -80,6 +80,14 @@
       "default": "./dist/components/json-editor/json-editor-enhancement.js"
     },
     "./highlighters/shiki": {
+      "types": "./dist/highlighters/shiki/default.d.ts",
+      "browser": "./src/highlighters/shiki/default.ts",
+      "node": "./dist/server/highlighters/shiki/default.js",
+      "svelte": "./src/highlighters/shiki/default.ts",
+      "import": "./src/highlighters/shiki/default.ts",
+      "default": "./dist/highlighters/shiki/default.js"
+    },
+    "./highlighters/shiki/curated": {
       "types": "./dist/highlighters/shiki/index.d.ts",
       "browser": "./src/highlighters/shiki/index.ts",
       "node": "./dist/server/highlighters/shiki/index.js",
@@ -6290,6 +6298,7 @@
     "svelte2tsx": "^0.7.33",
     "ts-morph": "^28.0.0",
     "typescript": "^5.9.0",
+    "vite": "^8.0.9",
     "zod": "4.4.1"
   },
   "peerDependencies": {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6283,6 +6283,7 @@
     "@types/qrcode": "^1.5.6",
     "chalk": "^5.6.2",
     "change-case": "^5.4.4",
+    "esbuild": "^0.25.0",
     "happy-dom": "^15.11.7",
     "js-yaml": "^4.1.0",
     "oxlint": "^1.56.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6283,7 +6283,7 @@
     "@types/qrcode": "^1.5.6",
     "chalk": "^5.6.2",
     "change-case": "^5.4.4",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.27.0",
     "happy-dom": "^15.11.7",
     "js-yaml": "^4.1.0",
     "oxlint": "^1.56.0",

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -268,6 +268,7 @@ const staticSubpathEntrypoints = [
   `${sourceRoot}/components/icons/index.ts`,
   `${sourceRoot}/components/json-editor/json-editor-enhancement.ts`,
   `${sourceRoot}/highlighters/shiki/index.ts`,
+  `${sourceRoot}/highlighters/shiki/default.ts`,
   `${sourceRoot}/styles/base-guard.ts`,
 ];
 
@@ -645,6 +646,9 @@ const expectedPaths: string[] = [
   `${distributionDirectory}/highlighters/shiki/index.js`,
   `${distributionDirectory}/highlighters/shiki/index.d.ts`,
   `${distributionDirectory}/server/highlighters/shiki/index.js`,
+  `${distributionDirectory}/highlighters/shiki/default.js`,
+  `${distributionDirectory}/highlighters/shiki/default.d.ts`,
+  `${distributionDirectory}/server/highlighters/shiki/default.js`,
   // Dev-only base-loaded guard — browser + server builds, plus types.
   `${distributionDirectory}/styles/base-guard.js`,
   `${distributionDirectory}/styles/base-guard.d.ts`,

--- a/packages/components/scripts/generate-component-examples.ts
+++ b/packages/components/scripts/generate-component-examples.ts
@@ -603,7 +603,7 @@ export async function generateAllExamples(): Promise<GenerateExamplesResult> {
   // can import their siblings via the same `@lostgradient/cinder/<subpath>` contract.
   // Static non-component sub-paths (the first-party Shiki adapter, etc.)
   // are listed alongside.
-  const validCinderSubpaths = new Set<string>(['highlighters/shiki']);
+  const validCinderSubpaths = new Set<string>(['highlighters/shiki', 'highlighters/shiki/curated']);
   for (const component of components) {
     if (component.isExperimental) {
       validCinderSubpaths.add(`experimental/${component.name}`);

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -91,6 +91,7 @@ const PACKAGE_JSON_KEY = './package.json';
 const ICONS_KEY = './icons';
 const JSON_EDITOR_ENHANCEMENT_KEY = './json-editor/enhancement';
 const HIGHLIGHTERS_SHIKI_KEY = './highlighters/shiki';
+const HIGHLIGHTERS_SHIKI_CURATED_KEY = './highlighters/shiki/curated';
 
 /**
  * Keys that the generator owns at the top level but never emits via
@@ -110,6 +111,7 @@ const RESERVED_KEYS = new Set([
   ICONS_KEY,
   JSON_EDITOR_ENHANCEMENT_KEY,
   HIGHLIGHTERS_SHIKI_KEY,
+  HIGHLIGHTERS_SHIKI_CURATED_KEY,
 ]);
 
 /**
@@ -172,14 +174,14 @@ export function shouldPreserveLegacyEntry(
  * and not an upstream re-export); the generator stitches this in alongside
  * the styles entries.
  */
-function highlightersShikiExport(): ExportEntry {
+function highlightersShikiExport(source = 'default'): ExportEntry {
   return orderedExportEntry({
-    types: './dist/highlighters/shiki/index.d.ts',
-    browser: './src/highlighters/shiki/index.ts',
-    svelte: './src/highlighters/shiki/index.ts',
-    node: './dist/server/highlighters/shiki/index.js',
-    import: './src/highlighters/shiki/index.ts',
-    default: './dist/highlighters/shiki/index.js',
+    types: `./dist/highlighters/shiki/${source}.d.ts`,
+    browser: `./src/highlighters/shiki/${source}.ts`,
+    svelte: `./src/highlighters/shiki/${source}.ts`,
+    node: `./dist/server/highlighters/shiki/${source}.js`,
+    import: `./src/highlighters/shiki/${source}.ts`,
+    default: `./dist/highlighters/shiki/${source}.js`,
   });
 }
 
@@ -698,6 +700,7 @@ async function main(): Promise<void> {
     next[ICONS_KEY] = iconsExport();
     next[JSON_EDITOR_ENHANCEMENT_KEY] = jsonEditorEnhancementExport();
     next[HIGHLIGHTERS_SHIKI_KEY] = highlightersShikiExport();
+    next[HIGHLIGHTERS_SHIKI_CURATED_KEY] = highlightersShikiExport('index');
 
     // Preserve legacy flat component subpaths whose component still exists as
     // a flat .svelte file (not yet migrated to a directory).

--- a/packages/components/src/components/code-block/code-block-default-highlighter.integration.test.ts
+++ b/packages/components/src/components/code-block/code-block-default-highlighter.integration.test.ts
@@ -61,7 +61,7 @@ describe('CodeBlock default-highlighter seam (real Shiki adapter)', () => {
     const highlighter = mock((code: string) => `<pre><code>${code}</code></pre>`);
     const shikiHighlighter = mock(() => highlighter);
 
-    mock.module('../../highlighters/shiki/index.ts', () => ({ shikiHighlighter }));
+    mock.module('../../highlighters/shiki/default.ts', () => ({ shikiHighlighter }));
     try {
       const { loadDefaultHighlighter } = await import('./code-block-default-highlighter.ts');
       const first = await loadDefaultHighlighter();

--- a/packages/components/src/components/code-block/code-block-default-highlighter.ts
+++ b/packages/components/src/components/code-block/code-block-default-highlighter.ts
@@ -31,7 +31,7 @@
 import type { Highlighter } from '../../utilities/highlighter.ts';
 import { createRetryingLoaderCache } from '../../utilities/retrying-loader-cache.ts';
 
-type ShikiAdapterModule = typeof import('../../highlighters/shiki/index.ts');
+type ShikiAdapterModule = typeof import('../../highlighters/shiki/default.ts');
 
 /**
  * Dynamically import the Shiki adapter module. Kept as a dedicated arrow so
@@ -40,7 +40,7 @@ type ShikiAdapterModule = typeof import('../../highlighters/shiki/index.ts');
  * is no static edge (asserted by `code-block.bundle-boundary.test.ts`).
  */
 const loadShikiAdapterModule = createRetryingLoaderCache<ShikiAdapterModule>(
-  () => import('../../highlighters/shiki/index.ts'),
+  () => import('../../highlighters/shiki/default.ts'),
 );
 
 /** Memoized default highlighter instance, created once on first success. */

--- a/packages/components/src/components/code-block/code-block.bundle-boundary.test.ts
+++ b/packages/components/src/components/code-block/code-block.bundle-boundary.test.ts
@@ -12,8 +12,8 @@
  * module specifier in:
  *   - `code-block.svelte` (instance + module scripts)
  *   - `code-block-default-highlighter.ts` (the seam CodeBlock imports)
- * and asserts NONE resolve to `src/highlighters/shiki/index.ts`. Dynamic
- * `import('../../highlighters/shiki/index.ts')` is allowed (and asserted to
+ * and asserts NONE resolve to `src/highlighters/shiki/default.ts`. Dynamic
+ * `import('../../highlighters/shiki/default.ts')` is allowed (and asserted to
  * exist as a positive control so a future refactor that drops the lazy edge
  * entirely is caught).
  */
@@ -25,7 +25,7 @@ import { parse } from 'svelte/compiler';
 import ts from 'typescript';
 
 const HERE = import.meta.dir;
-const SHIKI_ADAPTER = resolvePath(HERE, '../../highlighters/shiki/index.ts');
+const SHIKI_ADAPTER = resolvePath(HERE, '../../highlighters/shiki/default.ts');
 
 /** Resolve a relative specifier to the candidate absolute files it could mean. */
 function resolveSpecifierCandidates(fromFile: string, specifier: string): string[] {

--- a/packages/components/src/exports-drift.test.ts
+++ b/packages/components/src/exports-drift.test.ts
@@ -107,6 +107,7 @@ describe('exports drift', () => {
       './icons',
       './highlighters/shiki',
       './json-editor/enhancement',
+      './highlighters/shiki/curated',
     ]);
     for (const key of Object.keys(existing)) {
       if (RESERVED.has(key)) continue;

--- a/packages/components/src/highlighters/shiki/default.ts
+++ b/packages/components/src/highlighters/shiki/default.ts
@@ -1,9 +1,7 @@
-import { bundledLanguages } from 'shiki/langs';
-import { bundledThemes } from 'shiki/themes';
-
 import {
   createRetryingLoaderCache,
   shikiHighlighter as createShikiHighlighter,
+  createShikiModule,
   type ShikiHighlighterOptions,
 } from './index.ts';
 
@@ -15,12 +13,17 @@ export function shikiHighlighter(
   options: ShikiHighlighterOptions = {},
   moduleLoader?: Parameters<typeof createShikiHighlighter>[1],
 ): ReturnType<typeof createShikiHighlighter> {
-  return createShikiHighlighter(
-    {
-      ...options,
-      languageLoaders: options.languageLoaders ?? bundledLanguages,
-      themeLoaders: options.themeLoaders ?? bundledThemes,
-    },
-    moduleLoader,
-  );
+  const loadModule =
+    moduleLoader ??
+    (async () => {
+      const [{ bundledLanguages }, { bundledThemes }] = await Promise.all([
+        import('shiki/langs'),
+        import('shiki/themes'),
+      ]);
+      return createShikiModule(
+        options.languageLoaders ?? bundledLanguages,
+        options.themeLoaders ?? bundledThemes,
+      );
+    });
+  return createShikiHighlighter(options, loadModule);
 }

--- a/packages/components/src/highlighters/shiki/default.ts
+++ b/packages/components/src/highlighters/shiki/default.ts
@@ -17,7 +17,7 @@ function getDefaultModuleLoader(): () => Promise<ShikiModule> {
       import('shiki/langs'),
       import('shiki/themes'),
     ]);
-    return createShikiModule(bundledLanguages, bundledThemes);
+    return createShikiModule(bundledLanguages, bundledThemes, false);
   });
   return sharedDefaultModuleLoader;
 }

--- a/packages/components/src/highlighters/shiki/default.ts
+++ b/packages/components/src/highlighters/shiki/default.ts
@@ -39,6 +39,7 @@ export function shikiHighlighter(
           return createShikiModule(
             options.languageLoaders ?? bundledLanguages,
             options.themeLoaders ?? bundledThemes,
+            options.languageLoaders !== undefined,
           );
         });
   return createShikiHighlighter(options, loadModule);

--- a/packages/components/src/highlighters/shiki/default.ts
+++ b/packages/components/src/highlighters/shiki/default.ts
@@ -2,9 +2,13 @@ import { bundledLanguages } from 'shiki/langs';
 import { bundledThemes } from 'shiki/themes';
 
 import {
+  createRetryingLoaderCache,
   shikiHighlighter as createShikiHighlighter,
   type ShikiHighlighterOptions,
 } from './index.ts';
+
+export { createRetryingLoaderCache };
+export type { ShikiHighlighterOptions };
 
 /** The bundled adapter with the complete Shiki language and theme registries. */
 export function shikiHighlighter(

--- a/packages/components/src/highlighters/shiki/default.ts
+++ b/packages/components/src/highlighters/shiki/default.ts
@@ -1,0 +1,22 @@
+import { bundledLanguages } from 'shiki/langs';
+import { bundledThemes } from 'shiki/themes';
+
+import {
+  shikiHighlighter as createShikiHighlighter,
+  type ShikiHighlighterOptions,
+} from './index.ts';
+
+/** The bundled adapter with the complete Shiki language and theme registries. */
+export function shikiHighlighter(
+  options: ShikiHighlighterOptions = {},
+  moduleLoader?: Parameters<typeof createShikiHighlighter>[1],
+): ReturnType<typeof createShikiHighlighter> {
+  return createShikiHighlighter(
+    {
+      ...options,
+      languageLoaders: options.languageLoaders ?? bundledLanguages,
+      themeLoaders: options.themeLoaders ?? bundledThemes,
+    },
+    moduleLoader,
+  );
+}

--- a/packages/components/src/highlighters/shiki/default.ts
+++ b/packages/components/src/highlighters/shiki/default.ts
@@ -8,6 +8,20 @@ import {
 export { createRetryingLoaderCache };
 export type { ShikiHighlighterOptions };
 
+type ShikiModule = Awaited<ReturnType<typeof createShikiModule>>;
+let sharedDefaultModuleLoader: (() => Promise<ShikiModule>) | undefined;
+
+function getDefaultModuleLoader(): () => Promise<ShikiModule> {
+  sharedDefaultModuleLoader ??= createRetryingLoaderCache(async () => {
+    const [{ bundledLanguages }, { bundledThemes }] = await Promise.all([
+      import('shiki/langs'),
+      import('shiki/themes'),
+    ]);
+    return createShikiModule(bundledLanguages, bundledThemes);
+  });
+  return sharedDefaultModuleLoader;
+}
+
 /** The bundled adapter with the complete Shiki language and theme registries. */
 export function shikiHighlighter(
   options: ShikiHighlighterOptions = {},
@@ -15,15 +29,17 @@ export function shikiHighlighter(
 ): ReturnType<typeof createShikiHighlighter> {
   const loadModule =
     moduleLoader ??
-    (async () => {
-      const [{ bundledLanguages }, { bundledThemes }] = await Promise.all([
-        import('shiki/langs'),
-        import('shiki/themes'),
-      ]);
-      return createShikiModule(
-        options.languageLoaders ?? bundledLanguages,
-        options.themeLoaders ?? bundledThemes,
-      );
-    });
+    (options.languageLoaders === undefined && options.themeLoaders === undefined
+      ? getDefaultModuleLoader()
+      : async () => {
+          const [{ bundledLanguages }, { bundledThemes }] = await Promise.all([
+            import('shiki/langs'),
+            import('shiki/themes'),
+          ]);
+          return createShikiModule(
+            options.languageLoaders ?? bundledLanguages,
+            options.themeLoaders ?? bundledThemes,
+          );
+        });
   return createShikiHighlighter(options, loadModule);
 }

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -108,6 +108,10 @@ export type ShikiHighlighterOptions = {
    * first-render flash for those languages).
    */
   langs?: ReadonlyArray<string>;
+  /** Curated Shiki language loader map. When supplied, the default registry is not imported. */
+  languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>;
+  /** Curated Shiki theme loader map. When supplied, the default registry is not imported. */
+  themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>;
 };
 
 const DEFAULT_THEME: { light: string; dark: string } = {
@@ -146,8 +150,8 @@ function plaintextBlock(code: string): string {
  * here are keyed by a `lang`/theme name string that is only known to be a
  * member of that union after a runtime `Object.hasOwn` check.
  */
-type BundledLanguages = Record<string, DynamicImportLanguageRegistration>;
-type BundledThemes = Record<string, DynamicImportThemeRegistration>;
+type BundledLanguages = Readonly<Record<string, DynamicImportLanguageRegistration>>;
+type BundledThemes = Readonly<Record<string, DynamicImportThemeRegistration>>;
 
 type ShikiModule = {
   highlighter: HighlighterCore;
@@ -230,26 +234,35 @@ async function loadGuessedEmbeddedLanguages(
  */
 let sharedShikiModule: (() => Promise<ShikiModule>) | undefined;
 
-function getSharedShikiModule(): Promise<ShikiModule> {
-  sharedShikiModule ??= createRetryingLoaderCache(async (): Promise<ShikiModule> => {
-    const [{ createOnigurumaEngine }, coreModule, langsModule, themesModule] = await Promise.all([
-      import('@shikijs/engine-oniguruma'),
-      import('shiki/core'),
-      import('shiki/langs'),
-      import('shiki/themes'),
-    ]);
-    const highlighter = await coreModule.createHighlighterCore({
-      themes: [],
-      langs: [],
-      engine: createOnigurumaEngine(import('shiki/wasm')),
-    });
-    return {
-      highlighter,
-      bundledLanguages: langsModule.bundledLanguages,
-      bundledThemes: themesModule.bundledThemes,
-      guessEmbeddedLanguages: coreModule.guessEmbeddedLanguages,
-    };
+async function createShikiModule(
+  languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>,
+  themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>,
+): Promise<ShikiModule> {
+  const [{ createOnigurumaEngine }, coreModule] = await Promise.all([
+    import('@shikijs/engine-oniguruma'),
+    import('shiki/core'),
+  ]);
+  const highlighter = await coreModule.createHighlighterCore({
+    themes: [],
+    langs: [],
+    engine: createOnigurumaEngine(import('shiki/wasm')),
   });
+  return {
+    highlighter,
+    bundledLanguages: languageLoaders ?? {},
+    bundledThemes: themeLoaders ?? {},
+    guessEmbeddedLanguages: coreModule.guessEmbeddedLanguages,
+  };
+}
+
+function getSharedShikiModule(
+  languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>,
+  themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>,
+): Promise<ShikiModule> {
+  if (languageLoaders !== undefined || themeLoaders !== undefined) {
+    return createShikiModule(languageLoaders, themeLoaders);
+  }
+  sharedShikiModule ??= createRetryingLoaderCache(() => createShikiModule());
   return sharedShikiModule();
 }
 
@@ -262,7 +275,7 @@ export function shikiHighlighter(
   options: ShikiHighlighterOptions = {},
   moduleLoader?: ShikiModuleLoader,
 ): Highlighter {
-  const { theme = DEFAULT_THEME, langs } = options;
+  const { theme = DEFAULT_THEME, langs, languageLoaders, themeLoaders } = options;
   const warnedLanguages = new Set<string>();
 
   // Resolve Shiki lazily on the first highlight call. The cache wrapper
@@ -272,7 +285,7 @@ export function shikiHighlighter(
   const loadShiki = createRetryingLoaderCache(
     moduleLoader ??
       (async (): Promise<ShikiModule> => {
-        const shikiModule = await getSharedShikiModule();
+        const shikiModule = await getSharedShikiModule(languageLoaders, themeLoaders);
 
         // Optional preload — if the consumer named specific languages, load
         // the configured theme once and each named language, so Shiki

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -235,14 +235,6 @@ async function loadGuessedEmbeddedLanguages(
 let sharedShikiModule: (() => Promise<ShikiModule>) | undefined;
 const sharedCuratedModules = new WeakMap<object, WeakMap<object, () => Promise<ShikiModule>>>();
 const EMPTY_LOADERS: Readonly<Record<string, never>> = {};
-const LANGUAGE_ALIASES: Readonly<Record<string, string>> = {
-  ts: 'typescript',
-  js: 'javascript',
-  py: 'python',
-  rb: 'ruby',
-  md: 'markdown',
-  yml: 'yaml',
-};
 
 export async function createShikiModule(
   languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>,
@@ -299,6 +291,7 @@ export function shikiHighlighter(
 ): Highlighter {
   const { theme = DEFAULT_THEME, langs, languageLoaders, themeLoaders } = options;
   const warnedLanguages = new Set<string>();
+  const resolvedLanguageAliases = new Map<string, string | undefined>();
 
   // Resolve Shiki lazily on the first highlight call. The cache wrapper
   // de-duplicates concurrent loads and evicts rejected promises so a
@@ -354,13 +347,31 @@ export function shikiHighlighter(
       return plaintextBlock(code);
     }
 
-    // Shiki's `bundledLanguages` table already exposes both canonical names
-    // and aliases as top-level keys (`typescript` AND `ts`, `javascript` AND
-    // `js`, etc.), so a single hasOwn check accepts whatever Shiki accepts
-    // natively without us inventing additional aliases.
-    const languageKey = Object.hasOwn(shiki.bundledLanguages, normalizedLang)
+    // The full Shiki registry exposes aliases as top-level keys, while a
+    // curated registry usually exposes only canonical ids. Resolve aliases
+    // from each grammar's own metadata so curated consumers retain the
+    // complete Shiki alias contract without maintaining a partial list here.
+    let languageKey: string | undefined = Object.hasOwn(shiki.bundledLanguages, normalizedLang)
       ? normalizedLang
-      : LANGUAGE_ALIASES[normalizedLang];
+      : resolvedLanguageAliases.get(normalizedLang);
+    if (languageKey === undefined && !resolvedLanguageAliases.has(normalizedLang)) {
+      for (const [candidate, loader] of Object.entries(shiki.bundledLanguages)) {
+        try {
+          const module = await loader();
+          const registrations = module.default;
+          if (
+            registrations.some((registration) => registration.aliases?.includes(normalizedLang))
+          ) {
+            languageKey = candidate;
+            break;
+          }
+        } catch {
+          // A broken optional grammar should not prevent other candidates
+          // from resolving this alias or force the whole highlight to fail.
+        }
+      }
+      resolvedLanguageAliases.set(normalizedLang, languageKey);
+    }
     if (languageKey === undefined || !Object.hasOwn(shiki.bundledLanguages, languageKey)) {
       if (!warnedLanguages.has(normalizedLang)) {
         warnedLanguages.add(normalizedLang);

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -235,8 +235,16 @@ async function loadGuessedEmbeddedLanguages(
 let sharedShikiModule: (() => Promise<ShikiModule>) | undefined;
 const sharedCuratedModules = new WeakMap<object, WeakMap<object, () => Promise<ShikiModule>>>();
 const EMPTY_LOADERS: Readonly<Record<string, never>> = {};
+const LANGUAGE_ALIASES: Readonly<Record<string, string>> = {
+  ts: 'typescript',
+  js: 'javascript',
+  py: 'python',
+  rb: 'ruby',
+  md: 'markdown',
+  yml: 'yaml',
+};
 
-async function createShikiModule(
+export async function createShikiModule(
   languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>,
   themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>,
 ): Promise<ShikiModule> {
@@ -350,7 +358,10 @@ export function shikiHighlighter(
     // and aliases as top-level keys (`typescript` AND `ts`, `javascript` AND
     // `js`, etc.), so a single hasOwn check accepts whatever Shiki accepts
     // natively without us inventing additional aliases.
-    if (!Object.hasOwn(shiki.bundledLanguages, normalizedLang)) {
+    const languageKey = Object.hasOwn(shiki.bundledLanguages, normalizedLang)
+      ? normalizedLang
+      : LANGUAGE_ALIASES[normalizedLang];
+    if (languageKey === undefined || !Object.hasOwn(shiki.bundledLanguages, languageKey)) {
       if (!warnedLanguages.has(normalizedLang)) {
         warnedLanguages.add(normalizedLang);
         console.warn(
@@ -361,7 +372,7 @@ export function shikiHighlighter(
     }
 
     try {
-      await ensureLanguageLoaded(shiki, normalizedLang);
+      await ensureLanguageLoaded(shiki, languageKey);
       await ensureThemesLoaded(shiki, theme);
       await loadGuessedEmbeddedLanguages(shiki, code, normalizedLang);
       const html = shiki.highlighter.codeToHtml(code, {

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -212,16 +212,52 @@ async function loadGuessedEmbeddedLanguages(
   shiki: ShikiModule,
   code: string,
   lang: string,
+  resolvedLanguageAliases: Map<string, string | undefined>,
 ): Promise<void> {
   for (const guessed of shiki.guessEmbeddedLanguages(code, lang)) {
-    if (!Object.hasOwn(shiki.bundledLanguages, guessed)) continue;
     try {
-      await ensureLanguageLoaded(shiki, guessed);
+      const languageKey = await resolveLanguageKey(shiki, guessed, resolvedLanguageAliases);
+      if (languageKey !== undefined) await ensureLanguageLoaded(shiki, languageKey);
     } catch {
       // Best-effort — an embedded grammar that fails to load only costs
       // that nested region its highlighting, not the whole block.
     }
   }
+}
+
+async function resolveLanguageKey(
+  shiki: ShikiModule,
+  normalizedLang: string,
+  resolvedLanguageAliases: Map<string, string | undefined>,
+): Promise<string | undefined> {
+  let languageKey: string | undefined = Object.hasOwn(shiki.bundledLanguages, normalizedLang)
+    ? normalizedLang
+    : resolvedLanguageAliases.get(normalizedLang);
+  if (
+    languageKey === undefined &&
+    shiki.resolveLanguageAliases &&
+    !resolvedLanguageAliases.has(normalizedLang)
+  ) {
+    let loaderFailed = false;
+    for (const [candidate, loader] of Object.entries(shiki.bundledLanguages)) {
+      try {
+        const module = await loader();
+        const registrations = module.default;
+        if (registrations.some((registration) => registration.aliases?.includes(normalizedLang))) {
+          languageKey = candidate;
+          break;
+        }
+      } catch {
+        loaderFailed = true;
+      }
+    }
+    if (!loaderFailed || languageKey !== undefined) {
+      resolvedLanguageAliases.set(normalizedLang, languageKey);
+    }
+  }
+  return languageKey !== undefined && Object.hasOwn(shiki.bundledLanguages, languageKey)
+    ? languageKey
+    : undefined;
 }
 
 /**
@@ -355,35 +391,7 @@ export function shikiHighlighter(
     // curated registry usually exposes only canonical ids. Resolve aliases
     // from each grammar's own metadata so curated consumers retain the
     // complete Shiki alias contract without maintaining a partial list here.
-    let languageKey: string | undefined = Object.hasOwn(shiki.bundledLanguages, normalizedLang)
-      ? normalizedLang
-      : resolvedLanguageAliases.get(normalizedLang);
-    if (
-      languageKey === undefined &&
-      shiki.resolveLanguageAliases &&
-      !resolvedLanguageAliases.has(normalizedLang)
-    ) {
-      let loaderFailed = false;
-      for (const [candidate, loader] of Object.entries(shiki.bundledLanguages)) {
-        try {
-          const module = await loader();
-          const registrations = module.default;
-          if (
-            registrations.some((registration) => registration.aliases?.includes(normalizedLang))
-          ) {
-            languageKey = candidate;
-            break;
-          }
-        } catch {
-          loaderFailed = true;
-          // A broken optional grammar should not prevent other candidates
-          // from resolving this alias or force the whole highlight to fail.
-        }
-      }
-      if (!loaderFailed || languageKey !== undefined) {
-        resolvedLanguageAliases.set(normalizedLang, languageKey);
-      }
-    }
+    const languageKey = await resolveLanguageKey(shiki, normalizedLang, resolvedLanguageAliases);
     if (languageKey === undefined || !Object.hasOwn(shiki.bundledLanguages, languageKey)) {
       if (!warnedLanguages.has(normalizedLang)) {
         warnedLanguages.add(normalizedLang);
@@ -397,7 +405,7 @@ export function shikiHighlighter(
     try {
       await ensureLanguageLoaded(shiki, languageKey);
       await ensureThemesLoaded(shiki, theme);
-      await loadGuessedEmbeddedLanguages(shiki, code, normalizedLang);
+      await loadGuessedEmbeddedLanguages(shiki, code, normalizedLang, resolvedLanguageAliases);
       const html = shiki.highlighter.codeToHtml(code, {
         lang: normalizedLang,
         ...buildThemeOption(theme),

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -363,6 +363,7 @@ export function shikiHighlighter(
       shiki.resolveLanguageAliases &&
       !resolvedLanguageAliases.has(normalizedLang)
     ) {
+      let loaderFailed = false;
       for (const [candidate, loader] of Object.entries(shiki.bundledLanguages)) {
         try {
           const module = await loader();
@@ -374,11 +375,14 @@ export function shikiHighlighter(
             break;
           }
         } catch {
+          loaderFailed = true;
           // A broken optional grammar should not prevent other candidates
           // from resolving this alias or force the whole highlight to fail.
         }
       }
-      resolvedLanguageAliases.set(normalizedLang, languageKey);
+      if (!loaderFailed || languageKey !== undefined) {
+        resolvedLanguageAliases.set(normalizedLang, languageKey);
+      }
     }
     if (languageKey === undefined || !Object.hasOwn(shiki.bundledLanguages, languageKey)) {
       if (!warnedLanguages.has(normalizedLang)) {

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -166,6 +166,8 @@ type ShikiModule = {
    * their own `shiki/core` import.
    */
   guessEmbeddedLanguages: (code: string, lang: string) => string[];
+  /** Whether aliases should be discovered from curated grammar metadata. */
+  resolveLanguageAliases: boolean;
 };
 
 type ShikiModuleLoader = () => Promise<ShikiModule>;
@@ -239,6 +241,7 @@ const EMPTY_LOADERS: Readonly<Record<string, never>> = {};
 export async function createShikiModule(
   languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>,
   themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>,
+  resolveLanguageAliases = true,
 ): Promise<ShikiModule> {
   const [{ createOnigurumaEngine }, coreModule] = await Promise.all([
     import('@shikijs/engine-oniguruma'),
@@ -254,6 +257,7 @@ export async function createShikiModule(
     bundledLanguages: languageLoaders ?? {},
     bundledThemes: themeLoaders ?? {},
     guessEmbeddedLanguages: coreModule.guessEmbeddedLanguages,
+    resolveLanguageAliases,
   };
 }
 
@@ -354,7 +358,11 @@ export function shikiHighlighter(
     let languageKey: string | undefined = Object.hasOwn(shiki.bundledLanguages, normalizedLang)
       ? normalizedLang
       : resolvedLanguageAliases.get(normalizedLang);
-    if (languageKey === undefined && !resolvedLanguageAliases.has(normalizedLang)) {
+    if (
+      languageKey === undefined &&
+      shiki.resolveLanguageAliases &&
+      !resolvedLanguageAliases.has(normalizedLang)
+    ) {
       for (const [candidate, loader] of Object.entries(shiki.bundledLanguages)) {
         try {
           const module = await loader();

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -108,9 +108,9 @@ export type ShikiHighlighterOptions = {
    * first-render flash for those languages).
    */
   langs?: ReadonlyArray<string>;
-  /** Curated Shiki language loader map. When supplied, the default registry is not imported. */
+  /** Curated Shiki language loader map for the `/highlighters/shiki/curated` entrypoint. */
   languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>;
-  /** Curated Shiki theme loader map. When supplied, the default registry is not imported. */
+  /** Curated Shiki theme loader map for the `/highlighters/shiki/curated` entrypoint. */
   themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>;
 };
 
@@ -234,6 +234,7 @@ async function loadGuessedEmbeddedLanguages(
  */
 let sharedShikiModule: (() => Promise<ShikiModule>) | undefined;
 const sharedCuratedModules = new WeakMap<object, WeakMap<object, () => Promise<ShikiModule>>>();
+const EMPTY_LOADERS: Readonly<Record<string, never>> = {};
 
 async function createShikiModule(
   languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>,
@@ -261,8 +262,8 @@ function getSharedShikiModule(
   themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>,
 ): Promise<ShikiModule> {
   if (languageLoaders !== undefined || themeLoaders !== undefined) {
-    const languageKey = languageLoaders ?? {};
-    const themeKey = themeLoaders ?? {};
+    const languageKey = languageLoaders ?? EMPTY_LOADERS;
+    const themeKey = themeLoaders ?? EMPTY_LOADERS;
     let themes = sharedCuratedModules.get(languageKey);
     if (themes === undefined) {
       themes = new WeakMap();

--- a/packages/components/src/highlighters/shiki/index.ts
+++ b/packages/components/src/highlighters/shiki/index.ts
@@ -233,6 +233,7 @@ async function loadGuessedEmbeddedLanguages(
  * entirely (see `shikiHighlighter`'s second parameter).
  */
 let sharedShikiModule: (() => Promise<ShikiModule>) | undefined;
+const sharedCuratedModules = new WeakMap<object, WeakMap<object, () => Promise<ShikiModule>>>();
 
 async function createShikiModule(
   languageLoaders?: Readonly<Record<string, DynamicImportLanguageRegistration>>,
@@ -260,7 +261,19 @@ function getSharedShikiModule(
   themeLoaders?: Readonly<Record<string, DynamicImportThemeRegistration>>,
 ): Promise<ShikiModule> {
   if (languageLoaders !== undefined || themeLoaders !== undefined) {
-    return createShikiModule(languageLoaders, themeLoaders);
+    const languageKey = languageLoaders ?? {};
+    const themeKey = themeLoaders ?? {};
+    let themes = sharedCuratedModules.get(languageKey);
+    if (themes === undefined) {
+      themes = new WeakMap();
+      sharedCuratedModules.set(languageKey, themes);
+    }
+    let loader = themes.get(themeKey);
+    if (loader === undefined) {
+      loader = createRetryingLoaderCache(() => createShikiModule(languageLoaders, themeLoaders));
+      themes.set(themeKey, loader);
+    }
+    return loader();
   }
   sharedShikiModule ??= createRetryingLoaderCache(() => createShikiModule());
   return sharedShikiModule();

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -12,10 +12,7 @@ afterEach(async () => {
 
 test('Vite curated Shiki fixture emits only configured language and theme candidates', async () => {
   const result =
-    await Bun.$`${resolve(fixtureDirectory, '../../../../node_modules/.bin/vite')} build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`
-      .quiet()
-      .nothrow();
-  expect(result.exitCode).toBe(0);
+    await Bun.$`${resolve(fixtureDirectory, '../../../../node_modules/.bin/vite')} build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`;
   const assets = await readdir(resolve(outputDirectory, 'assets'));
   const assetNames = assets.join('\n');
   expect(assetNames).toContain('typescript');

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -12,7 +12,7 @@ afterEach(async () => {
 
 test('Vite curated Shiki fixture emits only configured language and theme candidates', async () => {
   const result =
-    await Bun.$`bunx vite build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`
+    await Bun.$`${resolve(fixtureDirectory, '../../../../node_modules/.bin/vite')} build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`
       .quiet()
       .nothrow();
   expect(result.exitCode).toBe(0);

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -5,13 +5,15 @@ import { afterEach, expect, test } from 'bun:test';
 
 const fixtureDirectory = resolve(import.meta.dir, '../../../fixtures/shiki-curated-vite');
 const outputDirectory = resolve(fixtureDirectory, '.dist');
+const viteExecutable =
+  Bun.which('vite') ?? resolve(fixtureDirectory, '../../../../node_modules/.bin/vite');
 
 afterEach(async () => {
   await rm(outputDirectory, { recursive: true, force: true });
 });
 
 test('Vite curated Shiki fixture emits only configured language and theme candidates', async () => {
-  await Bun.$`${resolve(fixtureDirectory, '../../../../node_modules/.bin/vite')} build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`;
+  await Bun.$`${viteExecutable} build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`;
   const assets = await readdir(resolve(outputDirectory, 'assets'));
   const assetNames = assets.join('\n');
   expect(assetNames).toContain('typescript');

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -23,7 +23,8 @@ test('Vite curated Shiki fixture emits only configured language and theme candid
   expect(assetNames).not.toContain('python');
   const oversized = [];
   for (const asset of assets) {
-    const size = (await stat(resolve(outputDirectory, 'assets', asset))).size;
+    const metadata = await stat(resolve(outputDirectory, 'assets', asset));
+    const size = metadata.size;
     if (size > 500 * 1024) oversized.push({ asset, size });
   }
   // Oniguruma's WASM payload is the only expected chunk above Vite's default

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -5,8 +5,7 @@ import { afterEach, expect, test } from 'bun:test';
 
 const fixtureDirectory = resolve(import.meta.dir, '../../../fixtures/shiki-curated-vite');
 const outputDirectory = resolve(fixtureDirectory, '.dist');
-const viteExecutable =
-  Bun.which('vite') ?? resolve(fixtureDirectory, '../../../../node_modules/.bin/vite');
+const viteExecutable = resolve(fixtureDirectory, '../../../../node_modules/.bin/vite');
 
 afterEach(async () => {
   await rm(outputDirectory, { recursive: true, force: true });

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -1,4 +1,4 @@
-import { readdir, rm } from 'node:fs/promises';
+import { readdir, rm, stat } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { afterEach, expect, test } from 'bun:test';
@@ -21,4 +21,14 @@ test('Vite curated Shiki fixture emits only configured language and theme candid
   expect(assetNames).not.toContain('javascript');
   expect(assetNames).not.toContain('github-dark');
   expect(assetNames).not.toContain('python');
+  const oversized = [];
+  for (const asset of assets) {
+    const size = (await stat(resolve(outputDirectory, 'assets', asset))).size;
+    if (size > 500 * 1024) oversized.push({ asset, size });
+  }
+  // Oniguruma's WASM payload is the only expected chunk above Vite's default
+  // warning threshold; keep it bounded so the fixture cannot hide regressions.
+  expect(oversized).toHaveLength(1);
+  expect(oversized[0]?.asset).toContain('wasm');
+  expect(oversized[0]?.size).toBeLessThan(700 * 1024);
 });

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -4,7 +4,7 @@ import { resolve } from 'node:path';
 import { afterEach, expect, test } from 'bun:test';
 
 const fixtureDirectory = resolve(import.meta.dir, '../../../fixtures/shiki-curated-vite');
-const outputDirectory = resolve(import.meta.dir, '.shiki-curated-vite-dist');
+const outputDirectory = resolve(fixtureDirectory, '.dist');
 
 afterEach(async () => {
   await rm(outputDirectory, { recursive: true, force: true });

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -1,0 +1,26 @@
+import { readdir, rm } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { afterEach, expect, test } from 'bun:test';
+
+const fixtureDirectory = resolve(import.meta.dir, '../../../fixtures/shiki-curated-vite');
+const outputDirectory = resolve(import.meta.dir, '.shiki-curated-vite-dist');
+
+afterEach(async () => {
+  await rm(outputDirectory, { recursive: true, force: true });
+});
+
+test('Vite curated Shiki fixture emits only configured language and theme candidates', async () => {
+  const result =
+    await Bun.$`bunx vite build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`
+      .quiet()
+      .nothrow();
+  expect(result.exitCode).toBe(0);
+  const assets = await readdir(resolve(outputDirectory, 'assets'));
+  const assetNames = assets.join('\n');
+  expect(assetNames).toContain('typescript');
+  expect(assetNames).toContain('github-light');
+  expect(assetNames).not.toContain('javascript');
+  expect(assetNames).not.toContain('github-dark');
+  expect(assetNames).not.toContain('python');
+});

--- a/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki-curated-vite.test.ts
@@ -11,8 +11,7 @@ afterEach(async () => {
 });
 
 test('Vite curated Shiki fixture emits only configured language and theme candidates', async () => {
-  const result =
-    await Bun.$`${resolve(fixtureDirectory, '../../../../node_modules/.bin/vite')} build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`;
+  await Bun.$`${resolve(fixtureDirectory, '../../../../node_modules/.bin/vite')} build ${fixtureDirectory} --config ${resolve(fixtureDirectory, 'vite.config.ts')} --outDir ${outputDirectory}`;
   const assets = await readdir(resolve(outputDirectory, 'assets'));
   const assetNames = assets.join('\n');
   expect(assetNames).toContain('typescript');

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -186,6 +186,7 @@ describe('shikiHighlighter — fallback contract', () => {
       });
 
       expect(await highlight('const answer = 42;', 'typescript')).toMatch(/<span[^>]*style=/);
+      expect(await highlight('const answer = 42;', 'ts')).toMatch(/<span[^>]*style=/);
       expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
       expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
       expect(warnings.filter((warning) => warning.includes('javascript')).length).toBe(1);

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -180,13 +180,17 @@ describe('shikiHighlighter — fallback contract', () => {
     const { warnings, restore } = captureWarnings();
     try {
       const highlight = shikiHighlighter({
-        languageLoaders: { typescript: () => import('@shikijs/langs/typescript') },
+        languageLoaders: {
+          typescript: () => import('@shikijs/langs/typescript'),
+          shellscript: () => import('@shikijs/langs/shellscript'),
+        },
         themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
         theme: 'github-light',
       });
 
       expect(await highlight('const answer = 42;', 'typescript')).toMatch(/<span[^>]*style=/);
       expect(await highlight('const answer = 42;', 'ts')).toMatch(/<span[^>]*style=/);
+      expect(await highlight('echo answer', 'sh')).toMatch(/<span[^>]*style=/);
       expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
       expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
       expect(warnings.filter((warning) => warning.includes('javascript')).length).toBe(1);

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -10,7 +10,7 @@ import { stripRootPreTabIndex } from './strip-root-pre-tab-index.ts';
 
 setupHappyDom();
 
-const { shikiHighlighter } = await import('./index.ts');
+const { shikiHighlighter } = await import('./default.ts');
 
 const originalConsoleWarn = console.warn;
 afterEach(() => {
@@ -176,6 +176,17 @@ describe('shikiHighlighter — happy path', () => {
 });
 
 describe('shikiHighlighter — fallback contract', () => {
+  test('uses curated language and theme loader maps', async () => {
+    const highlight = shikiHighlighter({
+      languageLoaders: { typescript: () => import('@shikijs/langs/typescript') },
+      themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
+      theme: 'github-light',
+    });
+
+    expect(await highlight('const answer = 42;', 'typescript')).toMatch(/<span[^>]*style=/);
+    expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
+  });
+
   test('empty lang returns escaped-plaintext fallback', async () => {
     const highlight = shikiHighlighter();
     const html = await highlight('const x = 1;', '');
@@ -332,8 +343,8 @@ describe('shikiHighlighter — import strategy (issue #773)', () => {
 
     expect(specifiers).not.toContain('shiki');
     expect(specifiers).toContain('shiki/core');
-    expect(specifiers).toContain('shiki/langs');
-    expect(specifiers).toContain('shiki/themes');
+    expect(specifiers).not.toContain('shiki/langs');
+    expect(specifiers).not.toContain('shiki/themes');
     expect(specifiers).toContain('shiki/wasm');
     expect(specifiers).toContain('@shikijs/engine-oniguruma');
   });

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -199,6 +199,24 @@ describe('shikiHighlighter — fallback contract', () => {
     }
   });
 
+  test('retries alias discovery after a transient grammar-loader failure', async () => {
+    let attempts = 0;
+    const languageLoader = async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('transient grammar failure');
+      return import('@shikijs/langs/typescript');
+    };
+    const highlight = shikiHighlighter({
+      languageLoaders: { typescript: languageLoader },
+      themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
+      theme: 'github-light',
+    });
+
+    expect(await highlight('const answer = 42;', 'ts')).toContain('shiki-plaintext');
+    expect(await highlight('const answer = 42;', 'ts')).toMatch(/<span[^>]*style=/);
+    expect(attempts).toBeGreaterThanOrEqual(2);
+  });
+
   test('empty lang returns escaped-plaintext fallback', async () => {
     const highlight = shikiHighlighter();
     const html = await highlight('const x = 1;', '');

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -200,21 +200,27 @@ describe('shikiHighlighter — fallback contract', () => {
   });
 
   test('retries alias discovery after a transient grammar-loader failure', async () => {
+    const { warnings, restore } = captureWarnings();
     let attempts = 0;
     const languageLoader = async () => {
       attempts += 1;
       if (attempts === 1) throw new Error('transient grammar failure');
       return import('@shikijs/langs/typescript');
     };
-    const highlight = shikiHighlighter({
-      languageLoaders: { typescript: languageLoader },
-      themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
-      theme: 'github-light',
-    });
+    try {
+      const highlight = shikiHighlighter({
+        languageLoaders: { typescript: languageLoader },
+        themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
+        theme: 'github-light',
+      });
 
-    expect(await highlight('const answer = 42;', 'ts')).toContain('shiki-plaintext');
-    expect(await highlight('const answer = 42;', 'ts')).toMatch(/<span[^>]*style=/);
-    expect(attempts).toBeGreaterThanOrEqual(2);
+      expect(await highlight('const answer = 42;', 'ts')).toContain('shiki-plaintext');
+      expect(await highlight('const answer = 42;', 'ts')).toMatch(/<span[^>]*style=/);
+      expect(attempts).toBeGreaterThanOrEqual(2);
+      expect(warnings.filter((warning) => warning.includes('"ts"')).length).toBe(1);
+    } finally {
+      restore();
+    }
   });
 
   test('empty lang returns escaped-plaintext fallback', async () => {

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -177,14 +177,21 @@ describe('shikiHighlighter — happy path', () => {
 
 describe('shikiHighlighter — fallback contract', () => {
   test('uses curated language and theme loader maps', async () => {
-    const highlight = shikiHighlighter({
-      languageLoaders: { typescript: () => import('@shikijs/langs/typescript') },
-      themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
-      theme: 'github-light',
-    });
+    const { warnings, restore } = captureWarnings();
+    try {
+      const highlight = shikiHighlighter({
+        languageLoaders: { typescript: () => import('@shikijs/langs/typescript') },
+        themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
+        theme: 'github-light',
+      });
 
-    expect(await highlight('const answer = 42;', 'typescript')).toMatch(/<span[^>]*style=/);
-    expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
+      expect(await highlight('const answer = 42;', 'typescript')).toMatch(/<span[^>]*style=/);
+      expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
+      expect(await highlight('const answer = 42;', 'javascript')).toContain('shiki-plaintext');
+      expect(warnings.filter((warning) => warning.includes('javascript')).length).toBe(1);
+    } finally {
+      restore();
+    }
   });
 
   test('empty lang returns escaped-plaintext fallback', async () => {

--- a/packages/components/src/highlighters/shiki/shiki.test.ts
+++ b/packages/components/src/highlighters/shiki/shiki.test.ts
@@ -223,6 +223,22 @@ describe('shikiHighlighter — fallback contract', () => {
     }
   });
 
+  test('resolves aliases for embedded grammars in curated maps', async () => {
+    const highlight = shikiHighlighter({
+      languageLoaders: {
+        markdown: () => import('@shikijs/langs/markdown'),
+        typescript: () => import('@shikijs/langs/typescript'),
+      },
+      themeLoaders: { 'github-light': () => import('@shikijs/themes/github-light') },
+      theme: 'github-light',
+    });
+    const html = await highlight('```ts\nconst x: number = 1;\n```\n', 'markdown');
+    const colors = new Set(
+      Array.from(html.matchAll(/color:#[0-9A-Fa-f]{6}/g), (match) => match[0]),
+    );
+    expect(colors.size).toBeGreaterThan(1);
+  });
+
   test('empty lang returns escaped-plaintext fallback', async () => {
     const highlight = shikiHighlighter();
     const html = await highlight('const x = 1;', '');


### PR DESCRIPTION
Closes #867

## Summary
- expose curated language/theme loader maps for the Shiki adapter
- keep the default full registries in the CodeBlock-only adapter path
- add a Vite fixture proving curated builds omit unconfigured candidates

## Validation
- focused Shiki and CodeBlock tests
- components:check
- exports:check