### PR TITLE
Settle focus styles before browser paint assertions

### DIFF
--- a/packages/testing/src/helpers/focus-ring.test.ts
+++ b/packages/testing/src/helpers/focus-ring.test.ts
@@ -3,7 +3,7 @@
 import type { Locator } from '@playwright/test';
 import { describe, expect, test } from 'bun:test';
 
-import { waitForFocusStyleFrame } from './focus-ring';
+import { waitForFocusStyleFrame } from './focus-ring.ts';
 
 describe('waitForFocusStyleFrame', () => {
   test('settles on exactly the next animation frame', async () => {

--- a/packages/testing/src/helpers/focus-ring.test.ts
+++ b/packages/testing/src/helpers/focus-ring.test.ts
@@ -9,9 +9,11 @@ describe('waitForFocusStyleFrame', () => {
   test('settles on exactly the next animation frame', async () => {
     const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
     let frameCallback: FrameRequestCallback | undefined;
+    let frameRequests = 0;
     let resolved = false;
 
     globalThis.requestAnimationFrame = (callback) => {
+      frameRequests += 1;
       frameCallback = callback;
       return 1;
     };
@@ -28,10 +30,12 @@ describe('waitForFocusStyleFrame', () => {
       await Promise.resolve();
       expect(resolved).toBe(false);
       expect(frameCallback).toBeDefined();
+      expect(frameRequests).toBe(1);
 
       frameCallback!(0);
       await result;
       expect(resolved).toBe(true);
+      expect(frameRequests).toBe(1);
     } finally {
       globalThis.requestAnimationFrame = originalRequestAnimationFrame;
     }

--- a/packages/testing/src/helpers/focus-ring.test.ts
+++ b/packages/testing/src/helpers/focus-ring.test.ts
@@ -1,0 +1,39 @@
+/// <reference lib="dom" />
+
+import type { Locator } from '@playwright/test';
+import { describe, expect, test } from 'bun:test';
+
+import { waitForFocusStyleFrame } from './focus-ring';
+
+describe('waitForFocusStyleFrame', () => {
+  test('settles on exactly the next animation frame', async () => {
+    const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+    let frameCallback: FrameRequestCallback | undefined;
+    let resolved = false;
+
+    globalThis.requestAnimationFrame = (callback) => {
+      frameCallback = callback;
+      return 1;
+    };
+
+    const target = {
+      evaluate: async (callback: () => Promise<void>) => callback(),
+    } as unknown as Locator;
+
+    try {
+      const result = waitForFocusStyleFrame(target).then(() => {
+        resolved = true;
+        return undefined;
+      });
+      await Promise.resolve();
+      expect(resolved).toBe(false);
+      expect(frameCallback).toBeDefined();
+
+      frameCallback!(0);
+      await result;
+      expect(resolved).toBe(true);
+    } finally {
+      globalThis.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+  });
+});

--- a/packages/testing/src/helpers/focus-ring.ts
+++ b/packages/testing/src/helpers/focus-ring.ts
@@ -15,6 +15,19 @@
 import type { Locator, Page } from '@playwright/test';
 
 /**
+ * Wait for the render frame after keyboard focus changes before sampling paint.
+ *
+ * Chromium updates `document.activeElement` and `:focus-visible` synchronously,
+ * but can expose the previous cascade's computed outline until the next render
+ * frame. This is one render-boundary synchronization, not polling or a retry.
+ */
+export async function waitForFocusStyleFrame(target: Locator): Promise<void> {
+  await target.evaluate(
+    () => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())),
+  );
+}
+
+/**
  * Walk Tab from `document.body` until `target` is the active element, capped at
  * `maxPresses`. Returns true when focus landed on the target. Blurs first so the
  * walk is deterministic regardless of any prior autofocus.

--- a/packages/testing/tests/domain-focus-rings.playwright.ts
+++ b/packages/testing/tests/domain-focus-rings.playwright.ts
@@ -8,6 +8,7 @@
  */
 import { expect, test, type Browser, type Locator, type Page } from '@playwright/test';
 
+import { boxShadowLayerCount, waitForFocusStyleFrame } from '../src/helpers/focus-ring.ts';
 import { PLAYGROUND_URL } from '../src/helpers/playground-url.ts';
 import { THEME_STORAGE_KEY } from '../src/helpers/theme.ts';
 
@@ -89,17 +90,16 @@ async function tabUntilFocused(
   );
 }
 
-function boxShadowLayerCount(boxShadow: string): number {
-  return boxShadow.split(/,(?![^(]*\))/).length;
-}
-
 async function focusPaint(target: Locator): Promise<{
   boxShadow: string;
+  forcedColorsActive: boolean;
   matchesFocusVisible: boolean;
+  outlineColor: string;
   outlineColorAlpha: number;
   outlineStyle: string;
   outlineWidth: string;
 }> {
+  await waitForFocusStyleFrame(target);
   return target.evaluate((element) => {
     function colorAlpha(color: string): number {
       const canvas = document.createElement('canvas');
@@ -116,7 +116,9 @@ async function focusPaint(target: Locator): Promise<{
     const styles = getComputedStyle(element as HTMLElement);
     return {
       boxShadow: styles.boxShadow,
+      forcedColorsActive: window.matchMedia('(forced-colors: active)').matches,
       matchesFocusVisible: element.matches(':focus-visible'),
+      outlineColor: styles.outlineColor,
       outlineColorAlpha: colorAlpha(styles.outlineColor),
       outlineStyle: styles.outlineStyle,
       outlineWidth: styles.outlineWidth,
@@ -130,7 +132,10 @@ async function assertSharedOuterRing(target: Locator, label: string): Promise<vo
   expect(paint.matchesFocusVisible, `${label} should match :focus-visible`).toBe(true);
   expect(paint.outlineStyle, `${label} should reserve an outline channel`).toBe('solid');
   expect(parseFloat(paint.outlineWidth), `${label} outline width`).toBeGreaterThan(0);
-  expect(paint.outlineColorAlpha, `${label} outline should be transparent`).toBe(0);
+  expect(
+    paint.outlineColorAlpha,
+    `${label} outline should be transparent (${paint.outlineColor}, forced colors: ${paint.forcedColorsActive})`,
+  ).toBe(0);
   expect(paint.boxShadow, `${label} should paint a focus shadow`).not.toBe('none');
   expect(
     boxShadowLayerCount(paint.boxShadow),
@@ -145,7 +150,10 @@ async function assertInsetRing(target: Locator, label: string): Promise<void> {
   expect(paint.matchesFocusVisible, `${label} should match :focus-visible`).toBe(true);
   expect(paint.outlineStyle, `${label} should reserve an outline channel`).toBe('solid');
   expect(parseFloat(paint.outlineWidth), `${label} outline width`).toBeGreaterThan(0);
-  expect(paint.outlineColorAlpha, `${label} outline should be transparent`).toBe(0);
+  expect(
+    paint.outlineColorAlpha,
+    `${label} outline should be transparent (${paint.outlineColor}, forced colors: ${paint.forcedColorsActive})`,
+  ).toBe(0);
   expect(paint.boxShadow, `${label} should paint an inset focus shadow`).toContain('inset');
 }
 


### PR DESCRIPTION
## Summary

- wait for the next browser render frame before shared focus-ring paint measurements
- preserve the original numeric alpha assertion while reporting the raw outline color and forced-colors state on failure
- add a focused contract proving the helper waits for exactly one animation frame

The flaky failure sampled the global foundation outline even though the more-specific scoped Chat rule was present and matched. Keyboard focus updates the active element and `:focus-visible` synchronously, while the final computed paint can settle on the next render frame. The shared helper now synchronizes at that boundary without polling, retrying, increasing a timeout, or weakening the assertion.

## Verification

- `bun test packages/testing/src/helpers/focus-ring.test.ts`
- `bun run --filter=@cinder/testing typecheck`
- `bunx oxlint packages/testing/src/helpers/focus-ring.ts packages/testing/src/helpers/focus-ring.test.ts packages/testing/tests/domain-focus-rings.playwright.ts`
- `bunx prettier --check packages/testing/src/helpers/focus-ring.ts packages/testing/src/helpers/focus-ring.test.ts packages/testing/tests/domain-focus-rings.playwright.ts`
- two independent runs of `CI=1 bun run --filter=@cinder/testing test:playwright -- tests/domain-focus-rings.playwright.ts --workers=2 --repeat-each=30` (60/60 each)
- one additional post-rebase run of the same 60-case/two-worker command (60/60)

Closes #873