### PR TITLE
fix(chat): widen Cinder peer range to ^0.18.0 for the 0.18.0 release

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -22,7 +22,7 @@
     },
     "packages/chat": {
       "name": "@lostgradient/chat",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "dependencies": {
         "conversationalist": "^0.5.0",
         "zod": "4.4.1",
@@ -43,14 +43,14 @@
         "typescript": "^5.9.0",
       },
       "peerDependencies": {
-        "@lostgradient/cinder": "^0.17.0",
+        "@lostgradient/cinder": "^0.18.0",
         "@lostgradient/markdown": "^0.1.0",
         "svelte": ">=5.56.0 <6",
       },
     },
     "packages/components": {
       "name": "@lostgradient/cinder",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "bin": {
         "cinder": "./dist/cli/index.js",
       },

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -187,7 +187,7 @@
     "typescript": "^5.9.0"
   },
   "peerDependencies": {
-    "@lostgradient/cinder": "^0.17.0",
+    "@lostgradient/cinder": "^0.18.0",
     "@lostgradient/markdown": "^0.1.0",
     "svelte": ">=5.56.0 <6"
   },

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -40,20 +40,17 @@ describe('Chat package ownership boundary', () => {
       conversationalist: '^0.5.0',
       zod: '4.4.1',
     });
-    // The Cinder floor is deliberately ^0.17.0, not ^0.16.x: every 0.16
-    // release still has `lucide-svelte` as a peer dependency, so a consumer
-    // resolves its own Lucide version against Cinder's prebuilt SSR bundle and
-    // hits a hydration_mismatch — while Chat's README now tells them they do
-    // not need to install Lucide at all. Accepting 0.16 would ship correct
-    // docs against a broken combination.
-    //
-    // 0.17.0 rather than 0.16.2 because pending `minor` changesets (payload
-    // inspector, sidebar brand snippet, run-step timeline) carry Cinder from
-    // 0.16.1 to 0.17.0. A `^0.16.2` floor would have been UNSATISFIABLE
-    // against that release — caret on 0.x pins the minor — and would have
-    // excluded the very version carrying this fix.
+    // The Cinder floor tracks the Cinder minor released alongside Chat —
+    // caret on 0.x pins the minor, so each Cinder minor bump MUST widen this
+    // range or `validate-consumers` hard-fails the release (see the 0.18.0
+    // release failure and #879, which asks the version-packages flow to
+    // reconcile this automatically). The floor stays >=0.17 for the original
+    // reason: every 0.16 release still had `lucide-svelte` as a peer, so a
+    // consumer resolved its own Lucide against Cinder's prebuilt SSR bundle
+    // and hit a hydration_mismatch, while Chat's README says Lucide is not
+    // needed at all.
     expect(chatManifest.peerDependencies).toEqual({
-      '@lostgradient/cinder': '^0.17.0',
+      '@lostgradient/cinder': '^0.18.0',
       '@lostgradient/markdown': '^0.1.0',
       svelte: '>=5.56.0 <6',
     });


### PR DESCRIPTION
## Problem

The version-packages PR (#875) bumped `@lostgradient/cinder` to 0.18.0 but left Chat's `peerDependencies` at `^0.17.0`, which excludes 0.18.0 under 0.x semver caret rules. `validate-consumers` correctly hard-failed the release run before publishing either artifact:

```
error: Cinder 0.18.0 does not satisfy Chat peer ^0.17.0, and no pending Cinder changeset can reconcile them
```

## Fix

Widen Chat's Cinder peer to `^0.18.0` (plus the corresponding `bun.lock` sync). Chat 0.3.0 is versioned-but-unpublished, so amending it in place is the minimal correct reconciliation — no changeset needed (a changeset would spin up an unnecessary 0.3.1).

## Follow-up (class fix, filed separately)

Changesets' `updateInternalDependencies: patch` updates the internal *dependency* pins but never widens *peer* ranges, so every future Cinder minor will hit this again unless the version PR generation (or a pre-merge guard on `changeset-release/main`) reconciles Chat's peer range automatically. Issue to follow.

After merge: re-run the `release` workflow on main to publish cinder@0.18.0 + chat@0.3.0.