### PR TITLE
ci: gate packed manifest drift before merge

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -293,6 +293,11 @@ jobs:
           bun run --filter=@lostgradient/chat components:check
           bun run --filter=@lostgradient/editor components:check
 
+      # Cheap packed-artifact contract: catches export/manifest drift before merge.
+      # Full consumer fixtures remain release-only.
+      - name: Consumer manifest smoke (cinder)
+        run: bun run --filter=@lostgradient/cinder validate:consumer:manifest-smoke
+
       # Scoped to the pull request's affected packages via `turbo run
       # --affected` (diffing against TURBO_SCM_BASE) so a chat-only PR stops
       # building cinder and vice versa. Push/workflow_dispatch runs the full

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -256,6 +256,7 @@ const allowedNonComponentExportKeys = new Set([
   './icons',
   './highlighters/shiki',
   './highlighters/shiki/curated',
+  './json-editor/enhancement',
   // Upstream re-export root barrels. These (and their `/subpath` children,
   // skipped below) are not component exports; node-consumer validates them.
   './markdown',

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -265,6 +265,9 @@ const allowedNonComponentExportKeys = new Set([
   './diff',
 ]);
 
+// This non-manifest runtime entry is still part of the packed resolver contract.
+assertRuntimeResolvable('@lostgradient/cinder/json-editor/enhancement');
+
 /** Convert a `@lostgradient/cinder/...` or `@lostgradient/cinder` specifier to its `./...` export key. */
 function specifierToExportKey(specifier) {
   if (specifier === '@lostgradient/cinder') return '.';

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6251,6 +6251,7 @@
     "validate": "bun run lint && bun run lint:invariants && bun run typecheck && bun run check:changeset-prerelease-bumps && bun run check:placeholder-docs && bun run test:coverage && bun run platform:audit -- --strict && bun run colors:audit -- --strict && bun run tokens:audit -- --strict && bun run aggregator:check && bun run components:check && bun run validate:workflow && bun run validate:svelte-peer",
     "validate:consumer": "bun run scripts/validate-consumers.ts",
     "validate:consumer:hydration-smoke": "bun run scripts/validate-consumers.ts --hydration-smoke",
+    "validate:consumer:manifest-smoke": "bun run scripts/validate-consumers.ts --manifest-smoke",
     "validate:release-workflow": "bun run scripts/validate-release-workflow.ts",
     "validate:resolver-matrix": "bun run scripts/validate-resolver-matrix.ts",
     "validate:svelte-peer": "bun run scripts/validate-svelte-peer-contract.ts",

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2556,8 +2556,24 @@ async function hydrationSmoke(): Promise<void> {
   }
 }
 
+/** Cheap PR gate for packed manifest/export consistency; no browser or registry fixtures. */
+async function manifestSmoke(): Promise<void> {
+  installHookProcessCleanup();
+  ensureSupportedPlatform();
+  await ensureNodeOnPath();
+  await runBuild();
+  await packWorkspaceDependencyTarballs();
+  await packTarball();
+  await runManifestConsumerFixture();
+  process.stdout.write('[validate-consumers] manifest smoke passed.\n');
+}
+
 if (import.meta.main) {
-  const entry = process.argv.includes('--hydration-smoke') ? hydrationSmoke : main;
+  const entry = process.argv.includes('--hydration-smoke')
+    ? hydrationSmoke
+    : process.argv.includes('--manifest-smoke')
+      ? manifestSmoke
+      : main;
   try {
     await withLocalValidationGateLock(entry);
   } catch (error) {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2561,7 +2561,9 @@ async function manifestSmoke(): Promise<void> {
   installHookProcessCleanup();
   ensureSupportedPlatform();
   await ensureNodeOnPath();
-  await runBuild();
+  await runHookCommand('bun', ['run', '--filter=@lostgradient/cinder', 'build'], {
+    cwd: workspaceRoot,
+  });
   await packWorkspaceDependencyTarballs();
   await packTarball();
   await runManifestConsumerFixture();


### PR DESCRIPTION
Closes #881

Run the hermetic packed Cinder manifest-consumer contract in PR unit-test CI. The new manifest smoke packs the package and workspace Markdown dependency, then verifies Node ESM/CJS resolution and export/manifest consistency without browser or registry fixtures. Full consumer validation remains release-only.