### PR TITLE
fix(cinder): advertise component enhancement artifacts generically

### DIFF
--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -2740,7 +2740,8 @@
       "artifacts": {
         "schema": "@lostgradient/cinder/json-editor/schema",
         "variables": "@lostgradient/cinder/json-editor/variables",
-        "examples": "@lostgradient/cinder/json-editor/examples"
+        "examples": "@lostgradient/cinder/json-editor/examples",
+        "enhancement": "@lostgradient/cinder/json-editor/enhancement"
       },
       "a11y": {
         "keyboard": [

--- a/packages/components/fixtures/manifest-consumer/check.mjs
+++ b/packages/components/fixtures/manifest-consumer/check.mjs
@@ -285,15 +285,21 @@ for (const component of manifest.components) {
   assertRuntimeResolvable(importSpecifier);
   expectedComponentExportKeys.add(specifierToExportKey(importSpecifier));
 
-  // 2b. schema + variables: full runtime entry points (task 4176c51c). The
+  // 2b. schema + variables + component-owned runtime enhancements: full runtime
+  //     entry points (task 4176c51c). The
   //     `types` declaration target must exist AND the subpath must runtime-resolve
   //     via both the ESM and CJS resolvers.
-  for (const metadataKey of ['schema', 'variables']) {
-    const specifier = artifacts[metadataKey];
+  for (const artifactKey of ['schema', 'variables', 'enhancement']) {
+    const specifier = artifacts[artifactKey];
+    if (specifier === undefined) {
+      if (artifactKey === 'enhancement') continue;
+      record(`${id}: manifest is missing artifacts.${artifactKey}`);
+      continue;
+    }
     // Accumulate (don't throw) so one malformed component doesn't mask the rest.
-    if (specifier !== `${importSpecifier}/${metadataKey}`) {
+    if (specifier !== `${importSpecifier}/${artifactKey}`) {
       record(
-        `${id}: artifacts.${metadataKey} ("${specifier}") must equal import + "/${metadataKey}"`,
+        `${id}: artifacts.${artifactKey} ("${specifier}") must equal import + "/${artifactKey}"`,
       );
       continue;
     }
@@ -329,8 +335,7 @@ for (const component of manifest.components) {
       }
     }
 
-    // Runtime entry point: the default-exported JSON Schema / variables value
-    // must be importable from a plain Node/Vite consumer.
+    // Runtime entry point must be importable from a plain Node/Vite consumer.
     assertRuntimeResolvable(specifier);
   }
 
@@ -432,7 +437,7 @@ if (failures.length > 0) {
 
 process.stdout.write(
   `manifest-consumer OK — verified ${manifest.components.length} components ` +
-    `(import + schema/variables/examples/constraints/styles runtime-resolvable via ESM+CJS; ` +
+    `(import + schema/variables/examples/constraints/enhancements/styles runtime-resolvable via ESM+CJS; ` +
     `schema/variables type-target present; ` +
     `two-way export↔manifest consistency holds).\n`,
 );

--- a/packages/components/scripts/generate-exports.test.ts
+++ b/packages/components/scripts/generate-exports.test.ts
@@ -210,6 +210,26 @@ describe('computeExports', () => {
     });
   });
 
+  it('does not emit enhancement exports for experimental components', () => {
+    const packageRoot = mkdtempSync(join(tmpdir(), 'cinder-experimental-enhancement-'));
+    const enhancementPath = join(
+      packageRoot,
+      'src/components/experimental/second-editor/second-editor-enhancement.ts',
+    );
+    mkdirSync(dirname(enhancementPath), { recursive: true });
+    writeFileSync(enhancementPath, 'export function enhance() {}\n');
+
+    try {
+      const out = computeExports(
+        [{ name: 'second-editor', isExperimental: true, hasCss: false }],
+        packageRoot,
+      );
+      expect(out['./experimental/second-editor/enhancement']).toBeUndefined();
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   // Task 4176c51c: schema/variables are runtime entry points. The build compiles
   // each `<name>.schema.ts` / `<name>.variables.ts` to its own JS, so a plain
   // Node/Vite consumer resolving `@lostgradient/cinder/<name>/schema` under the `default`
@@ -217,6 +237,33 @@ describe('computeExports', () => {
   // pins the `default` (and `node`) condition at the generator so a regression
   // that drops the runtime condition is caught before it ships. The
   // manifest-consumer fixture asserts the same at Node runtime.
+  it('emits an enhancement export for any stable component with an enhancement source file', () => {
+    const packageRoot = mkdtempSync(join(tmpdir(), 'cinder-enhancement-'));
+    const enhancementPath = join(
+      packageRoot,
+      'src/components/second-editor/second-editor-enhancement.ts',
+    );
+    mkdirSync(dirname(enhancementPath), { recursive: true });
+    writeFileSync(enhancementPath, 'export function enhance() {}\n');
+
+    try {
+      const out = computeExports(
+        [{ name: 'second-editor', isExperimental: false, hasCss: false }],
+        packageRoot,
+      );
+      expect(out['./second-editor/enhancement']).toEqual({
+        types: './dist/components/second-editor/second-editor-enhancement.d.ts',
+        browser: './src/components/second-editor/second-editor-enhancement.ts',
+        node: './dist/server/components/second-editor/second-editor-enhancement.js',
+        svelte: './src/components/second-editor/second-editor-enhancement.ts',
+        import: './src/components/second-editor/second-editor-enhancement.ts',
+        default: './dist/components/second-editor/second-editor-enhancement.js',
+      });
+    } finally {
+      rmSync(packageRoot, { recursive: true, force: true });
+    }
+  });
+
   it('emits a default (and node) runtime condition on every /schema and /variables export', () => {
     const out = computeExports([
       { name: 'button', isExperimental: false, hasCss: false },

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -89,7 +89,6 @@ const STYLES_GUARD_KEY = './styles/guard';
 const ROOT_KEY = '.';
 const PACKAGE_JSON_KEY = './package.json';
 const ICONS_KEY = './icons';
-const JSON_EDITOR_ENHANCEMENT_KEY = './json-editor/enhancement';
 const HIGHLIGHTERS_SHIKI_KEY = './highlighters/shiki';
 
 /**
@@ -108,7 +107,6 @@ const RESERVED_KEYS = new Set([
   STYLES_GUARD_KEY,
   PACKAGE_JSON_KEY,
   ICONS_KEY,
-  JSON_EDITOR_ENHANCEMENT_KEY,
   HIGHLIGHTERS_SHIKI_KEY,
 ]);
 
@@ -195,14 +193,20 @@ function iconsExport(): ExportEntry {
   });
 }
 
-function jsonEditorEnhancementExport(): ExportEntry {
+function componentEnhancementExport(
+  name: string,
+  srcDir: string,
+  distDir: string,
+  serverDistDir: string,
+): ExportEntry {
+  const fileName = `${name}-enhancement`;
   return orderedExportEntry({
-    types: './dist/components/json-editor/json-editor-enhancement.d.ts',
-    browser: './src/components/json-editor/json-editor-enhancement.ts',
-    node: './dist/server/components/json-editor/json-editor-enhancement.js',
-    svelte: './src/components/json-editor/json-editor-enhancement.ts',
-    import: './src/components/json-editor/json-editor-enhancement.ts',
-    default: './dist/components/json-editor/json-editor-enhancement.js',
+    types: `${distDir}/${fileName}.d.ts`,
+    browser: `${srcDir}/${fileName}.ts`,
+    node: `${serverDistDir}/${fileName}.js`,
+    svelte: `${srcDir}/${fileName}.ts`,
+    import: `${srcDir}/${fileName}.ts`,
+    default: `${distDir}/${fileName}.js`,
   });
 }
 
@@ -505,6 +509,25 @@ export function computeExports(
       const relPath = `${srcDir}/${name}.constraints.json`;
       out[`${prefix}/constraints`] = jsonSidecarExport(relPath);
     }
+
+    // Component-owned runtime enhancements are emitted for stable components
+    // when their `<name>-enhancement.ts` source file exists. The source and
+    // compiled paths follow the same layout as the other per-component modules.
+    const enhancementSourcePath = join(
+      packageRoot,
+      'src',
+      'components',
+      name,
+      `${name}-enhancement.ts`,
+    );
+    if (!isExperimental && existsSync(enhancementSourcePath)) {
+      out[`${prefix}/enhancement`] = componentEnhancementExport(
+        name,
+        srcDir,
+        distDir,
+        serverDistDir,
+      );
+    }
   }
 
   return out;
@@ -696,7 +719,12 @@ async function main(): Promise<void> {
     }
     next[STYLES_GUARD_KEY] = stylesGuardExport();
     next[ICONS_KEY] = iconsExport();
-    next[JSON_EDITOR_ENHANCEMENT_KEY] = jsonEditorEnhancementExport();
+    // Keep component-owned enhancement entries at their historical position
+    // before the package-level highlighter export while deriving them from the
+    // generic component computation above.
+    for (const [key, entry] of Object.entries(componentComputed)) {
+      if (key.endsWith('/enhancement')) next[key] = entry;
+    }
     next[HIGHLIGHTERS_SHIKI_KEY] = highlightersShikiExport();
 
     // Preserve legacy flat component subpaths whose component still exists as

--- a/packages/components/scripts/generate-manifest.test.ts
+++ b/packages/components/scripts/generate-manifest.test.ts
@@ -8,6 +8,8 @@
  * `manifest.schema.json`.
  */
 
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import Ajv from 'ajv/dist/2020.js';
@@ -15,9 +17,11 @@ import { beforeAll, describe, expect, it } from 'bun:test';
 
 import type { Manifest, ManifestComponent } from './generate-manifest.ts';
 import {
+  buildManifest,
   findDanglingAlternatives,
   formatDanglingAlternativeMessage,
   formatExtractionErrorMessage,
+  hasEnhancementArtifact,
 } from './generate-manifest.ts';
 
 // ---------------------------------------------------------------------------
@@ -424,6 +428,36 @@ describe('buildManifest() error formatting', () => {
     expect(message).toContain('comp-9');
     expect(message).not.toContain('comp-10');
     expect(message).toMatch(/… and 4 more errors \(14 total\)/);
+  });
+});
+
+describe('component-owned artifacts', () => {
+  it('detects an enhancement for any stable component with an enhancement source file', () => {
+    const componentsRoot = mkdtempSync(join(tmpdir(), 'cinder-manifest-enhancement-'));
+    const enhancementPath = join(componentsRoot, 'second-editor/second-editor-enhancement.ts');
+    mkdirSync(join(componentsRoot, 'second-editor'), { recursive: true });
+    writeFileSync(enhancementPath, 'export function enhance() {}\n');
+    const experimentalEnhancementPath = join(
+      componentsRoot,
+      'experimental/second-editor/second-editor-enhancement.ts',
+    );
+    mkdirSync(join(componentsRoot, 'experimental/second-editor'), { recursive: true });
+    writeFileSync(experimentalEnhancementPath, 'export function enhance() {}\n');
+
+    try {
+      expect(hasEnhancementArtifact('second-editor', false, componentsRoot)).toBe(true);
+      expect(hasEnhancementArtifact('second-editor', true, componentsRoot)).toBe(true);
+      expect(hasEnhancementArtifact('missing-editor', false, componentsRoot)).toBe(false);
+    } finally {
+      rmSync(componentsRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('advertises JsonEditor’s lazy enhancement entry point', async () => {
+    const manifest = await buildManifest();
+    const jsonEditor = manifest.components.find((component) => component.id === 'json-editor');
+
+    expect(jsonEditor?.artifacts.enhancement).toBe('@lostgradient/cinder/json-editor/enhancement');
   });
 });
 

--- a/packages/components/scripts/generate-manifest.ts
+++ b/packages/components/scripts/generate-manifest.ts
@@ -82,6 +82,7 @@ export type ManifestComponent = {
     variables: string;
     examples?: string;
     constraints?: string;
+    enhancement?: string;
   };
 };
 
@@ -162,6 +163,22 @@ function hasConstraintsArtifact(id: string, isExperimental: boolean): boolean {
     ? join(COMPONENTS_ROOT, 'experimental', id)
     : join(COMPONENTS_ROOT, id);
   return existsSync(join(componentDir, `${id}.constraints.json`));
+}
+
+/**
+ * Check whether the component has a separately published runtime enhancement.
+ * The source probe follows the same stable/experimental directory policy as
+ * the schema, variables, examples, and constraints artifact probes.
+ */
+export function hasEnhancementArtifact(
+  id: string,
+  isExperimental: boolean,
+  componentsRoot: string = COMPONENTS_ROOT,
+): boolean {
+  const componentDir = isExperimental
+    ? join(componentsRoot, 'experimental', id)
+    : join(componentsRoot, id);
+  return existsSync(join(componentDir, `${id}-enhancement.ts`));
 }
 
 /**
@@ -285,6 +302,9 @@ export async function buildManifest(): Promise<Manifest> {
       }
       if (hasConstraintsFlag) {
         artifacts.constraints = artifactSubpath(meta.id, meta.isExperimental, 'constraints');
+      }
+      if (!meta.isExperimental && hasEnhancementArtifact(meta.id, meta.isExperimental)) {
+        artifacts.enhancement = artifactSubpath(meta.id, meta.isExperimental, 'enhancement');
       }
 
       return {

--- a/packages/components/src/cli/manifest-validation.ts
+++ b/packages/components/src/cli/manifest-validation.ts
@@ -78,7 +78,8 @@ function isManifestComponent(value: unknown): value is ManifestComponent {
     typeof artifacts['schema'] === 'string' &&
     typeof artifacts['variables'] === 'string' &&
     (artifacts['examples'] === undefined || typeof artifacts['examples'] === 'string') &&
-    (artifacts['constraints'] === undefined || typeof artifacts['constraints'] === 'string')
+    (artifacts['constraints'] === undefined || typeof artifacts['constraints'] === 'string') &&
+    (artifacts['enhancement'] === undefined || typeof artifacts['enhancement'] === 'string')
   );
 }
 

--- a/packages/components/src/cli/types.ts
+++ b/packages/components/src/cli/types.ts
@@ -22,6 +22,7 @@ export type ManifestComponent = {
     variables: string;
     examples?: string;
     constraints?: string;
+    enhancement?: string;
   };
   a11y?: {
     pattern?: string;

--- a/packages/components/src/schemas/manifest.schema.json
+++ b/packages/components/src/schemas/manifest.schema.json
@@ -254,6 +254,11 @@
                 "type": "string",
                 "description": "Import specifier for the constraints sidecar. Present only when hasConstraints is true.",
                 "examples": ["cinder/button/constraints"]
+              },
+              "enhancement": {
+                "type": "string",
+                "description": "Import specifier for a separately published runtime enhancement owned by this component.",
+                "examples": ["cinder/json-editor/enhancement"]
               }
             }
           },


### PR DESCRIPTION
Unblocks the 0.18.0 release (second blocker, after #878): the release run's manifest-consumer check rejects `./json-editor/enhancement` as an orphan export — #874 added the export but nothing advertised it.

## What

Generalizes the component-artifact rule instead of special-casing: any non-experimental component with `src/components/<id>/<id>-enhancement.ts` gets its `./<id>/enhancement` export emitted by `generate-exports.ts` and advertised by `generate-manifest.ts` (schema/types/CLI validation updated; check.mjs validates the artifact as a full runtime entry point). The pre-existing hardcoded `JSON_EDITOR_ENHANCEMENT_KEY` special case from #874 is removed; json-editor's generated exports are byte-identical before/after (verified via regeneration diff).

## Validation

- `validate:consumer` (the exact failing release gate): FAIL before / PASS after — independently re-run and confirmed green
- `exports:check`, `bun run build`, generator + manifest tests (43 + 29), full cinder suite 7,217 pass
- Regression test covers a hypothetical second component with an enhancement artifact

Related: #881 (consumer validation should also gate PRs so this class fails pre-merge). Implemented by a Codex (Luna) agent; independently reviewed, de-special-cased on review, and re-validated.