### PR TITLE
fix(cinder): build generic enhancement artifacts

### DIFF
--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -14,6 +14,7 @@ import {
   type CommentScanState,
 } from './lib/cinder-specifier-residue.ts';
 import {
+  componentEnhancementKey,
   componentEnhancementOutputPaths,
   discoverComponentEnhancements,
 } from './lib/component-enhancements.ts';
@@ -261,6 +262,9 @@ const perComponentMetadataEntrypoints = components.flatMap((component) =>
 const componentEnhancements = discoverComponentEnhancements(components, `${sourceRoot}/components`);
 const componentEnhancementEntrypoints = componentEnhancements.map(
   (enhancement) => enhancement.sourcePath,
+);
+const componentEnhancementsByKey = new Map(
+  componentEnhancements.map((enhancement) => [componentEnhancementKey(enhancement), enhancement]),
 );
 
 /**
@@ -685,7 +689,7 @@ for (const component of components) {
     expectedPaths.push(`${directory}/${component.name}.${metadataKind}.d.ts`);
     expectedPaths.push(`${serverDirectory}/${component.name}.${metadataKind}.js`);
   }
-  const enhancement = componentEnhancements.find(({ name }) => name === component.name);
+  const enhancement = componentEnhancementsByKey.get(componentEnhancementKey(component));
   if (enhancement !== undefined) {
     const enhancementPaths = componentEnhancementOutputPaths(
       distributionDirectory,

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -13,6 +13,10 @@ import {
   lineHasUpstreamSpecifierResidue,
   type CommentScanState,
 } from './lib/cinder-specifier-residue.ts';
+import {
+  componentEnhancementOutputPaths,
+  discoverComponentEnhancements,
+} from './lib/component-enhancements.ts';
 import { discoverComponents, type ComponentDiscovery } from './lib/discover-components.ts';
 import { hasSourceCssImport } from './prepend-source-index-css-import.ts';
 import { createServerEntrySource } from './server-entry.ts';
@@ -254,10 +258,15 @@ const perComponentMetadataEntrypoints = components.flatMap((component) =>
   componentMetadataEntrypoints(component),
 );
 
+const componentEnhancements = discoverComponentEnhancements(components, `${sourceRoot}/components`);
+const componentEnhancementEntrypoints = componentEnhancements.map(
+  (enhancement) => enhancement.sourcePath,
+);
+
 /**
- * Static sub-paths cinder exposes outside the `components/` tree. Today this
- * includes the first-party Shiki adapter, the shared icons barrel, and the
- * dev-only base-loaded guard; new non-component
+ * Static sub-paths cinder exposes outside the discovered component entries.
+ * Today this includes the first-party Shiki adapter, the shared icons barrel,
+ * and the dev-only base-loaded guard; new non-component
  * static sub-paths get listed here so the build emits a predictable
  * `dist/<rel>.js` for each one. `shiki` itself stays external (declared in
  * cinder's `dependencies` + the `runtimeDependencyExternals` list) — the
@@ -266,7 +275,6 @@ const perComponentMetadataEntrypoints = components.flatMap((component) =>
  */
 const staticSubpathEntrypoints = [
   `${sourceRoot}/components/icons/index.ts`,
-  `${sourceRoot}/components/json-editor/json-editor-enhancement.ts`,
   `${sourceRoot}/highlighters/shiki/index.ts`,
   `${sourceRoot}/highlighters/shiki/default.ts`,
   `${sourceRoot}/styles/base-guard.ts`,
@@ -330,6 +338,7 @@ const browserEntrypoints = [
   browserRootEntrypoint,
   ...perComponentEntrypoints,
   ...perComponentMetadataEntrypoints,
+  ...componentEnhancementEntrypoints,
   ...staticSubpathEntrypoints,
   ...deprecatedAliasEntrypoints,
 ];
@@ -453,6 +462,7 @@ const perComponentServerBuildResult = await Bun.build({
     serverRootEntrypoint,
     ...perComponentEntrypoints,
     ...perComponentMetadataEntrypoints,
+    ...componentEnhancementEntrypoints,
     ...staticSubpathEntrypoints,
     ...deprecatedAliasEntrypoints,
   ],
@@ -640,9 +650,6 @@ const expectedPaths: string[] = [
   `${distributionDirectory}/components/icons/index.js`,
   `${distributionDirectory}/components/icons/index.d.ts`,
   `${distributionDirectory}/server/components/icons/index.js`,
-  `${distributionDirectory}/components/json-editor/json-editor-enhancement.js`,
-  `${distributionDirectory}/components/json-editor/json-editor-enhancement.d.ts`,
-  `${distributionDirectory}/server/components/json-editor/json-editor-enhancement.js`,
   `${distributionDirectory}/highlighters/shiki/index.js`,
   `${distributionDirectory}/highlighters/shiki/index.d.ts`,
   `${distributionDirectory}/server/highlighters/shiki/index.js`,
@@ -677,6 +684,14 @@ for (const component of components) {
     expectedPaths.push(`${directory}/${component.name}.${metadataKind}.js`);
     expectedPaths.push(`${directory}/${component.name}.${metadataKind}.d.ts`);
     expectedPaths.push(`${serverDirectory}/${component.name}.${metadataKind}.js`);
+  }
+  const enhancement = componentEnhancements.find(({ name }) => name === component.name);
+  if (enhancement !== undefined) {
+    const enhancementPaths = componentEnhancementOutputPaths(
+      distributionDirectory,
+      enhancement.name,
+    );
+    expectedPaths.push(enhancementPaths.browser, enhancementPaths.types, enhancementPaths.server);
   }
   if (existsSync(componentCssSource(component))) {
     expectedPaths.push(componentCssDestination(component));

--- a/packages/components/scripts/generate-exports.test.ts
+++ b/packages/components/scripts/generate-exports.test.ts
@@ -212,18 +212,28 @@ describe('computeExports', () => {
 
   it('does not emit enhancement exports for experimental components', () => {
     const packageRoot = mkdtempSync(join(tmpdir(), 'cinder-experimental-enhancement-'));
+    const stableEnhancementPath = join(
+      packageRoot,
+      'src/components/second-editor/second-editor-enhancement.ts',
+    );
     const enhancementPath = join(
       packageRoot,
       'src/components/experimental/second-editor/second-editor-enhancement.ts',
     );
+    mkdirSync(dirname(stableEnhancementPath), { recursive: true });
     mkdirSync(dirname(enhancementPath), { recursive: true });
+    writeFileSync(stableEnhancementPath, 'export function enhance() {}\n');
     writeFileSync(enhancementPath, 'export function enhance() {}\n');
 
     try {
       const out = computeExports(
-        [{ name: 'second-editor', isExperimental: true, hasCss: false }],
+        [
+          { name: 'second-editor', isExperimental: false, hasCss: false },
+          { name: 'second-editor', isExperimental: true, hasCss: false },
+        ],
         packageRoot,
       );
+      expect(out['./second-editor/enhancement']).toBeDefined();
       expect(out['./experimental/second-editor/enhancement']).toBeUndefined();
     } finally {
       rmSync(packageRoot, { recursive: true, force: true });

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -53,6 +53,7 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
+import { discoverComponentEnhancements } from './lib/component-enhancements.ts';
 import { discoverComponents, type ComponentDiscovery } from './lib/discover-components.ts';
 import { readJsonFile } from './lib/read-json-file.ts';
 
@@ -400,6 +401,11 @@ export function computeExports(
   packageRoot: string = DEFAULT_PACKAGE_ROOT,
 ): Record<string, ExportEntry | JsonExportEntry> {
   const out: Record<string, ExportEntry | JsonExportEntry> = {};
+  const enhancementNames = new Set(
+    discoverComponentEnhancements(components, join(packageRoot, 'src', 'components')).map(
+      (enhancement) => enhancement.name,
+    ),
+  );
 
   // Package-level manifest entry (always present).
   out['./manifest'] = manifestExport();
@@ -515,14 +521,7 @@ export function computeExports(
     // Component-owned runtime enhancements are emitted for stable components
     // when their `<name>-enhancement.ts` source file exists. The source and
     // compiled paths follow the same layout as the other per-component modules.
-    const enhancementSourcePath = join(
-      packageRoot,
-      'src',
-      'components',
-      name,
-      `${name}-enhancement.ts`,
-    );
-    if (!isExperimental && existsSync(enhancementSourcePath)) {
+    if (enhancementNames.has(name)) {
       out[`${prefix}/enhancement`] = componentEnhancementExport(
         name,
         srcDir,

--- a/packages/components/scripts/generate-exports.ts
+++ b/packages/components/scripts/generate-exports.ts
@@ -53,7 +53,10 @@
 import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { discoverComponentEnhancements } from './lib/component-enhancements.ts';
+import {
+  componentEnhancementKey,
+  discoverComponentEnhancements,
+} from './lib/component-enhancements.ts';
 import { discoverComponents, type ComponentDiscovery } from './lib/discover-components.ts';
 import { readJsonFile } from './lib/read-json-file.ts';
 
@@ -401,9 +404,9 @@ export function computeExports(
   packageRoot: string = DEFAULT_PACKAGE_ROOT,
 ): Record<string, ExportEntry | JsonExportEntry> {
   const out: Record<string, ExportEntry | JsonExportEntry> = {};
-  const enhancementNames = new Set(
+  const enhancementKeys = new Set(
     discoverComponentEnhancements(components, join(packageRoot, 'src', 'components')).map(
-      (enhancement) => enhancement.name,
+      componentEnhancementKey,
     ),
   );
 
@@ -521,7 +524,7 @@ export function computeExports(
     // Component-owned runtime enhancements are emitted for stable components
     // when their `<name>-enhancement.ts` source file exists. The source and
     // compiled paths follow the same layout as the other per-component modules.
-    if (enhancementNames.has(name)) {
+    if (enhancementKeys.has(componentEnhancementKey({ name, isExperimental }))) {
       out[`${prefix}/enhancement`] = componentEnhancementExport(
         name,
         srcDir,

--- a/packages/components/scripts/generate-manifest.test.ts
+++ b/packages/components/scripts/generate-manifest.test.ts
@@ -18,6 +18,7 @@ import { beforeAll, describe, expect, it } from 'bun:test';
 import type { Manifest, ManifestComponent } from './generate-manifest.ts';
 import {
   buildManifest,
+  enhancementArtifactSubpath,
   findDanglingAlternatives,
   formatDanglingAlternativeMessage,
   formatExtractionErrorMessage,
@@ -450,13 +451,17 @@ describe('component-owned artifacts', () => {
           [{ name: 'second-editor', isExperimental: false }],
           componentsRoot,
         ),
-      ).toEqual([{ name: 'second-editor', sourcePath: enhancementPath }]);
+      ).toEqual([{ name: 'second-editor', isExperimental: false, sourcePath: enhancementPath }]);
       expect(
         discoverComponentEnhancements(
           [{ name: 'second-editor', isExperimental: true }],
           componentsRoot,
         ),
       ).toEqual([]);
+      expect(enhancementArtifactSubpath('second-editor', false, componentsRoot)).toBe(
+        '@lostgradient/cinder/second-editor/enhancement',
+      );
+      expect(enhancementArtifactSubpath('second-editor', true, componentsRoot)).toBeUndefined();
       expect(
         discoverComponentEnhancements(
           [{ name: 'missing-editor', isExperimental: false }],

--- a/packages/components/scripts/generate-manifest.test.ts
+++ b/packages/components/scripts/generate-manifest.test.ts
@@ -21,8 +21,8 @@ import {
   findDanglingAlternatives,
   formatDanglingAlternativeMessage,
   formatExtractionErrorMessage,
-  hasEnhancementArtifact,
 } from './generate-manifest.ts';
+import { discoverComponentEnhancements } from './lib/component-enhancements.ts';
 
 // ---------------------------------------------------------------------------
 // Schema loader helper
@@ -445,9 +445,24 @@ describe('component-owned artifacts', () => {
     writeFileSync(experimentalEnhancementPath, 'export function enhance() {}\n');
 
     try {
-      expect(hasEnhancementArtifact('second-editor', false, componentsRoot)).toBe(true);
-      expect(hasEnhancementArtifact('second-editor', true, componentsRoot)).toBe(true);
-      expect(hasEnhancementArtifact('missing-editor', false, componentsRoot)).toBe(false);
+      expect(
+        discoverComponentEnhancements(
+          [{ name: 'second-editor', isExperimental: false }],
+          componentsRoot,
+        ),
+      ).toEqual([{ name: 'second-editor', sourcePath: enhancementPath }]);
+      expect(
+        discoverComponentEnhancements(
+          [{ name: 'second-editor', isExperimental: true }],
+          componentsRoot,
+        ),
+      ).toEqual([]);
+      expect(
+        discoverComponentEnhancements(
+          [{ name: 'missing-editor', isExperimental: false }],
+          componentsRoot,
+        ),
+      ).toEqual([]);
     } finally {
       rmSync(componentsRoot, { recursive: true, force: true });
     }

--- a/packages/components/scripts/generate-manifest.ts
+++ b/packages/components/scripts/generate-manifest.ts
@@ -31,6 +31,7 @@ import type {
   ComponentMetadata,
 } from './generate-component-metadata.ts';
 import { extractAllComponentMetadata } from './generate-component-metadata.ts';
+import { discoverComponentEnhancements } from './lib/component-enhancements.ts';
 import { parseJsonFile, readJsonFile } from './lib/read-json-file.ts';
 
 // ---------------------------------------------------------------------------
@@ -166,22 +167,6 @@ function hasConstraintsArtifact(id: string, isExperimental: boolean): boolean {
 }
 
 /**
- * Check whether the component has a separately published runtime enhancement.
- * The source probe follows the same stable/experimental directory policy as
- * the schema, variables, examples, and constraints artifact probes.
- */
-export function hasEnhancementArtifact(
-  id: string,
-  isExperimental: boolean,
-  componentsRoot: string = COMPONENTS_ROOT,
-): boolean {
-  const componentDir = isExperimental
-    ? join(componentsRoot, 'experimental', id)
-    : join(componentsRoot, id);
-  return existsSync(join(componentDir, `${id}-enhancement.ts`));
-}
-
-/**
  * Derive the artifact subpath prefix. Per the plan, artifact subpaths do NOT
  * include the `experimental/` prefix — they use the same flat `@lostgradient/cinder/{id}/…`
  * pattern regardless of whether the component is experimental.
@@ -303,7 +288,12 @@ export async function buildManifest(): Promise<Manifest> {
       if (hasConstraintsFlag) {
         artifacts.constraints = artifactSubpath(meta.id, meta.isExperimental, 'constraints');
       }
-      if (!meta.isExperimental && hasEnhancementArtifact(meta.id, meta.isExperimental)) {
+      const hasEnhancement =
+        discoverComponentEnhancements(
+          [{ name: meta.id, isExperimental: meta.isExperimental }],
+          COMPONENTS_ROOT,
+        ).length > 0;
+      if (hasEnhancement) {
         artifacts.enhancement = artifactSubpath(meta.id, meta.isExperimental, 'enhancement');
       }
 

--- a/packages/components/scripts/generate-manifest.ts
+++ b/packages/components/scripts/generate-manifest.ts
@@ -183,6 +183,19 @@ function artifactSubpath(id: string, isExperimental: boolean, suffix: string): s
   return `${prefix}/${suffix}`;
 }
 
+/** Return the manifest subpath when this component owns a runtime enhancement. */
+export function enhancementArtifactSubpath(
+  id: string,
+  isExperimental: boolean,
+  componentsRoot: string = COMPONENTS_ROOT,
+): string | undefined {
+  const enhancement = discoverComponentEnhancements(
+    [{ name: id, isExperimental }],
+    componentsRoot,
+  )[0];
+  return enhancement === undefined ? undefined : artifactSubpath(id, isExperimental, 'enhancement');
+}
+
 // ---------------------------------------------------------------------------
 // Core builder
 // ---------------------------------------------------------------------------
@@ -288,13 +301,9 @@ export async function buildManifest(): Promise<Manifest> {
       if (hasConstraintsFlag) {
         artifacts.constraints = artifactSubpath(meta.id, meta.isExperimental, 'constraints');
       }
-      const hasEnhancement =
-        discoverComponentEnhancements(
-          [{ name: meta.id, isExperimental: meta.isExperimental }],
-          COMPONENTS_ROOT,
-        ).length > 0;
-      if (hasEnhancement) {
-        artifacts.enhancement = artifactSubpath(meta.id, meta.isExperimental, 'enhancement');
+      const enhancementArtifact = enhancementArtifactSubpath(meta.id, meta.isExperimental);
+      if (enhancementArtifact !== undefined) {
+        artifacts.enhancement = enhancementArtifact;
       }
 
       return {

--- a/packages/components/scripts/lib/component-enhancements.test.ts
+++ b/packages/components/scripts/lib/component-enhancements.test.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'bun:test';
+
+import {
+  componentEnhancementOutputPaths,
+  discoverComponentEnhancements,
+} from './component-enhancements.ts';
+
+describe('component enhancements', () => {
+  it('discovers and builds browser/server outputs for a hypothetical second component', async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), 'cinder-component-enhancement-'));
+    const sourceRoot = join(fixtureRoot, 'src');
+    const componentsRoot = join(sourceRoot, 'components');
+    const sourcePath = join(componentsRoot, 'second-editor', 'second-editor-enhancement.ts');
+    const browserOutput = join(fixtureRoot, 'dist');
+    const serverOutput = join(fixtureRoot, 'dist', 'server');
+    mkdirSync(join(componentsRoot, 'second-editor'), { recursive: true });
+    writeFileSync(sourcePath, 'export const enhancement = "second-editor";\n');
+
+    try {
+      const enhancements = discoverComponentEnhancements(
+        [{ name: 'second-editor', isExperimental: false }],
+        componentsRoot,
+      );
+      expect(enhancements).toEqual([{ name: 'second-editor', sourcePath }]);
+
+      const browserBuild = await Bun.build({
+        entrypoints: enhancements.map((enhancement) => enhancement.sourcePath),
+        outdir: browserOutput,
+        root: sourceRoot,
+        target: 'browser',
+        format: 'esm',
+        naming: { entry: '[dir]/[name].[ext]' },
+      });
+      const serverBuild = await Bun.build({
+        entrypoints: enhancements.map((enhancement) => enhancement.sourcePath),
+        outdir: serverOutput,
+        root: sourceRoot,
+        target: 'node',
+        format: 'esm',
+        naming: { entry: '[dir]/[name].[ext]' },
+      });
+
+      expect(browserBuild.success).toBe(true);
+      expect(serverBuild.success).toBe(true);
+      const outputPaths = componentEnhancementOutputPaths(browserOutput, 'second-editor');
+      expect(await Bun.file(outputPaths.browser).exists()).toBe(true);
+      expect(await Bun.file(outputPaths.server).exists()).toBe(true);
+    } finally {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/components/scripts/lib/component-enhancements.test.ts
+++ b/packages/components/scripts/lib/component-enhancements.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'bun:test';
 
 import {
+  componentEnhancementKey,
   componentEnhancementOutputPaths,
   discoverComponentEnhancements,
 } from './component-enhancements.ts';
@@ -25,7 +26,8 @@ describe('component enhancements', () => {
         [{ name: 'second-editor', isExperimental: false }],
         componentsRoot,
       );
-      expect(enhancements).toEqual([{ name: 'second-editor', sourcePath }]);
+      expect(enhancements).toEqual([{ name: 'second-editor', isExperimental: false, sourcePath }]);
+      expect(componentEnhancementKey(enhancements[0]!)).toBe('stable/second-editor');
 
       const browserBuild = await Bun.build({
         entrypoints: enhancements.map((enhancement) => enhancement.sourcePath),

--- a/packages/components/scripts/lib/component-enhancements.ts
+++ b/packages/components/scripts/lib/component-enhancements.ts
@@ -1,0 +1,40 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { ComponentDiscovery } from './discover-components.ts';
+
+export type ComponentEnhancement = {
+  name: string;
+  sourcePath: string;
+};
+
+/**
+ * Discover stable component-owned runtime enhancements.
+ *
+ * Enhancement exports intentionally follow the same non-experimental policy as
+ * `generate-exports.ts`: a component contributes an enhancement when its
+ * directory contains `<name>-enhancement.ts`.
+ */
+export function discoverComponentEnhancements(
+  components: ReadonlyArray<Pick<ComponentDiscovery, 'name' | 'isExperimental'>>,
+  componentsRoot: string,
+): ComponentEnhancement[] {
+  return components.flatMap((component) => {
+    if (component.isExperimental) return [];
+    const sourcePath = join(componentsRoot, component.name, `${component.name}-enhancement.ts`);
+    return existsSync(sourcePath) ? [{ name: component.name, sourcePath }] : [];
+  });
+}
+
+/** Return the browser, declaration, and server outputs for one enhancement. */
+export function componentEnhancementOutputPaths(
+  distributionDirectory: string,
+  name: string,
+): { browser: string; types: string; server: string } {
+  const directory = join(distributionDirectory, 'components', name);
+  return {
+    browser: join(directory, `${name}-enhancement.js`),
+    types: join(directory, `${name}-enhancement.d.ts`),
+    server: join(distributionDirectory, 'server', 'components', name, `${name}-enhancement.js`),
+  };
+}

--- a/packages/components/scripts/lib/component-enhancements.ts
+++ b/packages/components/scripts/lib/component-enhancements.ts
@@ -5,8 +5,16 @@ import type { ComponentDiscovery } from './discover-components.ts';
 
 export type ComponentEnhancement = {
   name: string;
+  isExperimental: boolean;
   sourcePath: string;
 };
+
+/** Return the stable/experimental identity used to match enhancement artifacts. */
+export function componentEnhancementKey(
+  component: Pick<ComponentDiscovery, 'name' | 'isExperimental'>,
+): string {
+  return `${component.isExperimental ? 'experimental' : 'stable'}/${component.name}`;
+}
 
 /**
  * Discover stable component-owned runtime enhancements.
@@ -22,7 +30,9 @@ export function discoverComponentEnhancements(
   return components.flatMap((component) => {
     if (component.isExperimental) return [];
     const sourcePath = join(componentsRoot, component.name, `${component.name}-enhancement.ts`);
-    return existsSync(sourcePath) ? [{ name: component.name, sourcePath }] : [];
+    return existsSync(sourcePath)
+      ? [{ name: component.name, isExperimental: component.isExperimental, sourcePath }]
+      : [];
   });
 }
 


### PR DESCRIPTION
Closes the follow-up from #884's post-merge review thread: the enhancement-artifact rule was generic in exports/manifest generation but `scripts/build.ts` still hardcoded json-editor's entrypoint — a future `<id>-enhancement.ts` component would advertise a subpath with no compiled targets in the pack.

Now all three consumers (build entrypoints + packed-output verification, exports generation, manifest generation) share ONE discovery module (`scripts/lib/component-enhancements.ts`), so the rule cannot drift between layers.

Validation (independently re-run by the reviewer): helper + manifest tests 30/30, full cinder build green, `exports:check` green, `validate:consumer` green in the agent run. Implemented by a Codex (Luna) agent; independently reviewed and re-validated.