### PR TITLE
fix(chat): place composer popovers above input

### DIFF
--- a/.changeset/tidy-composer-popover.md
+++ b/.changeset/tidy-composer-popover.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Default `ChatComposerPopover` suggestions to `top-start` so menus open above bottom-anchored composers.

--- a/packages/chat/src/lib/components/chat-composer-popover/README.md
+++ b/packages/chat/src/lib/components/chat-composer-popover/README.md
@@ -36,6 +36,11 @@ Chat composer-bound slash-command and mention listbox primitive.
 </ChatComposerPopover>
 ```
 
+The default placement is `top-start`, which keeps suggestions above a composer
+anchored near the bottom of the viewport. Pass `placement` when a different
+starting side is appropriate; the underlying floating overlay still flips and
+shifts the menu when available space requires it.
+
 When the composer is the full `Chat` surface, commit a selection with the
 public range API. `insertAtRange()` updates the popover's bound value through
 `oncomposerinput`, so no synthetic DOM event is needed:

--- a/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.schema.json
+++ b/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.schema.json
@@ -32,7 +32,7 @@
         "bottom-start",
         "bottom-end"
       ],
-      "description": "Caret-relative placement. Default `'bottom-start'`."
+      "description": "Caret-relative placement. Default `'top-start'`, which keeps the menu above a bottom composer."
     },
     "offset": {
       "type": "number",

--- a/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.schema.ts
+++ b/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.schema.ts
@@ -35,7 +35,8 @@ const schema = {
         'bottom-start',
         'bottom-end',
       ],
-      description: "Caret-relative placement. Default `'bottom-start'`.",
+      description:
+        "Caret-relative placement. Default `'top-start'`, which keeps the menu above a bottom composer.",
     },
     offset: {
       type: 'number',

--- a/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.svelte
+++ b/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.svelte
@@ -55,7 +55,7 @@
     items,
     triggers = ['/', '@'],
     label = 'Composer suggestions',
-    placement = 'bottom-start',
+    placement = 'top-start',
     offset = 6,
     composer,
     item,

--- a/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.test.ts
+++ b/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.test.ts
@@ -5,12 +5,14 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const computePositionSpy = mock(async () => ({
-  x: 12,
-  y: 34,
-  placement: 'bottom-start',
-  middlewareData: {},
-}));
+const computePositionSpy = mock(
+  async (_anchor: unknown, _panel: HTMLElement, options: { placement: string }) => ({
+    x: 12,
+    y: 34,
+    placement: options.placement,
+    middlewareData: {},
+  }),
+);
 const autoUpdateTeardown = mock(() => {});
 const autoUpdateSpy = mock((_anchor: unknown, _panel: HTMLElement, update: () => void) => {
   update();
@@ -77,6 +79,11 @@ describe('ChatComposerPopover', () => {
 
     await waitFor(() => expect(queryListbox()).not.toBeNull());
     const listbox = queryListbox()!;
+
+    await waitFor(() => expect(computePositionSpy).toHaveBeenCalled());
+    expect(computePositionSpy.mock.calls.at(-1)?.[2]).toMatchObject({
+      placement: 'top-start',
+    });
 
     expect(composer.getAttribute('role')).toBe('combobox');
     expect(composer.getAttribute('aria-autocomplete')).toBe('list');

--- a/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.types.ts
+++ b/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.types.ts
@@ -62,7 +62,7 @@ export type ChatComposerPopoverProps<TItem extends ChatComposerPopoverItem> = {
   triggers?: readonly string[];
   /** Accessible listbox label. Default `'Composer suggestions'`. */
   label?: string;
-  /** Caret-relative placement. Default `'bottom-start'`. */
+  /** Caret-relative placement. Default `'top-start'`, which keeps the menu above a bottom composer. */
   placement?: PopoverPlacement;
   /** Distance in px between the caret and popover. Default `6`. */
   offset?: number;


### PR DESCRIPTION
Closes #888

Default `ChatComposerPopover` to `top-start` so its menu opens above bottom-anchored composers. Keep the existing Floating UI flip/shift collision handling, and update the generated schema and usage docs. Add a regression assertion for the default placement.

Validation:
- `bun test --conditions browser --conditions svelte --parallel=1 src/lib/components/chat-composer-popover/chat-composer-popover.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run components:check`