### PR TITLE
docs(chat): define message action button styling

### DIFF
--- a/.changeset/quiet-buttons-chat.md
+++ b/.changeset/quiet-buttons-chat.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Document the `chat-message-action-button` class contract for native buttons rendered through `messageActions`.

--- a/packages/chat/src/lib/components/chat/README.md
+++ b/packages/chat/src/lib/components/chat/README.md
@@ -339,8 +339,14 @@ and edit controls. For native buttons, add the shared
 hover, and touch styles:
 
 ```svelte
+<script lang="ts">
+  let panelOpen = $state(false);
+</script>
+
 {#snippet messageActions()}
-  <button type="button" class="chat-message-action-button" onclick={openPanel}> Open panel </button>
+  <button type="button" class="chat-message-action-button" onclick={() => (panelOpen = true)}>
+    Open panel
+  </button>
 {/snippet}
 ```
 

--- a/packages/chat/src/lib/components/chat/README.md
+++ b/packages/chat/src/lib/components/chat/README.md
@@ -333,6 +333,22 @@ optional resolved `toolCallPair` and `artifact` values:
 </ChatArtifactLayout>
 ```
 
+`messageActions` is rendered in the same action row as Chat's built-in copy
+and edit controls. For native buttons, add the shared
+`chat-message-action-button` class to opt into the action-row sizing, focus,
+hover, and touch styles:
+
+```svelte
+{#snippet messageActions()}
+  <button type="button" class="chat-message-action-button" onclick={openPanel}> Open panel </button>
+{/snippet}
+```
+
+The class is intentionally opt-in so consumers can use their own button
+component or visual treatment without Chat overriding it. Cinder `Button`
+instances already provide their own complete styling and do not need this
+class.
+
 A paired `tool-result` message does not render a second visible row and does not
 invoke the snippets separately. Chat folds that result into the corresponding
 tool-call row's `toolCallPair` and resolves `cinder:artifact` metadata from the

--- a/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-action-buttons.test.ts
@@ -12,8 +12,14 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const source = readFileSync(resolve(import.meta.dir, 'chat-message.svelte'), 'utf8');
+const readme = readFileSync(resolve(import.meta.dir, '../README.md'), 'utf8');
 
 describe('chat message action buttons', () => {
+  test('documents the opt-in styling contract for native consumer actions', () => {
+    expect(readme).toContain('`chat-message-action-button` class');
+    expect(readme).toContain('class="chat-message-action-button"');
+  });
+
   test('copy action uses CopyButton with both shared base class and copy-specific class', () => {
     // CopyButton receives the classes as a prop; source shows them in the `class` attribute value.
     expect(source).toContain('chat-message-action-button chat-message-copy');


### PR DESCRIPTION
Closes #887

Document the opt-in `chat-message-action-button` class for native buttons rendered by `messageActions`, including the shared sizing, focus, hover, and touch styling contract. Add a source regression test for the documented contract.

Validation:
- `bun test --conditions browser --conditions svelte --parallel=1 src/lib/components/chat/message/chat-message-action-buttons.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run components:check`