### PR TITLE
fix(chat): highlight artifacts and hide attachment input from AT

### DIFF
--- a/.changeset/chat-artifact-code-and-input-a11y.md
+++ b/.changeset/chat-artifact-code-and-input-a11y.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Improve chat artifact and composer accessibility: code artifacts now use Cinder's syntax-highlighted `CodeBlock` by default with an optional `codeRenderer` hook, and the programmatic attachment input is hidden from the accessibility tree.

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -77,7 +77,17 @@ Use `messageActions` to open application-owned panel state, then render the sele
 
 ## Rendering Mermaid artifacts
 
-`ArtifactViewer` renders HTML and SVG in sandboxed iframes and renders code as escaped source. Mermaid stays consumer-owned so applications can choose their Mermaid version, configuration, and security policy. Without a renderer, Mermaid artifacts show their source and an explicit fallback note.
+`ArtifactViewer` renders HTML and SVG in sandboxed iframes. Code artifacts use Cinder's `CodeBlock` with the artifact language for lazy syntax highlighting; pass `codeRenderer` when an application needs a custom code viewer. Mermaid stays consumer-owned so applications can choose their Mermaid version, configuration, and security policy. Without a renderer, Mermaid artifacts show their source and an explicit fallback note.
+
+The `codeRenderer` snippet receives `(content, 'code', language)` and is invoked only for code artifacts:
+
+```svelte
+{#snippet codeRenderer(source, _type, language)}
+  <MyCodeViewer {source} {language} />
+{/snippet}
+
+<ArtifactViewer type="code" content={source} language="svelte" {codeRenderer} />
+```
 
 Pass a `mermaidRenderer` snippet to delegate only the Mermaid branch to an application component:
 
@@ -96,4 +106,4 @@ Pass a `mermaidRenderer` snippet to delegate only the Mermaid branch to an appli
 <ArtifactViewer type="mermaid" {content} {mermaidRenderer} />
 ```
 
-The snippet has type `Snippet<[content: string, type: 'mermaid']>`. `ArtifactViewer` invokes it only when `type` is `mermaid`; HTML, SVG, and code continue through the built-in renderers. The application-owned component is responsible for loading Mermaid, handling asynchronous rendering and errors, and applying its required content-safety policy.
+The Mermaid snippet has type `Snippet<[content: string, type: 'mermaid']>`. `ArtifactViewer` invokes it only when `type` is `mermaid`; HTML, SVG, and code continue through their built-in renderers unless a code snippet is supplied. The application-owned component is responsible for loading Mermaid, handling asynchronous rendering and errors, and applying its required content-safety policy.

--- a/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
@@ -12,8 +12,10 @@
 
 <script lang="ts">
   import type { ArtifactViewerProps } from './artifact-viewer.types.ts';
+  import CodeBlock from '@lostgradient/cinder/code-block';
 
-  let { type, content, language, title, mermaidRenderer }: ArtifactViewerProps = $props();
+  let { type, content, language, title, mermaidRenderer, codeRenderer }: ArtifactViewerProps =
+    $props();
 
   const svgDocument = $derived(type === 'svg' ? wrapSvgInHtml(content) : '');
 </script>
@@ -36,7 +38,16 @@
   ></iframe>
 {:else if type === 'code'}
   <div class="artifact-viewer artifact-viewer-code">
-    <pre class="artifact-code-block" data-language={language}><code>{content}</code></pre>
+    {#if codeRenderer}
+      {@render codeRenderer(content, 'code', language)}
+    {:else}
+      <CodeBlock
+        code={content}
+        {...language === undefined ? {} : { language }}
+        showLanguageLabel={false}
+        class="artifact-code-block"
+      />
+    {/if}
   </div>
 {:else if type === 'mermaid'}
   <div class="artifact-viewer artifact-viewer-mermaid">
@@ -89,6 +100,12 @@
     line-height: var(--leading-relaxed);
     color: var(--cinder-text);
     white-space: pre;
+    tab-size: 2;
+  }
+
+  .artifact-code-block :global(.cinder-code-block__pre),
+  .artifact-code-block :global(.shiki) {
+    tab-size: 2;
   }
 
   .artifact-code-block code {

--- a/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-viewer.svelte
@@ -54,7 +54,7 @@
     {#if mermaidRenderer}
       {@render mermaidRenderer(content, 'mermaid')}
     {:else}
-      <pre class="artifact-code-block" data-language="mermaid"><code>{content}</code></pre>
+      <pre class="artifact-source-block" data-language="mermaid"><code>{content}</code></pre>
       <p class="artifact-mermaid-note" aria-live="polite">
         No Mermaid renderer was provided. Showing diagram source.
       </p>
@@ -88,7 +88,7 @@
     padding: var(--cinder-space-4);
   }
 
-  .artifact-code-block {
+  .artifact-source-block {
     margin: 0;
     padding: var(--cinder-space-4);
     background: var(--cinder-surface-raised);
@@ -103,16 +103,20 @@
     tab-size: 2;
   }
 
-  .artifact-code-block :global(.cinder-code-block__pre),
-  .artifact-code-block :global(.shiki) {
+  .artifact-code-block {
     tab-size: 2;
   }
 
-  .artifact-code-block code {
+  .artifact-source-block code {
     font-family: inherit;
     font-size: inherit;
     background: none;
     padding: 0;
+  }
+
+  .artifact-code-block :global(.cinder-code-block__pre),
+  .artifact-code-block :global(.shiki) {
+    tab-size: 2;
   }
 
   .artifact-mermaid-note {

--- a/packages/chat/src/lib/components/chat/artifact/artifact-viewer.types.ts
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-viewer.types.ts
@@ -12,6 +12,7 @@ export type ChatArtifact = {
 
 /** Consumer-owned Mermaid rendering snippet. */
 export type MermaidRenderer = Snippet<[content: string, type: 'mermaid']>;
+export type CodeRenderer = Snippet<[content: string, type: 'code', language: string | undefined]>;
 
 export type ArtifactViewerProps = {
   type: ArtifactContentType;
@@ -23,4 +24,6 @@ export type ArtifactViewerProps = {
    * for `type="mermaid"`; otherwise ArtifactViewer uses its built-in renderer.
    */
   mermaidRenderer?: MermaidRenderer;
+  /** Renders code artifacts with a consumer-owned highlighter or viewer. */
+  codeRenderer?: CodeRenderer;
 };

--- a/packages/chat/src/lib/components/chat/artifact/artifact.test.ts
+++ b/packages/chat/src/lib/components/chat/artifact/artifact.test.ts
@@ -3,7 +3,7 @@ import { fireEvent, render } from '@testing-library/svelte';
 import { describe, expect, mock, test } from 'bun:test';
 import { createRawSnippet } from 'svelte';
 
-import type { ArtifactViewerProps, MermaidRenderer } from '../index.ts';
+import type { ArtifactViewerProps, CodeRenderer, MermaidRenderer } from '../index.ts';
 import ArtifactPanelFixture from './artifact-panel-fixture.svelte';
 import ArtifactViewer from './artifact-viewer.svelte';
 import ChatArtifactLayoutFixture from './chat-artifact-layout-fixture.svelte';
@@ -29,7 +29,7 @@ describe('Chat artifact components', () => {
     expect(container.querySelector('iframe')?.getAttribute('srcdoc')).toContain('<svg></svg>');
 
     await rerender({ type: 'code', content: 'const value = 1;', language: 'typescript' });
-    expect(container.querySelector('pre')?.dataset['language']).toBe('typescript');
+    expect(container.querySelector('.cinder-code-block')).not.toBeNull();
     expect(container.querySelector('code')?.textContent).toBe('const value = 1;');
     expect(rendererInvocation).not.toHaveBeenCalled();
   });
@@ -65,6 +65,32 @@ describe('Chat artifact components', () => {
     expect(renderedDiagram?.textContent).toBe('graph TD; Start-->Finish;');
     expect(container.querySelector('.artifact-mermaid-note')).toBeNull();
     expect(container.querySelector('pre')).toBeNull();
+  });
+
+  test('renders code through the built-in CodeBlock and supports a custom renderer', () => {
+    const rendererInvocation = mock(
+      (getContent: () => string, getType: () => 'code', getLanguage: () => string | undefined) => ({
+        render: () =>
+          `<output data-testid="code-renderer" data-type="${getType()}" data-language="${getLanguage()}">${getContent()}</output>`,
+      }),
+    );
+    const codeRenderer: CodeRenderer = createRawSnippet(rendererInvocation);
+    const { container, rerender } = render(ArtifactViewer, {
+      props: { type: 'code', content: 'const value = 1;', language: 'typescript' },
+    });
+    expect(container.querySelector('.artifact-code-block')).not.toBeNull();
+    expect(container.querySelector('.artifact-code-block')?.querySelector('pre')).not.toBeNull();
+
+    void rerender({
+      type: 'code',
+      content: 'const value = 1;',
+      language: 'typescript',
+      codeRenderer,
+    });
+    expect(rendererInvocation).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="code-renderer"]')?.textContent).toBe(
+      'const value = 1;',
+    );
   });
 
   test('renders panel content, focuses close, and dispatches close', async () => {

--- a/packages/chat/src/lib/components/chat/artifact/index.ts
+++ b/packages/chat/src/lib/components/chat/artifact/index.ts
@@ -4,6 +4,7 @@ export type {
   ArtifactContentType,
   ArtifactViewerProps,
   ChatArtifact,
+  CodeRenderer,
   MermaidRenderer,
 } from './artifact-viewer.types.ts';
 export { default as ChatArtifactLayout } from './chat-artifact-layout.svelte';

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -176,5 +176,6 @@ export type {
   ArtifactContentType,
   ArtifactViewerProps,
   ChatArtifact,
+  CodeRenderer,
   MermaidRenderer,
 } from './artifact/index.ts';

--- a/packages/chat/src/lib/components/chat/input/chat-input.svelte
+++ b/packages/chat/src/lib/components/chat/input/chat-input.svelte
@@ -610,6 +610,7 @@
           class="sr-only"
           onchange={handleFileSelect}
           aria-label="Attach files"
+          aria-hidden="true"
           tabindex={-1}
         />
         <Button

--- a/packages/chat/src/lib/components/chat/input/chat-input.test.ts
+++ b/packages/chat/src/lib/components/chat/input/chat-input.test.ts
@@ -69,6 +69,14 @@ describe('ChatInput', () => {
     expect(composer?.readOnly).toBe(true);
   });
 
+  test('hides the programmatic file picker from the accessibility tree', () => {
+    const { container } = render(ChatInput, { id: 'attachment-a11y' });
+    const picker = container.querySelector<HTMLInputElement>('input[type="file"]');
+    expect(picker?.getAttribute('aria-hidden')).toBe('true');
+    expect(picker?.tabIndex).toBe(-1);
+    expect(container.querySelector('button[aria-label="Attach file"]')).not.toBeNull();
+  });
+
   describe('getValue()', () => {
     test('returns the current composer text after the user types', async () => {
       const target = document.createElement('div');


### PR DESCRIPTION
Closes #889
Closes #890

## Summary
- Render code artifacts through Cinder CodeBlock with language-aware highlighting and an optional typed codeRenderer snippet.
- Hide the programmatic attachment file input from the accessibility tree.
- Add regressions, README guidance, and a chat package changeset.

## Validation
- bun test --conditions browser --conditions svelte --parallel=1 src/lib/components/chat/artifact/artifact.test.ts src/lib/components/chat/input/chat-input.test.ts
- bun run --filter=@lostgradient/chat lint
- bun run --filter=@lostgradient/chat typecheck
- bun run --filter=@lostgradient/chat components:check
- bun run --filter=@lostgradient/chat build