### PR TITLE
fix(chat): ignore stale sentinel entries while scrolling

### DIFF
--- a/.changeset/chat-scroll-sentinel-guard.md
+++ b/.changeset/chat-scroll-sentinel-guard.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Keep stale bottom-sentinel observations from undoing an in-flight programmatic scroll away from the bottom.

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -304,7 +304,7 @@
           scrollState.setAtBottom(false);
           updateAtBottomBinding(false);
         }
-        scrollState.withUserScrollGuard(() => {
+        scrollState.withUserScrollGuard(viewport, () => {
           chatVirtualizer.scrollToOffset(0, { behavior: scrollState.getScrollBehavior() });
         });
       }
@@ -1519,7 +1519,7 @@
       // virtualizer remeasurement, and without this guard it would keep
       // snapping the viewport back toward the bottom mid-scroll since
       // `isUserScrolling` was never set for this branch.
-      scrollState.withUserScrollGuard(() => {
+      scrollState.withUserScrollGuard(viewport, () => {
         chatVirtualizer.scrollToOffset(0, { behavior: scrollState.getScrollBehavior() });
       });
     } else {

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -268,6 +268,13 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * Exposed for use with useIntersection attachment-based wiring.
    */
   function handleSentinelEntry(entry: IntersectionObserverEntry): void {
+    // A smooth programmatic scroll away from the bottom can receive an
+    // already-queued "visible" entry before the sentinel actually leaves the
+    // viewport. The explicit scroll-away state owns this interval; allowing
+    // the stale entry to win would immediately flip atBottom back to true and
+    // clear unread state before the scroll has moved.
+    if (isUserScrolling) return;
+
     const sentinelVisible = entry.isIntersecting;
     if (sentinelVisible && !atBottom) {
       atBottom = true;

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -85,16 +85,19 @@ export interface UseChatScrollStateReturn {
   /**
    * Run a programmatic scroll `action` while suppressing the auto-stick-to-bottom
    * effect, mirroring the guard `jumpToLatest` already applies. Sets
-   * `isUserScrolling` for the duration of the scroll animation (based on the
-   * reduced-motion preference), then clears it. A new call cancels any prior
-   * in-flight guard's timer first, so overlapping guarded scrolls can never
-   * leave a stale timer that clears the flag out from under a later one.
-   * `onSettled`, if given, runs once this guard's own timer fires (not if a
-   * later guard cancels it first). Use this for any caller-driven scroll
+   * `isUserScrolling` until the viewport emits `scrollend` or stops emitting
+   * scroll events for the reduced-motion-aware backstop interval, then clears
+   * it. A new call cancels any prior in-flight guard's listeners and backstop.
+   * `onSettled`, if given, runs only when this guard settles (not if a later
+   * guard cancels it first). Use this for any caller-driven scroll
    * (e.g. a virtualized `scrollToOffset`/`scrollToIndex` call) that isn't
    * already routed through `scrollToBottom`/`scrollToTop`/`jumpToLatest`.
    */
-  withUserScrollGuard(action: () => void, onSettled?: () => void): void;
+  withUserScrollGuard(
+    viewport: HTMLElement | null,
+    action: () => void,
+    onSettled?: () => void,
+  ): void;
   /**
    * Immediately cancel any in-flight `withUserScrollGuard`/`jumpToLatest`
    * session and clear `isUserScrolling`, without arming a replacement timer.
@@ -428,7 +431,11 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * latest, scroll-to-top, jump-to-start) can never leave a stale timer behind
    * that clears the flag mid-animation for a different call.
    */
-  function withUserScrollGuard(action: () => void, onSettled?: () => void): void {
+  function withUserScrollGuard(
+    viewport: HTMLElement | null,
+    action: () => void,
+    onSettled?: () => void,
+  ): void {
     // Cancel any previous in-flight guard first: without this, an earlier
     // overlapping guarded scroll (e.g. jumpToLatest() immediately followed by
     // scrollToTop(), or two quick Home presses) would have its OWN timer flip
@@ -437,32 +444,44 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     activeUserScrollGuardCancel?.();
     isUserScrolling = true;
 
-    // Arm the timer AFTER `action()` runs (in `finally`, so a throwing
-    // `action` still gets the flag cleared) rather than before. `action` can
-    // include synchronous work with real cost — e.g. jumpToLatest's forced
-    // layout pass, which reflows every row before the scroll even starts. On
-    // a large transcript that can eat a meaningful slice of the animation
-    // budget; arming the timer first would start the clock before the scroll
-    // command was even issued, letting the guard expire mid-animation.
-    const scrollDuration = reducedMotion.current ? 50 : 500;
+    const settleBackstopDuration = reducedMotion.current ? 50 : 500;
     let settled = false;
-    let timer: ReturnType<typeof setTimeout>;
+    let backstop: ReturnType<typeof setTimeout> | undefined;
+
+    function cancel(): void {
+      if (settled) return;
+      settled = true;
+      if (backstop !== undefined) clearTimeout(backstop);
+      viewport?.removeEventListener('scrollend', settle);
+      viewport?.removeEventListener('scroll', armBackstop);
+    }
+
+    function settle(): void {
+      if (settled) return;
+      cancel();
+      activeUserScrollGuardCancel = null;
+      isUserScrolling = false;
+      applyPendingSentinelVisibility();
+      onSettled?.();
+    }
+
+    function armBackstop(): void {
+      if (backstop !== undefined) clearTimeout(backstop);
+      backstop = setTimeout(settle, settleBackstopDuration);
+    }
+
+    activeUserScrollGuardCancel = cancel;
+    viewport?.addEventListener('scrollend', settle, { once: true });
+    viewport?.addEventListener('scroll', armBackstop, { passive: true });
+
+    // Arm the no-event backstop AFTER `action()` runs. The action can include
+    // a costly synchronous layout pass before it issues the scroll command;
+    // starting the clock first would consume settlement budget before the
+    // animation even begins. Every subsequent scroll tick re-arms it.
     try {
       action();
     } finally {
-      timer = setTimeout(() => {
-        if (settled) return;
-        settled = true;
-        activeUserScrollGuardCancel = null;
-        isUserScrolling = false;
-        applyPendingSentinelVisibility();
-        onSettled?.();
-      }, scrollDuration);
-      activeUserScrollGuardCancel = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-      };
+      armBackstop();
     }
   }
 
@@ -496,7 +515,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     if (viewport.scrollHeight > viewport.clientHeight) {
       atBottom = false;
     }
-    withUserScrollGuard(() => {
+    withUserScrollGuard(viewport, () => {
       viewport.scrollTo({ top: 0, behavior: getScrollBehavior() });
     });
   }
@@ -508,6 +527,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     if (!viewport) return;
 
     withUserScrollGuard(
+      viewport,
       () => {
         withForcedLayout(viewport, () => {
           viewport.scrollTo({ top: viewport.scrollHeight, behavior: getScrollBehavior() });

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -199,9 +199,10 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
   let scrollTicking = false;
   let isUserScrolling = false; // Prevents auto-scroll from interrupting user-initiated smooth scroll
   // IntersectionObserver does not repeat an unchanged observation after a
-  // guard settles. Coalesce entries received during the guard so the latest
-  // real sentinel state can take ownership once the programmatic scroll ends.
-  let pendingSentinelVisibility: boolean | null = null;
+  // guard settles. Preserve the latest entry received during the guard, then
+  // re-read its target geometry at settlement so callback ordering cannot
+  // replay a stale intersection snapshot.
+  let pendingSentinelEntry: IntersectionObserverEntry | null = null;
   // Cancel function for the in-flight withForcedLayout session, if any. A new
   // session cancels the previous one's listeners/timer before starting its
   // own — see withForcedLayout below for why this matters.
@@ -212,6 +213,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
   // overlapping guarded scroll's timer could flip isUserScrolling back to
   // false while a later guarded scroll's animation is still in progress.
   let activeUserScrollGuardCancel: (() => void) | null = null;
+  let activeUserScrollViewport: HTMLElement | null = null;
 
   /**
    * Set atBottom state directly.
@@ -281,10 +283,23 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     }
   }
 
-  function applyPendingSentinelVisibility(): void {
-    if (pendingSentinelVisibility === null) return;
-    const sentinelVisible = pendingSentinelVisibility;
-    pendingSentinelVisibility = null;
+  function applyPendingSentinelEntry(viewport: HTMLElement | null): void {
+    if (pendingSentinelEntry === null) return;
+    const entry = pendingSentinelEntry;
+    pendingSentinelEntry = null;
+
+    let sentinelVisible = entry.isIntersecting;
+    if (viewport !== null && entry.target instanceof Element && entry.target.isConnected) {
+      const sentinelBounds = entry.target.getBoundingClientRect();
+      const viewportBounds = viewport.getBoundingClientRect();
+      const bottomMargin = getBottomThreshold?.() ?? bottomThreshold;
+      sentinelVisible =
+        sentinelBounds.bottom >= viewportBounds.top &&
+        sentinelBounds.top <= viewportBounds.bottom + bottomMargin &&
+        sentinelBounds.right >= viewportBounds.left &&
+        sentinelBounds.left <= viewportBounds.right;
+    }
+
     applySentinelVisibility(sentinelVisible);
   }
 
@@ -295,7 +310,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     // including the case where the sentinel remains visible and the observer
     // will not emit the same unchanged intersection again.
     if (isUserScrolling) {
-      pendingSentinelVisibility = entry.isIntersecting;
+      pendingSentinelEntry = entry;
       return;
     }
 
@@ -460,8 +475,9 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
       if (settled) return;
       cancel();
       activeUserScrollGuardCancel = null;
+      activeUserScrollViewport = null;
       isUserScrolling = false;
-      applyPendingSentinelVisibility();
+      applyPendingSentinelEntry(viewport);
       onSettled?.();
     }
 
@@ -471,6 +487,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     }
 
     activeUserScrollGuardCancel = cancel;
+    activeUserScrollViewport = viewport;
     viewport?.addEventListener('scrollend', settle, { once: true });
     viewport?.addEventListener('scroll', armBackstop, { passive: true });
 
@@ -490,10 +507,12 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * `UseChatScrollStateReturn.clearUserScrollGuard` for details.
    */
   function clearUserScrollGuard(): void {
+    const viewport = activeUserScrollViewport;
     activeUserScrollGuardCancel?.();
     activeUserScrollGuardCancel = null;
+    activeUserScrollViewport = null;
     isUserScrolling = false;
-    applyPendingSentinelVisibility();
+    applyPendingSentinelEntry(viewport);
   }
 
   /**
@@ -557,8 +576,9 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     activeForcedLayoutCancel = null;
     activeUserScrollGuardCancel?.();
     activeUserScrollGuardCancel = null;
+    activeUserScrollViewport = null;
     isUserScrolling = false;
-    pendingSentinelVisibility = null;
+    pendingSentinelEntry = null;
   }
 
   return {

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -195,6 +195,10 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
   // Non-reactive bookkeeping
   let scrollTicking = false;
   let isUserScrolling = false; // Prevents auto-scroll from interrupting user-initiated smooth scroll
+  // IntersectionObserver does not repeat an unchanged observation after a
+  // guard settles. Coalesce entries received during the guard so the latest
+  // real sentinel state can take ownership once the programmatic scroll ends.
+  let pendingSentinelVisibility: boolean | null = null;
   // Cancel function for the in-flight withForcedLayout session, if any. A new
   // session cancels the previous one's listeners/timer before starting its
   // own — see withForcedLayout below for why this matters.
@@ -267,19 +271,32 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * IntersectionObserver callback for the bottom sentinel element.
    * Exposed for use with useIntersection attachment-based wiring.
    */
-  function handleSentinelEntry(entry: IntersectionObserverEntry): void {
-    // A smooth programmatic scroll away from the bottom can receive an
-    // already-queued "visible" entry before the sentinel actually leaves the
-    // viewport. The explicit scroll-away state owns this interval; allowing
-    // the stale entry to win would immediately flip atBottom back to true and
-    // clear unread state before the scroll has moved.
-    if (isUserScrolling) return;
-
-    const sentinelVisible = entry.isIntersecting;
+  function applySentinelVisibility(sentinelVisible: boolean): void {
     if (sentinelVisible && !atBottom) {
       atBottom = true;
       onReachBottom?.();
     }
+  }
+
+  function applyPendingSentinelVisibility(): void {
+    if (pendingSentinelVisibility === null) return;
+    const sentinelVisible = pendingSentinelVisibility;
+    pendingSentinelVisibility = null;
+    applySentinelVisibility(sentinelVisible);
+  }
+
+  function handleSentinelEntry(entry: IntersectionObserverEntry): void {
+    // A smooth programmatic scroll can receive observations for transient
+    // positions before it settles. Coalesce them rather than applying them
+    // immediately: the latest observation owns the state once the guard ends,
+    // including the case where the sentinel remains visible and the observer
+    // will not emit the same unchanged intersection again.
+    if (isUserScrolling) {
+      pendingSentinelVisibility = entry.isIntersecting;
+      return;
+    }
+
+    applySentinelVisibility(entry.isIntersecting);
   }
 
   /**
@@ -438,6 +455,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
         settled = true;
         activeUserScrollGuardCancel = null;
         isUserScrolling = false;
+        applyPendingSentinelVisibility();
         onSettled?.();
       }, scrollDuration);
       activeUserScrollGuardCancel = () => {
@@ -456,6 +474,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     activeUserScrollGuardCancel?.();
     activeUserScrollGuardCancel = null;
     isUserScrolling = false;
+    applyPendingSentinelVisibility();
   }
 
   /**
@@ -519,6 +538,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     activeUserScrollGuardCancel?.();
     activeUserScrollGuardCancel = null;
     isUserScrolling = false;
+    pendingSentinelVisibility = null;
   }
 
   return {

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -176,7 +176,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     let called = false;
 
     expect(state.isUserScrolling).toBe(false);
-    state.withUserScrollGuard(() => {
+    state.withUserScrollGuard(null, () => {
       // Runs synchronously inside the guard, mirroring
       // `chatVirtualizer.scrollToOffset(0, ...)` in chat.svelte.
       called = true;
@@ -213,7 +213,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
 
     try {
       const state = useChatScrollState();
-      state.withUserScrollGuard(() => {});
+      state.withUserScrollGuard(null, () => {});
       expect(state.isUserScrolling).toBe(true);
 
       jest.advanceTimersByTime(49);
@@ -237,7 +237,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     // A second, independent guarded scroll must also resolve back to false —
     // proving the flag resets on its own timer rather than requiring some
     // other code path to clear it.
-    state.withUserScrollGuard(() => {});
+    state.withUserScrollGuard(viewport, () => {});
     expect(state.isUserScrolling).toBe(true);
     jest.advanceTimersByTime(500);
     expect(state.isUserScrolling).toBe(false);
@@ -253,9 +253,9 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     jest.useFakeTimers();
     const state = useChatScrollState();
 
-    state.withUserScrollGuard(() => {}); // session A: timer armed for ~500ms from t=0
+    state.withUserScrollGuard(null, () => {}); // session A: backstop armed for ~500ms from t=0
     jest.advanceTimersByTime(50);
-    state.withUserScrollGuard(() => {}); // session B: timer armed for ~500ms from t=50
+    state.withUserScrollGuard(null, () => {}); // session B: backstop armed for ~500ms from t=50
 
     // At t≈520ms: session A's original (500ms) deadline has passed, but
     // session B's (550ms) has not. isUserScrolling must still be true —
@@ -344,6 +344,47 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(reachedBottom).toBe(0);
   });
 
+  test('a scroll lasting longer than the backstop cannot replay stale sentinel state mid-animation', () => {
+    jest.useFakeTimers();
+    let reachedBottom = 0;
+    const state = useChatScrollState({
+      onReachBottom: () => {
+        reachedBottom += 1;
+      },
+    });
+    const viewport = createViewport();
+
+    state.setAtBottom(false);
+    state.withUserScrollGuard(viewport, () => {});
+    state.handleSentinelEntry({
+      isIntersecting: true,
+    } as IntersectionObserverEntry);
+
+    // Keep the animation active well beyond the original fixed 500ms guard.
+    // Every real scroll tick must re-arm settlement instead of letting the
+    // initial visible observation replay on its original wall-clock deadline.
+    for (let index = 0; index < 3; index += 1) {
+      jest.advanceTimersByTime(400);
+      viewport.dispatchEvent(new Event('scroll'));
+      expect(state.isUserScrolling).toBe(true);
+      expect(state.atBottom).toBe(false);
+      expect(reachedBottom).toBe(0);
+    }
+
+    // The final observer state is hidden. It owns the transition only after
+    // the viewport has actually stopped producing scroll events.
+    state.handleSentinelEntry({
+      isIntersecting: false,
+    } as IntersectionObserverEntry);
+    jest.advanceTimersByTime(499);
+    expect(state.isUserScrolling).toBe(true);
+    expect(state.atBottom).toBe(false);
+    jest.advanceTimersByTime(1);
+    expect(state.isUserScrolling).toBe(false);
+    expect(state.atBottom).toBe(false);
+    expect(reachedBottom).toBe(0);
+  });
+
   test('a sentinel that remains visible during the guard is applied once the scroll settles', () => {
     jest.useFakeTimers();
     let reachedBottom = 0;
@@ -352,9 +393,10 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
         reachedBottom += 1;
       },
     });
+    const viewport = createViewport();
 
     state.setAtBottom(false);
-    state.withUserScrollGuard(() => {});
+    state.withUserScrollGuard(viewport, () => {});
     state.handleSentinelEntry({
       isIntersecting: true,
     } as IntersectionObserverEntry);
@@ -394,7 +436,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     const state = useChatScrollState();
     let clearedDuringAction = false;
 
-    state.withUserScrollGuard(() => {
+    state.withUserScrollGuard(null, () => {
       // Simulate action() itself consuming the guard's entire duration. If
       // the timer had been armed before action() ran, this would fire it
       // while still inside action() — proving the bug.

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -48,6 +48,22 @@ function createShortViewport(): HTMLElement {
   return viewport;
 }
 
+function createIntersectionObserverEntry(
+  isIntersecting: boolean,
+  target: Element = document.createElement('div'),
+): IntersectionObserverEntry {
+  const bounds = target.getBoundingClientRect();
+  return {
+    time: 0,
+    target,
+    rootBounds: null,
+    boundingClientRect: bounds,
+    intersectionRect: isIntersecting ? bounds : new DOMRect(),
+    isIntersecting,
+    intersectionRatio: isIntersecting ? 1 : 0,
+  };
+}
+
 describe('useChatScrollState — withForcedLayout backstop', () => {
   test('sets data-cinder-force-visible for the duration of scrollToBottom', () => {
     const state = useChatScrollState();
@@ -318,12 +334,8 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
       },
     });
     const viewport = createViewport();
-    const visibleSentinelEntry = {
-      isIntersecting: true,
-    } as IntersectionObserverEntry;
-    const hiddenSentinelEntry = {
-      isIntersecting: false,
-    } as IntersectionObserverEntry;
+    const visibleSentinelEntry = createIntersectionObserverEntry(true);
+    const hiddenSentinelEntry = createIntersectionObserverEntry(false);
 
     state.scrollToTop(viewport);
     expect(state.atBottom).toBe(false);
@@ -356,9 +368,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
 
     state.setAtBottom(false);
     state.withUserScrollGuard(viewport, () => {});
-    state.handleSentinelEntry({
-      isIntersecting: true,
-    } as IntersectionObserverEntry);
+    state.handleSentinelEntry(createIntersectionObserverEntry(true));
 
     // Keep the animation active well beyond the original fixed 500ms guard.
     // Every real scroll tick must re-arm settlement instead of letting the
@@ -373,9 +383,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
 
     // The final observer state is hidden. It owns the transition only after
     // the viewport has actually stopped producing scroll events.
-    state.handleSentinelEntry({
-      isIntersecting: false,
-    } as IntersectionObserverEntry);
+    state.handleSentinelEntry(createIntersectionObserverEntry(false));
     jest.advanceTimersByTime(499);
     expect(state.isUserScrolling).toBe(true);
     expect(state.atBottom).toBe(false);
@@ -424,10 +432,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
 
     state.setAtBottom(false);
     state.withUserScrollGuard(viewport, () => {});
-    state.handleSentinelEntry({
-      isIntersecting: true,
-      target: sentinel,
-    } as IntersectionObserverEntry);
+    state.handleSentinelEntry(createIntersectionObserverEntry(true, sentinel));
 
     // The scroll finishes with the sentinel outside the viewport, but
     // scrollend wins the event-loop race against IntersectionObserver's final
@@ -439,10 +444,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(state.atBottom).toBe(false);
     expect(reachedBottom).toBe(0);
 
-    state.handleSentinelEntry({
-      isIntersecting: false,
-      target: sentinel,
-    } as IntersectionObserverEntry);
+    state.handleSentinelEntry(createIntersectionObserverEntry(false, sentinel));
     expect(state.atBottom).toBe(false);
     expect(reachedBottom).toBe(0);
   });
@@ -459,9 +461,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
 
     state.setAtBottom(false);
     state.withUserScrollGuard(viewport, () => {});
-    state.handleSentinelEntry({
-      isIntersecting: true,
-    } as IntersectionObserverEntry);
+    state.handleSentinelEntry(createIntersectionObserverEntry(true));
 
     expect(state.atBottom).toBe(false);
     expect(reachedBottom).toBe(0);

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -309,6 +309,38 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(state.atBottom).toBe(false);
   });
 
+  test('a visible sentinel cannot undo scrollToTop state while its programmatic scroll guard is active', () => {
+    jest.useFakeTimers();
+    let reachedBottom = 0;
+    const state = useChatScrollState({
+      onReachBottom: () => {
+        reachedBottom += 1;
+      },
+    });
+    const viewport = createViewport();
+    const visibleSentinelEntry = {
+      isIntersecting: true,
+    } as IntersectionObserverEntry;
+
+    state.scrollToTop(viewport);
+    expect(state.atBottom).toBe(false);
+    expect(state.isUserScrolling).toBe(true);
+
+    // IntersectionObserver can deliver an entry queued while the bottom
+    // sentinel was still visible, before the smooth scroll moved it away.
+    state.handleSentinelEntry(visibleSentinelEntry);
+
+    expect(state.atBottom).toBe(false);
+    expect(reachedBottom).toBe(0);
+
+    // Once the programmatic scroll has settled, a genuinely visible sentinel
+    // once again owns the bottom-state transition and unread cleanup.
+    jest.advanceTimersByTime(500);
+    state.handleSentinelEntry(visibleSentinelEntry);
+    expect(state.atBottom).toBe(true);
+    expect(reachedBottom).toBe(1);
+  });
+
   test('scrollToTop preserves atBottom when the viewport cannot actually leave the bottom', () => {
     // Regression guard (Codex review on #787): a transcript short enough to
     // fit entirely within the viewport (scrollHeight <= clientHeight) is

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -309,7 +309,7 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(state.atBottom).toBe(false);
   });
 
-  test('a visible sentinel cannot undo scrollToTop state while its programmatic scroll guard is active', () => {
+  test('sentinel observations are coalesced until a programmatic scroll settles', () => {
     jest.useFakeTimers();
     let reachedBottom = 0;
     const state = useChatScrollState({
@@ -320,6 +320,9 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     const viewport = createViewport();
     const visibleSentinelEntry = {
       isIntersecting: true,
+    } as IntersectionObserverEntry;
+    const hiddenSentinelEntry = {
+      isIntersecting: false,
     } as IntersectionObserverEntry;
 
     state.scrollToTop(viewport);
@@ -333,10 +336,35 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(state.atBottom).toBe(false);
     expect(reachedBottom).toBe(0);
 
-    // Once the programmatic scroll has settled, a genuinely visible sentinel
-    // once again owns the bottom-state transition and unread cleanup.
+    // The sentinel then leaves the viewport as the scroll progresses. Its
+    // latest observation must replace the stale visible one.
+    state.handleSentinelEntry(hiddenSentinelEntry);
     jest.advanceTimersByTime(500);
-    state.handleSentinelEntry(visibleSentinelEntry);
+    expect(state.atBottom).toBe(false);
+    expect(reachedBottom).toBe(0);
+  });
+
+  test('a sentinel that remains visible during the guard is applied once the scroll settles', () => {
+    jest.useFakeTimers();
+    let reachedBottom = 0;
+    const state = useChatScrollState({
+      onReachBottom: () => {
+        reachedBottom += 1;
+      },
+    });
+
+    state.setAtBottom(false);
+    state.withUserScrollGuard(() => {});
+    state.handleSentinelEntry({
+      isIntersecting: true,
+    } as IntersectionObserverEntry);
+
+    expect(state.atBottom).toBe(false);
+    expect(reachedBottom).toBe(0);
+
+    // IntersectionObserver does not repeat an unchanged intersection after
+    // the guard expires, so the coalesced latest entry must be applied here.
+    jest.advanceTimersByTime(500);
     expect(state.atBottom).toBe(true);
     expect(reachedBottom).toBe(1);
   });

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -385,6 +385,68 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(reachedBottom).toBe(0);
   });
 
+  test('scrollend rechecks sentinel geometry before a delayed final observer entry arrives', () => {
+    jest.useFakeTimers();
+    let reachedBottom = 0;
+    const state = useChatScrollState({
+      onReachBottom: () => {
+        reachedBottom += 1;
+      },
+    });
+    const viewport = createViewport();
+    const sentinel = document.createElement('div');
+    viewport.appendChild(sentinel);
+    viewport.getBoundingClientRect = () =>
+      ({
+        top: 0,
+        right: 400,
+        bottom: 400,
+        left: 0,
+        width: 400,
+        height: 400,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    let sentinelTop = 350;
+    sentinel.getBoundingClientRect = () =>
+      ({
+        top: sentinelTop,
+        right: 400,
+        bottom: sentinelTop + 1,
+        left: 0,
+        width: 400,
+        height: 1,
+        x: 0,
+        y: sentinelTop,
+        toJSON: () => ({}),
+      }) as DOMRect;
+
+    state.setAtBottom(false);
+    state.withUserScrollGuard(viewport, () => {});
+    state.handleSentinelEntry({
+      isIntersecting: true,
+      target: sentinel,
+    } as IntersectionObserverEntry);
+
+    // The scroll finishes with the sentinel outside the viewport, but
+    // scrollend wins the event-loop race against IntersectionObserver's final
+    // hidden notification. Settlement must inspect current geometry instead
+    // of replaying the queued visible snapshot.
+    sentinelTop = 1_000;
+    viewport.dispatchEvent(new Event('scrollend'));
+    expect(state.isUserScrolling).toBe(false);
+    expect(state.atBottom).toBe(false);
+    expect(reachedBottom).toBe(0);
+
+    state.handleSentinelEntry({
+      isIntersecting: false,
+      target: sentinel,
+    } as IntersectionObserverEntry);
+    expect(state.atBottom).toBe(false);
+    expect(reachedBottom).toBe(0);
+  });
+
   test('a sentinel that remains visible during the guard is applied once the scroll settles', () => {
     jest.useFakeTimers();
     let reachedBottom = 0;


### PR DESCRIPTION
## Summary

- ignore bottom-sentinel observations while a guarded programmatic scroll is in flight
- preserve explicit scroll-away state and unread accrual until the scroll settles
- add a focused state-machine regression covering stale delivery and post-settle recovery

## Validation

- `bun test --conditions browser --conditions svelte --parallel=1 packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts packages/chat/src/lib/components/chat/chat.test.ts` (54 pass)
- `bunx oxlint --type-aware --tsconfig packages/chat/tsconfig.json packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts`
- `bunx prettier --check packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts .changeset/chat-scroll-sentinel-guard.md`
- `git diff --check`

Closes #864