### PR TITLE
fix(chat): invalidate stale push handlers after teardown

### DIFF
--- a/.changeset/899-stale-push-handlers.md
+++ b/.changeset/899-stale-push-handlers.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Ignore push callbacks that arrive after a Chat adapter subscription is torn down.

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -822,21 +822,32 @@
     if (!resolvedAdapter?.subscribe) return;
 
     const currentConversationId = conversationId;
+    let active = true;
     const handlers: ChatPushHandlers = {
-      onMessage: (message) => untrack(() => onpushmessage)?.(message),
+      onMessage: (message) => {
+        if (active) untrack(() => onpushmessage)?.(message);
+      },
       onTypingChange: (isTyping) => {
+        if (!active) return;
         // Drive the C6 per-participant typing indicator via the adapter path.
         typingIndicatorState.handleAdapterTypingChange(isTyping);
         untrack(() => ontypingchange)?.(isTyping);
       },
       onReadReceipt: (event) => {
+        if (!active) return;
         // Accumulate the receipt into C6 read receipt state.
         readReceiptsState.handleAdapterReadReceipt(event);
         untrack(() => onreadreceipt)?.(event);
       },
-      onStreamBegin: (messageId) => beginStreaming(messageId),
-      onTokenPush: (token) => pushToken(token),
-      onStreamEnd: () => endStreaming(),
+      onStreamBegin: (messageId) => {
+        if (active) beginStreaming(messageId);
+      },
+      onTokenPush: (token) => {
+        if (active) pushToken(token);
+      },
+      onStreamEnd: () => {
+        if (active) endStreaming();
+      },
     };
 
     const unsubscribe = resolvedAdapter.subscribe(currentConversationId, handlers);
@@ -851,6 +862,7 @@
     // participant, a pending live-region timer, and accumulated receipts alive
     // (the conversation-change effect above only fires on an id change).
     return () => {
+      active = false;
       if (typeof unsubscribe === 'function') unsubscribe();
       endStreaming();
       typingIndicatorState.reset();


### PR DESCRIPTION
Closes #899\n\nInvalidate Chat push handlers during subscription teardown so late adapter callbacks cannot mutate state.