### PR TITLE
fix(chat): warn on newer conversation schemas

### DIFF
--- a/.changeset/future-schema-warning.md
+++ b/.changeset/future-schema-warning.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Warn when Chat receives a conversation history stamped with a newer schema version.

--- a/packages/chat/src/lib/components/chat/README.md
+++ b/packages/chat/src/lib/components/chat/README.md
@@ -127,7 +127,8 @@ directly — that is supported, it just is not something Chat requires.
 
 The exported schema version comes from the `conversationalist` version Chat
 depends on. Histories produced by an older compatible schema can render
-as-is; a newer schema requires upgrading `@lostgradient/chat`.
+as-is; a newer schema causes Chat to emit a console warning and requires
+upgrading `@lostgradient/chat` before relying on that history.
 
 ## Layout and sizing
 

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -18,12 +18,14 @@
 </script>
 
 <script lang="ts">
+  import { CURRENT_SCHEMA_VERSION } from 'conversationalist/versioning';
   import { classNames } from '../../utilities/class-names.ts';
   import ChatImplementation from './container/chat.svelte';
   import type { ChatAnnounceLevel, ChatProps } from './chat.types.ts';
 
   let {
     class: className,
+    conversation,
     atBottom = $bindable(true),
     unreadCount = $bindable(0),
     newMessageIndicatorVisible = $bindable(false),
@@ -31,6 +33,17 @@
   }: ChatProps = $props();
 
   const mergedClassName = $derived(classNames(className));
+  let warnedSchemaVersion: number | undefined;
+
+  $effect(() => {
+    const schemaVersion = conversation.schemaVersion;
+    if (schemaVersion <= CURRENT_SCHEMA_VERSION || warnedSchemaVersion === schemaVersion) return;
+
+    warnedSchemaVersion = schemaVersion;
+    console.warn(
+      `[Chat] Conversation schema version ${schemaVersion} is newer than the supported version ${CURRENT_SCHEMA_VERSION}. Upgrade @lostgradient/chat before relying on this history.`,
+    );
+  });
 
   function handleAtBottomBindingChange(value: boolean): void {
     atBottom = value;
@@ -119,6 +132,7 @@
 <ChatImplementation
   bind:this={impl}
   {...rest}
+  {conversation}
   {atBottom}
   {unreadCount}
   {newMessageIndicatorVisible}

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -15,6 +15,8 @@
    * @related markdown-editor
    */
   export type { ChatAnnounceLevel, ChatProps } from './chat.types.ts';
+
+  const warnedSchemaVersions = new Set<number>();
 </script>
 
 <script lang="ts">
@@ -33,16 +35,22 @@
   }: ChatProps = $props();
 
   const mergedClassName = $derived(classNames(className));
-  let warnedSchemaVersion: number | undefined;
 
-  $effect(() => {
-    const schemaVersion = conversation.schemaVersion;
-    if (schemaVersion <= CURRENT_SCHEMA_VERSION || warnedSchemaVersion === schemaVersion) return;
+  function warnForSchemaVersion(schemaVersion: number): void {
+    if (schemaVersion <= CURRENT_SCHEMA_VERSION || warnedSchemaVersions.has(schemaVersion)) return;
 
-    warnedSchemaVersion = schemaVersion;
+    warnedSchemaVersions.add(schemaVersion);
     console.warn(
       `[Chat] Conversation schema version ${schemaVersion} is newer than the supported version ${CURRENT_SCHEMA_VERSION}. Upgrade @lostgradient/chat before relying on this history.`,
     );
+  }
+
+  // Run during both SSR and client initialization so a server-rendered Chat
+  // still surfaces an incompatible history when it is never hydrated.
+  warnForSchemaVersion(conversation.schemaVersion);
+
+  $effect(() => {
+    warnForSchemaVersion(conversation.schemaVersion);
   });
 
   function handleAtBottomBindingChange(value: boolean): void {

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -18,10 +18,10 @@
 </script>
 
 <script lang="ts">
-  import { CURRENT_SCHEMA_VERSION } from 'conversationalist/versioning';
   import { classNames } from '../../utilities/class-names.ts';
   import ChatImplementation from './container/chat.svelte';
   import type { ChatAnnounceLevel, ChatProps } from './chat.types.ts';
+  import { CURRENT_SCHEMA_VERSION } from './index.ts';
 
   let {
     class: className,

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -242,6 +242,28 @@ describe('Chat — basic render', () => {
     expect(region?.id).toBe('chat-basic');
   });
 
+  test('warns when a conversation requires a newer schema version', async () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => warnings.push(args);
+
+    try {
+      const conversation = createConversation({ id: 'future-schema' });
+      conversation.schemaVersion = 6;
+      render(Chat, {
+        props: { id: 'future-schema-chat', conversation },
+      });
+      await tick();
+
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]?.[0]).toBe(
+        '[Chat] Conversation schema version 6 is newer than the supported version 5. Upgrade @lostgradient/chat before relying on this history.',
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
   test('derives the timeline id from the component id', () => {
     const conversation = createConversation({ id: 'conversation-timeline' });
     const { container } = render(Chat, {

--- a/packages/chat/src/lib/components/chat/chat.test.ts
+++ b/packages/chat/src/lib/components/chat/chat.test.ts
@@ -250,15 +250,26 @@ describe('Chat — basic render', () => {
     try {
       const conversation = createConversation({ id: 'future-schema' });
       conversation.schemaVersion = 6;
-      render(Chat, {
+      const first = render(Chat, {
         props: { id: 'future-schema-chat', conversation },
       });
       await tick();
 
-      expect(warnings).toHaveLength(1);
-      expect(warnings[0]?.[0]).toBe(
+      const newerConversation = { ...conversation, schemaVersion: 7 };
+      first.rerender({ conversation: newerConversation });
+      await tick();
+      first.rerender({ conversation });
+      await tick();
+      render(Chat, {
+        props: { id: 'second-future-schema-chat', conversation },
+      });
+      await tick();
+
+      expect(warnings).toHaveLength(2);
+      expect(warnings.map((warning) => warning[0])).toEqual([
         '[Chat] Conversation schema version 6 is newer than the supported version 5. Upgrade @lostgradient/chat before relying on this history.',
-      );
+        '[Chat] Conversation schema version 7 is newer than the supported version 5. Upgrade @lostgradient/chat before relying on this history.',
+      ]);
     } finally {
       console.warn = originalWarn;
     }


### PR DESCRIPTION
Closes #896

Implement the documented forward-schema contract at the public Chat conversation boundary. Chat now warns once per newer schema version, while preserving the immutable history for consumers to decide how to recover. Update the README contract and add a runtime regression test plus patch changeset.

Validation:
- `bun test --conditions browser --conditions svelte --parallel=1 src/lib/components/chat/chat.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run components:check`