### PR TITLE
fix(chat): single-flight message retries

### DIFF
--- a/.changeset/retry-message-single-flight.md
+++ b/.changeset/retry-message-single-flight.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Prevent concurrent retry actions for the same failed message from dispatching duplicate adapter commands.

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -294,6 +294,38 @@ describe('ChatAdapter — command equivalence', () => {
     unmount(instance);
   });
 
+  test('does not let an old conversation clear a newer retry flight', async () => {
+    let calls = 0;
+    const releases: Array<() => void> = [];
+    const adapter: ChatAdapter = {
+      sendMessage: async () => {},
+      retryMessage: async () => {
+        calls += 1;
+        await new Promise<void>((resolve) => releases.push(resolve));
+      },
+    };
+    const instance = mount(AdapterSwitchFixture, {
+      target: document.body,
+      props: { initial: failedConversation('conversation-a'), adapter },
+    }) as unknown as SwitchFixtureInstance;
+    const container = document.body;
+    flushSync();
+
+    clickRetry(container);
+    instance.setConversation(failedConversation('conversation-b'));
+    flushSync();
+    clickRetry(container);
+    expect(calls).toBe(2);
+
+    releases[0]?.();
+    await Promise.resolve();
+    clickRetry(container);
+    expect(calls).toBe(2);
+
+    releases[1]?.();
+    unmount(instance);
+  });
+
   test('the adapter takes precedence over the callback (no double-dispatch)', async () => {
     const adapterRetried: string[] = [];
     const callbackRetried: string[] = [];

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -264,6 +264,36 @@ describe('ChatAdapter — command equivalence', () => {
     unmount(instance);
   });
 
+  test('single-flights concurrent retries for the same message', async () => {
+    let calls = 0;
+    let release!: () => void;
+    const retryFinished = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const adapter: ChatAdapter = {
+      sendMessage: async () => {},
+      retryMessage: async () => {
+        calls += 1;
+        await retryFinished;
+      },
+    };
+    const { container, instance } = mountChat({
+      id: 'chat-retry-single-flight',
+      conversation: failedConversation(),
+      adapter,
+    });
+
+    clickRetry(container);
+    clickRetry(container);
+    await Promise.resolve();
+    expect(calls).toBe(1);
+
+    release();
+    await retryFinished;
+
+    unmount(instance);
+  });
+
   test('the adapter takes precedence over the callback (no double-dispatch)', async () => {
     const adapterRetried: string[] = [];
     const callbackRetried: string[] = [];

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -206,6 +206,7 @@
   // part re-derives to show the resolved state.
   let approvedToolCallIds = $state(new Set<string>());
   let deniedToolCallIds = $state(new Set<string>());
+  let pendingRetryMessageIds = $state(new Set<string>());
 
   // Per-message disclosure state (reasoning blocks + tool-call cards). UI-only;
   // never written to the transcript. Both are collapsed by default; toggling
@@ -233,6 +234,7 @@
   $effect(() => {
     conversationId;
     approvedToolCallIds = new Set();
+    pendingRetryMessageIds = new Set();
     deniedToolCallIds = new Set();
     reasoningState.reset();
     toolCallState.reset();
@@ -1156,16 +1158,28 @@
   }
 
   function handleRetry(messageId: string): void {
-    void dispatchCommand(
-      'retryMessage',
-      // Return `undefined` ONLY when the optional method is absent; otherwise
-      // wrap its result so a present-but-sync method still counts as handled.
-      (resolvedAdapter) =>
-        resolvedAdapter.retryMessage
-          ? Promise.resolve(resolvedAdapter.retryMessage(messageId))
-          : undefined,
-      () => onretry?.(messageId),
-    );
+    if (pendingRetryMessageIds.has(messageId)) return;
+    pendingRetryMessageIds = new Set([...pendingRetryMessageIds, messageId]);
+    const clearPending = (): void => {
+      pendingRetryMessageIds = removeFromSet(pendingRetryMessageIds, messageId);
+    };
+    try {
+      const run = dispatchCommand(
+        'retryMessage',
+        // Return `undefined` ONLY when the optional method is absent; otherwise
+        // wrap its result so a present-but-sync method still counts as handled.
+        (resolvedAdapter) =>
+          resolvedAdapter.retryMessage
+            ? Promise.resolve(resolvedAdapter.retryMessage(messageId))
+            : undefined,
+        () => onretry?.(messageId),
+      );
+      if (run !== undefined) void run.finally(clearPending);
+      else clearPending();
+    } catch (error) {
+      clearPending();
+      throw error;
+    }
   }
 
   function handleEdit(event: { messageId: string; content: string }): void {

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -206,7 +206,7 @@
   // part re-derives to show the resolved state.
   let approvedToolCallIds = $state(new Set<string>());
   let deniedToolCallIds = $state(new Set<string>());
-  let pendingRetryMessageIds = $state(new Set<string>());
+  let pendingRetryMessageTokens = $state(new Map<string, symbol>());
 
   // Per-message disclosure state (reasoning blocks + tool-call cards). UI-only;
   // never written to the transcript. Both are collapsed by default; toggling
@@ -234,7 +234,7 @@
   $effect(() => {
     conversationId;
     approvedToolCallIds = new Set();
-    pendingRetryMessageIds = new Set();
+    pendingRetryMessageTokens = new Map();
     deniedToolCallIds = new Set();
     reasoningState.reset();
     toolCallState.reset();
@@ -1158,10 +1158,14 @@
   }
 
   function handleRetry(messageId: string): void {
-    if (pendingRetryMessageIds.has(messageId)) return;
-    pendingRetryMessageIds = new Set([...pendingRetryMessageIds, messageId]);
+    if (pendingRetryMessageTokens.has(messageId)) return;
+    const flightToken = Symbol(messageId);
+    pendingRetryMessageTokens = new Map(pendingRetryMessageTokens).set(messageId, flightToken);
     const clearPending = (): void => {
-      pendingRetryMessageIds = removeFromSet(pendingRetryMessageIds, messageId);
+      if (pendingRetryMessageTokens.get(messageId) !== flightToken) return;
+      const next = new Map(pendingRetryMessageTokens);
+      next.delete(messageId);
+      pendingRetryMessageTokens = next;
     };
     try {
       const run = dispatchCommand(


### PR DESCRIPTION
Closes #897

## Summary
- Guard retry dispatches per message id while an adapter retry is in flight.
- Clear the guard on completion, rejection, synchronous handling, or conversation changes.
- Add a concurrent retry regression and a chat patch changeset.

## Validation
- bun test --conditions browser --conditions svelte --parallel=1 src/lib/components/chat/adapter/chat-adapter.test.ts
- bun run --filter=@lostgradient/chat lint
- bun run --filter=@lostgradient/chat typecheck
- bun run --filter=@lostgradient/chat components:check
- bun run --filter=@lostgradient/chat build