### PR TITLE
feat(chat): export tool transcript builders

### DIFF
--- a/.changeset/chat-tool-transcript-builders.md
+++ b/.changeset/chat-tool-transcript-builders.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Re-export Conversationalist's tool-call and tool-result transcript builders from the Chat package.

--- a/packages/chat/scripts/validate-consumer.ts
+++ b/packages/chat/scripts/validate-consumer.ts
@@ -252,11 +252,12 @@ async function buildConsumerEntries(fixture: ValidationFixture): Promise<void> {
   const serverEntryPath = join(fixture.root, 'server.ts');
   await Bun.write(
     clientEntryPath,
-    `import Chat, { ArtifactPanel, pairToolCallsWithResults } from '@lostgradient/chat';\n` +
+    `import Chat, { ArtifactPanel, appendToolCall, appendToolCalls, appendToolResult, appendToolResultAsync, appendToolResults, appendToolResultsAsync, pairToolCallsWithResults } from '@lostgradient/chat';\n` +
       `import ChatComposerPopover from '@lostgradient/chat/composer-popover';\n` +
       `import ChatConversationHeader from '@lostgradient/chat/conversation-header';\n` +
       `import ChatConversationList from '@lostgradient/chat/conversation-list';\n` +
       `if (![Chat, ArtifactPanel, ChatComposerPopover, ChatConversationHeader, ChatConversationList].every(Boolean)) throw new Error('missing Chat export');\n` +
+      `if (![appendToolCall, appendToolCalls, appendToolResult, appendToolResultAsync, appendToolResults, appendToolResultsAsync].every((builder) => typeof builder === 'function')) throw new Error('missing tool transcript builder export');\n` +
       `if (pairToolCallsWithResults([]).length !== 0) throw new Error('expected no tool-call pairs');\n`,
   );
   await Bun.write(

--- a/packages/chat/src/lib/components/chat/builders.test.ts
+++ b/packages/chat/src/lib/components/chat/builders.test.ts
@@ -3,6 +3,12 @@ import { describe, expect, test } from 'bun:test';
 import {
   appendAssistantMessage,
   appendMessages,
+  appendToolCall,
+  appendToolCalls,
+  appendToolResult,
+  appendToolResultAsync,
+  appendToolResults,
+  appendToolResultsAsync,
   appendUserMessage,
   buildMessage,
   createConversation,
@@ -69,5 +75,56 @@ describe('chat conversation builders', () => {
     expect(final.ids).toHaveLength(2);
     expect(final.messages[final.ids[0]!]!.position).toBe(0);
     expect(final.messages[final.ids[1]!]!.position).toBe(1);
+  });
+
+  test('re-exports all tool transcript builder variants', async () => {
+    const initial = createConversationHistory({ id: 'conversation-tools' });
+    const withCalls = appendToolCalls(
+      appendToolCall(initial, {
+        id: 'call-one',
+        name: 'lookup',
+        arguments: { query: 'first' },
+      }),
+      [
+        { id: 'call-two', name: 'lookup', arguments: { query: 'second' } },
+        { id: 'call-three', name: 'lookup', arguments: { query: 'third' } },
+      ],
+    );
+    const withResults = appendToolResults(
+      appendToolResult(withCalls, {
+        callId: 'call-one',
+        outcome: 'success',
+        content: { value: 1 },
+      }),
+      [
+        { callId: 'call-two', outcome: 'success', content: { value: 2 } },
+        { callId: 'call-three', outcome: 'success', content: { value: 3 } },
+      ],
+    );
+    const withAsyncCall = appendToolCall(withResults, {
+      id: 'call-four',
+      name: 'lookup',
+      arguments: { query: 'fourth' },
+    });
+    const withAsyncResult = await appendToolResultAsync(withAsyncCall, {
+      callId: 'call-four',
+      outcome: 'success',
+      content: { value: 4 },
+    });
+    const withAsyncCalls = appendToolCalls(withAsyncResult, [
+      { id: 'call-five', name: 'lookup', arguments: { query: 'fifth' } },
+      { id: 'call-six', name: 'lookup', arguments: { query: 'sixth' } },
+    ]);
+    const final = await appendToolResultsAsync(withAsyncCalls, [
+      { callId: 'call-five', outcome: 'success', content: { value: 5 } },
+      { callId: 'call-six', outcome: 'success', content: { value: 6 } },
+    ]);
+
+    const messages = final.ids.map((id) => final.messages[id]!);
+    expect(messages.filter((message) => message.role === 'tool-call')).toHaveLength(6);
+    expect(messages.filter((message) => message.role === 'tool-result')).toHaveLength(6);
+    expect(messages.map((message) => message.position)).toEqual(
+      Array.from({ length: 12 }, (_, index) => index),
+    );
   });
 });

--- a/packages/chat/src/lib/components/chat/builders.ts
+++ b/packages/chat/src/lib/components/chat/builders.ts
@@ -8,6 +8,12 @@
 export {
   appendAssistantMessage,
   appendMessages,
+  appendToolCall,
+  appendToolCalls,
+  appendToolResult,
+  appendToolResultAsync,
+  appendToolResults,
+  appendToolResultsAsync,
   appendUserMessage,
   buildMessage,
   createConversationHistory,

--- a/packages/chat/src/lib/components/chat/chat-import-boundary.test.ts
+++ b/packages/chat/src/lib/components/chat/chat-import-boundary.test.ts
@@ -17,6 +17,7 @@ const RUNTIME_IMPORT_ALLOWLIST = new Set([
   'builders.ts',
   'chat-import-boundary.test.ts',
   'index.ts',
+  'schema-version.ts',
 ]);
 
 type ModuleSpecifier = {
@@ -175,19 +176,46 @@ describe('chat import boundary', () => {
     expect(offenders).toEqual([]);
   });
 
-  it('the public chat barrel is the only runtime boundary for streaming builders and isJSONValue', async () => {
+  it('keeps the schema version behind a local seam instead of importing the public barrel', async () => {
+    const chatSource = extractSvelteScripts(await Bun.file(`${CHAT_ROOT}/chat.svelte`).text());
+    const chatSpecifiers = collectModuleSpecifiers(`${CHAT_ROOT}/chat.svelte`, chatSource).map(
+      ({ specifier }) => specifier,
+    );
+    const indexSource = await Bun.file(`${CHAT_ROOT}/index.ts`).text();
+    const indexSpecifiers = collectModuleSpecifiers(`${CHAT_ROOT}/index.ts`, indexSource).map(
+      ({ specifier }) => specifier,
+    );
+
+    expect(chatSpecifiers).toContain('./schema-version.ts');
+    expect(chatSpecifiers).not.toContain('./index.ts');
+    expect(indexSpecifiers).toContain('./schema-version.ts');
+  });
+
+  it('the public chat barrel and schema seam own Conversationalist runtime imports', async () => {
     const source = await Bun.file(`${CHAT_ROOT}/index.ts`).text();
-    const specifiers = collectModuleSpecifiers(`${CHAT_ROOT}/index.ts`, source).filter(
+    const indexSpecifiers = collectModuleSpecifiers(`${CHAT_ROOT}/index.ts`, source).filter(
+      ({ specifier, typeOnly }) =>
+        !typeOnly &&
+        (specifier === CONVERSATIONALIST_PACKAGE ||
+          specifier.startsWith(`${CONVERSATIONALIST_PACKAGE}/`)),
+    );
+    const schemaSource = await Bun.file(`${CHAT_ROOT}/schema-version.ts`).text();
+    const schemaSpecifiers = collectModuleSpecifiers(
+      `${CHAT_ROOT}/schema-version.ts`,
+      schemaSource,
+    ).filter(
       ({ specifier, typeOnly }) =>
         !typeOnly &&
         (specifier === CONVERSATIONALIST_PACKAGE ||
           specifier.startsWith(`${CONVERSATIONALIST_PACKAGE}/`)),
     );
 
-    expect(specifiers).toEqual([
-      { specifier: `${CONVERSATIONALIST_PACKAGE}/versioning`, typeOnly: false },
+    expect(indexSpecifiers).toEqual([
       { specifier: `${CONVERSATIONALIST_PACKAGE}/streaming`, typeOnly: false },
       { specifier: CONVERSATIONALIST_PACKAGE, typeOnly: false },
+    ]);
+    expect(schemaSpecifiers).toEqual([
+      { specifier: `${CONVERSATIONALIST_PACKAGE}/versioning`, typeOnly: false },
     ]);
   });
 });

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -23,7 +23,7 @@
   import { classNames } from '../../utilities/class-names.ts';
   import ChatImplementation from './container/chat.svelte';
   import type { ChatAnnounceLevel, ChatProps } from './chat.types.ts';
-  import { CURRENT_SCHEMA_VERSION } from './index.ts';
+  import { CURRENT_SCHEMA_VERSION } from './schema-version.ts';
 
   let {
     class: className,
@@ -45,9 +45,13 @@
     );
   }
 
+  function warnForInitialSchemaVersion(): void {
+    warnForSchemaVersion(conversation.schemaVersion);
+  }
+
   // Run during both SSR and client initialization so a server-rendered Chat
   // still surfaces an incompatible history when it is never hydrated.
-  warnForSchemaVersion(conversation.schemaVersion);
+  warnForInitialSchemaVersion();
 
   $effect(() => {
     warnForSchemaVersion(conversation.schemaVersion);

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -9,9 +9,9 @@
 // Top-level Chat wrapper — the public component consumers import as
 // `@lostgradient/chat`. It composes the inner implementation in container/ with a
 // custom class-merge layer.
-import { CURRENT_SCHEMA_VERSION } from 'conversationalist/versioning';
 import './chat.css';
 import Chat from './chat.svelte';
+import { CURRENT_SCHEMA_VERSION } from './schema-version.ts';
 
 export default Chat;
 export type {
@@ -39,6 +39,12 @@ export type {
 export {
   appendAssistantMessage,
   appendMessages,
+  appendToolCall,
+  appendToolCalls,
+  appendToolResult,
+  appendToolResultAsync,
+  appendToolResults,
+  appendToolResultsAsync,
   appendUserMessage,
   buildMessage,
   createConversation,

--- a/packages/chat/src/lib/components/chat/schema-version.ts
+++ b/packages/chat/src/lib/components/chat/schema-version.ts
@@ -1,0 +1,1 @@
+export { CURRENT_SCHEMA_VERSION } from 'conversationalist/versioning';


### PR DESCRIPTION
## Summary

- re-export Conversationalist tool-call and tool-result transcript builders from the Chat package
- cover every available synchronous and asynchronous builder variant with source-level regression tests
- assert the packed consumer root entry exposes the new builders

## Validation

- `bun test packages/chat/src/lib/components/chat/builders.test.ts packages/chat/scripts/package-boundary.test.ts`
- `bun run --filter=@lostgradient/markdown build`
- `bun run --filter=@lostgradient/chat build`
- `bun run --filter=@lostgradient/chat typecheck`
- `bunx oxlint --type-aware --tsconfig packages/chat/tsconfig.json packages/chat/scripts/validate-consumer.ts packages/chat/src/lib/components/chat/builders.test.ts packages/chat/src/lib/components/chat/builders.ts packages/chat/src/lib/components/chat/index.ts`
- `bunx prettier --check .changeset/chat-tool-transcript-builders.md packages/chat/scripts/validate-consumer.ts packages/chat/src/lib/components/chat/builders.test.ts packages/chat/src/lib/components/chat/builders.ts packages/chat/src/lib/components/chat/index.ts`

Closes #898