### PR TITLE
fix(faceted-filter-bar): prevent select text clipping

### DIFF
--- a/.changeset/faceted-filter-select-height.md
+++ b/.changeset/faceted-filter-select-height.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Prevent FacetedFilterBar select labels from clipping by allowing controls to grow to fit their line box.

--- a/packages/components/src/components/faceted-filter-bar/faceted-filter-bar.css
+++ b/packages/components/src/components/faceted-filter-bar/faceted-filter-bar.css
@@ -54,7 +54,7 @@
     font: inherit;
     font-size: var(--cinder-text-sm);
     line-height: var(--cinder-leading-normal);
-    block-size: var(--cinder-control-height-sm, 2rem);
+    min-block-size: var(--cinder-control-height-sm, 2rem);
     cursor: pointer;
     transition:
       border-color var(--cinder-duration-fast) var(--cinder-ease-standard),

--- a/packages/components/src/components/faceted-filter-bar/faceted-filter-bar.test.ts
+++ b/packages/components/src/components/faceted-filter-bar/faceted-filter-bar.test.ts
@@ -344,6 +344,8 @@ describe('FacetedFilterBar CSS snapshot', () => {
     expect(css).toContain('@layer cinder.components');
     expect(css).toContain('.cinder-faceted-filter-bar');
     expect(css).toContain('.cinder-faceted-filter-bar__select:focus-visible');
+    expect(css).toContain('min-block-size: var(--cinder-control-height-sm, 2rem);');
+    expect(css).not.toMatch(/^\s*block-size: var\(--cinder-control-height-sm, 2rem\);/m);
     expect(css).toContain('outline: var(--cinder-ring-width) solid transparent');
     expect(css).toContain('@media (forced-colors: active)');
     expect(css).toContain('outline: var(--cinder-ring-width) solid ButtonText');


### PR DESCRIPTION
Closes #906

Use min-block-size for facet selects so padding and the declared line box can fit without clipping labels. Add a CSS regression assertion and patch changeset.

Validation:
- `bun test --conditions browser --conditions svelte --parallel=1 src/components/faceted-filter-bar/faceted-filter-bar.test.ts`
- `bun run lint`
- `bun run components:check`