### PR TITLE
fix(stat-group): load nested Stat styles

### DIFF
--- a/.changeset/stat-group-styles.md
+++ b/.changeset/stat-group-styles.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Load Stat styles when using the StatGroup compound component API.

--- a/packages/components/src/components/stat-group/index.ts
+++ b/packages/components/src/components/stat-group/index.ts
@@ -1,4 +1,4 @@
-import Stat from '../stat/stat.svelte';
+import Stat from '../stat/index.ts';
 import './stat-group.css';
 import StatGroupRoot from './stat-group.svelte';
 

--- a/packages/components/src/components/stat-group/index.ts
+++ b/packages/components/src/components/stat-group/index.ts
@@ -1,4 +1,4 @@
-import Stat from '../stat/index.ts';
+import Stat from '../stat/stat.svelte';
 import './stat-group.css';
 import StatGroupRoot from './stat-group.svelte';
 

--- a/packages/components/src/components/stat-group/stat-group.css
+++ b/packages/components/src/components/stat-group/stat-group.css
@@ -1,3 +1,5 @@
+@import '../stat/stat.css';
+
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
 @layer cinder.components {
   .cinder-stat-group {

--- a/packages/components/src/components/stat-group/stat-group.css
+++ b/packages/components/src/components/stat-group/stat-group.css
@@ -1,6 +1,5 @@
-@import '../stat/stat.css';
-
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../stat/stat.css';
 @layer cinder.components {
   .cinder-stat-group {
     --cinder-stat-group-gap: var(--cinder-space-4, 1rem);

--- a/packages/components/src/components/stat-group/stat-group.test.ts
+++ b/packages/components/src/components/stat-group/stat-group.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -19,6 +20,12 @@ function textSnippet(text: string) {
 }
 
 describe('StatGroup', () => {
+  test('loads the Stat entrypoint so compound Stat styles are registered', async () => {
+    const source = await readFile(new URL('./index.ts', import.meta.url), 'utf8');
+    expect(source).toContain("import Stat from '../stat/index.ts';");
+    expect(source).not.toContain("import Stat from '../stat/stat.svelte';");
+  });
+
   test('renders .cinder-stat-group wrapping its children', () => {
     const { container } = render(StatGroup, {
       children: textSnippet('stat content'),

--- a/packages/components/src/components/stat-group/stat-group.test.ts
+++ b/packages/components/src/components/stat-group/stat-group.test.ts
@@ -20,10 +20,10 @@ function textSnippet(text: string) {
 }
 
 describe('StatGroup', () => {
-  test('loads the Stat entrypoint so compound Stat styles are registered', async () => {
+  test('imports the Stat leaf source for compound namespace composition', async () => {
     const source = await readFile(new URL('./index.ts', import.meta.url), 'utf8');
-    expect(source).toContain("import Stat from '../stat/index.ts';");
-    expect(source).not.toContain("import Stat from '../stat/stat.svelte';");
+    expect(source).toContain("import Stat from '../stat/stat.svelte';");
+    expect(source).not.toContain("import Stat from '../stat/index.ts';");
   });
 
   test('aggregates Stat styles in the parent CSS sidecar', async () => {

--- a/packages/components/src/components/stat-group/stat-group.test.ts
+++ b/packages/components/src/components/stat-group/stat-group.test.ts
@@ -26,6 +26,11 @@ describe('StatGroup', () => {
     expect(source).not.toContain("import Stat from '../stat/stat.svelte';");
   });
 
+  test('aggregates Stat styles in the parent CSS sidecar', async () => {
+    const css = await Bun.file(new URL('./stat-group.css', import.meta.url)).text();
+    expect(css).toContain("@import '../stat/stat.css';");
+  });
+
   test('renders .cinder-stat-group wrapping its children', () => {
     const { container } = render(StatGroup, {
       children: textSnippet('stat content'),


### PR DESCRIPTION
Closes #905

Route StatGroup.Stat through the Stat public entrypoint so its stylesheet side effect is included for compound API consumers. Add a regression guard and a patch changeset.

Validation:
- `bun test --conditions browser --conditions svelte --parallel=1 src/components/stat-group/stat-group.test.ts`
- `bun run lint`
- `bun run components:check`