### PR TITLE
fix(select): improve label parity and invalid value diagnostics

### DIFF
--- a/.changeset/select-label-and-value-diagnostics.md
+++ b/.changeset/select-label-and-value-diagnostics.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Add visually hidden Select labels and warn when a bound value does not match any option.

--- a/packages/components/src/components/select/README.md
+++ b/packages/components/src/components/select/README.md
@@ -21,6 +21,7 @@ Native-style dropdown select for choosing a single option from a predefined list
 | `description` | `string`   | no       | —       | Helper text rendered below the control; wired via `aria-describedby`.                                                                                 |
 | `disabled`    | `boolean`  | no       | —       | Disables the control.                                                                                                                                 |
 | `error`       | `string`   | no       | —       | Validation error message; sets `aria-invalid="true"` and is wired via `aria-describedby`.                                                             |
+| `hideLabel`   | `boolean`  | no       | —       | Visually hides the label while keeping it available to assistive technology.                                                                          |
 | `id`          | `string`   | yes      | —       | Unique identifier — required for label association and ARIA wiring.                                                                                   |
 | `label`       | `string`   | no       | —       | Visible label rendered in a `<label>` associated via `for`.                                                                                           |
 | `required`    | `boolean`  | no       | —       | Marks the control required and sets the native `required` attribute.                                                                                  |

--- a/packages/components/src/components/select/select.schema.json
+++ b/packages/components/src/components/select/select.schema.json
@@ -18,6 +18,10 @@
       "type": "string",
       "description": "Visible label rendered in a `<label>` associated via `for`."
     },
+    "hideLabel": {
+      "type": "boolean",
+      "description": "Visually hides the label while keeping it available to assistive technology."
+    },
     "description": {
       "type": "string",
       "description": "Helper text rendered below the control; wired via `aria-describedby`."

--- a/packages/components/src/components/select/select.schema.ts
+++ b/packages/components/src/components/select/select.schema.ts
@@ -20,6 +20,10 @@ const schema = {
       type: 'string',
       description: 'Visible label rendered in a `<label>` associated via `for`.',
     },
+    hideLabel: {
+      type: 'boolean',
+      description: 'Visually hides the label while keeping it available to assistive technology.',
+    },
     description: {
       type: 'string',
       description: 'Helper text rendered below the control; wired via `aria-describedby`.',

--- a/packages/components/src/components/select/select.svelte
+++ b/packages/components/src/components/select/select.svelte
@@ -27,6 +27,7 @@
     value = $bindable(),
     options,
     label,
+    hideLabel = false,
     description,
     error,
     required,
@@ -67,13 +68,21 @@
       devWarn(
         '[cinder/Select] options is empty — pass at least one option, or ignore during async load.',
       );
+    } else if (value !== undefined && !options.some((option) => option.value === value)) {
+      devWarn(
+        '[cinder/Select] value does not match any option — pass a value from options or omit it.',
+      );
     }
   });
 </script>
 
 <div class={classNames('cinder-select-field', className)}>
   {#if label}
-    <label for={id} class="cinder-select-field__label" data-disabled={field.disabled || undefined}>
+    <label
+      for={id}
+      class={classNames('cinder-select-field__label', hideLabel && 'cinder-sr-only')}
+      data-disabled={field.disabled || undefined}
+    >
       {label}
       {#if field.required}
         <span class="cinder-_required-marker" aria-hidden="true">*</span>

--- a/packages/components/src/components/select/select.test.ts
+++ b/packages/components/src/components/select/select.test.ts
@@ -94,6 +94,22 @@ describe('Select', () => {
     expect(labelEl!.textContent?.trim()).toBe('Choose one');
   });
 
+  test('hideLabel keeps the label available to assistive technology while hiding it visually', () => {
+    const { container } = render(Select, {
+      props: {
+        id: 'hidden-label-select',
+        value: 'a',
+        options: defaultOptions,
+        label: 'Choose one',
+        hideLabel: true,
+      },
+    });
+    const labelEl = container.querySelector('label[for="hidden-label-select"]');
+    expect(labelEl).not.toBeNull();
+    expect(labelEl!.textContent?.trim()).toBe('Choose one');
+    expect(labelEl!.classList.contains('cinder-sr-only')).toBe(true);
+  });
+
   test('on user change event, bound value updates', async () => {
     const { container } = render(Select, {
       props: { id: 'test-select', value: 'a', options: defaultOptions },
@@ -114,6 +130,23 @@ describe('Select', () => {
       expect(selectEl!.getAttribute('data-cinder-empty')).toBe('true');
       expect(warnSpy).toHaveBeenCalledWith(
         '[cinder/Select] options is empty — pass at least one option, or ignore during async load.',
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test('unmatched value: dev warning emitted while retaining the native select', () => {
+    const warnSpy = spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { container } = render(Select, {
+        props: { id: 'unmatched-select', value: 'missing', options: defaultOptions },
+      });
+      const selectEl = container.querySelector('select#unmatched-select') as HTMLSelectElement;
+      expect(selectEl).not.toBeNull();
+      expect(selectEl.selectedIndex).toBe(-1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[cinder/Select] value does not match any option — pass a value from options or omit it.',
       );
     } finally {
       warnSpy.mockRestore();

--- a/packages/components/src/components/select/select.types.ts
+++ b/packages/components/src/components/select/select.types.ts
@@ -15,6 +15,8 @@ export type SelectProps<T extends string = string> = HTMLSelectAttributes & {
   options: readonly SelectOption<T>[];
   /** Visible label rendered in a `<label>` associated via `for`. */
   label?: string;
+  /** Visually hides the label while keeping it available to assistive technology. */
+  hideLabel?: boolean;
   /** Helper text rendered below the control; wired via `aria-describedby`. */
   description?: string;
   /** Validation error message; sets `aria-invalid="true"` and is wired via `aria-describedby`. */


### PR DESCRIPTION
Closes #907
Closes #908

Summary:
- add Select hideLabel parity with Input while preserving the accessible label
- warn in development when a non-empty Select value does not match any option
- add regression tests and regenerate Select schema/README metadata

Validation:
- bun test --conditions browser --conditions svelte --parallel=1 src/components/select/select.test.ts
- bun run --filter=@lostgradient/cinder lint
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder components:check