### PR TITLE
fix(chat): preserve typing indicator height

### DIFF
--- a/.changeset/chat-typing-indicator-flex.md
+++ b/.changeset/chat-typing-indicator-flex.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Prevent the participant typing indicator from flex-collapsing when the transcript overflows.

--- a/packages/chat/src/lib/components/chat/chat-typing-indicator.test.ts
+++ b/packages/chat/src/lib/components/chat/chat-typing-indicator.test.ts
@@ -592,6 +592,14 @@ describe('useChatTypingIndicator — debounce timer paths via adapter push', () 
 // ---------------------------------------------------------------------------
 
 describe('Chat — no scroll jump: outer typing wrapper always in DOM', () => {
+  test('participant typing wrapper cannot flex-collapse when the transcript overflows', async () => {
+    const source = await Bun.file(
+      `${import.meta.dir}/container/chat-participant-typing.svelte`,
+    ).text();
+
+    expect(source).toMatch(/\.chat-participant-typing\s*\{[^}]*flex-shrink:\s*0;/);
+  });
+
   test('participant typing outer wrapper is present even with no typingParticipants (prevents scroll-jump)', () => {
     // Regression guard: the outer .chat-participant-typing div must be in DOM
     // regardless of message count or typing state. If it were absent and then

--- a/packages/chat/src/lib/components/chat/container/chat-participant-typing.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat-participant-typing.svelte
@@ -55,6 +55,7 @@
   .chat-participant-typing {
     /* Reserve no space when empty — the inner content drives height. */
     min-height: 0;
+    flex-shrink: 0;
   }
 
   .chat-participant-typing-indicator {


### PR DESCRIPTION
## Summary

- prevent the typing indicator row from flex-collapsing when the transcript overflows
- add a source-level regression that guards the wrapper flex contract
- add a patch changeset for @lostgradient/chat

## Validation

- TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/chat/src/lib/components/chat/chat-typing-indicator.test.ts
- bun run --filter=@lostgradient/chat build
- bun run --filter=@lostgradient/chat typecheck
- bunx oxlint --type-aware --tsconfig packages/chat/tsconfig.json packages/chat/src/lib/components/chat/chat-typing-indicator.test.ts packages/chat/src/lib/components/chat/container/chat-participant-typing.svelte
- bunx stylelint packages/chat/src/lib/components/chat/container/chat-participant-typing.svelte

Closes #910