### PR TITLE
fix(logo-cloud): honor requested columns

### DIFF
--- a/.changeset/fuzzy-logos-count.md
+++ b/.changeset/fuzzy-logos-count.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Make LogoCloud honor column counts from three through six at its base container size.

--- a/packages/components/src/components/logo-cloud/logo-cloud.css
+++ b/packages/components/src/components/logo-cloud/logo-cloud.css
@@ -36,19 +36,19 @@
   }
 
   .cinder-logo-cloud[data-cinder-columns='3'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud[data-cinder-columns='4'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud__item {

--- a/packages/testing/tests/logo-cloud-columns.playwright.ts
+++ b/packages/testing/tests/logo-cloud-columns.playwright.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+
+import { expect, test } from '@playwright/test';
+
+test('LogoCloud computes a distinct grid track for every supported column value', async ({
+  page,
+}) => {
+  const logoCloudCss = readFileSync(
+    new URL('../../components/src/components/logo-cloud/logo-cloud.css', import.meta.url),
+    'utf8',
+  );
+
+  await page.setContent(`
+    <style>
+      ${logoCloudCss}
+      .cinder-logo-cloud {
+        inline-size: 600px;
+      }
+    </style>
+    ${[2, 3, 4, 5, 6]
+      .map(
+        (columns) => `
+          <section class="cinder-logo-cloud" data-cinder-columns="${columns}">
+            <ul class="cinder-logo-cloud__list" data-testid="columns-${columns}">
+              ${Array.from({ length: columns }, () => '<li></li>').join('')}
+            </ul>
+          </section>
+        `,
+      )
+      .join('')}
+    <section class="cinder-logo-cloud">
+      <ul class="cinder-logo-cloud__list" data-testid="columns-default">
+        <li></li>
+        <li></li>
+      </ul>
+    </section>
+  `);
+
+  for (const columns of [2, 3, 4, 5, 6]) {
+    const computedTracks = await page
+      .getByTestId(`columns-${columns}`)
+      .evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(' '));
+    expect(computedTracks).toHaveLength(columns);
+  }
+
+  const defaultTracks = await page
+    .getByTestId('columns-default')
+    .evaluate((element) => getComputedStyle(element).gridTemplateColumns.split(' '));
+  expect(defaultTracks).toHaveLength(2);
+});


### PR DESCRIPTION
## Summary

- correct LogoCloud base grid selectors for column counts 3 through 6
- add a real-browser computed-style regression covering the default and every supported count
- add a patch changeset

## Verification

- `bun test ./packages/components/src/components/logo-cloud/logo-cloud.test.ts`
- `./node_modules/.bin/playwright test --config=packages/testing/playwright.config.ts packages/testing/tests/logo-cloud-columns.playwright.ts`
- `bun run --filter=@cinder/testing typecheck`
- `bunx stylelint packages/components/src/components/logo-cloud/logo-cloud.css`
- `bunx oxlint packages/testing/tests/logo-cloud-columns.playwright.ts`

Closes #924