### PR TITLE
fix(load-more): require fresh sentinel entry

### DIFF
--- a/.changeset/steady-load-more-sentinel.md
+++ b/.changeset/steady-load-more-sentinel.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Prevent LoadMore from repeatedly auto-loading while its sentinel remains within the observer root.

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -38,6 +38,7 @@
   let errorState = $state(false);
   let sentinelRequestCount = $state(0);
   let sentinelArmed = $state(true);
+  let sentinelIntersecting = $state(false);
   // Tracks the last `hasMore` value the component reconciled against so a
   // parent-driven false -> true flip (new page of data arrived) can clear the
   // sentinel request cap and error latch exactly once per transition.
@@ -69,6 +70,7 @@
     if (!previousHasMore && hasMore) {
       sentinelRequestCount = 0;
       sentinelArmed = true;
+      sentinelIntersecting = false;
       errorState = false;
     }
     previousHasMore = hasMore;
@@ -85,7 +87,7 @@
 
     if (source === 'sentinel') {
       sentinelRequestCount += 1;
-    } else {
+    } else if (sentinelIntersecting) {
       // A manual request is itself the explicit load trigger. Do not let an
       // already-visible sentinel immediately follow it with another request.
       sentinelArmed = false;
@@ -110,6 +112,8 @@
   }
 
   function handleIntersect(entry: IntersectionObserverEntry): void {
+    sentinelIntersecting = entry.isIntersecting;
+
     if (!entry.isIntersecting) {
       sentinelArmed = true;
       return;

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -42,6 +42,7 @@
   let sentinelIntersecting = $state(false);
   let sentinelReported = $state(false);
   let manualObserverSuspended = $state(false);
+  let manualObserverDisarmPending = false;
   let previousSentinelEnabled = false;
   let previousMaxRetries: number | undefined;
   // Tracks the last `hasMore` value the component reconciled against so a
@@ -91,8 +92,20 @@
         previousMaxRetries !== undefined &&
         maxRetries > previousMaxRetries
       ) {
-        sentinelArmed = true;
+        if (manualObserverDisarmPending) {
+          manualObserverDisarmPending = false;
+        } else {
+          sentinelArmed = true;
+        }
       }
+    }
+    if (
+      manualObserverDisarmPending &&
+      !requestInFlight &&
+      previousMaxRetries !== undefined &&
+      maxRetries === previousMaxRetries
+    ) {
+      manualObserverDisarmPending = false;
     }
     previousSentinelEnabled = sentinelEnabled;
     previousMaxRetries = maxRetries;
@@ -121,6 +134,7 @@
       sentinelReported = false;
       sentinelIntersecting = false;
       manualObserverSuspended = true;
+      manualObserverDisarmPending = true;
     }
 
     requestInFlight = true;

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -83,7 +83,6 @@
     if (!previousSentinelEnabled && sentinelEnabled) {
       sentinelReported = false;
       sentinelIntersecting = false;
-      sentinelArmed = true;
     }
     previousSentinelEnabled = sentinelEnabled;
   });

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -102,7 +102,7 @@
 
     if (source === 'sentinel') {
       sentinelRequestCount += 1;
-    } else if (!sentinelReported || sentinelIntersecting) {
+    } else if (!sentinelEnabled || !sentinelReported || sentinelIntersecting) {
       // A manual request is itself the explicit load trigger. Do not let an
       // unreported or already-visible sentinel immediately follow it with
       // another request.

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -86,7 +86,11 @@
     if (!previousSentinelEnabled && sentinelEnabled) {
       sentinelReported = false;
       sentinelIntersecting = false;
-      if (previousMaxRetries !== undefined && maxRetries > previousMaxRetries) {
+      if (
+        !manualObserverSuspended &&
+        previousMaxRetries !== undefined &&
+        maxRetries > previousMaxRetries
+      ) {
         sentinelArmed = true;
       }
     }

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -36,17 +36,16 @@
 
   let requestInFlight = $state(false);
   let errorState = $state(false);
-  let autoLoadCount = $state(0);
+  let sentinelRequestCount = $state(0);
+  let sentinelArmed = $state(true);
   // Tracks the last `hasMore` value the component reconciled against so a
-  // parent-driven false -> true flip (new page of data arrived) can clear both
-  // sentinel and error budgets exactly once per transition.
+  // parent-driven false -> true flip (new page of data arrived) can clear the
+  // sentinel request cap and error latch exactly once per transition.
   let previousHasMore = hasMore;
 
   const mergedClassName = $derived(classNames('cinder-load-more', customClassName));
   const busy = $derived(loading || requestInFlight);
-  const sentinelEnabled = $derived(
-    hasMore && !loading && !errorState && !requestInFlight && autoLoadCount < maxRetries,
-  );
+  const sentinelEnabled = $derived(hasMore && !errorState && sentinelRequestCount < maxRetries);
   // `enabled` is a getter, so `useIntersection`'s own `$effect` re-evaluates
   // `sentinelEnabled` reactively and toggles the observer in place. Constructing
   // the attachment once (rather than inside `$derived`) avoids tearing down and
@@ -68,7 +67,8 @@
   // cleared in `requestNextPage`'s `finally`, so neither needs an effect.
   $effect(() => {
     if (!previousHasMore && hasMore) {
-      autoLoadCount = 0;
+      sentinelRequestCount = 0;
+      sentinelArmed = true;
       errorState = false;
     }
     previousHasMore = hasMore;
@@ -79,12 +79,16 @@
       return;
     }
 
-    if (source === 'sentinel' && (errorState || autoLoadCount >= maxRetries)) {
+    if (source === 'sentinel' && (errorState || sentinelRequestCount >= maxRetries)) {
       return;
     }
 
     if (source === 'sentinel') {
-      autoLoadCount += 1;
+      sentinelRequestCount += 1;
+    } else {
+      // A manual request is itself the explicit load trigger. Do not let an
+      // already-visible sentinel immediately follow it with another request.
+      sentinelArmed = false;
     }
 
     requestInFlight = true;
@@ -93,7 +97,7 @@
     try {
       await onLoadMore();
       if (source === 'button') {
-        autoLoadCount = 0;
+        sentinelRequestCount = 0;
       }
     } catch (error) {
       errorState = true;
@@ -106,7 +110,23 @@
   }
 
   function handleIntersect(entry: IntersectionObserverEntry): void {
-    if (!entry.isIntersecting) return;
+    if (!entry.isIntersecting) {
+      sentinelArmed = true;
+      return;
+    }
+
+    if (
+      !sentinelArmed ||
+      !hasMore ||
+      loading ||
+      requestInFlight ||
+      errorState ||
+      sentinelRequestCount >= maxRetries
+    ) {
+      return;
+    }
+
+    sentinelArmed = false;
     void requestNextPage('sentinel');
   }
 </script>

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -43,7 +43,7 @@
   let sentinelReported = $state(false);
   let manualObserverSuspended = $state(false);
   let previousSentinelEnabled = false;
-  let previousSentinelCapped = false;
+  let previousMaxRetries: number | undefined;
   // Tracks the last `hasMore` value the component reconciled against so a
   // parent-driven false -> true flip (new page of data arrived) can clear the
   // sentinel request cap and error latch exactly once per transition.
@@ -83,17 +83,15 @@
   });
 
   $effect(() => {
-    const sentinelCapped = sentinelRequestCount >= maxRetries;
-
     if (!previousSentinelEnabled && sentinelEnabled) {
       sentinelReported = false;
       sentinelIntersecting = false;
-      if (previousSentinelCapped && !sentinelCapped) {
+      if (previousMaxRetries !== undefined && maxRetries > previousMaxRetries) {
         sentinelArmed = true;
       }
     }
     previousSentinelEnabled = sentinelEnabled;
-    previousSentinelCapped = sentinelCapped;
+    previousMaxRetries = maxRetries;
   });
 
   $effect(() => {

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -15,6 +15,7 @@
 
 <script lang="ts">
   import type { LoadMoreProps } from './load-more.types.ts';
+  import { untrack } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
   import { useIntersection } from '../../utilities/use-intersection.svelte.ts';
@@ -39,6 +40,8 @@
   let sentinelRequestCount = $state(0);
   let sentinelArmed = $state(true);
   let sentinelIntersecting = $state(false);
+  let sentinelReported = $state(false);
+  let previousSentinelEnabled = false;
   // Tracks the last `hasMore` value the component reconciled against so a
   // parent-driven false -> true flip (new page of data arrived) can clear the
   // sentinel request cap and error latch exactly once per transition.
@@ -52,8 +55,8 @@
   // the attachment once (rather than inside `$derived`) avoids tearing down and
   // recreating the IntersectionObserver every time `sentinelEnabled` flips.
   const sentinelIntersection = useIntersection(handleIntersect, {
-    root,
-    rootMargin,
+    root: untrack(() => root),
+    rootMargin: untrack(() => rootMargin),
     enabled: () => sentinelEnabled,
   });
   const buttonText = $derived(errorState ? retryLabel : buttonLabel);
@@ -76,6 +79,19 @@
     previousHasMore = hasMore;
   });
 
+  $effect(() => {
+    if (!previousSentinelEnabled && sentinelEnabled) {
+      sentinelReported = false;
+      sentinelIntersecting = false;
+      sentinelArmed = true;
+    }
+    previousSentinelEnabled = sentinelEnabled;
+  });
+
+  $effect(() => {
+    requestFromSentinelIfReady();
+  });
+
   async function requestNextPage(source: 'button' | 'sentinel'): Promise<void> {
     if (!hasMore || loading || requestInFlight) {
       return;
@@ -87,9 +103,10 @@
 
     if (source === 'sentinel') {
       sentinelRequestCount += 1;
-    } else if (sentinelIntersecting) {
+    } else if (!sentinelReported || sentinelIntersecting) {
       // A manual request is itself the explicit load trigger. Do not let an
-      // already-visible sentinel immediately follow it with another request.
+      // unreported or already-visible sentinel immediately follow it with
+      // another request.
       sentinelArmed = false;
     }
 
@@ -111,7 +128,17 @@
     }
   }
 
+  function requestFromSentinelIfReady(): void {
+    if (!sentinelReported || !sentinelIntersecting || !sentinelArmed || !sentinelEnabled || busy) {
+      return;
+    }
+
+    sentinelArmed = false;
+    void requestNextPage('sentinel');
+  }
+
   function handleIntersect(entry: IntersectionObserverEntry): void {
+    sentinelReported = true;
     sentinelIntersecting = entry.isIntersecting;
 
     if (!entry.isIntersecting) {
@@ -119,19 +146,7 @@
       return;
     }
 
-    if (
-      !sentinelArmed ||
-      !hasMore ||
-      loading ||
-      requestInFlight ||
-      errorState ||
-      sentinelRequestCount >= maxRetries
-    ) {
-      return;
-    }
-
-    sentinelArmed = false;
-    void requestNextPage('sentinel');
+    requestFromSentinelIfReady();
   }
 </script>
 

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -41,7 +41,9 @@
   let sentinelArmed = $state(true);
   let sentinelIntersecting = $state(false);
   let sentinelReported = $state(false);
+  let manualObserverSuspended = $state(false);
   let previousSentinelEnabled = false;
+  let previousSentinelCapped = false;
   // Tracks the last `hasMore` value the component reconciled against so a
   // parent-driven false -> true flip (new page of data arrived) can clear the
   // sentinel request cap and error latch exactly once per transition.
@@ -50,6 +52,7 @@
   const mergedClassName = $derived(classNames('cinder-load-more', customClassName));
   const busy = $derived(loading || requestInFlight);
   const sentinelEnabled = $derived(hasMore && !errorState && sentinelRequestCount < maxRetries);
+  const sentinelObserverEnabled = $derived(sentinelEnabled && !manualObserverSuspended);
   // `enabled` is a getter, so `useIntersection`'s own `$effect` re-evaluates
   // `sentinelEnabled` reactively and toggles the observer in place. Constructing
   // the attachment once (rather than inside `$derived`) avoids tearing down and
@@ -57,7 +60,7 @@
   const sentinelIntersection = useIntersection(handleIntersect, {
     root: untrack(() => root),
     rootMargin: untrack(() => rootMargin),
-    enabled: () => sentinelEnabled,
+    enabled: () => sentinelObserverEnabled,
   });
   const buttonText = $derived(errorState ? retryLabel : buttonLabel);
   const buttonDisabled = $derived(busy && !errorState);
@@ -80,11 +83,17 @@
   });
 
   $effect(() => {
+    const sentinelCapped = sentinelRequestCount >= maxRetries;
+
     if (!previousSentinelEnabled && sentinelEnabled) {
       sentinelReported = false;
       sentinelIntersecting = false;
+      if (previousSentinelCapped && !sentinelCapped) {
+        sentinelArmed = true;
+      }
     }
     previousSentinelEnabled = sentinelEnabled;
+    previousSentinelCapped = sentinelCapped;
   });
 
   $effect(() => {
@@ -102,11 +111,14 @@
 
     if (source === 'sentinel') {
       sentinelRequestCount += 1;
-    } else if (!sentinelEnabled || !sentinelReported || sentinelIntersecting) {
-      // A manual request is itself the explicit load trigger. Do not let an
-      // unreported or already-visible sentinel immediately follow it with
-      // another request.
+    } else {
+      // A manual request supersedes every entry queued by the current observer.
+      // Suspending the observer makes its callback stale immediately; the
+      // replacement must report off-screen before it can re-arm.
       sentinelArmed = false;
+      sentinelReported = false;
+      sentinelIntersecting = false;
+      manualObserverSuspended = true;
     }
 
     requestInFlight = true;
@@ -124,6 +136,9 @@
       // Always clear the in-flight guard once the request settles, regardless of
       // whether the parent has flipped its own `loading` prop yet.
       requestInFlight = false;
+      if (source === 'button') {
+        manualObserverSuspended = false;
+      }
     }
   }
 

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -469,6 +469,38 @@ describe('LoadMore', () => {
     await waitFor(() => expect(calls).toBe(2));
   });
 
+  test('a manual load at the request cap keeps the reconnected sentinel disarmed', async () => {
+    let calls = 0;
+    const rendered = render(LoadMore, {
+      props: {
+        maxRetries: 1,
+        onLoadMore: async () => {
+          calls += 1;
+        },
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [initialRecord] = FakeIntersectionObserver.records;
+    initialRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(1));
+
+    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => {
+      expect(calls).toBe(2);
+      expect(FakeIntersectionObserver.records).toHaveLength(2);
+    });
+
+    const currentRecord = FakeIntersectionObserver.records.at(-1);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await Promise.resolve();
+    expect(calls).toBe(2);
+
+    currentRecord?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(3));
+  });
+
   test('a retry while visible does not queue a second sentinel request', async () => {
     let calls = 0;
     let resolveRetry: (() => void) | undefined;

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -434,6 +434,53 @@ describe('LoadMore', () => {
     expect(calls).toBe(2);
   });
 
+  test('a retry disarms a recreated sentinel after the old sentinel left view', async () => {
+    let calls = 0;
+    let rejectInitial: ((reason?: unknown) => void) | undefined;
+    let resolveRetry: (() => void) | undefined;
+
+    const rendered = render(LoadMore, {
+      props: {
+        onLoadMore: async () => {
+          calls += 1;
+          if (calls === 1) {
+            await new Promise<void>((_resolve, reject) => (rejectInitial = reject));
+          }
+          if (calls === 2) await new Promise<void>((resolve) => (resolveRetry = resolve));
+        },
+      },
+    });
+
+    const initialSentinel = rendered.container.querySelector(
+      '.cinder-load-more__sentinel',
+    ) as Element;
+    const [record] = FakeIntersectionObserver.records;
+    record?.callback([createEntry(initialSentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(1));
+    record?.callback([createEntry(initialSentinel, false)], {} as IntersectionObserver);
+    rejectInitial?.(new Error('network'));
+
+    await waitFor(() => {
+      expect(rendered.getByRole('button', { name: 'Retry loading' })).toBeDefined();
+    });
+
+    await fireEvent.click(rendered.getByRole('button', { name: 'Retry loading' }));
+    await waitFor(() => expect(calls).toBe(2));
+
+    const retrySentinel = rendered.container.querySelector(
+      '.cinder-load-more__sentinel',
+    ) as Element;
+    record?.callback([createEntry(retrySentinel, true)], {} as IntersectionObserver);
+    resolveRetry?.();
+
+    await waitFor(() => {
+      expect(rendered.getByRole('button', { name: 'Load more' }).hasAttribute('disabled')).toBe(
+        false,
+      );
+    });
+    expect(calls).toBe(2);
+  });
+
   test('calls onError when onLoadMore rejects', async () => {
     let seen: unknown;
     const { getByRole } = render(LoadMore, {

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -151,32 +151,52 @@ describe('LoadMore', () => {
     });
   });
 
-  test('caps repeated sentinel callbacks independently from the error retry count', async () => {
+  test('does not reconnect or load again while the sentinel remains intersecting', async () => {
     let calls = 0;
-    const rendered = render(LoadMore, {
+    const { container } = render(LoadMore, {
       props: {
-        maxRetries: 2,
-        onLoadMore: () => {
+        onloadmore: async () => {
           calls += 1;
         },
       },
     });
 
-    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
-    const [record] = FakeIntersectionObserver.records;
-    const entry = createEntry(sentinel, true);
+    const sentinel = container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [initialRecord] = FakeIntersectionObserver.records;
 
-    record?.callback([entry], {} as IntersectionObserver);
-    await waitFor(() => expect(calls).toBe(1));
-    await waitFor(() =>
-      expect(rendered.container.firstElementChild?.getAttribute('aria-busy')).toBe('false'),
-    );
-    record?.callback([entry], {} as IntersectionObserver);
-    await waitFor(() => expect(calls).toBe(2));
-    record?.callback([entry], {} as IntersectionObserver);
+    initialRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+
+    await waitFor(() => {
+      expect(calls).toBe(1);
+      expect(FakeIntersectionObserver.records).toHaveLength(1);
+    });
+
+    initialRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+
     await Promise.resolve();
+    expect(calls).toBe(1);
+  });
 
-    expect(calls).toBe(2);
+  test('re-arms auto-loading after the sentinel leaves and re-enters the observer root', async () => {
+    let calls = 0;
+    const { container } = render(LoadMore, {
+      props: {
+        onloadmore: async () => {
+          calls += 1;
+        },
+      },
+    });
+
+    const sentinel = container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [record] = FakeIntersectionObserver.records;
+
+    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(1));
+
+    record?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+
+    await waitFor(() => expect(calls).toBe(2));
   });
 
   test('ignores stale sentinel callbacks while loading or after an error', async () => {
@@ -265,7 +285,7 @@ describe('LoadMore', () => {
     });
   });
 
-  test('manual loads reset the sentinel retry budget after a failure', async () => {
+  test('manual loads reset the sentinel request cap after a failure', async () => {
     let calls = 0;
     let shouldFail = true;
 
@@ -297,6 +317,7 @@ describe('LoadMore', () => {
       expect(calls).toBe(2);
     });
 
+    record?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
     record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
 
     await waitFor(() => {

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -262,8 +262,10 @@ describe('LoadMore', () => {
     record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
     await waitFor(() => expect(calls).toBe(1));
 
-    record?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
-    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    const resetSentinel = container.querySelector('.cinder-load-more__sentinel') as Element;
+    const resetRecord = FakeIntersectionObserver.records.at(-1);
+    resetRecord?.callback([createEntry(resetSentinel, false)], {} as IntersectionObserver);
+    resetRecord?.callback([createEntry(resetSentinel, true)], {} as IntersectionObserver);
 
     await waitFor(() => expect(calls).toBe(2));
   });
@@ -385,8 +387,12 @@ describe('LoadMore', () => {
       expect(calls).toBe(2);
     });
 
-    record?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
-    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    const resetSentinel = rendered.container.querySelector(
+      '.cinder-load-more__sentinel',
+    ) as Element;
+    const resetRecord = FakeIntersectionObserver.records.at(-1);
+    resetRecord?.callback([createEntry(resetSentinel, false)], {} as IntersectionObserver);
+    resetRecord?.callback([createEntry(resetSentinel, true)], {} as IntersectionObserver);
 
     await waitFor(() => {
       expect(calls).toBe(3);

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -152,7 +152,28 @@ describe('LoadMore', () => {
     await waitFor(() => expect(calls).toBe(2));
   });
 
-  test('manual loading while the sentinel is visible consumes its current entry trigger', async () => {
+  test('manual loading before the sentinel reports consumes a potentially visible entry', async () => {
+    let calls = 0;
+    const rendered = render(LoadMore, {
+      props: {
+        onLoadMore: async () => {
+          calls += 1;
+        },
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [record] = FakeIntersectionObserver.records;
+
+    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
+    expect(calls).toBe(1);
+
+    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await Promise.resolve();
+    expect(calls).toBe(1);
+  });
+
+  test('loads an armed intersecting sentinel when the component becomes idle', async () => {
     let calls = 0;
     const rendered = render(LoadMore, {
       props: {
@@ -175,12 +196,8 @@ describe('LoadMore', () => {
         calls += 1;
       },
     });
-    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
-    expect(calls).toBe(1);
 
-    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
-    await Promise.resolve();
-    expect(calls).toBe(1);
+    await waitFor(() => expect(calls).toBe(1));
   });
 
   test('an intersecting sentinel entry calls onLoadMore', async () => {
@@ -251,7 +268,7 @@ describe('LoadMore', () => {
     await waitFor(() => expect(calls).toBe(2));
   });
 
-  test('ignores stale sentinel callbacks while loading or after an error', async () => {
+  test('replays a busy sentinel entry once and ignores stale callbacks after an error', async () => {
     let calls = 0;
     let rejectNextRequest = false;
 
@@ -290,9 +307,8 @@ describe('LoadMore', () => {
       loading: false,
     });
 
-    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
-
     await waitFor(() => {
+      expect(calls).toBe(1);
       expect(rendered.getByRole('button', { name: 'Retry loading' })).toBeDefined();
     });
 

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -148,7 +148,48 @@ describe('LoadMore', () => {
     await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
     expect(calls).toBe(1);
 
-    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(FakeIntersectionObserver.records).toHaveLength(2));
+    const currentRecord = FakeIntersectionObserver.records.at(-1);
+    currentRecord?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(2));
+  });
+
+  test('manual loading consumes intersections queued by the previous observer', async () => {
+    let calls = 0;
+    let resolveManualRequest: (() => void) | undefined;
+    const rendered = render(LoadMore, {
+      props: {
+        onLoadMore: async () => {
+          calls += 1;
+          if (calls === 1) {
+            await new Promise<void>((resolve) => (resolveManualRequest = resolve));
+          }
+        },
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [initialRecord] = FakeIntersectionObserver.records;
+
+    initialRecord?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => expect(calls).toBe(1));
+
+    initialRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    resolveManualRequest?.();
+
+    await waitFor(() => {
+      expect(FakeIntersectionObserver.records).toHaveLength(2);
+      expect(rendered.getByRole('button', { name: 'Load more' }).hasAttribute('disabled')).toBe(
+        false,
+      );
+    });
+    expect(calls).toBe(1);
+
+    const currentRecord = FakeIntersectionObserver.records.at(-1);
+    currentRecord?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
     await waitFor(() => expect(calls).toBe(2));
   });
 
@@ -399,6 +440,35 @@ describe('LoadMore', () => {
     });
   });
 
+  test('raising maxRetries re-arms the sentinel with the reconnected observer', async () => {
+    let calls = 0;
+    const rendered = render(LoadMore, {
+      props: {
+        maxRetries: 1,
+        onLoadMore: async () => {
+          calls += 1;
+        },
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [initialRecord] = FakeIntersectionObserver.records;
+    initialRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(1));
+
+    await rendered.rerender({
+      maxRetries: 2,
+      onLoadMore: async () => {
+        calls += 1;
+      },
+    });
+
+    await waitFor(() => expect(FakeIntersectionObserver.records).toHaveLength(2));
+    const currentRecord = FakeIntersectionObserver.records.at(-1);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(2));
+  });
+
   test('a retry while visible does not queue a second sentinel request', async () => {
     let calls = 0;
     let resolveRetry: (() => void) | undefined;
@@ -429,7 +499,8 @@ describe('LoadMore', () => {
     const retrySentinel = rendered.container.querySelector(
       '.cinder-load-more__sentinel',
     ) as Element;
-    record?.callback([createEntry(retrySentinel, true)], {} as IntersectionObserver);
+    const retryRecord = FakeIntersectionObserver.records.at(-1);
+    retryRecord?.callback([createEntry(retrySentinel, true)], {} as IntersectionObserver);
     resolveRetry?.();
 
     await waitFor(() => {
@@ -476,7 +547,8 @@ describe('LoadMore', () => {
     const retrySentinel = rendered.container.querySelector(
       '.cinder-load-more__sentinel',
     ) as Element;
-    record?.callback([createEntry(retrySentinel, true)], {} as IntersectionObserver);
+    const retryRecord = FakeIntersectionObserver.records.at(-1);
+    retryRecord?.callback([createEntry(retrySentinel, true)], {} as IntersectionObserver);
     resolveRetry?.();
 
     await waitFor(() => {

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -501,6 +501,49 @@ describe('LoadMore', () => {
     await waitFor(() => expect(calls).toBe(3));
   });
 
+  test('an in-flight manual load stays disarmed when maxRetries increases', async () => {
+    let calls = 0;
+    let resolveManualRequest: (() => void) | undefined;
+    const onLoadMore = async () => {
+      calls += 1;
+      if (calls === 2) {
+        await new Promise<void>((resolve) => (resolveManualRequest = resolve));
+      }
+    };
+    const rendered = render(LoadMore, {
+      props: {
+        maxRetries: 1,
+        onLoadMore,
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [initialRecord] = FakeIntersectionObserver.records;
+    initialRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(1));
+
+    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => expect(calls).toBe(2));
+    await rendered.rerender({ maxRetries: 2, onLoadMore });
+    resolveManualRequest?.();
+
+    await waitFor(() => {
+      expect(FakeIntersectionObserver.records).toHaveLength(2);
+      expect(rendered.getByRole('button', { name: 'Load more' }).hasAttribute('disabled')).toBe(
+        false,
+      );
+    });
+
+    const currentRecord = FakeIntersectionObserver.records.at(-1);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await Promise.resolve();
+    expect(calls).toBe(2);
+
+    currentRecord?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(3));
+  });
+
   test('a retry while visible does not queue a second sentinel request', async () => {
     let calls = 0;
     let resolveRetry: (() => void) | undefined;

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -393,6 +393,47 @@ describe('LoadMore', () => {
     });
   });
 
+  test('a retry while visible does not queue a second sentinel request', async () => {
+    let calls = 0;
+    let resolveRetry: (() => void) | undefined;
+
+    const rendered = render(LoadMore, {
+      props: {
+        onLoadMore: async () => {
+          calls += 1;
+          if (calls === 1) throw new Error('network');
+          if (calls === 2) await new Promise<void>((resolve) => (resolveRetry = resolve));
+        },
+      },
+    });
+
+    const initialSentinel = rendered.container.querySelector(
+      '.cinder-load-more__sentinel',
+    ) as Element;
+    const [record] = FakeIntersectionObserver.records;
+    record?.callback([createEntry(initialSentinel, true)], {} as IntersectionObserver);
+
+    await waitFor(() => {
+      expect(rendered.getByRole('button', { name: 'Retry loading' })).toBeDefined();
+    });
+
+    await fireEvent.click(rendered.getByRole('button', { name: 'Retry loading' }));
+    await waitFor(() => expect(calls).toBe(2));
+
+    const retrySentinel = rendered.container.querySelector(
+      '.cinder-load-more__sentinel',
+    ) as Element;
+    record?.callback([createEntry(retrySentinel, true)], {} as IntersectionObserver);
+    resolveRetry?.();
+
+    await waitFor(() => {
+      expect(rendered.getByRole('button', { name: 'Load more' }).hasAttribute('disabled')).toBe(
+        false,
+      );
+    });
+    expect(calls).toBe(2);
+  });
+
   test('calls onError when onLoadMore rejects', async () => {
     let seen: unknown;
     const { getByRole } = render(LoadMore, {

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -131,6 +131,58 @@ describe('LoadMore', () => {
     expect(calls).toBe(1);
   });
 
+  test('manual loading while the sentinel is off-screen preserves its next entry trigger', async () => {
+    let calls = 0;
+    const rendered = render(LoadMore, {
+      props: {
+        onLoadMore: async () => {
+          calls += 1;
+        },
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [record] = FakeIntersectionObserver.records;
+
+    record?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
+    expect(calls).toBe(1);
+
+    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(2));
+  });
+
+  test('manual loading while the sentinel is visible consumes its current entry trigger', async () => {
+    let calls = 0;
+    const rendered = render(LoadMore, {
+      props: {
+        loading: true,
+        onLoadMore: async () => {
+          calls += 1;
+        },
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [record] = FakeIntersectionObserver.records;
+
+    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    expect(calls).toBe(0);
+
+    await rendered.rerender({
+      loading: false,
+      onLoadMore: async () => {
+        calls += 1;
+      },
+    });
+    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
+    expect(calls).toBe(1);
+
+    record?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await Promise.resolve();
+    expect(calls).toBe(1);
+  });
+
   test('an intersecting sentinel entry calls onLoadMore', async () => {
     let calls = 0;
     const { container } = render(LoadMore, {
@@ -155,7 +207,7 @@ describe('LoadMore', () => {
     let calls = 0;
     const { container } = render(LoadMore, {
       props: {
-        onloadmore: async () => {
+        onLoadMore: async () => {
           calls += 1;
         },
       },
@@ -181,7 +233,7 @@ describe('LoadMore', () => {
     let calls = 0;
     const { container } = render(LoadMore, {
       props: {
-        onloadmore: async () => {
+        onLoadMore: async () => {
           calls += 1;
         },
       },

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -544,6 +544,45 @@ describe('LoadMore', () => {
     await waitFor(() => expect(calls).toBe(3));
   });
 
+  test('a direct manual promise stays disarmed when its resolution raises maxRetries', async () => {
+    let calls = 0;
+    let resolveManualRequest: (() => void) | undefined;
+    const onLoadMore = () => {
+      calls += 1;
+      if (calls === 2) {
+        return new Promise<void>((resolve) => (resolveManualRequest = resolve));
+      }
+      return Promise.resolve();
+    };
+    const rendered = render(LoadMore, {
+      props: {
+        maxRetries: 1,
+        onLoadMore,
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [initialRecord] = FakeIntersectionObserver.records;
+    initialRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(1));
+
+    await fireEvent.click(rendered.getByRole('button', { name: 'Load more' }));
+    await waitFor(() => expect(calls).toBe(2));
+    resolveManualRequest?.();
+    const rerenderPromise = rendered.rerender({ maxRetries: 2, onLoadMore });
+    await rerenderPromise;
+
+    await waitFor(() => expect(FakeIntersectionObserver.records).toHaveLength(2));
+    const currentRecord = FakeIntersectionObserver.records.at(-1);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await Promise.resolve();
+    expect(calls).toBe(2);
+
+    currentRecord?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    currentRecord?.callback([createEntry(sentinel, true)], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(3));
+  });
+
   test('a retry while visible does not queue a second sentinel request', async () => {
     let calls = 0;
     let resolveRetry: (() => void) | undefined;

--- a/packages/components/src/utilities/use-intersection.svelte.test.ts
+++ b/packages/components/src/utilities/use-intersection.svelte.test.ts
@@ -204,6 +204,40 @@ describe('useIntersection', () => {
     expect(FakeIntersectionObserver.records).toHaveLength(2);
   });
 
+  test('ignores queued entries from an observer that was replaced after reconnecting', async () => {
+    let enabled = true;
+    const seen: boolean[] = [];
+
+    const rendered = render(UseIntersectionAttachFixture, {
+      props: {
+        onIntersect: (entry: IntersectionObserverEntry) => seen.push(entry.isIntersecting),
+        options: { enabled: () => enabled },
+      },
+    });
+
+    const sentinel = rendered.getByTestId('sentinel');
+    const firstRecord = FakeIntersectionObserver.records[0];
+
+    enabled = false;
+    await rendered.rerender({
+      onIntersect: (entry: IntersectionObserverEntry) => seen.push(entry.isIntersecting),
+      options: { enabled: () => enabled },
+    });
+    enabled = true;
+    await rendered.rerender({
+      onIntersect: (entry: IntersectionObserverEntry) => seen.push(entry.isIntersecting),
+      options: { enabled: () => enabled },
+    });
+
+    firstRecord?.callback([createEntry(sentinel, false)], {} as IntersectionObserver);
+    FakeIntersectionObserver.records[1]?.callback(
+      [createEntry(sentinel, true)],
+      {} as IntersectionObserver,
+    );
+
+    expect(seen).toEqual([true]);
+  });
+
   test('observes immediately when enabled is omitted', () => {
     render(UseIntersectionAttachFixture, {
       props: {

--- a/packages/components/src/utilities/use-intersection.svelte.ts
+++ b/packages/components/src/utilities/use-intersection.svelte.ts
@@ -29,9 +29,9 @@ export function useIntersection(
         return;
       }
 
-      observer = new IntersectionObserver(
+      const currentObserver = new IntersectionObserver(
         (entries) => {
-          if (!enabled()) {
+          if (observer !== currentObserver || !enabled()) {
             return;
           }
 
@@ -46,7 +46,8 @@ export function useIntersection(
         },
       );
 
-      observer.observe(node);
+      observer = currentObserver;
+      currentObserver.observe(node);
 
       return () => {
         disconnectObserver();


### PR DESCRIPTION
## Summary
- keep LoadMore's IntersectionObserver attached across transient loading states
- latch each sentinel entry so a steady in-view sentinel triggers exactly once
- re-arm automatic loading only after a leave/re-enter transition, while preserving manual retry and the documented sentinel request cap

## Root cause
LoadMore disabled its observer while each request was in flight. Re-enabling it created a new observer, whose initial observation reported the still-visible sentinel as intersecting and started the next request. The in-flight guard prevented overlap but not this sequential loop.

## Validation
- `bun test packages/components/src/components/load-more/load-more.test.ts` (17 passed)
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder lint`
- `bunx oxlint --type-aware --tsconfig packages/components/tsconfig.json packages/components/src/components/load-more/load-more.test.ts`
- `bun run --filter=@lostgradient/cinder check:changeset-prerelease-bumps`

Closes #928