### PR TITLE
Keep CommandMenu dismissed after Escape

### DIFF
--- a/.changeset/command-menu-escape-dismissal.md
+++ b/.changeset/command-menu-escape-dismissal.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep slash-command menus dismissed after Escape until the host input state changes.

--- a/packages/components/src/components/command-menu/command-menu.svelte
+++ b/packages/components/src/components/command-menu/command-menu.svelte
@@ -199,12 +199,27 @@
     const clearEscapeDismissal = () => {
       escapeDismissal = null;
     };
+    const clearEscapeDismissalWhenSelectionChanges = () => {
+      if (
+        !escapeDismissal ||
+        escapeDismissal.anchor !== anchor ||
+        (anchor.selectionStart === escapeDismissal.selectionStart &&
+          anchor.selectionEnd === escapeDismissal.selectionEnd)
+      ) {
+        return;
+      }
+      escapeDismissal = null;
+    };
     const stopInput = on(anchor, 'input', clearEscapeDismissal, { capture: true });
     const stopPointerdown = on(anchor, 'pointerdown', clearEscapeDismissal, { capture: true });
+    const stopKeyup = on(anchor, 'keyup', clearEscapeDismissalWhenSelectionChanges);
+    const stopSelect = on(anchor, 'select', clearEscapeDismissalWhenSelectionChanges);
 
     return () => {
       stopInput();
       stopPointerdown();
+      stopKeyup();
+      stopSelect();
     };
   });
 

--- a/packages/components/src/components/command-menu/command-menu.svelte
+++ b/packages/components/src/components/command-menu/command-menu.svelte
@@ -160,8 +160,8 @@
     const anchorElement = anchor;
     if (reason === 'escape' && anchorElement) {
       // Keep host-owned text intact while suppressing re-evaluation of the exact
-      // trigger state. Input, navigation, paste, and undo/redo clear this guard;
-      // blur and refocus alone do not.
+      // trigger state. Input, caret movement, paste, undo/redo, and pointer
+      // interaction clear this guard; modifier keys and refocus alone do not.
       escapeDismissal = {
         anchor: anchorElement,
         value: anchorElement.value,
@@ -199,17 +199,12 @@
     const clearEscapeDismissal = () => {
       escapeDismissal = null;
     };
-    const clearEscapeDismissalOnKeydown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape') clearEscapeDismissal();
-    };
     const stopInput = on(anchor, 'input', clearEscapeDismissal, { capture: true });
     const stopPointerdown = on(anchor, 'pointerdown', clearEscapeDismissal, { capture: true });
-    const stopKeydown = on(anchor, 'keydown', clearEscapeDismissalOnKeydown, { capture: true });
 
     return () => {
       stopInput();
       stopPointerdown();
-      stopKeydown();
     };
   });
 

--- a/packages/components/src/components/command-menu/command-menu.svelte
+++ b/packages/components/src/components/command-menu/command-menu.svelte
@@ -60,6 +60,12 @@
 
   let mounted = $state(false);
   let listElement: HTMLElement | undefined = $state();
+  let escapeDismissal: {
+    anchor: HTMLInputElement | HTMLTextAreaElement;
+    value: string;
+    selectionStart: number | null;
+    selectionEnd: number | null;
+  } | null = $state(null);
   const commandList = createCommandListState(() => listboxId);
 
   const showEmpty = $derived(
@@ -94,6 +100,22 @@
 
   $effect(() => {
     mounted = true;
+  });
+
+  $effect(() => {
+    if (!open || !escapeDismissal) return;
+
+    const isUnchangedTriggerState =
+      anchor === escapeDismissal.anchor &&
+      anchor.value === escapeDismissal.value &&
+      anchor.selectionStart === escapeDismissal.selectionStart &&
+      anchor.selectionEnd === escapeDismissal.selectionEnd;
+
+    if (isUnchangedTriggerState) {
+      open = false;
+    } else {
+      escapeDismissal = null;
+    }
   });
 
   $effect(() => {
@@ -133,8 +155,22 @@
 
   setCommandListContext(commandList.createContext(activateItemById));
 
-  function dismiss() {
+  function dismiss(reason: 'escape' | 'pointer') {
     if (!open) return;
+    const anchorElement = anchor;
+    if (reason === 'escape' && anchorElement) {
+      // Keep host-owned text intact while suppressing re-evaluation of the exact
+      // trigger state. Input, navigation, paste, and undo/redo clear this guard;
+      // blur and refocus alone do not.
+      escapeDismissal = {
+        anchor: anchorElement,
+        value: anchorElement.value,
+        selectionStart: anchorElement.selectionStart,
+        selectionEnd: anchorElement.selectionEnd,
+      };
+    } else {
+      escapeDismissal = null;
+    }
     open = false;
     onDismiss?.();
   }
@@ -144,7 +180,7 @@
     commandList.handleKeydown({
       event,
       onEnter: activateItemById,
-      onEscape: dismiss,
+      onEscape: () => dismiss('escape'),
       ignoreModifiedNavigation: true,
     });
   }
@@ -154,8 +190,28 @@
     if (!(target instanceof Node)) return;
     if (anchor?.contains(target)) return;
     if (listElement?.contains(target)) return;
-    dismiss();
+    dismiss('pointer');
   }
+
+  $effect(() => {
+    if (!anchor) return;
+
+    const clearEscapeDismissal = () => {
+      escapeDismissal = null;
+    };
+    const clearEscapeDismissalOnKeydown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') clearEscapeDismissal();
+    };
+    const stopInput = on(anchor, 'input', clearEscapeDismissal, { capture: true });
+    const stopPointerdown = on(anchor, 'pointerdown', clearEscapeDismissal, { capture: true });
+    const stopKeydown = on(anchor, 'keydown', clearEscapeDismissalOnKeydown, { capture: true });
+
+    return () => {
+      stopInput();
+      stopPointerdown();
+      stopKeydown();
+    };
+  });
 
   $effect(() => {
     if (!open || !anchor) return;

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -205,6 +205,11 @@ describe('CommandMenu', () => {
       await settleCommandMenu();
       expect(queryMenu()).toBeNull();
 
+      await fireEvent.keyDown(host, { key: 'Shift' });
+      await fireEvent.keyUp(host, { key: 'Shift' });
+      await settleCommandMenu();
+      expect(queryMenu()).toBeNull();
+
       await fireEvent.blur(host);
       await fireEvent.focus(host);
       await settleCommandMenu();

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -189,6 +189,34 @@ describe('CommandMenu', () => {
     expect(dismissCount).toBe(1);
   });
 
+  test.each([{ value: '/' }, { value: '/a' }])(
+    'Escape keeps the menu dismissed for unchanged trigger text $value',
+    async ({ value }) => {
+      const { getByTestId } = render(CommandMenuHostFixture);
+      const host = getByTestId('host') as HTMLTextAreaElement;
+
+      await fireEvent.input(host, { target: { value } });
+      host.setSelectionRange(value.length, value.length);
+      await fireEvent.keyUp(host, { key: value.at(-1) });
+      await waitFor(() => expect(queryMenu()).not.toBeNull());
+
+      await fireEvent.keyDown(host, { key: 'Escape' });
+      await fireEvent.keyUp(host, { key: 'Escape' });
+      await settleCommandMenu();
+      expect(queryMenu()).toBeNull();
+
+      await fireEvent.blur(host);
+      await fireEvent.focus(host);
+      await settleCommandMenu();
+      expect(queryMenu()).toBeNull();
+
+      await fireEvent.input(host, { target: { value: '' } });
+      await fireEvent.input(host, { target: { value } });
+      host.setSelectionRange(value.length, value.length);
+      await waitFor(() => expect(queryMenu()).not.toBeNull());
+    },
+  );
+
   test('outside pointerdown dismisses the menu', async () => {
     let dismissCount = 0;
     const { getByTestId } = render(CommandMenuFixture, {

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -222,6 +222,29 @@ describe('CommandMenu', () => {
     },
   );
 
+  test('caret movement away from a dismissed trigger permits reopening when it returns', async () => {
+    const { getByTestId } = render(CommandMenuHostFixture);
+    const host = getByTestId('host') as HTMLTextAreaElement;
+
+    await fireEvent.input(host, { target: { value: '/' } });
+    host.setSelectionRange(1, 1);
+    await fireEvent.keyUp(host, { key: '/' });
+    await waitFor(() => expect(queryMenu()).not.toBeNull());
+
+    await fireEvent.keyDown(host, { key: 'Escape' });
+    await fireEvent.keyUp(host, { key: 'Escape' });
+    await settleCommandMenu();
+    expect(queryMenu()).toBeNull();
+
+    host.setSelectionRange(0, 0);
+    await fireEvent.keyUp(host, { key: 'ArrowLeft' });
+    expect(queryMenu()).toBeNull();
+
+    host.setSelectionRange(1, 1);
+    await fireEvent.keyUp(host, { key: 'ArrowRight' });
+    await waitFor(() => expect(queryMenu()).not.toBeNull());
+  });
+
   test('outside pointerdown dismisses the menu', async () => {
     let dismissCount = 0;
     const { getByTestId } = render(CommandMenuFixture, {

--- a/packages/components/src/test/fixtures/command-menu-host-fixture.svelte
+++ b/packages/components/src/test/fixtures/command-menu-host-fixture.svelte
@@ -75,6 +75,7 @@
     aria-controls={open ? listboxId : undefined}
     aria-activedescendant={open ? activeItemId : undefined}
     aria-autocomplete="list"
+    onfocus={(event) => syncTrigger(event.currentTarget)}
     oninput={(event) => syncTrigger(event.currentTarget)}
     onclick={(event) => syncTrigger(event.currentTarget)}
     onkeyup={(event) => syncTrigger(event.currentTarget)}
@@ -87,6 +88,7 @@
     aria-controls={open ? listboxId : undefined}
     aria-activedescendant={open ? activeItemId : undefined}
     aria-autocomplete="list"
+    onfocus={(event) => syncTrigger(event.currentTarget)}
     oninput={(event) => syncTrigger(event.currentTarget)}
     onclick={(event) => syncTrigger(event.currentTarget)}
     onkeyup={(event) => syncTrigger(event.currentTarget)}


### PR DESCRIPTION
## Summary

- remember the anchor value and caret state dismissed by Escape
- reject host-triggered reopen attempts while that exact trigger state is unchanged
- clear the guard on deliberate input, navigation, pointer interaction, paste, or undo/redo
- cover bare slash, slash queries, Escape keyup, blur/refocus, and restored input state

## Root cause

CommandMenu handled Escape on `keydown`, but host examples re-ran `detectTrigger` on `keyup`. Because Escape left the host-owned slash text unchanged, the keyup handler immediately set `open` back to true.

## Verification

- `bun test packages/components/src/components/command-menu/command-menu.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run --filter=@lostgradient/cinder check:changeset-prerelease-bumps`
- targeted Prettier and Oxlint checks

Closes #930