### PR TITLE
fix(access-gate): stabilize granted layout wrapper

### DIFF
--- a/.changeset/stabilize-access-gate-layout.md
+++ b/.changeset/stabilize-access-gate-layout.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep AccessGate's granted and denied states aligned to a shared inline baseline wrapper.

--- a/packages/components/src/components/access-gate/access-gate-fixtures.ts
+++ b/packages/components/src/components/access-gate/access-gate-fixtures.ts
@@ -10,6 +10,13 @@ export default [
     },
   },
   {
+    name: 'inline-granted',
+    host: './access-gate.fixture.svelte',
+    props: {
+      variant: 'inline-granted',
+    },
+  },
+  {
     name: 'section-denied',
     host: './access-gate.fixture.svelte',
     props: {

--- a/packages/components/src/components/access-gate/access-gate-fixtures.ts
+++ b/packages/components/src/components/access-gate/access-gate-fixtures.ts
@@ -17,6 +17,13 @@ export default [
     },
   },
   {
+    name: 'inline-toggle',
+    host: './access-gate.fixture.svelte',
+    props: {
+      variant: 'inline-toggle',
+    },
+  },
+  {
     name: 'section-denied',
     host: './access-gate.fixture.svelte',
     props: {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -6,7 +6,9 @@
 
   .cinder-access-gate__passthrough {
     display: inline-flex;
+    flex-wrap: wrap;
     align-items: baseline;
+    inline-size: 100%;
     vertical-align: baseline;
   }
 
@@ -35,18 +37,20 @@
   }
 
   .cinder-access-gate__inline-reason {
-    display: inline-flex;
+    position: relative;
+    display: inline-block;
     flex: 1 1 auto;
-    align-items: center;
-    gap: var(--cinder-space-1);
     min-inline-size: 0;
+    padding-inline-start: calc(0.875rem + var(--cinder-space-1));
     color: var(--cinder-text-muted);
     font-size: var(--cinder-text-xs);
     line-height: var(--cinder-leading-snug);
   }
 
   .cinder-access-gate__inline-reason > svg {
-    flex: 0 0 auto;
+    position: absolute;
+    inset-block-start: 0.1em;
+    inset-inline-start: 0;
   }
 
   .cinder-access-gate__inline-reason > span {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -17,7 +17,9 @@
     display: contents;
   }
 
-  .cinder-access-gate__passthrough:has(> [data-cinder-icon-only]):has(> :nth-child(2)) {
+  .cinder-access-gate__passthrough:where(
+    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only])))
+  ) {
     display: inline-flex;
     align-items: center;
     inline-size: auto;
@@ -25,6 +27,7 @@
 
   .cinder-access-gate__passthrough[data-cinder-variant='section'] {
     display: contents;
+    inline-size: auto;
   }
 
   .cinder-access-gate[data-cinder-variant='inline'] {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -5,19 +5,12 @@
   }
 
   .cinder-access-gate__passthrough {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: var(--cinder-space-2);
+    display: contents;
     vertical-align: baseline;
   }
 
   .cinder-access-gate__passthrough:has(> [data-cinder-full-width]) {
     inline-size: 100%;
-  }
-
-  .cinder-access-gate__passthrough:has(> :only-child) {
-    display: contents;
   }
 
   .cinder-access-gate__passthrough:where(

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -39,7 +39,6 @@
 
   .cinder-access-gate__inline-content {
     display: inline-flex;
-    align-self: flex-start;
     min-inline-size: 0;
   }
 
@@ -58,7 +57,7 @@
   .cinder-access-gate__inline-reason {
     position: relative;
     display: inline-block;
-    align-self: flex-start;
+    align-self: first baseline;
     flex: 1 1 auto;
     min-inline-size: 0;
     padding-inline-start: calc(0.875rem + var(--cinder-space-1));

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -8,8 +8,17 @@
     display: inline-flex;
     flex-wrap: wrap;
     align-items: baseline;
-    inline-size: 100%;
+    gap: var(--cinder-space-2);
     vertical-align: baseline;
+  }
+
+  .cinder-access-gate__passthrough:has(> [data-cinder-full-width]) {
+    display: flex;
+    inline-size: 100%;
+  }
+
+  .cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {
+    align-items: center;
   }
 
   .cinder-access-gate__passthrough[data-cinder-variant='section'] {
@@ -28,6 +37,12 @@
   .cinder-access-gate__inline-content {
     display: inline-flex;
     min-inline-size: 0;
+  }
+
+  .cinder-access-gate[data-cinder-variant='inline']:has(
+      .cinder-access-gate__inline-content > [data-cinder-icon-only]
+    ) {
+    align-items: center;
   }
 
   .cinder-access-gate__inline-content [data-cinder-access-gate-control] {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -5,11 +5,15 @@
   }
 
   .cinder-access-gate__passthrough {
-    display: contents;
+    display: inline-flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    max-inline-size: 100%;
     vertical-align: baseline;
   }
 
   .cinder-access-gate__passthrough:has(> [data-cinder-full-width]) {
+    display: flex;
     inline-size: 100%;
   }
 

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -5,10 +5,11 @@
   }
 
   .cinder-access-gate__passthrough {
-    display: inline-flex;
+    display: flex;
     flex-wrap: wrap;
     align-items: baseline;
     gap: var(--cinder-space-2);
+    inline-size: 100%;
     vertical-align: baseline;
   }
 
@@ -16,14 +17,10 @@
     display: contents;
   }
 
-  .cinder-access-gate__passthrough:has(> [data-cinder-full-width]):has(> :nth-child(2)) {
-    display: flex;
-    inline-size: 100%;
-  }
-
   .cinder-access-gate__passthrough:has(> [data-cinder-icon-only]):has(> :nth-child(2)) {
     display: inline-flex;
     align-items: center;
+    inline-size: auto;
   }
 
   .cinder-access-gate__passthrough[data-cinder-variant='section'] {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -14,7 +14,8 @@
   }
 
   .cinder-access-gate__passthrough:where(
-    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only])))
+    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only]))),
+    :has(> .cinder-tooltip-wrapper [data-cinder-icon-only])
   ) {
     display: inline-flex;
     align-items: center;

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -16,7 +16,7 @@
     display: contents;
   }
 
-  .cinder-access-gate__passthrough:has(> [data-cinder-full-width]) {
+  .cinder-access-gate__passthrough:has(> [data-cinder-full-width]):has(> :nth-child(2)) {
     display: flex;
     inline-size: 100%;
   }

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -21,7 +21,7 @@
     inline-size: 100%;
   }
 
-  .cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {
+  .cinder-access-gate__passthrough:has(> [data-cinder-icon-only]):has(> :nth-child(2)) {
     display: inline-flex;
     align-items: center;
   }

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -14,11 +14,11 @@
   }
 
   .cinder-access-gate__passthrough:where(
-    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only]))),
-    :has(> .cinder-tooltip-wrapper [data-cinder-icon-only])
+    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only])))
   ) {
     display: inline-flex;
     align-items: center;
+    gap: var(--cinder-space-2);
     inline-size: auto;
   }
 

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -12,17 +12,22 @@
     vertical-align: baseline;
   }
 
+  .cinder-access-gate__passthrough:has(> :only-child) {
+    display: contents;
+  }
+
   .cinder-access-gate__passthrough:has(> [data-cinder-full-width]) {
     display: flex;
     inline-size: 100%;
   }
 
   .cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {
+    display: inline-flex;
     align-items: center;
   }
 
   .cinder-access-gate__passthrough[data-cinder-variant='section'] {
-    display: block;
+    display: contents;
   }
 
   .cinder-access-gate[data-cinder-variant='inline'] {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -5,16 +5,22 @@
   }
 
   .cinder-access-gate__passthrough {
-    display: contents;
+    display: inline-flex;
+    align-items: baseline;
+    vertical-align: baseline;
+  }
+
+  .cinder-access-gate__passthrough[data-cinder-variant='section'] {
+    display: block;
   }
 
   .cinder-access-gate[data-cinder-variant='inline'] {
     display: inline-flex;
     flex-wrap: wrap;
-    align-items: center;
+    align-items: baseline;
     gap: var(--cinder-space-2);
     max-inline-size: 100%;
-    vertical-align: middle;
+    vertical-align: baseline;
   }
 
   .cinder-access-gate__inline-content {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -39,6 +39,7 @@
 
   .cinder-access-gate__inline-content {
     display: inline-flex;
+    align-self: flex-start;
     min-inline-size: 0;
   }
 
@@ -57,6 +58,7 @@
   .cinder-access-gate__inline-reason {
     position: relative;
     display: inline-block;
+    align-self: flex-start;
     flex: 1 1 auto;
     min-inline-size: 0;
     padding-inline-start: calc(0.875rem + var(--cinder-space-1));

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -17,6 +17,7 @@
     :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only])))
   ) {
     display: inline-flex;
+    flex-wrap: wrap;
     align-items: center;
     gap: var(--cinder-space-2);
     inline-size: auto;

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -47,6 +47,11 @@
     min-inline-size: 0;
   }
 
+  .cinder-access-gate__inline-content:has(> [data-cinder-full-width]) {
+    display: flex;
+    inline-size: 100%;
+  }
+
   .cinder-access-gate[data-cinder-variant='inline']:has(
       .cinder-access-gate__inline-content > [data-cinder-icon-only]
     ) {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -9,8 +9,11 @@
     flex-wrap: wrap;
     align-items: baseline;
     gap: var(--cinder-space-2);
-    inline-size: 100%;
     vertical-align: baseline;
+  }
+
+  .cinder-access-gate__passthrough:has(> [data-cinder-full-width]) {
+    inline-size: 100%;
   }
 
   .cinder-access-gate__passthrough:has(> :only-child) {

--- a/packages/components/src/components/access-gate/access-gate.css
+++ b/packages/components/src/components/access-gate/access-gate.css
@@ -39,6 +39,7 @@
 
   .cinder-access-gate__inline-content {
     display: inline-flex;
+    gap: var(--cinder-space-2);
     min-inline-size: 0;
   }
 

--- a/packages/components/src/components/access-gate/access-gate.fixture.svelte
+++ b/packages/components/src/components/access-gate/access-gate.fixture.svelte
@@ -4,10 +4,11 @@
   import { AccessGate } from './index.ts';
 
   type Props = {
-    variant?: 'inline' | 'inline-granted' | 'section';
+    variant?: 'inline' | 'inline-granted' | 'inline-toggle' | 'section';
   };
 
   let { variant = 'inline' }: Props = $props();
+  let toggleGranted = $state(false);
 </script>
 
 {#if variant === 'section'}
@@ -22,6 +23,19 @@
   <AccessGate granted={true} reason="Requires scope: workflows:cancel">
     <Button label="Cancel workflow" variant="danger" />
   </AccessGate>
+{:else if variant === 'inline-toggle'}
+  <Button
+    label="Toggle access"
+    size="sm"
+    onclick={() => {
+      toggleGranted = !toggleGranted;
+    }}
+  />
+  <span data-access-gate-toggle-anchor>
+    <AccessGate granted={toggleGranted} reason="Requires scope: workflows:cancel">
+      <Button label="Cancel workflow" variant="danger" />
+    </AccessGate>
+  </span>
 {:else}
   <AccessGate granted={false} reason="Requires scope: workflows:cancel">
     <Button label="Cancel workflow" variant="danger" />

--- a/packages/components/src/components/access-gate/access-gate.fixture.svelte
+++ b/packages/components/src/components/access-gate/access-gate.fixture.svelte
@@ -4,7 +4,7 @@
   import { AccessGate } from './index.ts';
 
   type Props = {
-    variant?: 'inline' | 'section';
+    variant?: 'inline' | 'inline-granted' | 'section';
   };
 
   let { variant = 'inline' }: Props = $props();
@@ -17,6 +17,11 @@
     reason="Requires scope: storage:admin"
     requirement="storage:admin"
   />
+{:else if variant === 'inline-granted'}
+  <span data-access-gate-baseline><Button label="Cancel workflow" variant="danger" /></span>
+  <AccessGate granted={true} reason="Requires scope: workflows:cancel">
+    <Button label="Cancel workflow" variant="danger" />
+  </AccessGate>
 {:else}
   <AccessGate granted={false} reason="Requires scope: workflows:cancel">
     <Button label="Cancel workflow" variant="danger" />

--- a/packages/components/src/components/access-gate/access-gate.svelte
+++ b/packages/components/src/components/access-gate/access-gate.svelte
@@ -60,7 +60,11 @@
 </script>
 
 {#if granted}
-  <span {...passthroughAttributes} class="cinder-access-gate__passthrough">
+  <span
+    {...passthroughAttributes}
+    class="cinder-access-gate__passthrough"
+    data-cinder-variant={variant}
+  >
     {@render children?.()}
   </span>
 {:else if variant === 'section'}

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -34,12 +34,18 @@ function markupSnippet(markup: string) {
 }
 
 describe('AccessGate', () => {
-  test('preserves full-width and wrapping layout while aligning denied copy to its text baseline', () => {
+  test('preserves intrinsic, full-width, wrapping, and icon-only inline layout', () => {
     const styles = readFileSync(new URL('./access-gate.css', import.meta.url), 'utf8');
 
     expect(styles).toContain('.cinder-access-gate__passthrough {');
     expect(styles).toContain('flex-wrap: wrap;');
+    expect(styles).toContain('gap: var(--cinder-space-2);');
+    expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-full-width])');
     expect(styles).toContain('inline-size: 100%;');
+    expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-icon-only])');
+    expect(styles).toContain(
+      ".cinder-access-gate[data-cinder-variant='inline']:has(\n      .cinder-access-gate__inline-content > [data-cinder-icon-only]",
+    );
     expect(styles).toContain('.cinder-access-gate__inline-reason {');
     expect(styles).toContain('display: inline-block;');
     expect(styles).toContain('padding-inline-start: calc(0.875rem + var(--cinder-space-1));');

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -58,6 +58,7 @@ describe('AccessGate', () => {
     );
     expect(styles).toContain('.cinder-access-gate__inline-reason {');
     expect(styles).toContain('display: inline-block;');
+    expect(styles).toContain('align-self: flex-start;');
     expect(styles).toContain('padding-inline-start: calc(0.875rem + var(--cinder-space-1));');
     expect(styles).toContain('.cinder-access-gate__inline-reason > svg {');
     expect(styles).toContain('position: absolute;');

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -56,6 +56,7 @@ describe('AccessGate', () => {
     expect(styles).toContain(
       ".cinder-access-gate[data-cinder-variant='inline']:has(\n      .cinder-access-gate__inline-content > [data-cinder-icon-only]",
     );
+    expect(styles).toContain('.cinder-access-gate__inline-content:has(> [data-cinder-full-width])');
     expect(styles).toContain('.cinder-access-gate__inline-reason {');
     expect(styles).toContain('display: inline-block;');
     expect(styles).toContain('align-self: first baseline;');

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -38,19 +38,23 @@ describe('AccessGate', () => {
     const styles = readFileSync(new URL('./access-gate.css', import.meta.url), 'utf8');
 
     expect(styles).toContain('.cinder-access-gate__passthrough {');
+    expect(styles).toContain(
+      '.cinder-access-gate__passthrough {\n    display: flex;\n    flex-wrap: wrap;',
+    );
     expect(styles).toContain('flex-wrap: wrap;');
     expect(styles).toContain('gap: var(--cinder-space-2);');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> :only-child)');
-    expect(styles).toContain(
-      '.cinder-access-gate__passthrough:has(> [data-cinder-full-width]):has(> :nth-child(2))',
-    );
     expect(styles).toContain('inline-size: 100%;');
+    expect(styles).not.toContain(
+      '.cinder-access-gate__passthrough:has(> [data-cinder-full-width])',
+    );
     expect(styles).toContain(
       '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]):has(> :nth-child(2))',
     );
     expect(styles).not.toContain(
       '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {',
     );
+    expect(styles).toContain('inline-size: auto;');
     expect(styles).toContain(
       ".cinder-access-gate__passthrough[data-cinder-variant='section'] {\n    display: contents;",
     );

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -40,9 +40,13 @@ describe('AccessGate', () => {
     expect(styles).toContain('.cinder-access-gate__passthrough {');
     expect(styles).toContain('flex-wrap: wrap;');
     expect(styles).toContain('gap: var(--cinder-space-2);');
+    expect(styles).toContain('.cinder-access-gate__passthrough:has(> :only-child)');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-full-width])');
     expect(styles).toContain('inline-size: 100%;');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-icon-only])');
+    expect(styles).toContain(
+      ".cinder-access-gate__passthrough[data-cinder-variant='section'] {\n    display: contents;",
+    );
     expect(styles).toContain(
       ".cinder-access-gate[data-cinder-variant='inline']:has(\n      .cinder-access-gate__inline-content > [data-cinder-icon-only]",
     );

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -38,7 +38,8 @@ describe('AccessGate', () => {
     const styles = readFileSync(new URL('./access-gate.css', import.meta.url), 'utf8');
 
     expect(styles).toContain('.cinder-access-gate__passthrough {');
-    expect(styles).toContain('.cinder-access-gate__passthrough {\n    display: contents;');
+    expect(styles).toContain('.cinder-access-gate__passthrough {\n    display: inline-flex;');
+    expect(styles).toContain('align-items: baseline;');
     expect(styles).not.toContain('.cinder-access-gate__passthrough:has(> :only-child)');
     expect(styles).toContain('inline-size: 100%;');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-full-width])');
@@ -68,7 +69,7 @@ describe('AccessGate', () => {
     cleanup();
   });
 
-  test('granted inline gates render children without an extra wrapper', () => {
+  test('granted inline gates render children in a semantic-neutral layout wrapper', () => {
     const { container } = render(AccessGate, {
       granted: true,
       reason: 'Requires scope: workflows:cancel',

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -58,7 +58,7 @@ describe('AccessGate', () => {
     );
     expect(styles).toContain('.cinder-access-gate__inline-reason {');
     expect(styles).toContain('display: inline-block;');
-    expect(styles).toContain('align-self: flex-start;');
+    expect(styles).toContain('align-self: first baseline;');
     expect(styles).toContain('padding-inline-start: calc(0.875rem + var(--cinder-space-1));');
     expect(styles).toContain('.cinder-access-gate__inline-reason > svg {');
     expect(styles).toContain('position: absolute;');

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -41,7 +41,9 @@ describe('AccessGate', () => {
     expect(styles).toContain('flex-wrap: wrap;');
     expect(styles).toContain('gap: var(--cinder-space-2);');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> :only-child)');
-    expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-full-width])');
+    expect(styles).toContain(
+      '.cinder-access-gate__passthrough:has(> [data-cinder-full-width]):has(> :nth-child(2))',
+    );
     expect(styles).toContain('inline-size: 100%;');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-icon-only])');
     expect(styles).toContain(

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -38,12 +38,8 @@ describe('AccessGate', () => {
     const styles = readFileSync(new URL('./access-gate.css', import.meta.url), 'utf8');
 
     expect(styles).toContain('.cinder-access-gate__passthrough {');
-    expect(styles).toContain(
-      '.cinder-access-gate__passthrough {\n    display: flex;\n    flex-wrap: wrap;',
-    );
-    expect(styles).toContain('flex-wrap: wrap;');
-    expect(styles).toContain('gap: var(--cinder-space-2);');
-    expect(styles).toContain('.cinder-access-gate__passthrough:has(> :only-child)');
+    expect(styles).toContain('.cinder-access-gate__passthrough {\n    display: contents;');
+    expect(styles).not.toContain('.cinder-access-gate__passthrough:has(> :only-child)');
     expect(styles).toContain('inline-size: 100%;');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-full-width])');
     expect(styles).toContain(

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -45,9 +45,7 @@ describe('AccessGate', () => {
     expect(styles).toContain('gap: var(--cinder-space-2);');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> :only-child)');
     expect(styles).toContain('inline-size: 100%;');
-    expect(styles).not.toContain(
-      '.cinder-access-gate__passthrough:has(> [data-cinder-full-width])',
-    );
+    expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-full-width])');
     expect(styles).toContain(
       '.cinder-access-gate__passthrough:where(\n    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only])))',
     );

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -48,6 +48,7 @@ describe('AccessGate', () => {
     expect(styles).not.toContain(
       '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {',
     );
+    expect(styles).toContain('gap: var(--cinder-space-2);');
     expect(styles).toContain('inline-size: auto;');
     expect(styles).toContain(
       ".cinder-access-gate__passthrough[data-cinder-variant='section'] {\n    display: contents;\n    inline-size: auto;",

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -37,22 +37,21 @@ describe('AccessGate', () => {
   test('preserves intrinsic, full-width, wrapping, and icon-only inline layout', () => {
     const styles = readFileSync(new URL('./access-gate.css', import.meta.url), 'utf8');
 
-    expect(styles).toContain('.cinder-access-gate__passthrough {');
-    expect(styles).toContain('.cinder-access-gate__passthrough {\n    display: inline-flex;');
+    expect(styles).toMatch(/\.cinder-access-gate__passthrough\s*\{\s*display:\s*inline-flex;/);
     expect(styles).toContain('align-items: baseline;');
     expect(styles).not.toContain('.cinder-access-gate__passthrough:has(> :only-child)');
     expect(styles).toContain('inline-size: 100%;');
     expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-full-width])');
-    expect(styles).toContain(
-      '.cinder-access-gate__passthrough:where(\n    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only])))',
+    expect(styles).toMatch(
+      /\.cinder-access-gate__passthrough:where\(\s*:has\(> \[data-cinder-icon-only\]\):has\(> :nth-child\(2\)\):not\(:has\(> :not\(\[data-cinder-icon-only\]\)\)\)/,
     );
     expect(styles).not.toContain(
       '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {',
     );
     expect(styles).toContain('gap: var(--cinder-space-2);');
     expect(styles).toContain('inline-size: auto;');
-    expect(styles).toContain(
-      ".cinder-access-gate__passthrough[data-cinder-variant='section'] {\n    display: contents;\n    inline-size: auto;",
+    expect(styles).toMatch(
+      /\.cinder-access-gate__passthrough\[data-cinder-variant='section'\]\s*\{\s*display:\s*contents;\s*inline-size:\s*auto;/,
     );
     expect(styles).toContain(
       ".cinder-access-gate[data-cinder-variant='inline']:has(\n      .cinder-access-gate__inline-content > [data-cinder-icon-only]",

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import type { AccessGateProps } from './access-gate.types.ts';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -33,6 +34,19 @@ function markupSnippet(markup: string) {
 }
 
 describe('AccessGate', () => {
+  test('preserves full-width and wrapping layout while aligning denied copy to its text baseline', () => {
+    const styles = readFileSync(new URL('./access-gate.css', import.meta.url), 'utf8');
+
+    expect(styles).toContain('.cinder-access-gate__passthrough {');
+    expect(styles).toContain('flex-wrap: wrap;');
+    expect(styles).toContain('inline-size: 100%;');
+    expect(styles).toContain('.cinder-access-gate__inline-reason {');
+    expect(styles).toContain('display: inline-block;');
+    expect(styles).toContain('padding-inline-start: calc(0.875rem + var(--cinder-space-1));');
+    expect(styles).toContain('.cinder-access-gate__inline-reason > svg {');
+    expect(styles).toContain('position: absolute;');
+  });
+
   afterEach(() => {
     cleanup();
   });

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -49,14 +49,14 @@ describe('AccessGate', () => {
       '.cinder-access-gate__passthrough:has(> [data-cinder-full-width])',
     );
     expect(styles).toContain(
-      '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]):has(> :nth-child(2))',
+      '.cinder-access-gate__passthrough:where(\n    :has(> [data-cinder-icon-only]):has(> :nth-child(2)):not(:has(> :not([data-cinder-icon-only])))',
     );
     expect(styles).not.toContain(
       '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {',
     );
     expect(styles).toContain('inline-size: auto;');
     expect(styles).toContain(
-      ".cinder-access-gate__passthrough[data-cinder-variant='section'] {\n    display: contents;",
+      ".cinder-access-gate__passthrough[data-cinder-variant='section'] {\n    display: contents;\n    inline-size: auto;",
     );
     expect(styles).toContain(
       ".cinder-access-gate[data-cinder-variant='inline']:has(\n      .cinder-access-gate__inline-content > [data-cinder-icon-only]",

--- a/packages/components/src/components/access-gate/access-gate.test.ts
+++ b/packages/components/src/components/access-gate/access-gate.test.ts
@@ -45,7 +45,12 @@ describe('AccessGate', () => {
       '.cinder-access-gate__passthrough:has(> [data-cinder-full-width]):has(> :nth-child(2))',
     );
     expect(styles).toContain('inline-size: 100%;');
-    expect(styles).toContain('.cinder-access-gate__passthrough:has(> [data-cinder-icon-only])');
+    expect(styles).toContain(
+      '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]):has(> :nth-child(2))',
+    );
+    expect(styles).not.toContain(
+      '.cinder-access-gate__passthrough:has(> [data-cinder-icon-only]) {',
+    );
     expect(styles).toContain(
       ".cinder-access-gate__passthrough[data-cinder-variant='section'] {\n    display: contents;",
     );

--- a/packages/components/src/components/input/input.svelte
+++ b/packages/components/src/components/input/input.svelte
@@ -160,7 +160,7 @@
   />
 {/snippet}
 
-<div class="cinder-input-field">
+<div class="cinder-input-field" data-cinder-full-width>
   {#if label}
     <label
       for={id}

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -31,7 +31,7 @@ function idsIn(container: Element): string[] {
 
 describe('Input rendering', () => {
   test('marks its root as a full-width layout participant', () => {
-    const { container } = render(Input, { id: 'name' });
+    const { container } = render(Input, { id: 'name', value: '' });
 
     expect(
       container.querySelector('.cinder-input-field')?.hasAttribute('data-cinder-full-width'),

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -31,7 +31,7 @@ function idsIn(container: Element): string[] {
 
 describe('Input rendering', () => {
   test('marks its root as a full-width layout participant', () => {
-    const { container } = render(Input, { id: 'name', value: '' });
+    const { container } = render(Input, { props: { id: 'name', value: '' } });
 
     expect(
       container.querySelector('.cinder-input-field')?.hasAttribute('data-cinder-full-width'),

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -30,6 +30,14 @@ function idsIn(container: Element): string[] {
 }
 
 describe('Input rendering', () => {
+  test('marks its root as a full-width layout participant', () => {
+    const { container } = render(Input, { id: 'name' });
+
+    expect(
+      container.querySelector('.cinder-input-field')?.hasAttribute('data-cinder-full-width'),
+    ).toBe(true);
+  });
+
   test('renders with required id prop', () => {
     const { container } = render(Input, {
       props: { id: 'test-input', value: '' },

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -37,6 +37,7 @@ import {
   fallbackToLastGood,
   handleRequest,
   isWarmupStable,
+  mergeGeneratedSchemaMetadata,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
   setPreparedShellServerRenderer,
@@ -1372,6 +1373,42 @@ describe('/api/manifest/:name', () => {
     const result = (await response.json()) as ComponentManifest;
     expect(result.importPath).toBe('@lostgradient/chat');
   }, 30_000);
+});
+
+describe('generated schema metadata', () => {
+  it('overlays defaults without adding private props or losing analyzer-owned bindability', () => {
+    const analyzedManifest: ComponentManifest = {
+      name: 'Input',
+      kebabName: 'input',
+      file: '/components/input/input.svelte',
+      importPath: '@lostgradient/cinder/input',
+      props: [
+        {
+          name: 'value',
+          control: { kind: 'text' },
+          bindable: true,
+          optional: true,
+        },
+      ],
+    };
+
+    const merged = mergeGeneratedSchemaMetadata(analyzedManifest, {
+      properties: {
+        value: { default: '' },
+        class: { default: 'schema-only-private-prop' },
+      },
+    });
+
+    expect(merged.props).toEqual([
+      {
+        name: 'value',
+        control: { kind: 'text' },
+        bindable: true,
+        optional: true,
+        defaultValue: '',
+      },
+    ]);
+  });
 });
 
 describe('/api/documentation/:name', () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -290,6 +290,7 @@ describe('startup warmup stability', () => {
   it('rejects a warmup when source changes before watcher validation', () => {
     expect(isWarmupStable(4, 4, 100, 101)).toBe(false);
     expect(isWarmupStable(4, 5, 100, 100)).toBe(false);
+    expect(isWarmupStable(4, 4, 100, 100, true)).toBe(false);
     expect(isWarmupStable(4, 4, 100, 100)).toBe(true);
   });
 });

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -36,6 +36,7 @@ import {
   createSharedDisposer,
   fallbackToLastGood,
   handleRequest,
+  isWarmupStable,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
   triggerReload,
@@ -282,6 +283,14 @@ describe('shared disposer', () => {
 
     expect(dispose()).toBe(firstDispose);
     expect(disposeCalls).toBe(1);
+  });
+});
+
+describe('startup warmup stability', () => {
+  it('rejects a warmup when source changes before watcher validation', () => {
+    expect(isWarmupStable(4, 4, 100, 101)).toBe(false);
+    expect(isWarmupStable(4, 5, 100, 100)).toBe(false);
+    expect(isWarmupStable(4, 4, 100, 100)).toBe(true);
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -38,6 +38,7 @@ import {
   handleRequest,
   isWarmupStable,
   mergeGeneratedSchemaMetadata,
+  readGeneratedComponentSchema,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
   setPreparedShellServerRenderer,
@@ -1376,6 +1377,15 @@ describe('/api/manifest/:name', () => {
 });
 
 describe('generated schema metadata', () => {
+  it('falls back when a generated schema disappears or is malformed during a read', async () => {
+    expect(
+      await readGeneratedComponentSchema({
+        exists: () => Promise.resolve(true),
+        json: () => Promise.reject(new SyntaxError('partial schema')),
+      }),
+    ).toBeNull();
+  });
+
   it('overlays defaults without adding private props or losing analyzer-owned bindability', () => {
     const analyzedManifest: ComponentManifest = {
       name: 'Input',

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -18,7 +18,7 @@
  * by the "playground bundle dependency build preflight" test.
  */
 
-import { afterEach, beforeAll, describe, expect, it } from 'bun:test';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
 import { rm, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
@@ -39,6 +39,7 @@ import {
   isWarmupStable,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
+  setPreparedShellServerRenderer,
   shellBuildSucceeded,
   triggerReload,
 } from './playground-server.ts';
@@ -73,6 +74,36 @@ beforeAll(async () => {
 });
 
 const temporaryServers: ReturnType<typeof Bun.serve>[] = [];
+const testShellServerRenderer: NonNullable<
+  Parameters<typeof setPreparedShellServerRenderer>[0]
+> = ({ initialComponent, documentation, initialSearch }) => {
+  const search = new URLSearchParams(initialSearch);
+  const focusClass = search.get('focus') === '1' ? 'shell focus-mode' : 'shell';
+  const viewportWidth = search.get('w') ?? '';
+  const documentationBody =
+    documentation === null
+      ? ''
+      : `<article class="documentation" data-canonical-documentation>
+          <h1>${documentation.component.name}</h1>
+          <h2>Overview</h2>
+          ${documentation.readme.html}
+          <h2>Props</h2>
+          <iframe src="/page/${initialComponent}?preview=1"></iframe>
+          <a href="/page/${initialComponent}">Open documentation</a>
+        </article>`;
+
+  return {
+    body: `<div id="shell-root"><div class="${focusClass}">
+      <input id="viewport-width-input" value="${viewportWidth}" />
+      ${documentationBody}
+    </div></div>`,
+    head: '<style>.documentation { display: block; }</style>',
+  };
+};
+
+beforeEach(() => {
+  setPreparedShellServerRenderer(testShellServerRenderer);
+});
 
 describe('last-good rebuild fallback', () => {
   it('does not treat a last-good shell fallback as a successful fresh build', () => {
@@ -93,6 +124,7 @@ describe('last-good rebuild fallback', () => {
 });
 
 afterEach(async () => {
+  setPreparedShellServerRenderer(null);
   const servers = temporaryServers.splice(0);
   await Promise.all(servers.map((server) => server.stop(true)));
 });

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -1419,6 +1419,24 @@ describe('generated schema metadata', () => {
       },
     ]);
   });
+
+  it('preserves schema metadata when no properties block is present', () => {
+    const analyzedManifest: ComponentManifest = {
+      name: 'Snippet',
+      kebabName: 'snippet',
+      file: '/components/snippet/snippet.svelte',
+      importPath: '@lostgradient/cinder/snippet',
+      props: [],
+    };
+
+    expect(
+      mergeGeneratedSchemaMetadata(analyzedManifest, {
+        metadata: {
+          unsupportedProps: [{ name: 'children', required: true, reason: 'function-or-snippet' }],
+        },
+      }).isCompound,
+    ).toBe(true);
+  });
 });
 
 describe('/api/documentation/:name', () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -39,6 +39,7 @@ import {
   isWarmupStable,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
+  shellBuildSucceeded,
   triggerReload,
 } from './playground-server.ts';
 import { jsonForScriptTag } from './render-shell.ts';
@@ -74,6 +75,12 @@ beforeAll(async () => {
 const temporaryServers: ReturnType<typeof Bun.serve>[] = [];
 
 describe('last-good rebuild fallback', () => {
+  it('does not treat a last-good shell fallback as a successful fresh build', () => {
+    expect(shellBuildSucceeded('last-good-shell', true)).toBe(false);
+    expect(shellBuildSucceeded('fresh-shell', false)).toBe(true);
+    expect(shellBuildSucceeded(null, false)).toBe(false);
+  });
+
   it('keeps a successful renderer available through a transient rebuild failure', () => {
     const renderer = () => ({ body: '<main>last good</main>', head: '' });
     expect(fallbackToLastGood(renderer, new Error('transient compile failure'))).toBe(renderer);

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1470,6 +1470,59 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
 
   const definition = await discoverComponentDefinition(componentName);
   if (definition === undefined) return null;
+  const generatedSchemaPath = join(
+    definition.source.componentsRoot,
+    componentName,
+    `${componentName}.schema.json`,
+  );
+  const generatedSchemaFile = Bun.file(generatedSchemaPath);
+  if (await generatedSchemaFile.exists()) {
+    const schema = (await generatedSchemaFile.json()) as {
+      properties?: Record<string, { type?: string; enum?: unknown[]; description?: string }>;
+      required?: string[];
+    };
+    if (schema.properties !== undefined) {
+      const manifest: ComponentManifest = {
+        name: componentName,
+        kebabName: componentName,
+        file: definition.filePath,
+        importPath: definition.importPath,
+        props: Object.entries(schema.properties).map(([name, property]) => {
+          const defaultText = property.description?.match(/Default `([^`]+)`/)?.[1];
+          const defaultValue =
+            defaultText === undefined
+              ? undefined
+              : defaultText === 'true'
+                ? true
+                : defaultText === 'false'
+                  ? false
+                  : Number.isNaN(Number(defaultText))
+                    ? defaultText
+                    : Number(defaultText);
+          const control =
+            property.enum !== undefined
+              ? { kind: 'select' as const, options: property.enum.map(String) }
+              : property.type === 'boolean'
+                ? { kind: 'boolean' as const }
+                : property.type === 'number' || property.type === 'integer'
+                  ? { kind: 'number' as const }
+                  : property.type === 'string'
+                    ? { kind: 'text' as const }
+                    : { kind: 'unknown' as const, rawType: property.type ?? 'unknown' };
+          return {
+            name,
+            control,
+            bindable: property.description?.includes('Bindable') ?? false,
+            optional: !(schema.required ?? []).includes(name),
+            ...(defaultValue === undefined ? {} : { defaultValue }),
+            ...(property.description === undefined ? {} : { description: property.description }),
+          };
+        }),
+      };
+      componentManifestCache.set(componentName, manifest);
+      return manifest;
+    }
+  }
   const generationAtStart = rebuildGeneration;
   const manifest = await analyzeComponent(definition.filePath, {
     importPath: definition.importPath,
@@ -2607,6 +2660,14 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   process.stdout.write(
     `[playground] Pre-built ${prebuild.succeeded}/${total} page bundles${failedSuffix}\n`,
   );
+  // Prepare the SSR shell renderer before advertising readiness. Requests must
+  // never pay the cold Svelte server compilation cost on the first navigation.
+  try {
+    await loadShellServerRenderer();
+  } catch (error) {
+    await dispose();
+    throw new Error('[playground] shell server renderer failed to prepare', { cause: error });
+  }
   startupReady = true;
   return {
     port: actualPort,

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2541,7 +2541,20 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   }
   process.stdout.write(`[playground] Listening at http://localhost:${actualPort}\n`);
 
-  const prebuild = await eagerPrebuildAll();
+  let prebuild;
+  let stable = false;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const generationAtStart = rebuildGeneration;
+    prebuild = await eagerPrebuildAll();
+    if (generationAtStart === rebuildGeneration) {
+      stable = true;
+      break;
+    }
+  }
+  if (!stable || !prebuild) {
+    await dispose();
+    throw new Error('[playground] eager prebuild invalidated repeatedly; refusing readiness');
+  }
   if (!prebuild.shellSucceeded) {
     await dispose();
     throw new Error('[playground] shell bundle failed to build — see logs above');

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -785,7 +785,7 @@ async function buildBundleUncached(
   // Captured before the (potentially slow) compile so we can tell, after it
   // resolves, whether an invalidation raced past us — see the publish guard
   // below.
-  const analysisGenerationAtStart = rebuildGeneration;
+  const generationAtStart = rebuildGeneration;
 
   // Bun's `naming` template uses the entrypoint basename for `[name]`. To
   // emit the entry as `bundle-<name>-<scenario>.js` (disjoint from the
@@ -1452,7 +1452,7 @@ async function getManifests(): Promise<ComponentManifest[]> {
   if (manifestCache !== null) return manifestCache;
   // Captured before awaiting so we can tell, once the analysis resolves,
   // whether an invalidation raced past us — see the publish guard below.
-  const analysisGenerationAtStart = rebuildGeneration;
+  const generationAtStart = rebuildGeneration;
   // Reuse the in-flight promise so concurrent callers don't each analyze the
   // same package sources. Discovery has already rejected duplicate route slugs.
   manifestPromise ??= discoverComponentDefinitions().then(async (definitions) => {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1499,8 +1499,14 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
   const generatedSchemaFile = Bun.file(generatedSchemaPath);
   if (await generatedSchemaFile.exists()) {
     const schema = (await generatedSchemaFile.json()) as {
-      properties?: Record<string, { type?: string; enum?: unknown[]; description?: string }>;
+      properties?: Record<
+        string,
+        { type?: string; enum?: unknown[]; description?: string; default?: unknown }
+      >;
       required?: string[];
+      metadata?: {
+        unsupportedProps?: Array<{ name: string; required?: boolean; reason?: string }>;
+      };
     };
     if (schema.properties !== undefined) {
       const manifest: ComponentManifest = {
@@ -1509,17 +1515,7 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
         file: definition.filePath,
         importPath: definition.importPath,
         props: Object.entries(schema.properties).map(([name, property]) => {
-          const defaultText = property.description?.match(/Default `([^`]+)`/)?.[1];
-          const defaultValue =
-            defaultText === undefined
-              ? undefined
-              : defaultText === 'true'
-                ? true
-                : defaultText === 'false'
-                  ? false
-                  : Number.isNaN(Number(defaultText))
-                    ? defaultText
-                    : Number(defaultText);
+          const defaultValue = property.default;
           const control =
             property.enum !== undefined
               ? { kind: 'select' as const, options: property.enum.map(String) }
@@ -1539,6 +1535,11 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
             ...(property.description === undefined ? {} : { description: property.description }),
           };
         }),
+        ...(schema.metadata?.unsupportedProps?.some(
+          (prop) => prop.required === true && prop.reason === 'function-or-snippet',
+        )
+          ? { isCompound: true }
+          : {}),
       };
       componentManifestCache.set(componentName, manifest);
       return manifest;
@@ -2697,6 +2698,8 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     } else {
       preparedShellServerRenderer = null;
       invalidateCachesForChange({ kind: 'components' });
+      prebuild = await eagerPrebuildAll();
+      if (!prebuild.shellSucceeded) break;
     }
   }
   if (!rendererPrepared) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -193,6 +193,7 @@ type ShellServerRenderer = (props: {
 let shellServerRendererPromise: Promise<ShellServerRenderer> | null = null;
 let lastGoodShellServerRenderer: ShellServerRenderer | null = null;
 let preparedShellServerRenderer: ShellServerRenderer | null = null;
+let shellRendererUsedFallback = false;
 
 /**
  * Server renderer for the canonical documentation page (`src/page-server-entry.ts`).
@@ -784,7 +785,7 @@ async function buildBundleUncached(
   // Captured before the (potentially slow) compile so we can tell, after it
   // resolves, whether an invalidation raced past us — see the publish guard
   // below.
-  const generationAtStart = rebuildGeneration;
+  const analysisGenerationAtStart = rebuildGeneration;
 
   // Bun's `naming` template uses the entrypoint basename for `[name]`. To
   // emit the entry as `bundle-<name>-<scenario>.js` (disjoint from the
@@ -1299,6 +1300,7 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
       const renderer = Reflect.get(loaded, 'renderShellBody') as ShellServerRenderer;
       if (generationAtStart === rebuildGeneration) {
         lastGoodShellServerRenderer = renderer;
+        shellRendererUsedFallback = false;
       }
       return renderer;
     } catch (error) {
@@ -1306,6 +1308,7 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
         '[playground] shell server rebuild failed; serving the last-good renderer:',
         error,
       );
+      shellRendererUsedFallback = true;
       return fallbackToLastGood(lastGoodShellServerRenderer, error);
     }
   })();
@@ -1449,7 +1452,7 @@ async function getManifests(): Promise<ComponentManifest[]> {
   if (manifestCache !== null) return manifestCache;
   // Captured before awaiting so we can tell, once the analysis resolves,
   // whether an invalidation raced past us — see the publish guard below.
-  const generationAtStart = rebuildGeneration;
+  const analysisGenerationAtStart = rebuildGeneration;
   // Reuse the in-flight promise so concurrent callers don't each analyze the
   // same package sources. Discovery has already rejected duplicate route slugs.
   manifestPromise ??= discoverComponentDefinitions().then(async (definitions) => {
@@ -1497,6 +1500,7 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
     `${componentName}.schema.json`,
   );
   const generatedSchemaFile = Bun.file(generatedSchemaPath);
+  const generationAtStart = rebuildGeneration;
   if (await generatedSchemaFile.exists()) {
     const schema = (await generatedSchemaFile.json()) as {
       properties?: Record<
@@ -1510,7 +1514,7 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
     };
     if (schema.properties !== undefined) {
       const manifest: ComponentManifest = {
-        name: componentName,
+        name: humanizeComponentName(componentName),
         kebabName: componentName,
         file: definition.filePath,
         importPath: definition.importPath,
@@ -1541,15 +1545,16 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
           ? { isCompound: true }
           : {}),
       };
-      componentManifestCache.set(componentName, manifest);
+      if (generationAtStart === rebuildGeneration)
+        componentManifestCache.set(componentName, manifest);
       return manifest;
     }
   }
-  const generationAtStart = rebuildGeneration;
+  const analysisGenerationAtStart = rebuildGeneration;
   const manifest = await analyzeComponent(definition.filePath, {
     importPath: definition.importPath,
   });
-  if (generationAtStart === rebuildGeneration) {
+  if (analysisGenerationAtStart === rebuildGeneration) {
     componentManifestCache.set(componentName, manifest);
   }
   return manifest;
@@ -2680,6 +2685,10 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
     try {
       preparedShellServerRenderer = await loadShellServerRenderer();
+      if (shellRendererUsedFallback) {
+        preparedShellServerRenderer = null;
+        continue;
+      }
     } catch (error) {
       await dispose();
       throw new Error('[playground] shell server renderer failed to prepare', { cause: error });

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1485,6 +1485,31 @@ async function getManifests(): Promise<ComponentManifest[]> {
   }
 }
 
+type GeneratedComponentSchema = {
+  properties?: Record<string, { default?: unknown }>;
+  metadata?: {
+    unsupportedProps?: Array<{ name: string; required?: boolean; reason?: string }>;
+  };
+};
+
+export function mergeGeneratedSchemaMetadata(
+  analyzedManifest: ComponentManifest,
+  schema: GeneratedComponentSchema,
+): ComponentManifest {
+  return {
+    ...analyzedManifest,
+    props: analyzedManifest.props.map((prop) => {
+      const defaultValue = schema.properties?.[prop.name]?.default;
+      return defaultValue === undefined ? prop : { ...prop, defaultValue };
+    }),
+    ...(schema.metadata?.unsupportedProps?.some(
+      (prop) => prop.required === true && prop.reason === 'function-or-snippet',
+    )
+      ? { isCompound: true }
+      : {}),
+  };
+}
+
 async function getComponentManifest(componentName: string): Promise<ComponentManifest | null> {
   const cached = componentManifestCache.get(componentName);
   if (cached !== undefined) return cached;
@@ -1501,60 +1526,17 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
   );
   const generatedSchemaFile = Bun.file(generatedSchemaPath);
   const generationAtStart = rebuildGeneration;
-  if (await generatedSchemaFile.exists()) {
-    const schema = (await generatedSchemaFile.json()) as {
-      properties?: Record<
-        string,
-        { type?: string; enum?: unknown[]; description?: string; default?: unknown }
-      >;
-      required?: string[];
-      metadata?: {
-        unsupportedProps?: Array<{ name: string; required?: boolean; reason?: string }>;
-      };
-    };
-    if (schema.properties !== undefined) {
-      const manifest: ComponentManifest = {
-        name: humanizeComponentName(componentName),
-        kebabName: componentName,
-        file: definition.filePath,
-        importPath: definition.importPath,
-        props: Object.entries(schema.properties).map(([name, property]) => {
-          const defaultValue = property.default;
-          const control =
-            property.enum !== undefined
-              ? { kind: 'select' as const, options: property.enum.map(String) }
-              : property.type === 'boolean'
-                ? { kind: 'boolean' as const }
-                : property.type === 'number' || property.type === 'integer'
-                  ? { kind: 'number' as const }
-                  : property.type === 'string'
-                    ? { kind: 'text' as const }
-                    : { kind: 'unknown' as const, rawType: property.type ?? 'unknown' };
-          return {
-            name,
-            control,
-            bindable: property.description?.includes('Bindable') ?? false,
-            optional: !(schema.required ?? []).includes(name),
-            ...(defaultValue === undefined ? {} : { defaultValue }),
-            ...(property.description === undefined ? {} : { description: property.description }),
-          };
-        }),
-        ...(schema.metadata?.unsupportedProps?.some(
-          (prop) => prop.required === true && prop.reason === 'function-or-snippet',
-        )
-          ? { isCompound: true }
-          : {}),
-      };
-      if (generationAtStart === rebuildGeneration)
-        componentManifestCache.set(componentName, manifest);
-      return manifest;
-    }
-  }
-  const analysisGenerationAtStart = rebuildGeneration;
-  const manifest = await analyzeComponent(definition.filePath, {
+  const analyzedManifest = await analyzeComponent(definition.filePath, {
     importPath: definition.importPath,
   });
-  if (analysisGenerationAtStart === rebuildGeneration) {
+  let manifest = analyzedManifest;
+  if (await generatedSchemaFile.exists()) {
+    const schema = (await generatedSchemaFile.json()) as GeneratedComponentSchema;
+    if (schema.properties !== undefined) {
+      manifest = mergeGeneratedSchemaMetadata(analyzedManifest, schema);
+    }
+  }
+  if (generationAtStart === rebuildGeneration) {
     componentManifestCache.set(componentName, manifest);
   }
   return manifest;

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2505,6 +2505,15 @@ export function createSharedDisposer(disposeWork: () => Promise<void>): () => Pr
   };
 }
 
+export function isWarmupStable(
+  generationAtStart: number,
+  generationAtEnd: number,
+  sourceMtimeAtStart: number | null,
+  sourceMtimeAtEnd: number | null,
+): boolean {
+  return generationAtStart === generationAtEnd && sourceMtimeAtStart === sourceMtimeAtEnd;
+}
+
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
   startupReady = false;
@@ -2538,11 +2547,27 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   let stable = false;
   for (let attempt = 0; attempt < 5; attempt += 1) {
     const generationAtStart = rebuildGeneration;
+    const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
     prebuild = await eagerPrebuildAll();
-    if (generationAtStart === rebuildGeneration) {
+    await getManifests().catch((error: unknown) => {
+      console.error('[playground] manifest pre-warm failed:', error);
+    });
+    if (watchers.length === 0) {
+      try {
+        watchers = startWatcher();
+      } catch (error) {
+        await dispose();
+        throw error;
+      }
+    }
+    const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
+    if (
+      isWarmupStable(generationAtStart, rebuildGeneration, sourceMtimeAtStart, sourceMtimeAtEnd)
+    ) {
       stable = true;
       break;
     }
+    invalidateCachesForChange({ kind: 'components' });
   }
   if (!stable || !prebuild) {
     await dispose();
@@ -2557,16 +2582,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   process.stdout.write(
     `[playground] Pre-built ${prebuild.succeeded}/${total} page bundles${failedSuffix}\n`,
   );
-  await getManifests().catch((error: unknown) => {
-    console.error('[playground] manifest pre-warm failed:', error);
-  });
   startupReady = true;
-  try {
-    watchers = startWatcher();
-  } catch (error) {
-    await dispose();
-    throw error;
-  }
   return {
     port: actualPort,
     dispose: async () => {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -192,6 +192,7 @@ type ShellServerRenderer = (props: {
 }) => { body: string; head: string };
 let shellServerRendererPromise: Promise<ShellServerRenderer> | null = null;
 let lastGoodShellServerRenderer: ShellServerRenderer | null = null;
+let preparedShellServerRenderer: ShellServerRenderer | null = null;
 
 /**
  * Server renderer for the canonical documentation page (`src/page-server-entry.ts`).
@@ -478,6 +479,7 @@ function invalidateCachesForChange(scope: ChangeScope): void {
   shellStale = true;
   shellBuildPromise = null;
   shellServerRendererPromise = null;
+  preparedShellServerRenderer = null;
   // The documentation page's server bundle shares the component graph the shell
   // rebuild invalidates, so drop its dedup slot on the same signal.
   pageServerRendererPromise = null;
@@ -1295,6 +1297,11 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
   })();
 
   return shellServerRendererPromise;
+}
+
+/** Inject the renderer prepared by server startup (or a deterministic test renderer). */
+export function setPreparedShellServerRenderer(renderer: ShellServerRenderer | null): void {
+  preparedShellServerRenderer = renderer;
 }
 
 /**
@@ -2362,7 +2369,7 @@ export async function handleRequest(request: Request): Promise<Response> {
     if (documentation === null) {
       return notFound(`Documentation for "${componentName}" not found`);
     }
-    const renderShellBody = await loadShellServerRenderer();
+    const renderShellBody = preparedShellServerRenderer ?? (await loadShellServerRenderer());
     const renderedShell = renderShellBody({
       initialComponent: componentName,
       components: sidebarComponents,
@@ -2385,7 +2392,7 @@ export async function handleRequest(request: Request): Promise<Response> {
       discoverSidebarComponents(),
       renderLandingReadmeHtml(),
     ]);
-    const renderShellBody = await loadShellServerRenderer();
+    const renderShellBody = preparedShellServerRenderer ?? (await loadShellServerRenderer());
     const renderedShell = renderShellBody({
       initialComponent: '',
       components: sidebarComponents,
@@ -2663,7 +2670,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   // Prepare the SSR shell renderer before advertising readiness. Requests must
   // never pay the cold Svelte server compilation cost on the first navigation.
   try {
-    await loadShellServerRenderer();
+    preparedShellServerRenderer = await loadShellServerRenderer();
   } catch (error) {
     await dispose();
     throw new Error('[playground] shell server renderer failed to prepare', { cause: error });

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -551,6 +551,19 @@ function startWatcher(): FSWatcher[] {
       }
     }
 
+    // Markdown is a transitive dependency of the shell and page bundles, but
+    // it is not one of the published component sources. Watch its source tree
+    // explicitly so a successful dependency rebuild invalidates cached
+    // artifacts instead of leaving stale renderer bytes in memory.
+    const markdownSourcePath = join(REPO_ROOT, 'packages', 'markdown', 'src');
+    if (existsSync(markdownSourcePath)) {
+      created.push(
+        watch(markdownSourcePath, { recursive: true }, (_event, filename) => {
+          if (filename) scheduleRebuild({ kind: 'components' });
+        }),
+      );
+    }
+
     // Examples directory: an edit to `<name>/<scenario>.example.svelte` can
     // only ever affect that one component's page bundle, so the scope is
     // precisely the touched component name (the first path segment). Other

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -115,6 +115,7 @@ export function resolvePreferredPort(): number {
 }
 
 export const PORT = resolvePreferredPort();
+let startupReady = true;
 const MAX_PORT_SCAN_ATTEMPTS = 100;
 const COMPONENTS_ROOT = CINDER_COMPONENT_SOURCE.packageRoot; // packages/components/
 const REPO_ROOT = join(PLAYGROUND_ROOT, '..', '..'); // repo root
@@ -1963,7 +1964,8 @@ export async function handleRequest(request: Request): Promise<Response> {
 
   // GET /ready
   if (pathname === '/ready') {
-    return new Response('ready', {
+    return new Response(startupReady ? 'ready' : 'warming', {
+      status: startupReady ? 200 : 503,
       headers: {
         'Content-Type': 'text/plain',
         'X-Cinder-Playground-Fingerprint': JSON.stringify(STARTUP_FINGERPRINT),
@@ -2505,6 +2507,7 @@ export function createSharedDisposer(disposeWork: () => Promise<void>): () => Pr
 
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
+  startupReady = false;
   const playgroundHttpServer = createHttpServerOnAvailablePort(port, handleRequest);
   const { port: actualPort, server } = playgroundHttpServer;
 
@@ -2551,7 +2554,14 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   await getManifests().catch((error: unknown) => {
     console.error('[playground] manifest pre-warm failed:', error);
   });
-  return { port: actualPort, dispose };
+  startupReady = true;
+  return {
+    port: actualPort,
+    dispose: async () => {
+      startupReady = false;
+      await dispose();
+    },
+  };
 }
 
 if (import.meta.main) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1298,9 +1298,9 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
         throw new Error('Shell server bundle did not export renderShellBody');
       }
       const renderer = Reflect.get(loaded, 'renderShellBody') as ShellServerRenderer;
+      shellRendererUsedFallback = false;
       if (generationAtStart === rebuildGeneration) {
         lastGoodShellServerRenderer = renderer;
-        shellRendererUsedFallback = false;
       }
       return renderer;
     } catch (error) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1492,6 +1492,17 @@ type GeneratedComponentSchema = {
   };
 };
 
+export async function readGeneratedComponentSchema(
+  generatedSchemaFile: Pick<Bun.BunFile, 'exists' | 'json'>,
+): Promise<GeneratedComponentSchema | null> {
+  try {
+    if (!(await generatedSchemaFile.exists())) return null;
+    return (await generatedSchemaFile.json()) as GeneratedComponentSchema;
+  } catch {
+    return null;
+  }
+}
+
 export function mergeGeneratedSchemaMetadata(
   analyzedManifest: ComponentManifest,
   schema: GeneratedComponentSchema,
@@ -1530,11 +1541,9 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
     importPath: definition.importPath,
   });
   let manifest = analyzedManifest;
-  if (await generatedSchemaFile.exists()) {
-    const schema = (await generatedSchemaFile.json()) as GeneratedComponentSchema;
-    if (schema.properties !== undefined) {
-      manifest = mergeGeneratedSchemaMetadata(analyzedManifest, schema);
-    }
+  const schema = await readGeneratedComponentSchema(generatedSchemaFile);
+  if (schema?.properties !== undefined) {
+    manifest = mergeGeneratedSchemaMetadata(analyzedManifest, schema);
   }
   if (generationAtStart === rebuildGeneration) {
     componentManifestCache.set(componentName, manifest);

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2553,10 +2553,9 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   for (let attempt = 0; attempt < 5; attempt += 1) {
     const generationAtStart = rebuildGeneration;
     const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
-    prebuild = await eagerPrebuildAll();
-    await getManifests().catch((error: unknown) => {
-      console.error('[playground] manifest pre-warm failed:', error);
-    });
+    // Register before the eager build so deletions and edits during warmup
+    // advance the generation even when the removed file is no longer present
+    // in the end-of-build mtime scan.
     if (watchers.length === 0) {
       try {
         watchers = startWatcher();
@@ -2565,6 +2564,10 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         throw error;
       }
     }
+    prebuild = await eagerPrebuildAll();
+    await getManifests().catch((error: unknown) => {
+      console.error('[playground] manifest pre-warm failed:', error);
+    });
     const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
     if (
       isWarmupStable(

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2682,11 +2682,35 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   );
   // Prepare the SSR shell renderer before advertising readiness. Requests must
   // never pay the cold Svelte server compilation cost on the first navigation.
-  try {
-    preparedShellServerRenderer = await loadShellServerRenderer();
-  } catch (error) {
+  let rendererPrepared = false;
+  for (let attempt = 0; attempt < 5 && !rendererPrepared; attempt += 1) {
+    const generationAtStart = rebuildGeneration;
+    const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
+    try {
+      preparedShellServerRenderer = await loadShellServerRenderer();
+    } catch (error) {
+      await dispose();
+      throw new Error('[playground] shell server renderer failed to prepare', { cause: error });
+    }
+    const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
+    if (
+      isWarmupStable(
+        generationAtStart,
+        rebuildGeneration,
+        sourceMtimeAtStart,
+        sourceMtimeAtEnd,
+        rebuildDebounceTimer !== null,
+      )
+    ) {
+      rendererPrepared = true;
+    } else {
+      preparedShellServerRenderer = null;
+      invalidateCachesForChange({ kind: 'components' });
+    }
+  }
+  if (!rendererPrepared) {
     await dispose();
-    throw new Error('[playground] shell server renderer failed to prepare', { cause: error });
+    throw new Error('[playground] shell renderer invalidated repeatedly; refusing readiness');
   }
   startupReady = true;
   return {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -181,8 +181,8 @@ const fixtureArtifactByPath = new Map<string, string>();
  */
 const pageBuildPromiseByKey = new Map<string, Promise<string | null>>();
 const scenarioBuildPromiseByKey = new Map<string, Promise<string | null>>();
-let shellBuildPromise: Promise<string | null> | null = null;
-let shellBuildUsedFallback = false;
+type ShellBuildResult = { code: string | null; usedFallback: boolean };
+let shellBuildPromise: Promise<ShellBuildResult> | null = null;
 type ShellServerRenderer = (props: {
   initialComponent: string;
   components: string[];
@@ -1370,20 +1370,18 @@ async function loadPageServerRenderer(): Promise<PageServerRenderer> {
  * falls back to the last-good cached shell (if any) instead — see
  * `shellStale`'s doc comment for why the shell specifically needs this.
  */
-async function buildShellBundle(): Promise<string | null> {
+async function buildShellBundle(): Promise<ShellBuildResult> {
   const cachedEntryPath = shellEntryByName.get('shell');
   const cachedCode =
     cachedEntryPath !== undefined ? shellArtifactByPath.get(cachedEntryPath) : undefined;
   if (cachedCode !== undefined && !shellStale) {
-    shellBuildUsedFallback = false;
-    return cachedCode;
+    return { code: cachedCode, usedFallback: false };
   }
 
   if (shellBuildPromise !== null) return shellBuildPromise;
 
-  const buildPromise: Promise<string | null> = (async () => {
+  const buildPromise: Promise<ShellBuildResult> = (async () => {
     const generationAtStart = rebuildGeneration;
-    shellBuildUsedFallback = false;
     // A Svelte syntax error makes the underlying `Bun.build()` call THROW
     // rather than resolve with `{ success: false }` — `.catch()` converts
     // that into the same graceful-failure path as a build that resolves
@@ -1394,11 +1392,10 @@ async function buildShellBundle(): Promise<string | null> {
       return null;
     });
     if (entry === null) {
-      shellBuildUsedFallback = true;
       console.error(
         '[playground] shell rebuild failed — serving last-good shell (if cached); will retry on next request',
       );
-      return cachedCode ?? null;
+      return { code: cachedCode ?? null, usedFallback: true };
     }
 
     // Always publish chunks (see buildPageBundle's comment for the
@@ -1409,7 +1406,7 @@ async function buildShellBundle(): Promise<string | null> {
       shellEntryByName.set('shell', entry.entryPath);
       shellStale = false;
     }
-    return entry.entryCode;
+    return { code: entry.entryCode, usedFallback: false };
   })();
   shellBuildPromise = buildPromise;
 
@@ -2179,10 +2176,10 @@ export async function handleRequest(request: Request): Promise<Response> {
     // be hashed chunks served from the cache above; we never lazily build
     // anything other than the entry on this route.
     if (filename !== 'shell') return notFound();
-    const code = await buildShellBundle();
-    if (code === null) return notFound('Shell bundle failed to build');
+    const shellResult = await buildShellBundle();
+    if (shellResult.code === null) return notFound('Shell bundle failed to build');
     // Bare, unhashed shell entry URL (`/shell-bundle/shell.js`) — never cache.
-    return new Response(code, {
+    return new Response(shellResult.code, {
       headers: {
         'Content-Type': 'application/javascript',
         'Cache-Control': NO_STORE_CACHE_CONTROL,
@@ -2480,7 +2477,7 @@ async function eagerPrebuildAll(): Promise<{
 }> {
   const shellPromise = buildShellBundle().catch((error) => {
     console.error('[playground] shell bundle threw during pre-build:', error);
-    return null;
+    return { code: null, usedFallback: true };
   });
   const components = await discoverSidebarComponents();
   // Sidebar components are a subset of all components, so each is a valid
@@ -2505,7 +2502,7 @@ async function eagerPrebuildAll(): Promise<{
   }
 
   return {
-    shellSucceeded: shellBuildSucceeded(shellCode, shellBuildUsedFallback),
+    shellSucceeded: shellBuildSucceeded(shellCode.code, shellCode.usedFallback),
     succeeded,
     failed,
   };

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2511,14 +2511,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   const playgroundHttpServer = createHttpServerOnAvailablePort(port, handleRequest);
   const { port: actualPort, server } = playgroundHttpServer;
 
-  let watchers: FSWatcher[];
-  try {
-    watchers = startWatcher();
-  } catch (error) {
-    // startWatcher() failed — stop the already-listening server before rethrowing.
-    await server.stop(true);
-    throw error;
-  }
+  let watchers: FSWatcher[] = [];
 
   const dispose = createSharedDisposer(async () => {
     for (const watcher of watchers) {
@@ -2568,6 +2561,12 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     console.error('[playground] manifest pre-warm failed:', error);
   });
   startupReady = true;
+  try {
+    watchers = startWatcher();
+  } catch (error) {
+    await dispose();
+    throw error;
+  }
   return {
     port: actualPort,
     dispose: async () => {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1542,7 +1542,7 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
   });
   let manifest = analyzedManifest;
   const schema = await readGeneratedComponentSchema(generatedSchemaFile);
-  if (schema?.properties !== undefined) {
+  if (schema !== null) {
     manifest = mergeGeneratedSchemaMetadata(analyzedManifest, schema);
   }
   if (generationAtStart === rebuildGeneration) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2636,7 +2636,6 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   let stable = false;
   for (let attempt = 0; attempt < 5; attempt += 1) {
     const generationAtStart = rebuildGeneration;
-    const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
     // Register before the eager build so deletions and edits during warmup
     // advance the generation even when the removed file is no longer present
     // in the end-of-build mtime scan.
@@ -2652,16 +2651,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     await getManifests().catch((error: unknown) => {
       console.error('[playground] manifest pre-warm failed:', error);
     });
-    const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
-    if (
-      isWarmupStable(
-        generationAtStart,
-        rebuildGeneration,
-        sourceMtimeAtStart,
-        sourceMtimeAtEnd,
-        rebuildDebounceTimer !== null,
-      )
-    ) {
+    if (generationAtStart === rebuildGeneration && rebuildDebounceTimer === null) {
       stable = true;
       break;
     }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -182,6 +182,7 @@ const fixtureArtifactByPath = new Map<string, string>();
 const pageBuildPromiseByKey = new Map<string, Promise<string | null>>();
 const scenarioBuildPromiseByKey = new Map<string, Promise<string | null>>();
 let shellBuildPromise: Promise<string | null> | null = null;
+let shellBuildUsedFallback = false;
 type ShellServerRenderer = (props: {
   initialComponent: string;
   components: string[];
@@ -1241,6 +1242,10 @@ export function fallbackToLastGood<T>(lastGood: T | null, error: unknown): T {
   return lastGood;
 }
 
+export function shellBuildSucceeded(code: string | null, usedFallback: boolean): boolean {
+  return code !== null && !usedFallback;
+}
+
 async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
   if (shellServerRendererPromise !== null) return shellServerRendererPromise;
 
@@ -1369,12 +1374,16 @@ async function buildShellBundle(): Promise<string | null> {
   const cachedEntryPath = shellEntryByName.get('shell');
   const cachedCode =
     cachedEntryPath !== undefined ? shellArtifactByPath.get(cachedEntryPath) : undefined;
-  if (cachedCode !== undefined && !shellStale) return cachedCode;
+  if (cachedCode !== undefined && !shellStale) {
+    shellBuildUsedFallback = false;
+    return cachedCode;
+  }
 
   if (shellBuildPromise !== null) return shellBuildPromise;
 
   const buildPromise: Promise<string | null> = (async () => {
     const generationAtStart = rebuildGeneration;
+    shellBuildUsedFallback = false;
     // A Svelte syntax error makes the underlying `Bun.build()` call THROW
     // rather than resolve with `{ success: false }` — `.catch()` converts
     // that into the same graceful-failure path as a build that resolves
@@ -1385,6 +1394,7 @@ async function buildShellBundle(): Promise<string | null> {
       return null;
     });
     if (entry === null) {
+      shellBuildUsedFallback = true;
       console.error(
         '[playground] shell rebuild failed — serving last-good shell (if cached); will retry on next request',
       );
@@ -2494,7 +2504,11 @@ async function eagerPrebuildAll(): Promise<{
     }
   }
 
-  return { shellSucceeded: shellCode !== null, succeeded, failed };
+  return {
+    shellSucceeded: shellBuildSucceeded(shellCode, shellBuildUsedFallback),
+    succeeded,
+    failed,
+  };
 }
 
 export function createSharedDisposer(disposeWork: () => Promise<void>): () => Promise<void> {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2505,29 +2505,6 @@ export function createSharedDisposer(disposeWork: () => Promise<void>): () => Pr
 
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
-  // Eager pre-build BEFORE binding the port. Sidebar clicks should serve
-  // from cache; we don't want the first user to pay a build cost.
-  // Shell-bundle failure is fatal — there's no UI without it.
-  const prebuild = await eagerPrebuildAll();
-  if (!prebuild.shellSucceeded) {
-    throw new Error('[playground] shell bundle failed to build — see logs above');
-  }
-  const total = prebuild.succeeded + prebuild.failed.length;
-  const failedSuffix = prebuild.failed.length > 0 ? ` (failed: ${prebuild.failed.join(', ')})` : '';
-  process.stdout.write(
-    `[playground] Pre-built ${prebuild.succeeded}/${total} page bundles${failedSuffix}\n`,
-  );
-
-  // Pre-warm the component manifest (ts-morph analysis) before binding the
-  // port. Without this, the first /api/documentation/:name request pays the
-  // cold-analysis cost and can exceed the validate-playground fetch timeout
-  // as the component count grows.
-  await getManifests().catch((error: unknown) => {
-    console.error('[playground] manifest pre-warm failed:', error);
-  });
-
-  // Start the HTTP server first — if binding fails for reasons other than an
-  // occupied port, no watchers are leaked.
   const playgroundHttpServer = createHttpServerOnAvailablePort(port, handleRequest);
   const { port: actualPort, server } = playgroundHttpServer;
 
@@ -2560,6 +2537,20 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     await Bun.write(portFile, `${actualPort}\n`);
   }
   process.stdout.write(`[playground] Listening at http://localhost:${actualPort}\n`);
+
+  const prebuild = await eagerPrebuildAll();
+  if (!prebuild.shellSucceeded) {
+    await dispose();
+    throw new Error('[playground] shell bundle failed to build — see logs above');
+  }
+  const total = prebuild.succeeded + prebuild.failed.length;
+  const failedSuffix = prebuild.failed.length > 0 ? ` (failed: ${prebuild.failed.join(', ')})` : '';
+  process.stdout.write(
+    `[playground] Pre-built ${prebuild.succeeded}/${total} page bundles${failedSuffix}\n`,
+  );
+  await getManifests().catch((error: unknown) => {
+    console.error('[playground] manifest pre-warm failed:', error);
+  });
   return { port: actualPort, dispose };
 }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2510,8 +2510,13 @@ export function isWarmupStable(
   generationAtEnd: number,
   sourceMtimeAtStart: number | null,
   sourceMtimeAtEnd: number | null,
+  hasPendingRebuild = false,
 ): boolean {
-  return generationAtStart === generationAtEnd && sourceMtimeAtStart === sourceMtimeAtEnd;
+  return (
+    generationAtStart === generationAtEnd &&
+    sourceMtimeAtStart === sourceMtimeAtEnd &&
+    !hasPendingRebuild
+  );
 }
 
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
@@ -2562,7 +2567,13 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     }
     const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
     if (
-      isWarmupStable(generationAtStart, rebuildGeneration, sourceMtimeAtStart, sourceMtimeAtEnd)
+      isWarmupStable(
+        generationAtStart,
+        rebuildGeneration,
+        sourceMtimeAtStart,
+        sourceMtimeAtEnd,
+        rebuildDebounceTimer !== null,
+      )
     ) {
       stable = true;
       break;

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -615,6 +615,7 @@ function startWatcher(): FSWatcher[] {
         if (
           filename &&
           !filename.startsWith('examples/') &&
+          !filename.startsWith('.tmp-') &&
           !filename.endsWith('.test.ts') &&
           !filename.startsWith('.')
         ) {

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -7,6 +7,7 @@ import {
   appendServerOutputBuffer,
   childProcessHasFinished,
   clearTrackedTimer,
+  enqueueOrderedBuild,
   finalPlaywrightExitCode,
   installSignalCleanupHandlers,
   localPlaygroundUrlForReportedPort,
@@ -152,6 +153,16 @@ describe('dependency rebuild scheduling', () => {
 
     expect(takeNextOrderedBuild(queue)).toEqual({ order: 0 });
     expect(queue).toEqual([{ order: 1 }, { order: 2 }]);
+  });
+
+  test('queues at most one pending build per package order', () => {
+    const queue = [{ order: 1, run: () => {} }];
+    const duplicate = { order: 1, run: () => {} };
+
+    enqueueOrderedBuild(queue, duplicate);
+
+    expect(queue).toHaveLength(1);
+    expect(queue[0]).not.toBe(duplicate);
   });
 
   test('removes a superseded debounce timer from the tracked set', () => {

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -142,6 +142,10 @@ describe('playground bundle dependency build preflight', () => {
       expect.stringMatching(/packages\/markdown\/src$/),
       expect.stringMatching(/packages\/markdown\/scripts$/),
     ]);
+    expect(playgroundBundleDependencySourceDirectories('@lostgradient/cinder')).toEqual([
+      expect.stringMatching(/packages\/components\/src$/),
+      expect.stringMatching(/packages\/components\/scripts$/),
+    ]);
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -14,6 +14,8 @@ import {
   playgroundBundleDependencyBuildArguments,
   playgroundBundleDependencyBuildPackages,
   playgroundBundleDependencyBuildProcess,
+  playgroundBundleDependencyWatchArguments,
+  playgroundBundleDependencyWatchProcess,
   playgroundServerArguments,
   playgroundServerWorkingDirectory,
   playgroundUrlForPath,
@@ -117,6 +119,21 @@ describe('playground bundle dependency build preflight', () => {
     expect(managedChildProcess.childProcess).toBe(childProcess);
     expect(managedChildProcess.name).toBe('@lostgradient/markdown build');
     expect(managedChildProcess.killProcessGroup).toBe(process.platform !== 'win32');
+  });
+
+  test('runs dependency builds in watch mode after the initial preflight', () => {
+    expect(playgroundBundleDependencyWatchArguments('@lostgradient/markdown')).toEqual([
+      '--watch',
+      'run',
+      '--filter=@lostgradient/markdown',
+      'build',
+    ]);
+    const childProcess = {} as ChildProcess;
+    expect(playgroundBundleDependencyWatchProcess(childProcess, '@lostgradient/markdown')).toEqual({
+      childProcess,
+      name: '@lostgradient/markdown watch',
+      killProcessGroup: process.platform !== 'win32',
+    });
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import {
   appendServerOutputBuffer,
   childProcessHasFinished,
+  clearTrackedTimer,
   finalPlaywrightExitCode,
   installSignalCleanupHandlers,
   localPlaygroundUrlForReportedPort,
@@ -28,7 +29,9 @@ import {
   shouldStartManagedChildProcess,
   shutdownExitCodeAfterRequest,
   stalePlaygroundServerMessage,
+  takeNextOrderedBuild,
   waitForExit,
+  waitForPlaygroundReadinessWithCleanup,
 } from './start-server.ts';
 
 describe('parsePlaygroundListeningPort', () => {
@@ -150,13 +153,53 @@ describe('playground bundle dependency build preflight', () => {
 });
 
 describe('playground server process', () => {
-  test('starts the server entrypoint in watch mode for runtime edits', () => {
+  test('leaves runtime edits to the managed source and dependency watchers', () => {
     const argumentsList = playgroundServerArguments();
 
-    expect(argumentsList).toEqual(['--watch', 'run', 'src/playground-server.ts']);
+    expect(argumentsList).toEqual(['run', 'src/playground-server.ts']);
     expect(argumentsList).not.toContain('dev');
-    expect(argumentsList).toContain('--watch');
+    expect(argumentsList).not.toContain('--watch');
     expect(playgroundServerWorkingDirectory().endsWith(join('packages', 'playground'))).toBe(true);
+  });
+});
+
+describe('dependency rebuild scheduling', () => {
+  test('dequeues the lowest-order build from the actual queue', () => {
+    const queue = [{ order: 2 }, { order: 0 }, { order: 1 }];
+
+    expect(takeNextOrderedBuild(queue)).toEqual({ order: 0 });
+    expect(queue).toEqual([{ order: 1 }, { order: 2 }]);
+  });
+
+  test('removes a superseded debounce timer from the tracked set', () => {
+    const timer = setTimeout(() => {}, 60_000);
+    const timers = new Set([timer]);
+
+    clearTrackedTimer(timer, timers);
+
+    expect(timers.size).toBe(0);
+  });
+});
+
+describe('playground readiness cleanup', () => {
+  test('cleans up a managed server whenever a readiness check fails', async () => {
+    const calls: string[] = [];
+    const readinessError = new Error('not warm');
+
+    await expect(
+      waitForPlaygroundReadinessWithCleanup(
+        () => Promise.reject(readinessError),
+        () => {
+          calls.push('shutdown-check');
+          return Promise.resolve();
+        },
+        () => {
+          calls.push('cleanup');
+          return Promise.resolve();
+        },
+      ),
+    ).rejects.toBe(readinessError);
+    expect(calls).toEqual(['shutdown-check', 'cleanup']);
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -16,8 +16,6 @@ import {
   playgroundBundleDependencyBuildPackages,
   playgroundBundleDependencyBuildProcess,
   playgroundBundleDependencySourceDirectories,
-  playgroundBundleDependencyWatchArguments,
-  playgroundBundleDependencyWatchProcess,
   playgroundServerArguments,
   playgroundServerWorkingDirectory,
   playgroundUrlForPath,
@@ -123,21 +121,6 @@ describe('playground bundle dependency build preflight', () => {
     expect(managedChildProcess.childProcess).toBe(childProcess);
     expect(managedChildProcess.name).toBe('@lostgradient/markdown build');
     expect(managedChildProcess.killProcessGroup).toBe(process.platform !== 'win32');
-  });
-
-  test('runs dependency builds in watch mode after the initial preflight', () => {
-    expect(playgroundBundleDependencyWatchArguments('@lostgradient/markdown')).toEqual([
-      '--watch',
-      'run',
-      '--filter=@lostgradient/markdown',
-      'build',
-    ]);
-    const childProcess = {} as ChildProcess;
-    expect(playgroundBundleDependencyWatchProcess(childProcess, '@lostgradient/markdown')).toEqual({
-      childProcess,
-      name: '@lostgradient/markdown watch',
-      killProcessGroup: process.platform !== 'win32',
-    });
   });
 
   test('watches package source and build-script directories explicitly', () => {

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -14,6 +14,7 @@ import {
   playgroundBundleDependencyBuildArguments,
   playgroundBundleDependencyBuildPackages,
   playgroundBundleDependencyBuildProcess,
+  playgroundBundleDependencySourceDirectories,
   playgroundBundleDependencyWatchArguments,
   playgroundBundleDependencyWatchProcess,
   playgroundServerArguments,
@@ -134,6 +135,13 @@ describe('playground bundle dependency build preflight', () => {
       name: '@lostgradient/markdown watch',
       killProcessGroup: process.platform !== 'win32',
     });
+  });
+
+  test('watches package source and build-script directories explicitly', () => {
+    expect(playgroundBundleDependencySourceDirectories('@lostgradient/markdown')).toEqual([
+      expect.stringMatching(/packages\/markdown\/src$/),
+      expect.stringMatching(/packages\/markdown\/scripts$/),
+    ]);
   });
 });
 

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import type { ChildProcess } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { once } from 'node:events';
 import { join } from 'node:path';
 
 import {
@@ -24,6 +25,7 @@ import {
   shouldStartManagedChildProcess,
   shutdownExitCodeAfterRequest,
   stalePlaygroundServerMessage,
+  waitForExit,
 } from './start-server.ts';
 
 describe('parsePlaygroundListeningPort', () => {
@@ -130,6 +132,13 @@ describe('playground server process', () => {
 });
 
 describe('child process cleanup', () => {
+  test('observes a child that exited before exit listeners were attached', async () => {
+    const childProcess = spawn(process.execPath, ['-e', 'process.exit(7)']);
+    await once(childProcess, 'exit');
+
+    await expect(waitForExit(childProcess)).resolves.toBe(7);
+  });
+
   test('stops starting new managed children after shutdown begins', () => {
     expect(shouldStartManagedChildProcess(null)).toBe(true);
     expect(shouldStartManagedChildProcess(130)).toBe(false);

--- a/packages/testing/scripts/start-server.test.ts
+++ b/packages/testing/scripts/start-server.test.ts
@@ -121,12 +121,12 @@ describe('playground bundle dependency build preflight', () => {
 });
 
 describe('playground server process', () => {
-  test('starts the plain server entrypoint instead of the watch-mode dev script', () => {
+  test('starts the server entrypoint in watch mode for runtime edits', () => {
     const argumentsList = playgroundServerArguments();
 
-    expect(argumentsList).toEqual(['run', 'src/playground-server.ts']);
+    expect(argumentsList).toEqual(['--watch', 'run', 'src/playground-server.ts']);
     expect(argumentsList).not.toContain('dev');
-    expect(argumentsList).not.toContain('--watch');
+    expect(argumentsList).toContain('--watch');
     expect(playgroundServerWorkingDirectory().endsWith(join('packages', 'playground'))).toBe(true);
   });
 });

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -221,8 +221,8 @@ export function waitForExit(childProcess: ChildProcess): Promise<number> {
     // Listen for both `exit` and `error`. If `spawn()` fails (ENOENT,
     // EACCES, etc.) the child emits `error` and may never emit `exit`,
     // which would hang the script indefinitely.
-    childProcess.once('exit', onExit);
-    childProcess.once('error', onError);
+    childProcess.on('exit', onExit);
+    childProcess.on('error', onError);
 
     // A cached build can finish between spawn() and listener registration.
     // Node retains the terminal status but does not replay the `exit` event,
@@ -553,6 +553,36 @@ type DependencyWatchController = {
   getFailure: () => Error | null;
 };
 
+export function takeNextOrderedBuild<T extends { order: number }>(
+  queuedBuilds: T[],
+): T | undefined {
+  queuedBuilds.sort((left, right) => left.order - right.order);
+  return queuedBuilds.shift();
+}
+
+export function clearTrackedTimer(
+  timer: ReturnType<typeof setTimeout> | null,
+  timers: Set<ReturnType<typeof setTimeout>>,
+): void {
+  if (timer === null) return;
+  clearTimeout(timer);
+  timers.delete(timer);
+}
+
+export async function waitForPlaygroundReadinessWithCleanup(
+  waitForReadiness: () => Promise<void>,
+  exitIfShuttingDown: () => Promise<void>,
+  cleanupAfterFailure: () => Promise<void>,
+): Promise<void> {
+  try {
+    await waitForReadiness();
+  } catch (error) {
+    await exitIfShuttingDown();
+    await cleanupAfterFailure();
+    throw error;
+  }
+}
+
 function startPlaygroundBundleDependencyWatchers(
   registerChildProcess: (managedChildProcess: ManagedChildProcess) => void,
   shouldContinueStartingChildProcesses: () => boolean,
@@ -606,10 +636,7 @@ function startPlaygroundBundleDependencyWatchers(
         }
         if (state.buildProcess === currentBuild) state.buildProcess = null;
         activeBuild = false;
-        queuedBuilds
-          .toSorted((left, right) => left.order - right.order)
-          .shift()
-          ?.run();
+        takeNextOrderedBuild(queuedBuilds)?.run();
         if (state.pending && failure === null) runBuild();
         resolveIdle();
         return undefined;
@@ -618,7 +645,9 @@ function startPlaygroundBundleDependencyWatchers(
     const scheduleBuild = (): void => {
       if (disposed) return;
       state.pending = true;
-      if (rebuildTimer !== null) clearTimeout(rebuildTimer);
+      if (rebuildTimer !== null) {
+        clearTrackedTimer(rebuildTimer, timers);
+      }
       rebuildTimer = setTimeout(() => {
         timers.delete(rebuildTimer!);
         rebuildTimer = null;
@@ -818,13 +847,11 @@ async function main(): Promise<void> {
     }
   }
 
-  try {
-    await waitForWarmPlayground(dependencyWatchController);
-  } catch (error) {
-    await exitIfShuttingDown();
-    await cleanupOnce();
-    throw error;
-  }
+  await waitForPlaygroundReadinessWithCleanup(
+    () => waitForWarmPlayground(dependencyWatchController),
+    exitIfShuttingDown,
+    cleanupOnce,
+  );
   await exitIfShuttingDown();
 
   const prep = spawn('bun', ['run', 'scripts/prepare-manifest.ts'], {
@@ -838,7 +865,11 @@ async function main(): Promise<void> {
   if (prepCode !== 0) {
     await exitAfterCleanup(prepCode);
   }
-  await waitForWarmPlayground(dependencyWatchController);
+  await waitForPlaygroundReadinessWithCleanup(
+    () => waitForWarmPlayground(dependencyWatchController),
+    exitIfShuttingDown,
+    cleanupOnce,
+  );
 
   const playwright = spawn('bunx', playwrightCommandArguments(args), {
     cwd: packageRoot,

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -423,21 +423,6 @@ export function playgroundBundleDependencyBuildProcess(
   };
 }
 
-export function playgroundBundleDependencyWatchArguments(packageName: string): string[] {
-  return ['--watch', 'run', `--filter=${packageName}`, 'build'];
-}
-
-export function playgroundBundleDependencyWatchProcess(
-  childProcess: ChildProcess,
-  packageName: string,
-): ManagedChildProcess {
-  return {
-    childProcess,
-    name: `${packageName} watch`,
-    killProcessGroup: process.platform !== 'win32',
-  };
-}
-
 export function playgroundBundleDependencySourceDirectories(packageName: string): string[] {
   const packageDirectory = playgroundBundleDependencyDirectories[packageName];
   if (packageDirectory === undefined)

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -1,6 +1,6 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { once } from 'node:events';
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, rmSync, watch, type FSWatcher } from 'node:fs';
 import { dirname, resolve as resolvePath } from 'node:path';
 import { setTimeout as delay } from 'node:timers/promises';
 import { fileURLToPath } from 'node:url';
@@ -432,6 +432,14 @@ export function playgroundBundleDependencyWatchProcess(
   };
 }
 
+export function playgroundBundleDependencySourceDirectories(packageName: string): string[] {
+  const packageDirectory = packageName.slice(packageName.lastIndexOf('/') + 1);
+  return [
+    resolvePath(repoRoot, 'packages', packageDirectory, 'src'),
+    resolvePath(repoRoot, 'packages', packageDirectory, 'scripts'),
+  ];
+}
+
 export function playgroundServerArguments(): string[] {
   // Keep server/runtime modules hot-reloaded in the managed test process. A
   // warmup cache invalidation cannot re-evaluate already imported modules.
@@ -519,17 +527,51 @@ async function buildPlaygroundBundleDependencies(
 function startPlaygroundBundleDependencyWatchers(
   registerChildProcess: (managedChildProcess: ManagedChildProcess) => void,
   shouldContinueStartingChildProcesses: () => boolean,
-): void {
+): FSWatcher[] {
+  const watchers: FSWatcher[] = [];
   for (const packageName of playgroundBundleDependencyPackages) {
-    if (!shouldContinueStartingChildProcesses()) return;
-    const watchProcess = spawn('bun', playgroundBundleDependencyWatchArguments(packageName), {
-      cwd: repoRoot,
-      detached: process.platform !== 'win32',
-      stdio: 'inherit',
-      env: process.env,
-    });
-    registerChildProcess(playgroundBundleDependencyWatchProcess(watchProcess, packageName));
+    if (!shouldContinueStartingChildProcesses()) return watchers;
+    let buildProcess: ChildProcess | null = null;
+    let rebuildPending = false;
+    let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
+    const runBuild = (): void => {
+      if (!shouldContinueStartingChildProcesses()) return;
+      if (buildProcess !== null && !childProcessHasFinished(buildProcess)) {
+        rebuildPending = true;
+        return;
+      }
+      rebuildPending = false;
+      buildProcess = spawn('bun', playgroundBundleDependencyBuildArguments(packageName), {
+        cwd: repoRoot,
+        detached: process.platform !== 'win32',
+        stdio: 'inherit',
+        env: process.env,
+      });
+      const currentBuild = buildProcess;
+      registerChildProcess(playgroundBundleDependencyBuildProcess(currentBuild, packageName));
+      void waitForExit(currentBuild).then(() => {
+        if (buildProcess === currentBuild) buildProcess = null;
+        if (rebuildPending) runBuild();
+        return undefined;
+      });
+    };
+    const scheduleBuild = (): void => {
+      rebuildPending = true;
+      if (rebuildTimer !== null) clearTimeout(rebuildTimer);
+      rebuildTimer = setTimeout(() => {
+        rebuildTimer = null;
+        runBuild();
+      }, 100);
+    };
+    for (const directory of playgroundBundleDependencySourceDirectories(packageName)) {
+      try {
+        watchers.push(watch(directory, { recursive: true }, scheduleBuild));
+      } catch (error) {
+        console.error(`[testing] unable to watch ${directory}:`, error);
+      }
+    }
   }
+  return watchers;
 }
 
 const isLocalDefault = isLocalDefaultPlaygroundUrl(PLAYGROUND_URL);
@@ -540,10 +582,13 @@ async function main(): Promise<void> {
   let serverProcess: ReturnType<typeof spawn> | null = null;
   let playgroundPortFile: string | null = null;
   const children: ManagedChildProcess[] = [];
+  let dependencyWatchers: FSWatcher[] = [];
   let cleanupPromise: Promise<void> | null = null;
   let shutdownExitCode: number | null = null;
 
   const cleanupOnce = async (): Promise<void> => {
+    for (const watcher of dependencyWatchers) watcher.close();
+    dependencyWatchers = [];
     cleanupPromise ??= cleanup(children, playgroundPortFile);
     await cleanupPromise;
   };
@@ -684,7 +729,7 @@ async function main(): Promise<void> {
     throw error;
   }
   await exitIfShuttingDown();
-  startPlaygroundBundleDependencyWatchers(
+  dependencyWatchers = startPlaygroundBundleDependencyWatchers(
     (childProcess) => children.push(childProcess),
     () => shouldStartManagedChildProcess(shutdownExitCode),
   );

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -418,7 +418,9 @@ export function playgroundBundleDependencyBuildProcess(
 }
 
 export function playgroundServerArguments(): string[] {
-  return ['run', 'src/playground-server.ts'];
+  // Keep server/runtime modules hot-reloaded in the managed test process. A
+  // warmup cache invalidation cannot re-evaluate already imported modules.
+  return ['--watch', 'run', 'src/playground-server.ts'];
 }
 
 export function playgroundServerWorkingDirectory(): string {

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -490,9 +490,13 @@ async function waitForWarmPlayground(
     if (readiness.ok) {
       stableReadinessReads += 1;
       if (stableReadinessReads >= PLAYGROUND_WARM_READINESS_STABLE_READS) {
-        await dependencyWatchController?.waitForIdle();
+        const rebuilt = (await dependencyWatchController?.waitForIdle()) ?? false;
         const finalFailure = dependencyWatchController?.getFailure();
         if (finalFailure !== null && finalFailure !== undefined) throw finalFailure;
+        if (rebuilt) {
+          stableReadinessReads = 0;
+          continue;
+        }
         return;
       }
     } else {
@@ -543,7 +547,7 @@ async function buildPlaygroundBundleDependencies(
 
 type DependencyWatchController = {
   dispose: () => void;
-  waitForIdle: () => Promise<void>;
+  waitForIdle: () => Promise<boolean>;
   getFailure: () => Error | null;
 };
 
@@ -554,12 +558,12 @@ function startPlaygroundBundleDependencyWatchers(
   const watchers: FSWatcher[] = [];
   const timers = new Set<ReturnType<typeof setTimeout>>();
   const states: Array<{ buildProcess: ChildProcess | null; pending: boolean }> = [];
-  const idleWaiters: Array<() => void> = [];
+  const idleWaiters: Array<(rebuilt: boolean) => void> = [];
   let disposed = false;
   let failure: Error | null = null;
   const resolveIdle = (): void => {
     if (states.some((state) => state.pending || state.buildProcess !== null)) return;
-    for (const resolve of idleWaiters.splice(0)) resolve();
+    for (const resolve of idleWaiters.splice(0)) resolve(true);
   };
   for (const packageName of playgroundBundleDependencyPackages) {
     if (!shouldContinueStartingChildProcesses()) break;
@@ -585,6 +589,7 @@ function startPlaygroundBundleDependencyWatchers(
       void waitForExit(currentBuild).then((buildCode) => {
         if (buildCode !== 0 && failure === null) {
           failure = new Error(`${packageName} watched build exited with code ${buildCode}`);
+          state.pending = false;
         }
         if (state.buildProcess === currentBuild) state.buildProcess = null;
         if (state.pending && failure === null) runBuild();
@@ -623,8 +628,8 @@ function startPlaygroundBundleDependencyWatchers(
     },
     waitForIdle: () =>
       states.every((state) => !state.pending && state.buildProcess === null)
-        ? Promise.resolve()
-        : new Promise<void>((resolve) => idleWaiters.push(resolve)),
+        ? Promise.resolve(false)
+        : new Promise<boolean>((resolve) => idleWaiters.push(resolve)),
     getFailure: () => failure,
   };
 }

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -561,6 +561,8 @@ function startPlaygroundBundleDependencyWatchers(
   const idleWaiters: Array<(rebuilt: boolean) => void> = [];
   let disposed = false;
   let failure: Error | null = null;
+  let activeBuild = false;
+  const queuedBuilds: Array<() => void> = [];
   const resolveIdle = (): void => {
     if (states.some((state) => state.pending || state.buildProcess !== null)) return;
     for (const resolve of idleWaiters.splice(0)) resolve(true);
@@ -577,6 +579,12 @@ function startPlaygroundBundleDependencyWatchers(
         return;
       }
       state.pending = false;
+      if (activeBuild) {
+        state.pending = true;
+        queuedBuilds.push(runBuild);
+        return;
+      }
+      activeBuild = true;
       state.buildProcess = spawn('bun', playgroundBundleDependencyBuildArguments(packageName), {
         cwd: repoRoot,
         detached: process.platform !== 'win32',
@@ -592,6 +600,8 @@ function startPlaygroundBundleDependencyWatchers(
           for (const pendingState of states) pendingState.pending = false;
         }
         if (state.buildProcess === currentBuild) state.buildProcess = null;
+        activeBuild = false;
+        queuedBuilds.shift()?.();
         if (state.pending && failure === null) runBuild();
         resolveIdle();
         return undefined;

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -22,6 +22,12 @@ const playgroundBundleDependencyPackages = [
   '@lostgradient/cinder',
   '@lostgradient/chat',
 ] as const;
+const playgroundBundleDependencyDirectories: Record<string, string> = {
+  '@lostgradient/markdown': 'markdown',
+  '@lostgradient/editor': 'editor',
+  '@lostgradient/cinder': 'components',
+  '@lostgradient/chat': 'chat',
+};
 // Probe the cheap liveness endpoint first. `/api/manifest` does real work and
 // can lag behind initial server readiness, which makes local startup look hung
 // even though the playground is already accepting requests.
@@ -433,7 +439,9 @@ export function playgroundBundleDependencyWatchProcess(
 }
 
 export function playgroundBundleDependencySourceDirectories(packageName: string): string[] {
-  const packageDirectory = packageName.slice(packageName.lastIndexOf('/') + 1);
+  const packageDirectory = playgroundBundleDependencyDirectories[packageName];
+  if (packageDirectory === undefined)
+    throw new Error(`Unknown playground dependency: ${packageName}`);
   return [
     resolvePath(repoRoot, 'packages', packageDirectory, 'src'),
     resolvePath(repoRoot, 'packages', packageDirectory, 'scripts'),
@@ -467,7 +475,9 @@ export function playgroundWarmReadinessMissingEndpointMessage(playgroundUrl: str
   );
 }
 
-async function waitForWarmPlayground(): Promise<void> {
+async function waitForWarmPlayground(
+  dependencyWatchController: DependencyWatchController | null = null,
+): Promise<void> {
   const startedAt = Date.now();
   const deadline = startedAt + PLAYGROUND_READY_TIMEOUT_MS;
   let stableReadinessReads = 0;
@@ -475,9 +485,16 @@ async function waitForWarmPlayground(): Promise<void> {
 
   while (Date.now() < deadline) {
     const readiness = await probePlaygroundPath(warmReadinessPath);
+    const dependencyFailure = dependencyWatchController?.getFailure();
+    if (dependencyFailure !== null && dependencyFailure !== undefined) throw dependencyFailure;
     if (readiness.ok) {
       stableReadinessReads += 1;
-      if (stableReadinessReads >= PLAYGROUND_WARM_READINESS_STABLE_READS) return;
+      if (stableReadinessReads >= PLAYGROUND_WARM_READINESS_STABLE_READS) {
+        await dependencyWatchController?.waitForIdle();
+        const finalFailure = dependencyWatchController?.getFailure();
+        if (finalFailure !== null && finalFailure !== undefined) throw finalFailure;
+        return;
+      }
     } else {
       if (readiness.status === 404) {
         throw new Error(playgroundWarmReadinessMissingEndpointMessage(targetPlaygroundUrl));
@@ -524,44 +541,67 @@ async function buildPlaygroundBundleDependencies(
   }
 }
 
+type DependencyWatchController = {
+  dispose: () => void;
+  waitForIdle: () => Promise<void>;
+  getFailure: () => Error | null;
+};
+
 function startPlaygroundBundleDependencyWatchers(
   registerChildProcess: (managedChildProcess: ManagedChildProcess) => void,
   shouldContinueStartingChildProcesses: () => boolean,
-): FSWatcher[] {
+): DependencyWatchController {
   const watchers: FSWatcher[] = [];
+  const timers = new Set<ReturnType<typeof setTimeout>>();
+  const states: Array<{ buildProcess: ChildProcess | null; pending: boolean }> = [];
+  const idleWaiters: Array<() => void> = [];
+  let disposed = false;
+  let failure: Error | null = null;
+  const resolveIdle = (): void => {
+    if (states.some((state) => state.pending || state.buildProcess !== null)) return;
+    for (const resolve of idleWaiters.splice(0)) resolve();
+  };
   for (const packageName of playgroundBundleDependencyPackages) {
     if (!shouldContinueStartingChildProcesses()) return watchers;
-    let buildProcess: ChildProcess | null = null;
-    let rebuildPending = false;
+    const state = { buildProcess: null as ChildProcess | null, pending: false };
+    states.push(state);
     let rebuildTimer: ReturnType<typeof setTimeout> | null = null;
     const runBuild = (): void => {
-      if (!shouldContinueStartingChildProcesses()) return;
-      if (buildProcess !== null && !childProcessHasFinished(buildProcess)) {
-        rebuildPending = true;
+      if (disposed || !shouldContinueStartingChildProcesses()) return;
+      if (state.buildProcess !== null && !childProcessHasFinished(state.buildProcess)) {
+        state.pending = true;
         return;
       }
-      rebuildPending = false;
-      buildProcess = spawn('bun', playgroundBundleDependencyBuildArguments(packageName), {
+      state.pending = false;
+      state.buildProcess = spawn('bun', playgroundBundleDependencyBuildArguments(packageName), {
         cwd: repoRoot,
         detached: process.platform !== 'win32',
         stdio: 'inherit',
         env: process.env,
       });
-      const currentBuild = buildProcess;
+      const currentBuild = state.buildProcess;
+      if (currentBuild === null) return;
       registerChildProcess(playgroundBundleDependencyBuildProcess(currentBuild, packageName));
-      void waitForExit(currentBuild).then(() => {
-        if (buildProcess === currentBuild) buildProcess = null;
-        if (rebuildPending) runBuild();
+      void waitForExit(currentBuild).then((buildCode) => {
+        if (buildCode !== 0 && failure === null) {
+          failure = new Error(`${packageName} watched build exited with code ${buildCode}`);
+        }
+        if (state.buildProcess === currentBuild) state.buildProcess = null;
+        if (state.pending && failure === null) runBuild();
+        resolveIdle();
         return undefined;
       });
     };
     const scheduleBuild = (): void => {
-      rebuildPending = true;
+      if (disposed) return;
+      state.pending = true;
       if (rebuildTimer !== null) clearTimeout(rebuildTimer);
       rebuildTimer = setTimeout(() => {
+        timers.delete(rebuildTimer!);
         rebuildTimer = null;
         runBuild();
       }, 100);
+      timers.add(rebuildTimer);
     };
     for (const directory of playgroundBundleDependencySourceDirectories(packageName)) {
       try {
@@ -571,7 +611,22 @@ function startPlaygroundBundleDependencyWatchers(
       }
     }
   }
-  return watchers;
+  return {
+    dispose: () => {
+      disposed = true;
+      for (const timer of timers) clearTimeout(timer);
+      timers.clear();
+      for (const watcher of watchers) watcher.close();
+      watchers.length = 0;
+      for (const state of states) state.pending = false;
+      resolveIdle();
+    },
+    waitForIdle: () =>
+      states.every((state) => !state.pending && state.buildProcess === null)
+        ? Promise.resolve()
+        : new Promise<void>((resolve) => idleWaiters.push(resolve)),
+    getFailure: () => failure,
+  };
 }
 
 const isLocalDefault = isLocalDefaultPlaygroundUrl(PLAYGROUND_URL);
@@ -582,13 +637,13 @@ async function main(): Promise<void> {
   let serverProcess: ReturnType<typeof spawn> | null = null;
   let playgroundPortFile: string | null = null;
   const children: ManagedChildProcess[] = [];
-  let dependencyWatchers: FSWatcher[] = [];
+  let dependencyWatchController: DependencyWatchController | null = null;
   let cleanupPromise: Promise<void> | null = null;
   let shutdownExitCode: number | null = null;
 
   const cleanupOnce = async (): Promise<void> => {
-    for (const watcher of dependencyWatchers) watcher.close();
-    dependencyWatchers = [];
+    dependencyWatchController?.dispose();
+    dependencyWatchController = null;
     cleanupPromise ??= cleanup(children, playgroundPortFile);
     await cleanupPromise;
   };
@@ -655,6 +710,10 @@ async function main(): Promise<void> {
       () => shouldStartManagedChildProcess(shutdownExitCode),
     );
     await exitIfShuttingDown();
+    dependencyWatchController = startPlaygroundBundleDependencyWatchers(
+      (childProcess) => children.push(childProcess),
+      () => shouldStartManagedChildProcess(shutdownExitCode),
+    );
     playgroundPortFile = resolvePath(repoRoot, 'tmp', `playground-port-${process.pid}.txt`);
     let reportedPlaygroundPort: number | null = null;
     mkdirSync(resolvePath(repoRoot, 'tmp'), { recursive: true });
@@ -722,17 +781,13 @@ async function main(): Promise<void> {
   }
 
   try {
-    await waitForWarmPlayground();
+    await waitForWarmPlayground(dependencyWatchController);
   } catch (error) {
     await exitIfShuttingDown();
     await cleanupOnce();
     throw error;
   }
   await exitIfShuttingDown();
-  dependencyWatchers = startPlaygroundBundleDependencyWatchers(
-    (childProcess) => children.push(childProcess),
-    () => shouldStartManagedChildProcess(shutdownExitCode),
-  );
 
   const prep = spawn('bun', ['run', 'scripts/prepare-manifest.ts'], {
     cwd: packageRoot,
@@ -757,6 +812,11 @@ async function main(): Promise<void> {
   children.push({ childProcess: playwright, name: 'Playwright', killProcessGroup: false });
   const playwrightCode = await waitForExit(playwright);
   await exitIfShuttingDown();
+  const dependencyFailure = dependencyWatchController?.getFailure();
+  if (dependencyFailure !== null && dependencyFailure !== undefined) {
+    console.error(`Watched dependency rebuild failed: ${dependencyFailure.message}`);
+    await exitAfterCleanup(1);
+  }
 
   const summary = spawn('bun', ['run', 'scripts/summarize-axe.ts'], {
     cwd: packageRoot,

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -417,6 +417,21 @@ export function playgroundBundleDependencyBuildProcess(
   };
 }
 
+export function playgroundBundleDependencyWatchArguments(packageName: string): string[] {
+  return ['--watch', 'run', `--filter=${packageName}`, 'build'];
+}
+
+export function playgroundBundleDependencyWatchProcess(
+  childProcess: ChildProcess,
+  packageName: string,
+): ManagedChildProcess {
+  return {
+    childProcess,
+    name: `${packageName} watch`,
+    killProcessGroup: process.platform !== 'win32',
+  };
+}
+
 export function playgroundServerArguments(): string[] {
   // Keep server/runtime modules hot-reloaded in the managed test process. A
   // warmup cache invalidation cannot re-evaluate already imported modules.
@@ -498,6 +513,22 @@ async function buildPlaygroundBundleDependencies(
     if (buildCode !== 0) {
       throw new Error(`${packageName} build exited with code ${buildCode}`);
     }
+  }
+}
+
+function startPlaygroundBundleDependencyWatchers(
+  registerChildProcess: (managedChildProcess: ManagedChildProcess) => void,
+  shouldContinueStartingChildProcesses: () => boolean,
+): void {
+  for (const packageName of playgroundBundleDependencyPackages) {
+    if (!shouldContinueStartingChildProcesses()) return;
+    const watchProcess = spawn('bun', playgroundBundleDependencyWatchArguments(packageName), {
+      cwd: repoRoot,
+      detached: process.platform !== 'win32',
+      stdio: 'inherit',
+      env: process.env,
+    });
+    registerChildProcess(playgroundBundleDependencyWatchProcess(watchProcess, packageName));
   }
 }
 
@@ -653,6 +684,10 @@ async function main(): Promise<void> {
     throw error;
   }
   await exitIfShuttingDown();
+  startPlaygroundBundleDependencyWatchers(
+    (childProcess) => children.push(childProcess),
+    () => shouldStartManagedChildProcess(shutdownExitCode),
+  );
 
   const prep = spawn('bun', ['run', 'scripts/prepare-manifest.ts'], {
     cwd: packageRoot,

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -700,6 +700,12 @@ async function main(): Promise<void> {
 
   if (alreadyUp) {
     console.log(`Reusing playground server at ${targetPlaygroundUrl}.`);
+    if (isLocalDefault) {
+      dependencyWatchController = startPlaygroundBundleDependencyWatchers(
+        (childProcess) => children.push(childProcess),
+        () => shouldStartManagedChildProcess(shutdownExitCode),
+      );
+    }
   } else if (!isLocalDefault) {
     // The local playground server starts from the local default port and scans
     // upward. Starting it cannot satisfy readiness for a custom `PLAYGROUND_URL`.

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -589,7 +589,7 @@ function startPlaygroundBundleDependencyWatchers(
       void waitForExit(currentBuild).then((buildCode) => {
         if (buildCode !== 0 && failure === null) {
           failure = new Error(`${packageName} watched build exited with code ${buildCode}`);
-          state.pending = false;
+          for (const pendingState of states) pendingState.pending = false;
         }
         if (state.buildProcess === currentBuild) state.buildProcess = null;
         if (state.pending && failure === null) runBuild();

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -449,9 +449,11 @@ export function playgroundBundleDependencySourceDirectories(packageName: string)
 }
 
 export function playgroundServerArguments(): string[] {
-  // Keep server/runtime modules hot-reloaded in the managed test process. A
-  // warmup cache invalidation cannot re-evaluate already imported modules.
-  return ['--watch', 'run', 'src/playground-server.ts'];
+  // The wrapper owns dependency rebuild ordering and the playground owns its
+  // source watchers. Bun's module watcher also observes rebuilt workspace
+  // dist files, so enabling it here restarts the server during its own warmup
+  // and prevents readiness from ever becoming stable.
+  return ['run', 'src/playground-server.ts'];
 }
 
 export function playgroundServerWorkingDirectory(): string {

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -863,6 +863,7 @@ async function main(): Promise<void> {
     exitIfShuttingDown,
     cleanupOnce,
   );
+  await exitIfShuttingDown();
 
   const playwright = spawn('bunx', playwrightCommandArguments(args), {
     cwd: packageRoot,

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -545,6 +545,14 @@ export function takeNextOrderedBuild<T extends { order: number }>(
   return queuedBuilds.shift();
 }
 
+export function enqueueOrderedBuild<T extends { order: number }>(
+  queuedBuilds: T[],
+  build: T,
+): void {
+  if (queuedBuilds.some((queuedBuild) => queuedBuild.order === build.order)) return;
+  queuedBuilds.push(build);
+}
+
 export function clearTrackedTimer(
   timer: ReturnType<typeof setTimeout> | null,
   timers: Set<ReturnType<typeof setTimeout>>,
@@ -598,7 +606,7 @@ function startPlaygroundBundleDependencyWatchers(
       state.pending = false;
       if (activeBuild) {
         state.pending = true;
-        queuedBuilds.push({
+        enqueueOrderedBuild(queuedBuilds, {
           order: playgroundBundleDependencyPackages.indexOf(packageName),
           run: runBuild,
         });

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -562,7 +562,7 @@ function startPlaygroundBundleDependencyWatchers(
   let disposed = false;
   let failure: Error | null = null;
   let activeBuild = false;
-  const queuedBuilds: Array<() => void> = [];
+  const queuedBuilds: Array<{ order: number; run: () => void }> = [];
   const resolveIdle = (): void => {
     if (states.some((state) => state.pending || state.buildProcess !== null)) return;
     for (const resolve of idleWaiters.splice(0)) resolve(true);
@@ -581,7 +581,10 @@ function startPlaygroundBundleDependencyWatchers(
       state.pending = false;
       if (activeBuild) {
         state.pending = true;
-        queuedBuilds.push(runBuild);
+        queuedBuilds.push({
+          order: playgroundBundleDependencyPackages.indexOf(packageName),
+          run: runBuild,
+        });
         return;
       }
       activeBuild = true;
@@ -601,7 +604,10 @@ function startPlaygroundBundleDependencyWatchers(
         }
         if (state.buildProcess === currentBuild) state.buildProcess = null;
         activeBuild = false;
-        queuedBuilds.shift()?.();
+        queuedBuilds
+          .toSorted((left, right) => left.order - right.order)
+          .shift()
+          ?.run();
         if (state.pending && failure === null) runBuild();
         resolveIdle();
         return undefined;
@@ -623,6 +629,15 @@ function startPlaygroundBundleDependencyWatchers(
         watchers.push(watch(directory, { recursive: true }, scheduleBuild));
       } catch (error) {
         console.error(`[testing] unable to watch ${directory}:`, error);
+      }
+    }
+    const packageDirectory = playgroundBundleDependencyDirectories[packageName]!;
+    for (const metadataPath of ['package.json', 'tsconfig.json']) {
+      const path = resolvePath(repoRoot, 'packages', packageDirectory, metadataPath);
+      try {
+        watchers.push(watch(path, scheduleBuild));
+      } catch {
+        // Optional metadata files are watched only when present.
       }
     }
   }
@@ -821,6 +836,7 @@ async function main(): Promise<void> {
   if (prepCode !== 0) {
     await exitAfterCleanup(prepCode);
   }
+  await waitForWarmPlayground(dependencyWatchController);
 
   const playwright = spawn('bunx', playwrightCommandArguments(args), {
     cwd: packageRoot,
@@ -833,6 +849,7 @@ async function main(): Promise<void> {
   children.push({ childProcess: playwright, name: 'Playwright', killProcessGroup: false });
   const playwrightCode = await waitForExit(playwright);
   await exitIfShuttingDown();
+  await dependencyWatchController?.waitForIdle();
   const dependencyFailure = dependencyWatchController?.getFailure();
   if (dependencyFailure !== null && dependencyFailure !== undefined) {
     console.error(`Watched dependency rebuild failed: ${dependencyFailure.message}`);

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -622,7 +622,15 @@ async function main(): Promise<void> {
     }
   }
 
+  try {
+    await waitForWarmPlayground();
+  } catch (error) {
+    await exitIfShuttingDown();
+    await cleanupOnce();
+    throw error;
+  }
   await exitIfShuttingDown();
+
   const prep = spawn('bun', ['run', 'scripts/prepare-manifest.ts'], {
     cwd: packageRoot,
     stdio: 'inherit',
@@ -634,15 +642,6 @@ async function main(): Promise<void> {
   if (prepCode !== 0) {
     await exitAfterCleanup(prepCode);
   }
-
-  try {
-    await waitForWarmPlayground();
-  } catch (error) {
-    await exitIfShuttingDown();
-    await cleanupOnce();
-    throw error;
-  }
-  await exitIfShuttingDown();
 
   const playwright = spawn('bunx', playwrightCommandArguments(args), {
     cwd: packageRoot,

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -196,16 +196,37 @@ export function appendServerOutputBuffer(
   return nextBuffer.length > 4096 ? nextBuffer.slice(-4096) : nextBuffer;
 }
 
-function waitForExit(childProcess: ChildProcess): Promise<number> {
+export function waitForExit(childProcess: ChildProcess): Promise<number> {
   return new Promise((resolve) => {
+    let settled = false;
+    const settle = (code: number): void => {
+      if (settled) return;
+      settled = true;
+      childProcess.off('exit', onExit);
+      childProcess.off('error', onError);
+      resolve(code);
+    };
+    const onExit = (code: number | null): void => settle(code ?? 1);
+    const onError = (error: Error): void => {
+      console.error('Child process error:', error);
+      settle(1);
+    };
+
     // Listen for both `exit` and `error`. If `spawn()` fails (ENOENT,
     // EACCES, etc.) the child emits `error` and may never emit `exit`,
     // which would hang the script indefinitely.
-    childProcess.once('exit', (code) => resolve(code ?? 1));
-    childProcess.once('error', (error) => {
-      console.error('Child process error:', error);
-      resolve(1);
-    });
+    childProcess.once('exit', onExit);
+    childProcess.once('error', onError);
+
+    // A cached build can finish between spawn() and listener registration.
+    // Node retains the terminal status but does not replay the `exit` event,
+    // so consume that status after the listeners are installed to close both
+    // sides of the race.
+    if (childProcess.exitCode !== null) {
+      settle(childProcess.exitCode);
+    } else if (childProcess.signalCode !== null) {
+      settle(1);
+    }
   });
 }
 

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -562,7 +562,7 @@ function startPlaygroundBundleDependencyWatchers(
     for (const resolve of idleWaiters.splice(0)) resolve();
   };
   for (const packageName of playgroundBundleDependencyPackages) {
-    if (!shouldContinueStartingChildProcesses()) return watchers;
+    if (!shouldContinueStartingChildProcesses()) break;
     const state = { buildProcess: null as ChildProcess | null, pending: false };
     states.push(state);
     let rebuildTimer: ReturnType<typeof setTimeout> | null = null;

--- a/packages/testing/tests/a11y-regressions.playwright.ts
+++ b/packages/testing/tests/a11y-regressions.playwright.ts
@@ -143,17 +143,16 @@ test.describe('a11y regressions', () => {
       const reasonRect = reason.getBoundingClientRect();
       return {
         display: getComputedStyle(element).display,
-        root,
-        controlRect,
-        reasonRect,
+        rootWidth: root.width,
+        rootHeight: root.height,
+        controlBottom: controlRect.bottom,
+        reasonBottom: reasonRect.bottom,
       };
     });
     expect(deniedGeometry.display).not.toBe('none');
-    expect(deniedGeometry.root.width).toBeGreaterThan(0);
-    expect(deniedGeometry.root.height).toBeGreaterThan(0);
-    expect(
-      Math.abs(deniedGeometry.controlRect.bottom - deniedGeometry.reasonRect.bottom),
-    ).toBeLessThan(12);
+    expect(deniedGeometry.rootWidth).toBeGreaterThan(0);
+    expect(deniedGeometry.rootHeight).toBeGreaterThan(0);
+    expect(Math.abs(deniedGeometry.controlBottom - deniedGeometry.reasonBottom)).toBeLessThan(12);
 
     const grantedPage = await componentPage.open({
       entry,
@@ -168,13 +167,18 @@ test.describe('a11y regressions', () => {
         const sibling = baseline.nextElementSibling!.querySelector('button')!;
         const baselineRect = baseline.querySelector('button')!.getBoundingClientRect();
         const siblingRect = sibling.getBoundingClientRect();
-        return { baselineRect, siblingRect };
+        return {
+          baselineTop: baselineRect.top,
+          baselineWidth: baselineRect.width,
+          baselineHeight: baselineRect.height,
+          siblingTop: siblingRect.top,
+          siblingWidth: siblingRect.width,
+          siblingHeight: siblingRect.height,
+        };
       });
-    expect(
-      Math.abs(grantedGeometry.baselineRect.top - grantedGeometry.siblingRect.top),
-    ).toBeLessThan(1);
-    expect(grantedGeometry.siblingRect.width).toBe(grantedGeometry.baselineRect.width);
-    expect(grantedGeometry.siblingRect.height).toBe(grantedGeometry.baselineRect.height);
+    expect(Math.abs(grantedGeometry.baselineTop - grantedGeometry.siblingTop)).toBeLessThan(1);
+    expect(grantedGeometry.siblingWidth).toBe(grantedGeometry.baselineWidth);
+    expect(grantedGeometry.siblingHeight).toBe(grantedGeometry.baselineHeight);
   });
 
   test('section-heading uses div roots without header landmarks', async ({ componentPage }) => {

--- a/packages/testing/tests/a11y-regressions.playwright.ts
+++ b/packages/testing/tests/a11y-regressions.playwright.ts
@@ -127,7 +127,7 @@ test.describe('a11y regressions', () => {
     componentPage,
   }) => {
     const entry = getEntry('access-gate');
-    const fixture = getFixture(entry, 'inline-denied');
+    const fixture = getFixture(entry, 'inline-toggle');
     const page = await componentPage.open({
       entry,
       theme: lightTheme,
@@ -135,50 +135,16 @@ test.describe('a11y regressions', () => {
       fixtureName: fixture.name,
       fixtureContentHash: fixture.fixtureContentHash,
     });
-    const deniedGeometry = await page.locator('.cinder-access-gate').evaluate((element) => {
-      const control = element.querySelector('[data-cinder-access-gate-control]')!;
-      const reason = element.querySelector('.cinder-access-gate__inline-reason')!;
-      const root = element.getBoundingClientRect();
-      const controlRect = control.getBoundingClientRect();
-      const reasonRect = reason.getBoundingClientRect();
-      return {
-        display: getComputedStyle(element).display,
-        rootWidth: root.width,
-        rootHeight: root.height,
-        controlBottom: controlRect.bottom,
-        reasonBottom: reasonRect.bottom,
-      };
-    });
-    expect(deniedGeometry.display).not.toBe('none');
-    expect(deniedGeometry.rootWidth).toBeGreaterThan(0);
-    expect(deniedGeometry.rootHeight).toBeGreaterThan(0);
-    expect(Math.abs(deniedGeometry.controlBottom - deniedGeometry.reasonBottom)).toBeLessThan(12);
+    const gatedControl = page.locator('[data-access-gate-toggle-anchor] button');
+    const deniedGeometry = await gatedControl.boundingBox();
+    expect(deniedGeometry).not.toBeNull();
 
-    const grantedPage = await componentPage.open({
-      entry,
-      theme: lightTheme,
-      viewport: desktopViewport,
-      fixtureName: 'inline-granted',
-      fixtureContentHash: getFixture(entry, 'inline-granted').fixtureContentHash,
-    });
-    const grantedGeometry = await grantedPage
-      .locator('[data-access-gate-baseline]')
-      .evaluate((baseline) => {
-        const sibling = baseline.nextElementSibling!.querySelector('button')!;
-        const baselineRect = baseline.querySelector('button')!.getBoundingClientRect();
-        const siblingRect = sibling.getBoundingClientRect();
-        return {
-          baselineTop: baselineRect.top,
-          baselineWidth: baselineRect.width,
-          baselineHeight: baselineRect.height,
-          siblingTop: siblingRect.top,
-          siblingWidth: siblingRect.width,
-          siblingHeight: siblingRect.height,
-        };
-      });
-    expect(Math.abs(grantedGeometry.baselineTop - grantedGeometry.siblingTop)).toBeLessThan(1);
-    expect(grantedGeometry.siblingWidth).toBe(grantedGeometry.baselineWidth);
-    expect(grantedGeometry.siblingHeight).toBe(grantedGeometry.baselineHeight);
+    await page.getByRole('button', { name: 'Toggle access' }).click();
+    const grantedGeometry = await gatedControl.boundingBox();
+    expect(grantedGeometry).not.toBeNull();
+    expect(Math.abs(grantedGeometry!.y - deniedGeometry!.y)).toBeLessThan(1);
+    expect(grantedGeometry!.width).toBe(deniedGeometry!.width);
+    expect(grantedGeometry!.height).toBe(deniedGeometry!.height);
   });
 
   test('section-heading uses div roots without header landmarks', async ({ componentPage }) => {

--- a/packages/testing/tests/a11y-regressions.playwright.ts
+++ b/packages/testing/tests/a11y-regressions.playwright.ts
@@ -123,6 +123,26 @@ test.describe('a11y regressions', () => {
     expectNoViolations('access-gate', sectionFixture.name, sectionBuckets);
   });
 
+  test('access-gate denied resting geometry remains measurable', async ({ componentPage }) => {
+    const entry = getEntry('access-gate');
+    const fixture = getFixture(entry, 'inline-denied');
+    const page = await componentPage.open({
+      entry,
+      theme: lightTheme,
+      viewport: desktopViewport,
+      fixtureName: fixture.name,
+      fixtureContentHash: fixture.fixtureContentHash,
+    });
+    const geometry = await page.locator('.cinder-access-gate').evaluate((element) => {
+      const style = getComputedStyle(element);
+      const rect = element.getBoundingClientRect();
+      return { display: style.display, width: rect.width, height: rect.height };
+    });
+    expect(geometry.display).not.toBe('none');
+    expect(geometry.width).toBeGreaterThan(0);
+    expect(geometry.height).toBeGreaterThan(0);
+  });
+
   test('section-heading uses div roots without header landmarks', async ({ componentPage }) => {
     const page = await componentPage.open({
       entry: getEntry('section-heading'),

--- a/packages/testing/tests/a11y-regressions.playwright.ts
+++ b/packages/testing/tests/a11y-regressions.playwright.ts
@@ -136,10 +136,12 @@ test.describe('a11y regressions', () => {
       fixtureContentHash: fixture.fixtureContentHash,
     });
     const gatedControl = page.locator('[data-access-gate-toggle-anchor] button');
+    await expect(gatedControl).toBeDisabled();
     const deniedGeometry = await gatedControl.boundingBox();
     expect(deniedGeometry).not.toBeNull();
 
     await page.getByRole('button', { name: 'Toggle access' }).click();
+    await expect(gatedControl).toBeEnabled();
     const grantedGeometry = await gatedControl.boundingBox();
     expect(grantedGeometry).not.toBeNull();
     expect(Math.abs(grantedGeometry!.y - deniedGeometry!.y)).toBeLessThan(1);

--- a/packages/testing/tests/a11y-regressions.playwright.ts
+++ b/packages/testing/tests/a11y-regressions.playwright.ts
@@ -143,8 +143,8 @@ test.describe('a11y regressions', () => {
     const grantedGeometry = await gatedControl.boundingBox();
     expect(grantedGeometry).not.toBeNull();
     expect(Math.abs(grantedGeometry!.y - deniedGeometry!.y)).toBeLessThan(1);
-    expect(grantedGeometry!.width).toBe(deniedGeometry!.width);
-    expect(grantedGeometry!.height).toBe(deniedGeometry!.height);
+    expect(Math.abs(grantedGeometry!.width - deniedGeometry!.width)).toBeLessThan(1);
+    expect(Math.abs(grantedGeometry!.height - deniedGeometry!.height)).toBeLessThan(1);
   });
 
   test('section-heading uses div roots without header landmarks', async ({ componentPage }) => {

--- a/packages/testing/tests/a11y-regressions.playwright.ts
+++ b/packages/testing/tests/a11y-regressions.playwright.ts
@@ -123,7 +123,9 @@ test.describe('a11y regressions', () => {
     expectNoViolations('access-gate', sectionFixture.name, sectionBuckets);
   });
 
-  test('access-gate denied resting geometry remains measurable', async ({ componentPage }) => {
+  test('access-gate denied and granted resting geometry remains aligned', async ({
+    componentPage,
+  }) => {
     const entry = getEntry('access-gate');
     const fixture = getFixture(entry, 'inline-denied');
     const page = await componentPage.open({
@@ -133,14 +135,46 @@ test.describe('a11y regressions', () => {
       fixtureName: fixture.name,
       fixtureContentHash: fixture.fixtureContentHash,
     });
-    const geometry = await page.locator('.cinder-access-gate').evaluate((element) => {
-      const style = getComputedStyle(element);
-      const rect = element.getBoundingClientRect();
-      return { display: style.display, width: rect.width, height: rect.height };
+    const deniedGeometry = await page.locator('.cinder-access-gate').evaluate((element) => {
+      const control = element.querySelector('[data-cinder-access-gate-control]')!;
+      const reason = element.querySelector('.cinder-access-gate__inline-reason')!;
+      const root = element.getBoundingClientRect();
+      const controlRect = control.getBoundingClientRect();
+      const reasonRect = reason.getBoundingClientRect();
+      return {
+        display: getComputedStyle(element).display,
+        root,
+        controlRect,
+        reasonRect,
+      };
     });
-    expect(geometry.display).not.toBe('none');
-    expect(geometry.width).toBeGreaterThan(0);
-    expect(geometry.height).toBeGreaterThan(0);
+    expect(deniedGeometry.display).not.toBe('none');
+    expect(deniedGeometry.root.width).toBeGreaterThan(0);
+    expect(deniedGeometry.root.height).toBeGreaterThan(0);
+    expect(
+      Math.abs(deniedGeometry.controlRect.bottom - deniedGeometry.reasonRect.bottom),
+    ).toBeLessThan(12);
+
+    const grantedPage = await componentPage.open({
+      entry,
+      theme: lightTheme,
+      viewport: desktopViewport,
+      fixtureName: 'inline-granted',
+      fixtureContentHash: getFixture(entry, 'inline-granted').fixtureContentHash,
+    });
+    const grantedGeometry = await grantedPage
+      .locator('[data-access-gate-baseline]')
+      .evaluate((baseline) => {
+        const sibling = baseline.nextElementSibling!.querySelector('button')!;
+        const baselineRect = baseline.querySelector('button')!.getBoundingClientRect();
+        const siblingRect = sibling.getBoundingClientRect();
+        return { baselineRect, siblingRect };
+      });
+    expect(
+      Math.abs(grantedGeometry.baselineRect.top - grantedGeometry.siblingRect.top),
+    ).toBeLessThan(1);
+    expect(grantedGeometry.siblingRect.width).toBe(grantedGeometry.baselineRect.width);
+    expect(grantedGeometry.siblingRect.height).toBe(grantedGeometry.baselineRect.height);
   });
 
   test('section-heading uses div roots without header landmarks', async ({ componentPage }) => {


### PR DESCRIPTION
Closes #934\n\nAccessGate now uses a shared inline baseline wrapper for granted content and aligns denied inline gates to the same baseline. Section grants preserve section layout semantics. The same-page browser regression toggles denied to granted and verifies the resting geometry without relying on exact subpixel equality.\n\nThe browser regression also exposed the playground test server's watch-mode self-restart race: dependency rebuilds could replace the server while warm-readiness polling was active. This pull request removes that self-watch path, makes build queue removal deterministic, cleans up superseded timers and readiness failures, and hardens child-process exit handling. Focused server lifecycle tests cover each operational change.\n\nValidation:\n- AccessGate component tests: 14 passed\n- Focused AccessGate browser regression: 1 passed\n- Playground/start-server lifecycle tests: 163 passed\n- Playground server/manifest tests: 121 passed\n- Input + AccessGate component tests: 68 passed\n- Package typecheck: 0 errors\n- Package lint: 0 errors, 0 warnings