### PR TITLE
fix(avatar): remove duplicate placeholder border

### DIFF
--- a/.changeset/fix-avatar-placeholder-border.md
+++ b/.changeset/fix-avatar-placeholder-border.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Remove the duplicate border from empty Avatar placeholders.

--- a/packages/components/src/components/avatar/avatar.css
+++ b/packages/components/src/components/avatar/avatar.css
@@ -71,7 +71,5 @@
   .cinder-avatar__placeholder {
     width: 100%;
     height: 100%;
-    background: var(--cinder-surface-inset);
-    border: 1px solid var(--cinder-border-muted);
   }
 }

--- a/packages/components/src/components/avatar/avatar.test.ts
+++ b/packages/components/src/components/avatar/avatar.test.ts
@@ -9,6 +9,12 @@ const { render } = await import('@testing-library/svelte');
 const { default: Avatar } = await import('./avatar.svelte');
 
 describe('Avatar', () => {
+  test('placeholder relies on the root chrome instead of adding a second border', () => {
+    const { container } = render(Avatar, {});
+    const placeholder = container.querySelector('.cinder-avatar__placeholder');
+    expect(placeholder).not.toBeNull();
+    expect(getComputedStyle(placeholder!).borderWidth).toBe('');
+  });
   test('renders an <img> when src is supplied', () => {
     const { container } = render(Avatar, { src: '/me.jpg', alt: 'Alice' });
     const img = container.querySelector('img');
@@ -80,8 +86,8 @@ describe('Avatar', () => {
     const css = await Bun.file(new URL('./avatar.css', import.meta.url)).text();
     const placeholderBlock = css.match(/\.cinder-avatar__placeholder\s*\{[^}]*\}/)?.[0] ?? '';
     expect(placeholderBlock).not.toContain('linear-gradient');
-    expect(placeholderBlock).toContain('background: var(--cinder-surface-inset)');
-    expect(placeholderBlock).toContain('border: 1px solid var(--cinder-border-muted)');
+    expect(placeholderBlock).not.toContain('background: var(--cinder-surface-inset)');
+    expect(placeholderBlock).not.toContain('border: 1px solid var(--cinder-border-muted)');
   });
 
   test('falls back to initials when the image fails to load', async () => {


### PR DESCRIPTION
Closes #935

Empty Avatar placeholders now rely on the root border/background, avoiding a doubled border and square edge clipped by circular overflow. Added a focused regression test and changeset.