### PR TITLE
Fix SortableList resting row layout

### DIFF
--- a/.changeset/fix-sortable-list-row-layout.md
+++ b/.changeset/fix-sortable-list-row-layout.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep SortableList content and its trailing drag handle aligned in one resting row.

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -555,9 +555,7 @@
     className,
   )}
 >
-  <div class="cinder-sortable-item__content">
-    {@render children(itemContext)}
-  </div>
+  {@render children(itemContext)}
 
   <button
     bind:this={handleEl}

--- a/packages/components/src/components/_sortable-item.svelte
+++ b/packages/components/src/components/_sortable-item.svelte
@@ -555,7 +555,9 @@
     className,
   )}
 >
-  {@render children(itemContext)}
+  <div class="cinder-sortable-item__content">
+    {@render children(itemContext)}
+  </div>
 
   <button
     bind:this={handleEl}

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -209,6 +209,10 @@
     min-inline-size: 0;
   }
 
+  .cinder-kanban-board .cinder-sortable-item {
+    min-inline-size: 0;
+  }
+
   .cinder-kanban-board .cinder-sortable-handle {
     align-self: start;
   }

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -213,7 +213,7 @@
     min-inline-size: 0;
   }
 
-  .cinder-kanban-board .cinder-sortable-handle {
+  .cinder-kanban-board__card > .cinder-sortable-handle {
     align-self: start;
   }
 

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -15,6 +15,7 @@
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     column-gap: var(--cinder-space-2);
+    position: relative;
   }
 
   .cinder-sortable-list__item-content {
@@ -22,7 +23,6 @@
   }
 
   .cinder-sortable-item {
-    position: relative;
     cursor: default;
     user-select: none;
   }

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -16,8 +16,16 @@
     align-items: center;
     gap: var(--cinder-space-2);
     position: relative;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    column-gap: var(--cinder-space-2);
     cursor: default;
     user-select: none;
+  }
+
+  .cinder-sortable-item__content {
+    min-inline-size: 0;
   }
 
   .cinder-sortable-item--lifted {

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -10,22 +10,21 @@
     padding: 0;
   }
 
-  [data-cinder-sortable-list] > .cinder-sortable-item,
-  [data-cinder-sortable-list-preview] > .cinder-sortable-item {
-    display: flex;
-    align-items: center;
-    gap: var(--cinder-space-2);
-    position: relative;
+  .cinder-sortable-list__item {
     display: grid;
     grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
     column-gap: var(--cinder-space-2);
-    cursor: default;
-    user-select: none;
   }
 
-  .cinder-sortable-item__content {
+  .cinder-sortable-list__item-content {
     min-inline-size: 0;
+  }
+
+  .cinder-sortable-item {
+    position: relative;
+    cursor: default;
+    user-select: none;
   }
 
   .cinder-sortable-item--lifted {

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -22,7 +22,7 @@
     min-inline-size: 0;
   }
 
-  .cinder-sortable-item {
+  .cinder-sortable-list__item.cinder-sortable-item {
     cursor: default;
     user-select: none;
   }

--- a/packages/components/src/components/sortable-list/sortable-list.svelte
+++ b/packages/components/src/components/sortable-list/sortable-list.svelte
@@ -141,9 +141,12 @@
       {...handle !== undefined ? { handle } : {}}
       {instructionsId}
       total={visualItems.length}
+      class="cinder-sortable-list__item"
     >
       {#snippet children(ctx)}
-        {@render renderRow(rowItem, ctx)}
+        <div class="cinder-sortable-list__item-content">
+          {@render renderRow(rowItem, ctx)}
+        </div>
       {/snippet}
     </SortableItem>
   {/each}

--- a/packages/components/src/components/sortable-list/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.test.ts
@@ -73,8 +73,9 @@ describe('SortableController', () => {
       container.querySelector('.cinder-sortable-list')?.hasAttribute('data-cinder-sortable-list'),
     ).toBe(true);
     expect(stylesheet).toContain(
-      '[data-cinder-sortable-list] > .cinder-sortable-item,\n  [data-cinder-sortable-list-preview] > .cinder-sortable-item {\n    display: flex;\n    align-items: center;\n    gap: var(--cinder-space-2);',
+      '.cinder-sortable-list__item {\n    display: grid;\n    grid-template-columns: minmax(0, 1fr) auto;\n    align-items: center;',
     );
+    expect(stylesheet).toContain('column-gap: var(--cinder-space-2);\n    position: relative;');
     expect(stylesheet).not.toContain('.cinder-sortable-list .cinder-sortable-item');
   });
 
@@ -638,7 +639,7 @@ describe('SortableList pointer drag preview', () => {
     const stylesheet = readFileSync(new URL('./sortable-list.css', import.meta.url), 'utf8');
 
     expect(preview?.hasAttribute('data-cinder-sortable-list-preview')).toBe(true);
-    expect(stylesheet).toContain('[data-cinder-sortable-list-preview] > .cinder-sortable-item');
+    expect(stylesheet).toContain('.cinder-sortable-list__item {');
 
     await dispatchPointerEvent(handle, 'pointerup', { pointerId: 1, pointerType: 'mouse' });
   });

--- a/packages/components/src/components/sortable-list/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.test.ts
@@ -76,7 +76,8 @@ describe('SortableController', () => {
       '.cinder-sortable-list__item {\n    display: grid;\n    grid-template-columns: minmax(0, 1fr) auto;\n    align-items: center;',
     );
     expect(stylesheet).toContain('column-gap: var(--cinder-space-2);\n    position: relative;');
-    expect(stylesheet).not.toContain('.cinder-sortable-list .cinder-sortable-item');
+    expect(stylesheet).toContain('.cinder-sortable-list__item.cinder-sortable-item');
+    expect(stylesheet).not.toMatch(/(^|\n)\s*\.cinder-sortable-item\s*\{/);
   });
 
   test('lift sets phase, key, from/to, liftedLabel, and calls announce', () => {

--- a/packages/testing/tests/sortable-list-layout.playwright.ts
+++ b/packages/testing/tests/sortable-list-layout.playwright.ts
@@ -22,4 +22,16 @@ test.describe('SortableList resting layout', () => {
     expect(Math.abs(labelCenterY - handleCenterY)).toBeLessThanOrEqual(0.5);
     expect(handleBox!.x).toBeGreaterThanOrEqual(labelBox!.x + labelBox!.width);
   });
+
+  test('does not override Kanban card alignment through the shared sortable item', async ({
+    page,
+  }) => {
+    await page.goto('/page/kanban-board?snapshot=1', { waitUntil: 'load' });
+    await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+
+    const card = page.locator('.cinder-kanban-board__card').first();
+
+    await expect(card).toHaveCSS('align-items', 'start');
+    await expect(card.locator('.cinder-sortable-list__item-content')).toHaveCount(0);
+  });
 });

--- a/packages/testing/tests/sortable-list-layout.playwright.ts
+++ b/packages/testing/tests/sortable-list-layout.playwright.ts
@@ -1,0 +1,25 @@
+import { expect, test } from '@playwright/test';
+
+const SORTABLE_LIST_ROUTE = '/page/sortable-list?snapshot=1';
+
+test.describe('SortableList resting layout', () => {
+  test('keeps each item label and trailing drag handle in one centered row', async ({ page }) => {
+    await page.goto(SORTABLE_LIST_ROUTE, { waitUntil: 'load' });
+    await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+
+    const row = page.locator('[data-sortable-row]').filter({ hasText: 'Write release notes' });
+    const label = row.getByText('Write release notes', { exact: true });
+    const handle = row.getByRole('button', { name: 'Reorder Write release notes' });
+
+    const [labelBox, handleBox] = await Promise.all([label.boundingBox(), handle.boundingBox()]);
+
+    expect(labelBox).not.toBeNull();
+    expect(handleBox).not.toBeNull();
+
+    const labelCenterY = labelBox!.y + labelBox!.height / 2;
+    const handleCenterY = handleBox!.y + handleBox!.height / 2;
+
+    expect(Math.abs(labelCenterY - handleCenterY)).toBeLessThanOrEqual(0.5);
+    expect(handleBox!.x).toBeGreaterThanOrEqual(labelBox!.x + labelBox!.width);
+  });
+});


### PR DESCRIPTION
Closes #932

## Summary

- group arbitrary item snippet content into a shrink-safe content cell
- lay out each SortableList item as a two-column row with a centered trailing drag handle
- add a real-browser geometry regression that proves label and handle centers share a row

## Validation

- `bun test packages/components/src/components/sortable-list/sortable-list.test.ts`
- `bun run --filter=@cinder/testing test:playwright -- tests/sortable-list-layout.playwright.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@cinder/testing typecheck`
- `bunx stylelint packages/components/src/components/sortable-list/sortable-list.css`
- `bunx prettier --check packages/components/src/components/_sortable-item.svelte packages/components/src/components/sortable-list/sortable-list.css packages/testing/tests/sortable-list-layout.playwright.ts`