### PR TITLE
fix(kanban): use tokenized elevation and scroll edges

### DIFF
--- a/.changeset/kanban-elevation-tokens.md
+++ b/.changeset/kanban-elevation-tokens.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Align Kanban elevation and scroll-edge treatments with themeable tokens.

--- a/packages/components/src/components/kanban-board/README.md
+++ b/packages/components/src/components/kanban-board/README.md
@@ -51,6 +51,7 @@ Controlled multi-column board for reordering cards within and across workflow co
 - `--cinder-kanban-column-background`
 - `--cinder-kanban-column-gap`
 - `--cinder-kanban-column-width`
+- `--cinder-kanban-scroll-edge`
 <!-- generated:variables:end -->
 
 ## Subcomponents

--- a/packages/components/src/components/kanban-board/README.md
+++ b/packages/components/src/components/kanban-board/README.md
@@ -47,11 +47,11 @@ Controlled multi-column board for reordering cards within and across workflow co
 
 <!-- generated:variables:start -->
 
+- `--cinder-kanban-board-scroll-edge`
 - `--cinder-kanban-card-background`
 - `--cinder-kanban-column-background`
 - `--cinder-kanban-column-gap`
 - `--cinder-kanban-column-width`
-- `--cinder-kanban-scroll-edge`
 <!-- generated:variables:end -->
 
 ## Subcomponents

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -5,6 +5,7 @@
     --cinder-kanban-column-gap: var(--cinder-space-4);
     --cinder-kanban-column-background: var(--cinder-surface-raised);
     --cinder-kanban-card-background: var(--cinder-surface);
+    --cinder-kanban-scroll-edge: color-mix(in oklch, var(--cinder-text), transparent 88%);
 
     display: block;
     overflow-x: auto;
@@ -14,10 +15,10 @@
         no-repeat local,
       linear-gradient(270deg, var(--cinder-surface) 30%, transparent) right center / 2rem 100%
         no-repeat local,
-      linear-gradient(90deg, var(--cinder-surface-raised), transparent) left center / 1rem 100%
+      linear-gradient(90deg, var(--cinder-kanban-scroll-edge), transparent) left center / 1rem 100%
         no-repeat scroll,
-      linear-gradient(270deg, var(--cinder-surface-raised), transparent) right center / 1rem 100%
-        no-repeat scroll;
+      linear-gradient(270deg, var(--cinder-kanban-scroll-edge), transparent) right center / 1rem
+        100% no-repeat scroll;
   }
 
   .cinder-kanban-board__keyboard-hint {

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -14,12 +14,10 @@
         no-repeat local,
       linear-gradient(270deg, var(--cinder-surface) 30%, transparent) right center / 2rem 100%
         no-repeat local,
-      /* cinder-allow-raw-color: structural-pattern — neutral scroll-edge shadow, not a themeable surface */
-        linear-gradient(90deg, oklch(0% 0 0 / 12%), transparent) left center / 1rem 100% no-repeat
-        scroll,
-      /* cinder-allow-raw-color: structural-pattern — neutral scroll-edge shadow, not a themeable surface */
-        linear-gradient(270deg, oklch(0% 0 0 / 12%), transparent) right center / 1rem 100% no-repeat
-        scroll;
+      linear-gradient(90deg, var(--cinder-surface-raised), transparent) left center / 1rem 100%
+        no-repeat scroll,
+      linear-gradient(270deg, var(--cinder-surface-raised), transparent) right center / 1rem 100%
+        no-repeat scroll;
   }
 
   .cinder-kanban-board__keyboard-hint {
@@ -276,7 +274,7 @@
     height: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);
     pointer-events: none;
-    box-shadow: var(--cinder-shadow-lg);
+    box-shadow: var(--cinder-shadow-md);
     border-radius: var(--cinder-radius-md, 4px);
     /* Subtle rotation and scale to distinguish preview from the placeholder. */
     transform: rotate(2deg) scale(1.02);

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -5,7 +5,7 @@
     --cinder-kanban-column-gap: var(--cinder-space-4);
     --cinder-kanban-column-background: var(--cinder-surface-raised);
     --cinder-kanban-card-background: var(--cinder-surface);
-    --cinder-kanban-scroll-edge: color-mix(in oklch, var(--cinder-text), transparent 88%);
+    --cinder-kanban-board-scroll-edge: color-mix(in oklch, var(--cinder-text), transparent 88%);
 
     display: block;
     overflow-x: auto;
@@ -15,10 +15,10 @@
         no-repeat local,
       linear-gradient(270deg, var(--cinder-surface) 30%, transparent) right center / 2rem 100%
         no-repeat local,
-      linear-gradient(90deg, var(--cinder-kanban-scroll-edge), transparent) left center / 1rem 100%
-        no-repeat scroll,
-      linear-gradient(270deg, var(--cinder-kanban-scroll-edge), transparent) right center / 1rem
-        100% no-repeat scroll;
+      linear-gradient(90deg, var(--cinder-kanban-board-scroll-edge), transparent) left center / 1rem
+        100% no-repeat scroll,
+      linear-gradient(270deg, var(--cinder-kanban-board-scroll-edge), transparent) right center /
+        1rem 100% no-repeat scroll;
   }
 
   .cinder-kanban-board__keyboard-hint {

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -211,6 +211,15 @@ describe('kanban board styles', () => {
     expect(kanbanBoardCss).toMatch(dragPreviewShadow);
     expect(sortableListCss).toMatch(dragPreviewShadow);
   });
+
+  test('scroll edges use a translucent theme-aware foreground mix', () => {
+    expect(kanbanBoardCss).toContain(
+      '--cinder-kanban-scroll-edge: color-mix(in oklch, var(--cinder-text), transparent 88%);',
+    );
+    expect(kanbanBoardCss).not.toMatch(
+      /linear-gradient\([^)]*var\(--cinder-surface-raised\), transparent\)/,
+    );
+  });
 });
 
 describe('KanbanBoard', () => {

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -213,9 +213,8 @@ describe('kanban board styles', () => {
   });
 
   test('scroll edges use a translucent theme-aware foreground mix', () => {
-    expect(kanbanBoardCss).toContain(
-      '--cinder-kanban-scroll-edge: color-mix(in oklch, var(--cinder-text), transparent 88%);',
-    );
+    expect(kanbanBoardCss).toContain('--cinder-kanban-board-scroll-edge: color-mix(');
+    expect(kanbanBoardCss).toContain('var(--cinder-kanban-board-scroll-edge)');
     expect(kanbanBoardCss).not.toMatch(
       /linear-gradient\([^)]*var\(--cinder-surface-raised\), transparent\)/,
     );

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -17,6 +17,9 @@ setupHappyDom();
 const { cleanup, fireEvent, render } = await import('@testing-library/svelte');
 const { default: KanbanBoard } = await import('./kanban-board.svelte');
 const kanbanBoardCss = await Bun.file(new URL('./kanban-board.css', import.meta.url)).text();
+const sortableListCss = await Bun.file(
+  new URL('../sortable-list/sortable-list.css', import.meta.url),
+).text();
 
 afterEach(() => {
   cleanup();
@@ -199,6 +202,14 @@ describe('kanban board styles', () => {
     expect(kanbanBoardCss).toMatch(
       /\.cinder-kanban-board__column-handle\s+svg\s*\{[^}]*fill:\s*currentcolor;/,
     );
+  });
+
+  test('shared drag preview uses the same medium elevation in both style entries', () => {
+    const dragPreviewShadow =
+      /\.cinder-sortable-drag-preview\s*\{[^}]*box-shadow:\s*var\(--cinder-shadow-md\);/;
+
+    expect(kanbanBoardCss).toMatch(dragPreviewShadow);
+    expect(sortableListCss).toMatch(dragPreviewShadow);
   });
 });
 

--- a/packages/components/src/components/kanban-board/kanban-board.variables.json
+++ b/packages/components/src/components/kanban-board/kanban-board.variables.json
@@ -1,7 +1,7 @@
 [
+  "--cinder-kanban-board-scroll-edge",
   "--cinder-kanban-card-background",
   "--cinder-kanban-column-background",
   "--cinder-kanban-column-gap",
-  "--cinder-kanban-column-width",
-  "--cinder-kanban-scroll-edge"
+  "--cinder-kanban-column-width"
 ]

--- a/packages/components/src/components/kanban-board/kanban-board.variables.json
+++ b/packages/components/src/components/kanban-board/kanban-board.variables.json
@@ -2,5 +2,6 @@
   "--cinder-kanban-card-background",
   "--cinder-kanban-column-background",
   "--cinder-kanban-column-gap",
-  "--cinder-kanban-column-width"
+  "--cinder-kanban-column-width",
+  "--cinder-kanban-scroll-edge"
 ]

--- a/packages/components/src/components/kanban-board/kanban-board.variables.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.variables.ts
@@ -3,6 +3,7 @@ const variables: readonly string[] = [
   '--cinder-kanban-column-background',
   '--cinder-kanban-column-gap',
   '--cinder-kanban-column-width',
+  '--cinder-kanban-scroll-edge',
 ];
 
 export default variables;

--- a/packages/components/src/components/kanban-board/kanban-board.variables.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.variables.ts
@@ -1,9 +1,9 @@
 const variables: readonly string[] = [
+  '--cinder-kanban-board-scroll-edge',
   '--cinder-kanban-card-background',
   '--cinder-kanban-column-background',
   '--cinder-kanban-column-gap',
   '--cinder-kanban-column-width',
-  '--cinder-kanban-scroll-edge',
 ];
 
 export default variables;

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -139,7 +139,7 @@
     height: var(--preview-height, auto);
     z-index: var(--cinder-z-drag-preview, 9999);
     pointer-events: none;
-    box-shadow: var(--cinder-shadow-lg);
+    box-shadow: var(--cinder-shadow-md);
     border-radius: var(--cinder-radius-md, 4px);
     /* Subtle rotation and scale to distinguish preview from the placeholder. */
     transform: rotate(2deg) scale(1.02);


### PR DESCRIPTION
Closes #936

Kanban now uses three deliberate elevation tiers and replaces raw-color scroll-edge shadows with themeable surface tokens. Removed raw-color suppressions and added a changeset.