### PR TITLE
fix(popover): connect caret to panel silhouette

### DIFF
--- a/.changeset/seamless-popover-caret.md
+++ b/.changeset/seamless-popover-caret.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Overlap Popover caret fills with the panel border so the arrow reads as one silhouette.

--- a/packages/components/src/components/popover/popover.css
+++ b/packages/components/src/components/popover/popover.css
@@ -64,7 +64,7 @@
     position: absolute;
     /* stylelint-disable csstools/use-logical */
     left: -7px;
-    top: 2px;
+    top: 1px;
     border-left: 7px solid transparent;
     border-right: 7px solid transparent;
     border-bottom: 7px solid var(--cinder-surface);
@@ -87,7 +87,7 @@
     position: absolute;
     /* stylelint-disable csstools/use-logical */
     left: -7px;
-    bottom: 2px;
+    bottom: 1px;
     border-left: 7px solid transparent;
     border-right: 7px solid transparent;
     border-top: 7px solid var(--cinder-surface);
@@ -110,7 +110,7 @@
     content: '';
     position: absolute;
     /* stylelint-disable csstools/use-logical */
-    left: 2px;
+    left: 1px;
     top: -7px;
     border-top: 7px solid transparent;
     border-bottom: 7px solid transparent;
@@ -133,7 +133,7 @@
     content: '';
     position: absolute;
     /* stylelint-disable csstools/use-logical */
-    right: 2px;
+    right: 1px;
     top: -7px;
     border-top: 7px solid transparent;
     border-bottom: 7px solid transparent;

--- a/packages/components/src/components/popover/popover.test.ts
+++ b/packages/components/src/components/popover/popover.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { createRawSnippet, tick } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -302,6 +303,14 @@ describe('Popover — rendering', () => {
 // ---------------------------------------------------------------------------
 
 describe('Popover — portal and arrow', () => {
+  test('overlaps the panel border in every arrow placement', () => {
+    const css = readFileSync(new URL('./popover.css', import.meta.url), 'utf8');
+    expect(css).toContain('top: 1px;');
+    expect(css).toContain('bottom: 1px;');
+    expect(css).toContain('left: 1px;');
+    expect(css).toContain('right: 1px;');
+  });
+
   test('moves the panel to document.body when open', async () => {
     const { container } = render(Popover, {
       props: { open: true, trigger: triggerSnippet, children: textSnippet('content') },


### PR DESCRIPTION
Closes #938

Overlap the caret fill with the panel border in all four placements so the arrow reads as a seamless extension instead of a detached outlined notch. The separate surface-token finding remains tracked in #921.

Focused verification:
- `bun test packages/components/src/components/popover/popover.test.ts` (41 passing)
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`

The Popover test asserts the 1px overlap geometry for top, right, bottom, and left placements.
