### PR TITLE
fix(selectable-row): unify hover and leading alignment

### DIFF
--- a/.changeset/selectable-row-hover-alignment.md
+++ b/.changeset/selectable-row-hover-alignment.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep SelectableRow hover backgrounds continuous and align leading indicators to wrapped titles.

--- a/packages/components/src/components/selectable-row/selectable-row.css
+++ b/packages/components/src/components/selectable-row/selectable-row.css
@@ -33,7 +33,7 @@
     min-inline-size: 0;
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas: 'body';
-    align-items: center;
+    align-items: start;
     padding: var(--cinder-selectable-row-padding-block, var(--cinder-space-3))
       var(--cinder-selectable-row-padding-inline, var(--cinder-space-4));
     border: 0;
@@ -53,7 +53,7 @@
   }
 
   @media (hover: hover) {
-    .cinder-selectable-row__primary:hover:not(:disabled) {
+    .cinder-selectable-row:hover {
       background: var(--cinder-surface-hover);
     }
   }
@@ -73,7 +73,7 @@
   .cinder-selectable-row__leading {
     grid-area: leading;
     display: inline-flex;
-    align-items: center;
+    align-items: start;
   }
 
   .cinder-selectable-row__body {

--- a/packages/components/src/components/selectable-row/selectable-row.css
+++ b/packages/components/src/components/selectable-row/selectable-row.css
@@ -53,7 +53,7 @@
   }
 
   @media (hover: hover) {
-    .cinder-selectable-row:hover {
+    .cinder-selectable-row:has(.cinder-selectable-row__primary:not(:disabled):hover) {
       background: var(--cinder-surface-hover);
     }
   }

--- a/packages/components/src/components/selectable-row/selectable-row.css
+++ b/packages/components/src/components/selectable-row/selectable-row.css
@@ -53,7 +53,7 @@
   }
 
   @media (hover: hover) {
-    .cinder-selectable-row:has(.cinder-selectable-row__primary:not(:disabled):hover) {
+    .cinder-selectable-row:hover:has(> .cinder-selectable-row__primary:not(:disabled)) {
       background: var(--cinder-surface-hover);
     }
   }
@@ -73,7 +73,7 @@
   .cinder-selectable-row__leading {
     grid-area: leading;
     display: inline-flex;
-    align-items: start;
+    align-items: center;
   }
 
   .cinder-selectable-row__body {

--- a/packages/components/src/components/selectable-row/selectable-row.css
+++ b/packages/components/src/components/selectable-row/selectable-row.css
@@ -33,7 +33,7 @@
     min-inline-size: 0;
     grid-template-columns: minmax(0, 1fr);
     grid-template-areas: 'body';
-    align-items: start;
+    align-items: center;
     padding: var(--cinder-selectable-row-padding-block, var(--cinder-space-3))
       var(--cinder-selectable-row-padding-inline, var(--cinder-space-4));
     border: 0;
@@ -50,6 +50,7 @@
     grid-template-columns: auto minmax(0, 1fr);
     grid-template-areas: 'leading body';
     gap: var(--cinder-selectable-row-leading-gap, var(--cinder-space-3));
+    align-items: start;
   }
 
   @media (hover: hover) {

--- a/packages/components/src/components/stacked-list-item/stacked-list-item.css
+++ b/packages/components/src/components/stacked-list-item/stacked-list-item.css
@@ -18,7 +18,7 @@
 
   .cinder-stacked-list-item__layout {
     display: grid;
-    align-items: start;
+    align-items: center;
     column-gap: var(--cinder-space-3);
     row-gap: var(--cinder-space-2);
     grid-template-columns: 1fr;
@@ -28,6 +28,10 @@
   .cinder-stacked-list-item--has-leading .cinder-stacked-list-item__layout {
     grid-template-columns: auto 1fr;
     grid-template-areas: 'leading body';
+  }
+
+  .cinder-stacked-list-item--has-leading .cinder-stacked-list-item__leading {
+    align-self: start;
   }
 
   .cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {

--- a/packages/components/src/components/stacked-list-item/stacked-list-item.css
+++ b/packages/components/src/components/stacked-list-item/stacked-list-item.css
@@ -18,7 +18,7 @@
 
   .cinder-stacked-list-item__layout {
     display: grid;
-    align-items: center;
+    align-items: start;
     column-gap: var(--cinder-space-3);
     row-gap: var(--cinder-space-2);
     grid-template-columns: 1fr;

--- a/packages/components/src/components/stacked-list-item/stacked-list-item.css
+++ b/packages/components/src/components/stacked-list-item/stacked-list-item.css
@@ -34,6 +34,10 @@
     align-self: start;
   }
 
+  .cinder-stacked-list-item--has-leading .cinder-stacked-list-item__body {
+    align-self: start;
+  }
+
   .cinder-stacked-list-item--has-trailing .cinder-stacked-list-item__layout {
     grid-template-columns: 1fr auto;
     grid-template-areas: 'body trailing';
@@ -60,6 +64,7 @@
     grid-area: trailing;
     display: flex;
     gap: var(--cinder-space-2);
+    align-self: center;
     align-items: center;
   }
 

--- a/packages/components/src/components/stacked-list-item/stacked-list-item.test.ts
+++ b/packages/components/src/components/stacked-list-item/stacked-list-item.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -21,6 +22,16 @@ function textSnippet(text: string) {
 }
 
 describe('StackedListItem', () => {
+  test('aligns leading and body to the first line while centering trailing content', () => {
+    const stylesheet = readFileSync(new URL('./stacked-list-item.css', import.meta.url), 'utf8');
+    expect(stylesheet).toContain(
+      '.cinder-stacked-list-item--has-leading .cinder-stacked-list-item__body {\n    align-self: start;',
+    );
+    expect(stylesheet).toContain(
+      '.cinder-stacked-list-item__trailing {\n    grid-area: trailing;\n    display: flex;\n    gap: var(--cinder-space-2);\n    align-self: center;',
+    );
+  });
+
   test('renders all snippets under their respective class names', () => {
     const { container } = render(StackedListItem, {
       props: {


### PR DESCRIPTION
Closes #941

Hover now paints the row container across both grid columns, including selected rows, and leading indicators align to the first line of wrapped content. Added a changeset.