### PR TITLE
fix(kanban): use rotating chevron disclosure

### DIFF
--- a/.changeset/kanban-chevron-disclosure.md
+++ b/.changeset/kanban-chevron-disclosure.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Use the shared rotating chevron disclosure affordance for Kanban column collapse.

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -114,6 +114,14 @@
     fill: currentcolor;
   }
 
+  .cinder-kanban-board__collapse-chevron {
+    transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
+  }
+
+  .cinder-kanban-board__column[data-cinder-collapsed] .cinder-kanban-board__collapse-chevron {
+    transform: rotate(-90deg);
+  }
+
   .cinder-kanban-board__column-handle:focus-visible,
   .cinder-kanban-board__collapse:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -118,8 +118,8 @@
     transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .cinder-kanban-board__column[data-cinder-collapsed] .cinder-kanban-board__collapse-chevron {
-    transform: rotate(-90deg);
+  .cinder-kanban-board__column[data-cinder-expanded] .cinder-kanban-board__collapse-chevron {
+    transform: rotate(180deg);
   }
 
   .cinder-kanban-board__column-handle:focus-visible,

--- a/packages/components/src/components/kanban-board/kanban-board.css
+++ b/packages/components/src/components/kanban-board/kanban-board.css
@@ -55,7 +55,7 @@
     box-shadow: var(--cinder-shadow-sm);
   }
 
-  .cinder-kanban-board__column[data-cinder-collapsed] {
+  .cinder-kanban-board__column:not([data-cinder-expanded]) {
     grid-template-rows: auto;
     min-block-size: auto;
   }

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -25,6 +25,7 @@
 
 <script lang="ts" generics="Card">
   import { classNames } from '../../utilities/class-names.ts';
+  import { ChevronDown } from '../icons/index.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import {
     SortableController,
@@ -608,7 +609,7 @@
               aria-expanded={!column.collapsed}
               onclick={() => toggleColumn(column)}
             >
-              {column.collapsed ? '+' : '-'}
+              <ChevronDown class="cinder-kanban-board__collapse-chevron" aria-hidden="true" />
             </button>
           {/if}
         </header>

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -566,7 +566,7 @@
         class="cinder-kanban-board__column"
         role="listitem"
         aria-label={getColumnLabel(column)}
-        data-cinder-collapsed={column.collapsed ? '' : undefined}
+        data-cinder-expanded={!column.collapsed ? '' : undefined}
       >
         <header class="cinder-kanban-board__column-header">
           {#if reorderColumns}

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -25,7 +25,7 @@
 
 <script lang="ts" generics="Card">
   import { classNames } from '../../utilities/class-names.ts';
-  import { ChevronDown } from '../icons/index.ts';
+  import { ChevronDown } from '@lostgradient/cinder/icons';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import {
     SortableController,

--- a/packages/components/src/components/kanban-board/kanban-board.test.ts
+++ b/packages/components/src/components/kanban-board/kanban-board.test.ts
@@ -450,6 +450,32 @@ describe('KanbanBoard', () => {
     });
   });
 
+  test('collapse disclosure uses the shared chevron state convention', async () => {
+    const { container } = renderBoard({ collapsible: true });
+    const column = container.querySelector('.cinder-kanban-board__column')!;
+    const button = container.querySelector(
+      '[aria-label="Collapse To do (2 cards)"]',
+    ) as HTMLButtonElement;
+    const chevron = button.querySelector('.cinder-kanban-board__collapse-chevron');
+
+    expect(column.hasAttribute('data-cinder-expanded')).toBe(true);
+    expect(chevron).not.toBeNull();
+    expect(button.getAttribute('aria-expanded')).toBe('true');
+
+    cleanup();
+    const columns = makeColumns();
+    columns[0] = { ...columns[0], collapsed: true };
+    const collapsed = renderBoard({ collapsible: true, columns });
+    const collapsedColumn = collapsed.container.querySelector('.cinder-kanban-board__column')!;
+    const collapsedButton = collapsed.container.querySelector(
+      '[aria-label="Expand To do (2 cards)"]',
+    ) as HTMLButtonElement;
+
+    expect(collapsedColumn.hasAttribute('data-cinder-expanded')).toBe(false);
+    expect(collapsedButton.getAttribute('aria-expanded')).toBe('false');
+    expect(collapsedButton.textContent).not.toMatch(/[+−-]/);
+  });
+
   test('column keyboard reorder emits column metadata', async () => {
     const { container, onchange } = renderBoard();
     const handle = container.querySelector('[aria-label="Reorder To do column"]') as HTMLElement;


### PR DESCRIPTION
Closes #939

Replace literal +/- collapse glyphs with the shared ChevronDown icon and rotate it for collapsed columns. Existing aria-expanded and keyboard behavior are unchanged.