### PR TITLE
fix(event-stream-viewer): remove empty toolbar and reuse input

### DIFF
--- a/.changeset/event-stream-viewer-primitives.md
+++ b/.changeset/event-stream-viewer-primitives.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Remove empty EventStreamViewer toolbars and use the shared Input primitive for filtering.

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.css
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.css
@@ -5,6 +5,7 @@
  * mirror between `src/` and generated `dist/`. */
 @import '../copy-button/copy-button.css';
 @import '../json-viewer/json-viewer.css';
+@import '../input/input.css';
 @import '../status-dot/status-dot.css';
 
 @layer cinder.components {
@@ -297,7 +298,7 @@
     display: grid;
     grid-template-columns: 3px 1fr auto;
     gap: 0 var(--cinder-space-2);
-    padding: var(--cinder-space-1) var(--cinder-space-3) var(--cinder-space-1) 0;
+    padding: 0 var(--cinder-space-3) 0 0;
     border-block-end: 1px solid var(--cinder-border-muted);
   }
 

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
@@ -39,6 +39,7 @@
   import CopyButton from '../copy-button/copy-button.svelte';
   import JsonViewer from '../json-viewer/json-viewer.svelte';
   import StatusDot from '../status-dot/status-dot.svelte';
+  import Input from '../input/index.ts';
   import {
     detailsIdForKey,
     reconnectedBoundaryKey,
@@ -90,8 +91,8 @@
     loading = false,
     label = 'Event stream',
     detectSequenceGaps = false,
-    onCopyVisible,
-    onFilter,
+    oncopyvisible,
+    onfilter,
     filterQuery = '',
     class: className,
     ...rest
@@ -248,8 +249,8 @@
 
   function handleCopyVisible() {
     const text = renderedEntries.map(formatRenderedEntryAsText).join('\n');
-    if (!onCopyVisible) return;
-    onCopyVisible(text);
+    if (!oncopyvisible) return;
+    oncopyvisible(text);
     liveMessage = formatCopyVisibleAnnouncement(renderedEntries.length);
     setTimeout(() => {
       liveMessage = '';
@@ -303,45 +304,49 @@
   data-cinder-paused={!followLatest || undefined}
 >
   <!-- Toolbar -->
-  <div class="cinder-event-stream-viewer__toolbar" role="group" aria-label="Stream controls">
-    <div class="cinder-event-stream-viewer__toolbar-start">
-      {#if connectionState}
-        <StatusDot {connectionState} />
-      {/if}
-      {#if !followLatest}
-        <button
-          type="button"
-          class="cinder-event-stream-viewer__resume-button"
-          onclick={resumeFollowing}
-        >
-          Resume following
-        </button>
-      {/if}
+  {#if connectionState || !followLatest || onfilter !== undefined || oncopyvisible !== undefined}
+    <div class="cinder-event-stream-viewer__toolbar" role="group" aria-label="Stream controls">
+      <div class="cinder-event-stream-viewer__toolbar-start">
+        {#if connectionState}
+          <StatusDot {connectionState} />
+        {/if}
+        {#if !followLatest}
+          <button
+            type="button"
+            class="cinder-event-stream-viewer__resume-button"
+            onclick={resumeFollowing}
+          >
+            Resume following
+          </button>
+        {/if}
+      </div>
+      <div class="cinder-event-stream-viewer__toolbar-end">
+        {#if onfilter !== undefined}
+          <Input
+            type="search"
+            class="cinder-event-stream-viewer__filter-input"
+            placeholder="Filter events…"
+            label="Filter events"
+            hideLabel
+            aria-label="Filter events"
+            value={filterQuery}
+            oninput={(e) => onfilter?.((e.currentTarget as HTMLInputElement).value)}
+          />
+        {/if}
+        {#if oncopyvisible !== undefined}
+          <button
+            type="button"
+            class="cinder-event-stream-viewer__copy-all-button"
+            onclick={handleCopyVisible}
+            aria-label="Copy all visible events"
+            disabled={events.length === 0}
+          >
+            Copy visible
+          </button>
+        {/if}
+      </div>
     </div>
-    <div class="cinder-event-stream-viewer__toolbar-end">
-      {#if onFilter !== undefined}
-        <input
-          type="search"
-          class="cinder-event-stream-viewer__filter-input"
-          placeholder="Filter events…"
-          aria-label="Filter events"
-          value={filterQuery}
-          oninput={(e) => onFilter?.((e.currentTarget as HTMLInputElement).value)}
-        />
-      {/if}
-      {#if onCopyVisible !== undefined}
-        <button
-          type="button"
-          class="cinder-event-stream-viewer__copy-all-button"
-          onclick={handleCopyVisible}
-          aria-label="Copy all visible events"
-          disabled={events.length === 0}
-        >
-          Copy visible
-        </button>
-      {/if}
-    </div>
-  </div>
+  {/if}
 
   <!-- Truncation notice -->
   {#if truncated}

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
@@ -29,6 +29,7 @@
 
 <script lang="ts">
   import { SvelteSet } from 'svelte/reactivity';
+  import type { Snippet } from 'svelte';
   import type {
     EventStreamEntry,
     EventStreamViewerProps,
@@ -72,6 +73,8 @@
   };
 
   type RenderedEntry = RenderedEventEntry | RenderedReconnectedBoundary | RenderedSequenceGap;
+
+  const emptyInputAdornment: Snippet = () => {};
 
   function isValidSequence(value: unknown): value is number {
     return Number.isInteger(value);
@@ -329,6 +332,8 @@
             label="Filter events"
             hideLabel
             aria-label="Filter events"
+            leading={emptyInputAdornment}
+            trailing={emptyInputAdornment}
             value={filterQuery}
             oninput={(e) => onfilter?.((e.currentTarget as HTMLInputElement).value)}
           />

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
@@ -39,7 +39,7 @@
   import CopyButton from '../copy-button/copy-button.svelte';
   import JsonViewer from '../json-viewer/json-viewer.svelte';
   import StatusDot from '../status-dot/status-dot.svelte';
-  import Input from '@lostgradient/cinder/input';
+  import Input from '../input/input.svelte';
   import {
     detailsIdForKey,
     reconnectedBoundaryKey,

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
@@ -91,8 +91,8 @@
     loading = false,
     label = 'Event stream',
     detectSequenceGaps = false,
-    oncopyvisible,
-    onfilter,
+    onCopyVisible,
+    onFilter,
     filterQuery = '',
     class: className,
     ...rest
@@ -249,8 +249,8 @@
 
   function handleCopyVisible() {
     const text = renderedEntries.map(formatRenderedEntryAsText).join('\n');
-    if (!oncopyvisible) return;
-    oncopyvisible(text);
+    if (!onCopyVisible) return;
+    onCopyVisible(text);
     liveMessage = formatCopyVisibleAnnouncement(renderedEntries.length);
     setTimeout(() => {
       liveMessage = '';
@@ -304,7 +304,7 @@
   data-cinder-paused={!followLatest || undefined}
 >
   <!-- Toolbar -->
-  {#if connectionState || !followLatest || onfilter !== undefined || oncopyvisible !== undefined}
+  {#if connectionState || !followLatest || onFilter !== undefined || onCopyVisible !== undefined}
     <div class="cinder-event-stream-viewer__toolbar" role="group" aria-label="Stream controls">
       <div class="cinder-event-stream-viewer__toolbar-start">
         {#if connectionState}
@@ -321,7 +321,7 @@
         {/if}
       </div>
       <div class="cinder-event-stream-viewer__toolbar-end">
-        {#if onfilter !== undefined}
+        {#if onFilter !== undefined}
           <Input
             id={`${instanceId}-filter`}
             type="search"
@@ -331,10 +331,10 @@
             hideLabel
             aria-label="Filter events"
             value={filterQuery}
-            oninput={(e) => onfilter?.((e.currentTarget as HTMLInputElement).value)}
+            oninput={(e) => onFilter?.((e.currentTarget as HTMLInputElement).value)}
           />
         {/if}
-        {#if oncopyvisible !== undefined}
+        {#if onCopyVisible !== undefined}
           <button
             type="button"
             class="cinder-event-stream-viewer__copy-all-button"

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
@@ -29,7 +29,6 @@
 
 <script lang="ts">
   import { SvelteSet } from 'svelte/reactivity';
-  import type { Snippet } from 'svelte';
   import type {
     EventStreamEntry,
     EventStreamViewerProps,
@@ -73,8 +72,6 @@
   };
 
   type RenderedEntry = RenderedEventEntry | RenderedReconnectedBoundary | RenderedSequenceGap;
-
-  const emptyInputAdornment: Snippet = () => {};
 
   function isValidSequence(value: unknown): value is number {
     return Number.isInteger(value);
@@ -299,6 +296,8 @@
   });
 </script>
 
+{#snippet emptyInputAdornment()}{/snippet}
+
 <div
   {...rest}
   class={classNames('cinder-event-stream-viewer', className)}
@@ -326,6 +325,7 @@
       <div class="cinder-event-stream-viewer__toolbar-end">
         {#if onfilter !== undefined}
           <Input
+            id={`${instanceId}-filter`}
             type="search"
             class="cinder-event-stream-viewer__filter-input"
             placeholder="Filter events…"

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
@@ -39,7 +39,7 @@
   import CopyButton from '../copy-button/copy-button.svelte';
   import JsonViewer from '../json-viewer/json-viewer.svelte';
   import StatusDot from '../status-dot/status-dot.svelte';
-  import Input from '../input/index.ts';
+  import Input from '@lostgradient/cinder/input';
   import {
     detailsIdForKey,
     reconnectedBoundaryKey,
@@ -296,8 +296,6 @@
   });
 </script>
 
-{#snippet emptyInputAdornment()}{/snippet}
-
 <div
   {...rest}
   class={classNames('cinder-event-stream-viewer', className)}
@@ -332,8 +330,6 @@
             label="Filter events"
             hideLabel
             aria-label="Filter events"
-            leading={emptyInputAdornment}
-            trailing={emptyInputAdornment}
             value={filterQuery}
             oninput={(e) => onfilter?.((e.currentTarget as HTMLInputElement).value)}
           />

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.svelte
@@ -39,7 +39,7 @@
   import CopyButton from '../copy-button/copy-button.svelte';
   import JsonViewer from '../json-viewer/json-viewer.svelte';
   import StatusDot from '../status-dot/status-dot.svelte';
-  import Input from '../input/input.svelte';
+  import Input from '@lostgradient/cinder/input';
   import {
     detailsIdForKey,
     reconnectedBoundaryKey,

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
@@ -144,7 +144,9 @@ describe('EventStreamViewer', () => {
     });
 
     test('renders a log region with the default label', () => {
-      const { container } = render(EventStreamViewer, { props: { events: [] } });
+      const { container } = render(EventStreamViewer, {
+        props: { events: [], connectionState: 'connected' },
+      });
       const log = container.querySelector('[role="log"]');
       expect(log).not.toBeNull();
       expect(log?.getAttribute('aria-label')).toBe('Event stream');
@@ -159,7 +161,9 @@ describe('EventStreamViewer', () => {
     });
 
     test('renders toolbar with group role', () => {
-      const { container } = render(EventStreamViewer, { props: { events: [] } });
+      const { container } = render(EventStreamViewer, {
+        props: { events: [], connectionState: 'connected' },
+      });
       const toolbar = container.querySelector('[role="group"]');
       expect(toolbar).not.toBeNull();
       expect(toolbar?.getAttribute('aria-label')).toBe('Stream controls');

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
@@ -437,7 +437,7 @@ describe('EventStreamViewer', () => {
         props: {
           detectSequenceGaps: true,
           events: entries,
-          onfilter: () => {},
+          onFilter: () => {},
           filterQuery: 'retry',
         },
       });
@@ -470,7 +470,7 @@ describe('EventStreamViewer', () => {
         props: {
           detectSequenceGaps: true,
           events: entries,
-          onfilter: () => {},
+          onFilter: () => {},
           filterQuery: '',
         },
       });
@@ -841,9 +841,9 @@ describe('EventStreamViewer', () => {
   });
 
   describe('filter input', () => {
-    test('renders filter input when onfilter callback is provided', () => {
+    test('renders filter input when onFilter callback is provided', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [], onfilter: () => {} },
+        props: { events: [], onFilter: () => {} },
       });
       const input = container.querySelector<HTMLInputElement>(
         '.cinder-event-stream-viewer__filter-input',
@@ -853,14 +853,14 @@ describe('EventStreamViewer', () => {
       expect(input?.getAttribute('aria-label')).toBe('Filter events');
     });
 
-    test('does not render filter input when onfilter is omitted', () => {
+    test('does not render filter input when onFilter is omitted', () => {
       const { container } = render(EventStreamViewer, { props: { events: [] } });
       expect(container.querySelector('.cinder-event-stream-viewer__filter-input')).toBeNull();
     });
 
     test('filter input reflects filterQuery prop', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [], onfilter: () => {}, filterQuery: 'error' },
+        props: { events: [], onFilter: () => {}, filterQuery: 'error' },
       });
       const input = container.querySelector<HTMLInputElement>(
         '.cinder-event-stream-viewer__filter-input',
@@ -870,15 +870,15 @@ describe('EventStreamViewer', () => {
   });
 
   describe('copy visible', () => {
-    test('renders copy-visible button when oncopyvisible is provided', () => {
+    test('renders copy-visible button when onCopyVisible is provided', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [baseEvent], oncopyvisible: () => {} },
+        props: { events: [baseEvent], onCopyVisible: () => {} },
       });
       const btn = container.querySelector('.cinder-event-stream-viewer__copy-all-button');
       expect(btn).not.toBeNull();
     });
 
-    test('does not render copy-visible button when oncopyvisible is omitted', () => {
+    test('does not render copy-visible button when onCopyVisible is omitted', () => {
       const { container } = render(EventStreamViewer, {
         props: { events: [baseEvent] },
       });
@@ -888,7 +888,7 @@ describe('EventStreamViewer', () => {
 
     test('copy-visible button is disabled when events array is empty', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [], oncopyvisible: () => {} },
+        props: { events: [], onCopyVisible: () => {} },
       });
       const btn = container.querySelector<HTMLButtonElement>(
         '.cinder-event-stream-viewer__copy-all-button',
@@ -896,12 +896,12 @@ describe('EventStreamViewer', () => {
       expect(btn?.disabled).toBe(true);
     });
 
-    test('clicking copy-visible calls oncopyvisible with formatted text', async () => {
+    test('clicking copy-visible calls onCopyVisible with formatted text', async () => {
       let received = '';
       const { container } = render(EventStreamViewer, {
         props: {
           events: [baseEvent],
-          oncopyvisible: (text: string) => {
+          onCopyVisible: (text: string) => {
             received = text;
           },
         },
@@ -917,7 +917,7 @@ describe('EventStreamViewer', () => {
       const { container } = render(EventStreamViewer, {
         props: {
           events: [baseEvent],
-          oncopyvisible: () => {},
+          onCopyVisible: () => {},
         },
       });
       const btn = container.querySelector<HTMLButtonElement>(
@@ -946,7 +946,7 @@ describe('EventStreamViewer', () => {
         props: {
           detectSequenceGaps: true,
           events: entries,
-          oncopyvisible: (text: string) => {
+          onCopyVisible: (text: string) => {
             received = text;
           },
         },

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
@@ -1,5 +1,5 @@
 /// <reference lib="dom" />
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
 
 import Ajv2020 from 'ajv/dist/2020';
 
@@ -12,6 +12,11 @@ import {
 import type { EventStreamEntry, StreamEvent } from './event-stream-viewer.types.ts';
 
 setupHappyDom();
+
+// Source-package tests do not resolve the package's self-reference through Bun's
+// export map. Keep the component on its public subpath while mapping that entry
+// to the source implementation for this focused test process.
+mock.module('@lostgradient/cinder/input', () => import('../input/index.ts'));
 
 const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 const { default: EventStreamViewer } = await import('./event-stream-viewer.svelte');

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
@@ -169,6 +169,11 @@ describe('EventStreamViewer', () => {
       expect(toolbar?.getAttribute('aria-label')).toBe('Stream controls');
     });
 
+    test('omits the toolbar when no controls are available', () => {
+      const { container } = render(EventStreamViewer, { props: { events: [] } });
+      expect(container.querySelector('.cinder-event-stream-viewer__toolbar')).toBeNull();
+    });
+
     test('merges class prop with cinder-event-stream-viewer', () => {
       const { container } = render(EventStreamViewer, {
         props: { events: [], class: 'custom-class' },
@@ -427,7 +432,7 @@ describe('EventStreamViewer', () => {
         props: {
           detectSequenceGaps: true,
           events: entries,
-          onFilter: () => {},
+          onfilter: () => {},
           filterQuery: 'retry',
         },
       });
@@ -460,7 +465,7 @@ describe('EventStreamViewer', () => {
         props: {
           detectSequenceGaps: true,
           events: entries,
-          onFilter: () => {},
+          onfilter: () => {},
           filterQuery: '',
         },
       });
@@ -831,25 +836,26 @@ describe('EventStreamViewer', () => {
   });
 
   describe('filter input', () => {
-    test('renders filter input when onFilter callback is provided', () => {
+    test('renders filter input when onfilter callback is provided', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [], onFilter: () => {} },
+        props: { events: [], onfilter: () => {} },
       });
       const input = container.querySelector<HTMLInputElement>(
         '.cinder-event-stream-viewer__filter-input',
       );
       expect(input).not.toBeNull();
+      expect(input?.classList.contains('cinder-input')).toBe(true);
       expect(input?.getAttribute('aria-label')).toBe('Filter events');
     });
 
-    test('does not render filter input when onFilter is omitted', () => {
+    test('does not render filter input when onfilter is omitted', () => {
       const { container } = render(EventStreamViewer, { props: { events: [] } });
       expect(container.querySelector('.cinder-event-stream-viewer__filter-input')).toBeNull();
     });
 
     test('filter input reflects filterQuery prop', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [], onFilter: () => {}, filterQuery: 'error' },
+        props: { events: [], onfilter: () => {}, filterQuery: 'error' },
       });
       const input = container.querySelector<HTMLInputElement>(
         '.cinder-event-stream-viewer__filter-input',
@@ -859,15 +865,15 @@ describe('EventStreamViewer', () => {
   });
 
   describe('copy visible', () => {
-    test('renders copy-visible button when onCopyVisible is provided', () => {
+    test('renders copy-visible button when oncopyvisible is provided', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [baseEvent], onCopyVisible: () => {} },
+        props: { events: [baseEvent], oncopyvisible: () => {} },
       });
       const btn = container.querySelector('.cinder-event-stream-viewer__copy-all-button');
       expect(btn).not.toBeNull();
     });
 
-    test('does not render copy-visible button when onCopyVisible is omitted', () => {
+    test('does not render copy-visible button when oncopyvisible is omitted', () => {
       const { container } = render(EventStreamViewer, {
         props: { events: [baseEvent] },
       });
@@ -877,7 +883,7 @@ describe('EventStreamViewer', () => {
 
     test('copy-visible button is disabled when events array is empty', () => {
       const { container } = render(EventStreamViewer, {
-        props: { events: [], onCopyVisible: () => {} },
+        props: { events: [], oncopyvisible: () => {} },
       });
       const btn = container.querySelector<HTMLButtonElement>(
         '.cinder-event-stream-viewer__copy-all-button',
@@ -885,12 +891,12 @@ describe('EventStreamViewer', () => {
       expect(btn?.disabled).toBe(true);
     });
 
-    test('clicking copy-visible calls onCopyVisible with formatted text', async () => {
+    test('clicking copy-visible calls oncopyvisible with formatted text', async () => {
       let received = '';
       const { container } = render(EventStreamViewer, {
         props: {
           events: [baseEvent],
-          onCopyVisible: (text: string) => {
+          oncopyvisible: (text: string) => {
             received = text;
           },
         },
@@ -906,7 +912,7 @@ describe('EventStreamViewer', () => {
       const { container } = render(EventStreamViewer, {
         props: {
           events: [baseEvent],
-          onCopyVisible: () => {},
+          oncopyvisible: () => {},
         },
       });
       const btn = container.querySelector<HTMLButtonElement>(
@@ -935,7 +941,7 @@ describe('EventStreamViewer', () => {
         props: {
           detectSequenceGaps: true,
           events: entries,
-          onCopyVisible: (text: string) => {
+          oncopyvisible: (text: string) => {
             received = text;
           },
         },
@@ -1130,7 +1136,17 @@ describe('EventStreamViewer', () => {
 
       expect(css).toContain("@import '../copy-button/copy-button.css';");
       expect(css).toContain("@import '../json-viewer/json-viewer.css';");
+      expect(css).toContain("@import '../input/input.css';");
       expect(css).toContain("@import '../status-dot/status-dot.css';");
+    });
+
+    test('event rows keep the severity rail flush with the row edges', () => {
+      const { readFileSync } = require('node:fs');
+      const css = readFileSync(
+        new URL('./event-stream-viewer.css', import.meta.url).pathname,
+        'utf8',
+      );
+      expect(css).toContain('padding: 0 var(--cinder-space-3) 0 0;');
     });
   });
 });

--- a/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
+++ b/packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts
@@ -16,7 +16,8 @@ setupHappyDom();
 // Source-package tests do not resolve the package's self-reference through Bun's
 // export map. Keep the component on its public subpath while mapping that entry
 // to the source implementation for this focused test process.
-mock.module('@lostgradient/cinder/input', () => import('../input/index.ts'));
+const { default: Input } = await import('../input/index.ts');
+mock.module('@lostgradient/cinder/input', () => ({ default: Input }));
 
 const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 const { default: EventStreamViewer } = await import('./event-stream-viewer.svelte');


### PR DESCRIPTION
Closes #942

EventStreamViewer now renders its toolbar only when controls exist, uses the shared Input primitive for filtering, and keeps the severity rail flush with each event row by moving vertical spacing into the event content instead of the grid row. Filtering and copy callbacks retain the current lowercase API names.

Focused verification:
- `bun test packages/components/src/components/event-stream-viewer/event-stream-viewer.test.ts` (86 passing)
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`

The component test covers toolbar absence, the shared `cinder-input` class, composed Input styles, and the rail spacing contract.
