### PR TITLE
fix(feature-section): close responsive split dead zone

### DIFF
--- a/.changeset/feature-section-responsive-split.md
+++ b/.changeset/feature-section-responsive-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Make FeatureSection split layouts continuous across responsive widths and bound media height.

--- a/packages/components/src/components/feature-section/feature-section.css
+++ b/packages/components/src/components/feature-section/feature-section.css
@@ -87,6 +87,7 @@
     padding: var(--cinder-space-4);
     min-block-size: 12rem;
     max-block-size: 32rem;
+    overflow: auto;
   }
 
   @container cinder-feature-section (max-width: 48rem) {
@@ -100,6 +101,11 @@
       .cinder-feature-section__body {
       grid-template-columns: repeat(2, minmax(0, 1fr));
       align-items: center;
+    }
+
+    .cinder-feature-section[data-cinder-layout='split'][data-cinder-has-media]
+      .cinder-feature-section__list {
+      grid-template-columns: minmax(0, 1fr);
     }
 
     .cinder-feature-section[data-cinder-layout='split'][data-cinder-has-media][data-cinder-media-position='start']

--- a/packages/components/src/components/feature-section/feature-section.css
+++ b/packages/components/src/components/feature-section/feature-section.css
@@ -90,13 +90,13 @@
     overflow: auto;
   }
 
-  @container cinder-feature-section (max-width: 48rem) {
+  @container cinder-feature-section (max-width: 64rem) {
     .cinder-feature-section__list {
       grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
     }
   }
 
-  @container cinder-feature-section (min-width: 48rem) {
+  @container cinder-feature-section (min-width: 64rem) {
     .cinder-feature-section[data-cinder-layout='split'][data-cinder-has-media]
       .cinder-feature-section__body {
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/packages/components/src/components/feature-section/feature-section.css
+++ b/packages/components/src/components/feature-section/feature-section.css
@@ -90,7 +90,7 @@
     overflow: auto;
   }
 
-  @container cinder-feature-section (max-width: 64rem) {
+  @container cinder-feature-section (max-width: 48rem) {
     .cinder-feature-section__list {
       grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
     }
@@ -118,6 +118,13 @@
       .cinder-feature-section__media {
       grid-column: 1;
       grid-row: 1;
+    }
+  }
+
+  @container cinder-feature-section (min-width: 48rem) and (max-width: 64rem) {
+    .cinder-feature-section[data-cinder-layout='split'][data-cinder-has-media]
+      .cinder-feature-section__list {
+      grid-template-columns: minmax(0, 1fr);
     }
   }
 }

--- a/packages/components/src/components/feature-section/feature-section.css
+++ b/packages/components/src/components/feature-section/feature-section.css
@@ -85,6 +85,8 @@
     border-radius: var(--cinder-radius-lg);
     background: var(--cinder-surface-raised);
     padding: var(--cinder-space-4);
+    min-block-size: 12rem;
+    max-block-size: 32rem;
   }
 
   @container cinder-feature-section (max-width: 48rem) {
@@ -93,7 +95,7 @@
     }
   }
 
-  @container cinder-feature-section (min-width: 64rem) {
+  @container cinder-feature-section (min-width: 48rem) {
     .cinder-feature-section[data-cinder-layout='split'][data-cinder-has-media]
       .cinder-feature-section__body {
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/packages/components/src/components/feature-section/feature-section.css.test.ts
+++ b/packages/components/src/components/feature-section/feature-section.css.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+
+const stylesheet = readFileSync(new URL('./feature-section.css', import.meta.url), 'utf8');
+
+describe('FeatureSection responsive layout', () => {
+  test('keeps the split breakpoint aligned with HeroSection and bounds media', () => {
+    expect(stylesheet).toContain('@container cinder-feature-section (max-width: 64rem)');
+    expect(stylesheet).toContain('@container cinder-feature-section (min-width: 64rem)');
+    expect(stylesheet).toContain('max-block-size: 32rem');
+    expect(stylesheet).toContain('overflow: auto');
+  });
+});

--- a/packages/components/src/components/feature-section/feature-section.css.test.ts
+++ b/packages/components/src/components/feature-section/feature-section.css.test.ts
@@ -5,7 +5,8 @@ const stylesheet = readFileSync(new URL('./feature-section.css', import.meta.url
 
 describe('FeatureSection responsive layout', () => {
   test('keeps the split breakpoint aligned with HeroSection and bounds media', () => {
-    expect(stylesheet).toContain('@container cinder-feature-section (max-width: 64rem)');
+    expect(stylesheet).toContain('@container cinder-feature-section (max-width: 48rem)');
+    expect(stylesheet).toContain('min-width: 48rem) and (max-width: 64rem)');
     expect(stylesheet).toContain('@container cinder-feature-section (min-width: 64rem)');
     expect(stylesheet).toContain('max-block-size: 32rem');
     expect(stylesheet).toContain('overflow: auto');


### PR DESCRIPTION
Closes #944

FeatureSection split layouts now follow HeroSection's 64rem container breakpoint, eliminating the intermediate responsive dead zone. The media block is bounded with minimum and maximum block sizes and overflow handling. Split lists remain one column below 64rem so cards stay readable.

Focused verification:
- `bun test packages/components/src/components/feature-section/feature-section.css.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`

The CSS regression test covers the 48rem/64rem thresholds and media bound.
