### PR TITLE
fix(transfer-list): use directional icons

### DIFF
--- a/.changeset/transfer-list-direction-icons.md
+++ b/.changeset/transfer-list-direction-icons.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Render TransferList move controls with directional Lucide icons while preserving their accessible names.

--- a/packages/components/src/components/transfer-list/transfer-list.css
+++ b/packages/components/src/components/transfer-list/transfer-list.css
@@ -138,5 +138,13 @@
       flex-direction: row;
       flex-wrap: wrap;
     }
+
+    .cinder-transfer-list__control--forward svg {
+      transform: rotate(90deg);
+    }
+
+    .cinder-transfer-list__control--backward svg {
+      transform: rotate(-90deg);
+    }
   }
 }

--- a/packages/components/src/components/transfer-list/transfer-list.css
+++ b/packages/components/src/components/transfer-list/transfer-list.css
@@ -139,12 +139,12 @@
       flex-wrap: wrap;
     }
 
-    .cinder-transfer-list__control--forward svg {
+    .cinder-transfer-list .cinder-transfer-list__control--forward svg {
       transform: rotate(90deg);
     }
 
-    .cinder-transfer-list__control--backward svg {
-      transform: rotate(-90deg);
+    .cinder-transfer-list .cinder-transfer-list__control--backward svg {
+      transform: rotate(90deg);
     }
   }
 }

--- a/packages/components/src/components/transfer-list/transfer-list.css
+++ b/packages/components/src/components/transfer-list/transfer-list.css
@@ -86,7 +86,7 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: var(--cinder-space-1);
+    gap: var(--cinder-space-2);
   }
 
   .cinder-transfer-list__control {
@@ -101,6 +101,10 @@
     color: var(--cinder-text);
     font: inherit;
     cursor: pointer;
+  }
+
+  .cinder-transfer-list:dir(rtl) .cinder-transfer-list__control svg {
+    transform: scaleX(-1);
   }
 
   .cinder-transfer-list__control:disabled {

--- a/packages/components/src/components/transfer-list/transfer-list.css
+++ b/packages/components/src/components/transfer-list/transfer-list.css
@@ -86,10 +86,12 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    gap: var(--cinder-space-2);
+    gap: var(--cinder-space-1);
   }
 
   .cinder-transfer-list__control {
+    display: inline-grid;
+    place-items: center;
     min-inline-size: 2.5rem;
     min-block-size: 2.25rem;
     padding: var(--cinder-space-1) var(--cinder-space-2);

--- a/packages/components/src/components/transfer-list/transfer-list.svelte
+++ b/packages/components/src/components/transfer-list/transfer-list.svelte
@@ -15,6 +15,10 @@
 </script>
 
 <script lang="ts">
+  import ChevronLeft from 'lucide-svelte/icons/chevron-left';
+  import ChevronRight from 'lucide-svelte/icons/chevron-right';
+  import ChevronsLeft from 'lucide-svelte/icons/chevrons-left';
+  import ChevronsRight from 'lucide-svelte/icons/chevrons-right';
   import { tick } from 'svelte';
   import { SvelteSet } from 'svelte/reactivity';
 
@@ -358,7 +362,7 @@
         disabled={movableLeftSelectedIds.length === 0}
         onclick={moveSelectedRight}
       >
-        Add
+        <ChevronRight size={18} strokeWidth={2} aria-hidden="true" />
       </button>
       <button
         type="button"
@@ -367,7 +371,7 @@
         disabled={movableLeftItemIds.length === 0}
         onclick={moveAllRight}
       >
-        Add all
+        <ChevronsRight size={18} strokeWidth={2} aria-hidden="true" />
       </button>
       <button
         type="button"
@@ -376,7 +380,7 @@
         disabled={movableRightSelectedIds.length === 0}
         onclick={moveSelectedLeft}
       >
-        Remove
+        <ChevronLeft size={18} strokeWidth={2} aria-hidden="true" />
       </button>
       <button
         type="button"
@@ -385,7 +389,7 @@
         disabled={movableRightItemIds.length === 0}
         onclick={moveAllLeft}
       >
-        Remove all
+        <ChevronsLeft size={18} strokeWidth={2} aria-hidden="true" />
       </button>
     </div>
 

--- a/packages/components/src/components/transfer-list/transfer-list.svelte
+++ b/packages/components/src/components/transfer-list/transfer-list.svelte
@@ -357,7 +357,7 @@
     <div class="cinder-transfer-list__controls" role="group" aria-label="Transfer controls">
       <button
         type="button"
-        class="cinder-transfer-list__control"
+        class="cinder-transfer-list__control cinder-transfer-list__control--forward"
         aria-label={`Move selected items to ${rightLabel}`}
         disabled={movableLeftSelectedIds.length === 0}
         onclick={moveSelectedRight}
@@ -366,7 +366,7 @@
       </button>
       <button
         type="button"
-        class="cinder-transfer-list__control"
+        class="cinder-transfer-list__control cinder-transfer-list__control--forward"
         aria-label={`Move all items to ${rightLabel}`}
         disabled={movableLeftItemIds.length === 0}
         onclick={moveAllRight}
@@ -375,7 +375,7 @@
       </button>
       <button
         type="button"
-        class="cinder-transfer-list__control"
+        class="cinder-transfer-list__control cinder-transfer-list__control--backward"
         aria-label={`Move selected items to ${leftLabel}`}
         disabled={movableRightSelectedIds.length === 0}
         onclick={moveSelectedLeft}
@@ -384,7 +384,7 @@
       </button>
       <button
         type="button"
-        class="cinder-transfer-list__control"
+        class="cinder-transfer-list__control cinder-transfer-list__control--backward"
         aria-label={`Move all items to ${leftLabel}`}
         disabled={movableRightItemIds.length === 0}
         onclick={moveAllLeft}

--- a/packages/components/src/components/transfer-list/transfer-list.test.ts
+++ b/packages/components/src/components/transfer-list/transfer-list.test.ts
@@ -31,6 +31,8 @@ describe('TransferList', () => {
     expect(css).toContain('container-name: cinder-transfer-list;');
     expect(css).toContain('@container cinder-transfer-list (max-width: 42rem)');
     expect(css).toContain('.cinder-transfer-list__layout');
+    expect(css).toContain('.cinder-transfer-list:dir(rtl) .cinder-transfer-list__control svg');
+    expect(css).toContain('transform: scaleX(-1)');
     expect(css).not.toContain('@media (max-width');
   });
 
@@ -52,7 +54,7 @@ describe('TransferList', () => {
       ['Move all items to Selected', 'lucide-chevrons-right'],
       ['Move selected items to Available', 'lucide-chevron-left'],
       ['Move all items to Available', 'lucide-chevrons-left'],
-    ];
+    ] as const;
     for (const [accessibleName, iconClassName] of expectedControls) {
       const control = screen.getByRole('button', { name: accessibleName });
       expect(control.querySelector(`svg.${iconClassName}`)).toBeTruthy();

--- a/packages/components/src/components/transfer-list/transfer-list.test.ts
+++ b/packages/components/src/components/transfer-list/transfer-list.test.ts
@@ -33,10 +33,9 @@ describe('TransferList', () => {
     expect(css).toContain('.cinder-transfer-list__layout');
     expect(css).toContain('.cinder-transfer-list:dir(rtl) .cinder-transfer-list__control svg');
     expect(css).toContain('transform: scaleX(-1)');
-    expect(css).toContain('.cinder-transfer-list__control--forward svg');
+    expect(css).toContain('.cinder-transfer-list .cinder-transfer-list__control--forward svg');
     expect(css).toContain('transform: rotate(90deg)');
-    expect(css).toContain('.cinder-transfer-list__control--backward svg');
-    expect(css).toContain('transform: rotate(-90deg)');
+    expect(css).toContain('.cinder-transfer-list .cinder-transfer-list__control--backward svg');
     expect(css).not.toContain('@media (max-width');
   });
 

--- a/packages/components/src/components/transfer-list/transfer-list.test.ts
+++ b/packages/components/src/components/transfer-list/transfer-list.test.ts
@@ -33,6 +33,10 @@ describe('TransferList', () => {
     expect(css).toContain('.cinder-transfer-list__layout');
     expect(css).toContain('.cinder-transfer-list:dir(rtl) .cinder-transfer-list__control svg');
     expect(css).toContain('transform: scaleX(-1)');
+    expect(css).toContain('.cinder-transfer-list__control--forward svg');
+    expect(css).toContain('transform: rotate(90deg)');
+    expect(css).toContain('.cinder-transfer-list__control--backward svg');
+    expect(css).toContain('transform: rotate(-90deg)');
     expect(css).not.toContain('@media (max-width');
   });
 

--- a/packages/components/src/components/transfer-list/transfer-list.test.ts
+++ b/packages/components/src/components/transfer-list/transfer-list.test.ts
@@ -47,12 +47,17 @@ describe('TransferList', () => {
     expect(selected.getAttribute('aria-multiselectable')).toBe('true');
     expect(within(available).getByRole('option', { name: 'Read' })).toBeTruthy();
     expect(controls).toBeTruthy();
-    expect(
-      screen.getByRole('button', { name: 'Move selected items to Selected' }).textContent,
-    ).toBe('Add');
-    expect(screen.getByRole('button', { name: 'Move all items to Selected' }).textContent).toBe(
-      'Add all',
-    );
+    const expectedControls = [
+      ['Move selected items to Selected', 'lucide-chevron-right'],
+      ['Move all items to Selected', 'lucide-chevrons-right'],
+      ['Move selected items to Available', 'lucide-chevron-left'],
+      ['Move all items to Available', 'lucide-chevrons-left'],
+    ];
+    for (const [accessibleName, iconClassName] of expectedControls) {
+      const control = screen.getByRole('button', { name: accessibleName });
+      expect(control.querySelector(`svg.${iconClassName}`)).toBeTruthy();
+      expect(control.textContent).toBe('');
+    }
     expect(screen.getByRole('alert')).toBeTruthy();
   });
 


### PR DESCRIPTION
Closes #940

## Summary

- Replace TransferList text controls with single/double Lucide chevrons.
- Preserve the existing accessible names and icon-only button semantics.
- Mirror directional SVGs in RTL layouts.
- Rotate forward/backward controls to down/up cues in the stacked container-query layout.
- Keep the control cluster spacing compatible with forced-colors focus outlines.
- Cover all four icon and accessible-name pairings with focused regression tests.

## Acceptance criteria

- [x] All four transfer controls render the correct single/double Lucide chevrons.
- [x] All four existing `aria-label` strings remain unchanged on the buttons.
- [x] No plain-text transfer glyphs remain in `transfer-list.svelte`.
- [x] RTL direction mirrors the visual icons without changing transfer semantics.
- [x] Stacked layouts show vertical down/up action cues.
- [x] Forced-colors focus outlines retain separation from neighboring controls.

## Verification

- `bun run --filter=@lostgradient/cinder test -- transfer-list/transfer-list.test.ts` (18 pass)
- `bun run --filter=@lostgradient/cinder typecheck`
- `bunx oxlint packages/components/src/components/transfer-list/transfer-list.svelte packages/components/src/components/transfer-list/transfer-list.test.ts`
- `bunx stylelint packages/components/src/components/transfer-list/transfer-list.css`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bunx prettier --check packages/components/src/components/transfer-list/transfer-list.svelte packages/components/src/components/transfer-list/transfer-list.css packages/components/src/components/transfer-list/transfer-list.test.ts .changeset/transfer-list-direction-icons.md`
