### PR TITLE
fix(table-of-contents): draw continuous rail

### DIFF
--- a/.changeset/continuous-toc-rail.md
+++ b/.changeset/continuous-toc-rail.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Render TableOfContents with one continuous rail behind its links.

--- a/packages/components/src/components/table-of-contents/table-of-contents.css
+++ b/packages/components/src/components/table-of-contents/table-of-contents.css
@@ -44,6 +44,8 @@
   }
 
   .cinder-table-of-contents__link {
+    position: relative;
+    z-index: 1;
     display: block;
     text-decoration: none;
     color: var(--cinder-table-of-contents-link-color);

--- a/packages/components/src/components/table-of-contents/table-of-contents.css
+++ b/packages/components/src/components/table-of-contents/table-of-contents.css
@@ -15,12 +15,22 @@
   }
 
   .cinder-table-of-contents__list {
+    position: relative;
     list-style: none;
     margin: 0;
     padding: 0;
     display: flex;
     flex-direction: column;
     gap: var(--cinder-space-1);
+  }
+
+  .cinder-table-of-contents__list::before {
+    position: absolute;
+    inset-block: 0;
+    inset-inline-start: 0;
+    width: 2px;
+    background: var(--cinder-table-of-contents-link-border-color);
+    content: '';
   }
 
   .cinder-table-of-contents__list--nested {
@@ -37,7 +47,7 @@
     display: block;
     text-decoration: none;
     color: var(--cinder-table-of-contents-link-color);
-    border-inline-start: 2px solid var(--cinder-table-of-contents-link-border-color);
+    border-inline-start: 2px solid transparent;
     padding: 0.125rem 0.75rem;
     transition:
       color var(--cinder-duration-fast) var(--cinder-ease-standard),

--- a/packages/components/src/components/table-of-contents/table-of-contents.test.ts
+++ b/packages/components/src/components/table-of-contents/table-of-contents.test.ts
@@ -91,6 +91,18 @@ afterEach(() => {
 });
 
 describe('TableOfContents', () => {
+  test('draws one continuous list rail while retaining active link segments', async () => {
+    const stylesheet = await Bun.file(new URL('./table-of-contents.css', import.meta.url)).text();
+
+    expect(stylesheet).toContain('.cinder-table-of-contents__list::before');
+    expect(stylesheet).toContain('background: var(--cinder-table-of-contents-link-border-color)');
+    expect(stylesheet).toContain('border-inline-start: 2px solid transparent');
+    expect(stylesheet).toContain(
+      'border-inline-start-color: var(--cinder-table-of-contents-link-active-border-color)',
+    );
+    expect(stylesheet).toContain('z-index: 1');
+  });
+
   test('does not render a nav landmark when there are no TOC entries', () => {
     const { container } = render(TableOfContents, {
       props: {


### PR DESCRIPTION
Closes #946

## What changed

- Move the TableOfContents rail from per-link borders to one `__list::before` rail, so `gap` spacing cannot disconnect it.
- Keep active links above the rail with a positioned stacking context; active links retain their highlighted border segment.
- Add a regression test that guards the continuous-rail and active-segment CSS contract.

## Acceptance criteria

- [x] Rail renders as one continuous line regardless of gaps between links.
- [x] Active section remains a highlighted segment of that rail.
- [x] Existing navigation, scroll-spy, keyboard, and accessibility behavior remains covered by the component test suite.

## Validation

- `bun test packages/components/src/components/table-of-contents/table-of-contents.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bunx prettier --check packages/components/src/components/table-of-contents/table-of-contents.test.ts packages/components/src/components/table-of-contents/table-of-contents.css .changeset/continuous-toc-rail.md`
