### PR TITLE
fix(charts): use shared table styling for fallbacks

### DIFF
--- a/.changeset/chart-table-primitive.md
+++ b/.changeset/chart-table-primitive.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Apply the shared table styling to chart data-table fallbacks.

--- a/packages/components/src/_internal/chart/chart-data-table.svelte
+++ b/packages/components/src/_internal/chart/chart-data-table.svelte
@@ -19,8 +19,8 @@
     caption: string;
     headers: string[];
     rows: ChartDataTableRow[];
-    visibilityClass?: string;
-    describedBy?: string;
+    visibilityClass?: string | undefined;
+    describedBy?: string | undefined;
   } = $props();
 </script>
 

--- a/packages/components/src/_internal/chart/chart-data-table.svelte
+++ b/packages/components/src/_internal/chart/chart-data-table.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import TableBody from '../../components/table-body/table-body.svelte';
+  import TableCell from '../../components/table-cell/table-cell.svelte';
+  import TableHeaderCell from '../../components/table-header-cell/table-header-cell.svelte';
+  import TableHeader from '../../components/table-header/table-header.svelte';
+  import TableRow from '../../components/table-row/table-row.svelte';
+  import TableRoot from '../../components/table/table.svelte';
+  import { classNames } from '../../utilities/class-names.ts';
+
+  type ChartDataTableRow = { id: string; header: string; cells: string[] };
+
+  let {
+    caption,
+    headers,
+    rows,
+    visibilityClass,
+    describedBy,
+  }: {
+    caption: string;
+    headers: string[];
+    rows: ChartDataTableRow[];
+    visibilityClass?: string;
+    describedBy?: string;
+  } = $props();
+</script>
+
+<TableRoot {caption} class={classNames(visibilityClass)} aria-describedby={describedBy}>
+  <TableHeader>
+    <TableRow>
+      {#each headers as header (header)}
+        <TableHeaderCell>{header}</TableHeaderCell>
+      {/each}
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    {#each rows as row (row.id)}
+      <TableRow>
+        <TableCell as="th">{row.header}</TableCell>
+        {#each row.cells as cell, index (index)}
+          <TableCell>{cell}</TableCell>
+        {/each}
+      </TableRow>
+    {/each}
+  </TableBody>
+</TableRoot>

--- a/packages/components/src/components/_internal/chart-data-table.svelte
+++ b/packages/components/src/components/_internal/chart-data-table.svelte
@@ -27,7 +27,7 @@
 <TableRoot {caption} class={classNames(visibilityClass)} aria-describedby={describedBy}>
   <TableHeader>
     <TableRow>
-      {#each headers as header (header)}
+      {#each headers as header, index (index)}
         <TableHeaderCell>{header}</TableHeaderCell>
       {/each}
     </TableRow>

--- a/packages/components/src/components/area-chart/area-chart.css
+++ b/packages/components/src/components/area-chart/area-chart.css
@@ -1,4 +1,5 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../table/table.css';
 @layer cinder.components {
   .cinder-area-chart {
     display: grid;

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -31,7 +31,7 @@
     createPointFocusRingGeometry,
   } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
-  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
+  import ChartDataTable from '../_internal/chart-data-table.svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import type { AreaChartProps } from './area-chart.types.ts';
 

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -381,7 +381,10 @@
       Use the data table to inspect this chart with a keyboard.
     </p>{/if}
   {#if hasDataTable}
-    <table class={dataTableClass(dataTableVisibility)} aria-describedby={guidanceId}>
+    <table
+      class={`cinder-table ${dataTableClass(dataTableVisibility)}`}
+      aria-describedby={guidanceId}
+    >
       <caption>{dataTableCaption ?? label}</caption>
       <thead
         ><tr><th scope="col">Series</th><th scope="col">X</th><th scope="col">Value</th></tr></thead

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -396,7 +396,7 @@
       >
       <tbody
         >{#each model.tableRows as row (row.id)}<tr class="cinder-table__row"
-            ><th class="cinder-table__header-cell" scope="row">{row.seriesLabel}</th><td
+            ><th class="cinder-table__cell" scope="row">{row.seriesLabel}</th><td
               class="cinder-table__cell">{row.xLabel}</td
             ><td class="cinder-table__cell">{row.valueLabel}</td></tr
           >{/each}</tbody

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -31,6 +31,7 @@
     createPointFocusRingGeometry,
   } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
+  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import type { AreaChartProps } from './area-chart.types.ts';
 
@@ -381,27 +382,17 @@
       Use the data table to inspect this chart with a keyboard.
     </p>{/if}
   {#if hasDataTable}
-    <table
-      class={classNames('cinder-table', dataTableClass(dataTableVisibility))}
-      aria-describedby={guidanceId}
-    >
-      <caption class="cinder-table__caption">{dataTableCaption ?? label}</caption>
-      <thead class="cinder-table__header"
-        ><tr class="cinder-table__row"
-          ><th class="cinder-table__header-cell" scope="col">Series</th><th
-            class="cinder-table__header-cell"
-            scope="col">X</th
-          ><th class="cinder-table__header-cell" scope="col">Value</th></tr
-        ></thead
-      >
-      <tbody class="cinder-table__body"
-        >{#each model.tableRows as row (row.id)}<tr class="cinder-table__row"
-            ><th class="cinder-table__cell" scope="row">{row.seriesLabel}</th><td
-              class="cinder-table__cell">{row.xLabel}</td
-            ><td class="cinder-table__cell">{row.valueLabel}</td></tr
-          >{/each}</tbody
-      >
-    </table>
+    <ChartDataTable
+      caption={dataTableCaption ?? label}
+      headers={['Series', 'X', 'Value']}
+      rows={model.tableRows.map((row) => ({
+        id: row.id,
+        header: row.seriesLabel,
+        cells: [row.xLabel, row.valueLabel],
+      }))}
+      visibilityClass={dataTableClass(dataTableVisibility)}
+      describedBy={guidanceId}
+    />
   {/if}
   {#if legendVisible(legendPosition, series.length) && legendPosition === 'bottom'}
     <div class="cinder-area-chart__legend" aria-label="Series">

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -394,7 +394,7 @@
           ><th class="cinder-table__header-cell" scope="col">Value</th></tr
         ></thead
       >
-      <tbody
+      <tbody class="cinder-table__body"
         >{#each model.tableRows as row (row.id)}<tr class="cinder-table__row"
             ><th class="cinder-table__cell" scope="row">{row.seriesLabel}</th><td
               class="cinder-table__cell">{row.xLabel}</td

--- a/packages/components/src/components/area-chart/area-chart.svelte
+++ b/packages/components/src/components/area-chart/area-chart.svelte
@@ -382,17 +382,23 @@
     </p>{/if}
   {#if hasDataTable}
     <table
-      class={`cinder-table ${dataTableClass(dataTableVisibility)}`}
+      class={classNames('cinder-table', dataTableClass(dataTableVisibility))}
       aria-describedby={guidanceId}
     >
-      <caption>{dataTableCaption ?? label}</caption>
-      <thead
-        ><tr><th scope="col">Series</th><th scope="col">X</th><th scope="col">Value</th></tr></thead
+      <caption class="cinder-table__caption">{dataTableCaption ?? label}</caption>
+      <thead class="cinder-table__header"
+        ><tr class="cinder-table__row"
+          ><th class="cinder-table__header-cell" scope="col">Series</th><th
+            class="cinder-table__header-cell"
+            scope="col">X</th
+          ><th class="cinder-table__header-cell" scope="col">Value</th></tr
+        ></thead
       >
       <tbody
-        >{#each model.tableRows as row (row.id)}<tr
-            ><th scope="row">{row.seriesLabel}</th><td>{row.xLabel}</td><td>{row.valueLabel}</td
-            ></tr
+        >{#each model.tableRows as row (row.id)}<tr class="cinder-table__row"
+            ><th class="cinder-table__header-cell" scope="row">{row.seriesLabel}</th><td
+              class="cinder-table__cell">{row.xLabel}</td
+            ><td class="cinder-table__cell">{row.valueLabel}</td></tr
           >{/each}</tbody
       >
     </table>

--- a/packages/components/src/components/bar-chart/bar-chart.css
+++ b/packages/components/src/components/bar-chart/bar-chart.css
@@ -1,4 +1,5 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../table/table.css';
 @layer cinder.components {
   .cinder-bar-chart {
     display: grid;

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -393,7 +393,10 @@
       Series/X/Value (line/area). This reflects that bar charts are category-
       primary: each row is one category, with each series as a column value.
     -->
-    <table class={dataTableClass(dataTableVisibility)} aria-describedby={guidanceId}>
+    <table
+      class={`cinder-table ${dataTableClass(dataTableVisibility)}`}
+      aria-describedby={guidanceId}
+    >
       <caption>{dataTableCaption ?? label}</caption>
       <thead
         ><tr><th scope="col">Category</th><th scope="col">Series</th><th scope="col">Value</th></tr

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -31,7 +31,7 @@
     createBarFocusRingGeometry,
   } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
-  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
+  import ChartDataTable from '../_internal/chart-data-table.svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import type { BarChartProps } from './bar-chart.types.ts';
 
@@ -399,7 +399,7 @@
       headers={['Category', 'Series', 'Value']}
       rows={model.tableRows.flatMap((row) =>
         row.values.map((value) => ({
-          id: `${row.categoryKey}:${value.seriesId}`,
+          id: JSON.stringify([row.categoryKey, value.seriesId]),
           header: row.categoryLabel,
           cells: [value.seriesLabel, value.valueLabel],
         })),

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -406,7 +406,7 @@
           ><th class="cinder-table__header-cell" scope="col">Value</th></tr
         ></thead
       >
-      <tbody>
+      <tbody class="cinder-table__body">
         {#each model.tableRows as row (row.categoryKey)}
           {#each row.values as value (value.seriesId)}
             <tr class="cinder-table__row"

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -394,21 +394,21 @@
       primary: each row is one category, with each series as a column value.
     -->
     <table
-      class={`cinder-table ${dataTableClass(dataTableVisibility)}`}
+      class={classNames('cinder-table', dataTableClass(dataTableVisibility))}
       aria-describedby={guidanceId}
     >
-      <caption>{dataTableCaption ?? label}</caption>
-      <thead
+      <caption class="cinder-table__caption">{dataTableCaption ?? label}</caption>
+      <thead class="cinder-table__header"
         ><tr><th scope="col">Category</th><th scope="col">Series</th><th scope="col">Value</th></tr
         ></thead
       >
       <tbody>
         {#each model.tableRows as row (row.categoryKey)}
           {#each row.values as value (value.seriesId)}
-            <tr
-              ><th scope="row">{row.categoryLabel}</th><td>{value.seriesLabel}</td><td
-                >{value.valueLabel}</td
-              ></tr
+            <tr class="cinder-table__row"
+              ><th class="cinder-table__header-cell" scope="row">{row.categoryLabel}</th><td
+                class="cinder-table__cell">{value.seriesLabel}</td
+              ><td class="cinder-table__cell">{value.valueLabel}</td></tr
             >
           {/each}
         {/each}

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -31,6 +31,7 @@
     createBarFocusRingGeometry,
   } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
+  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import type { BarChartProps } from './bar-chart.types.ts';
 
@@ -393,31 +394,19 @@
       Series/X/Value (line/area). This reflects that bar charts are category-
       primary: each row is one category, with each series as a column value.
     -->
-    <table
-      class={classNames('cinder-table', dataTableClass(dataTableVisibility))}
-      aria-describedby={guidanceId}
-    >
-      <caption class="cinder-table__caption">{dataTableCaption ?? label}</caption>
-      <thead class="cinder-table__header"
-        ><tr class="cinder-table__row"
-          ><th class="cinder-table__header-cell" scope="col">Category</th><th
-            class="cinder-table__header-cell"
-            scope="col">Series</th
-          ><th class="cinder-table__header-cell" scope="col">Value</th></tr
-        ></thead
-      >
-      <tbody class="cinder-table__body">
-        {#each model.tableRows as row (row.categoryKey)}
-          {#each row.values as value (value.seriesId)}
-            <tr class="cinder-table__row"
-              ><th class="cinder-table__cell" scope="row">{row.categoryLabel}</th><td
-                class="cinder-table__cell">{value.seriesLabel}</td
-              ><td class="cinder-table__cell">{value.valueLabel}</td></tr
-            >
-          {/each}
-        {/each}
-      </tbody>
-    </table>
+    <ChartDataTable
+      caption={dataTableCaption ?? label}
+      headers={['Category', 'Series', 'Value']}
+      rows={model.tableRows.flatMap((row) =>
+        row.values.map((value) => ({
+          id: `${row.categoryKey}:${value.seriesId}`,
+          header: row.categoryLabel,
+          cells: [value.seriesLabel, value.valueLabel],
+        })),
+      )}
+      visibilityClass={dataTableClass(dataTableVisibility)}
+      describedBy={guidanceId}
+    />
   {/if}
   {#if legendVisible(legendPosition, series.length) && legendPosition === 'bottom'}
     <div class="cinder-bar-chart__legend" aria-label="Series">

--- a/packages/components/src/components/bar-chart/bar-chart.svelte
+++ b/packages/components/src/components/bar-chart/bar-chart.svelte
@@ -399,14 +399,18 @@
     >
       <caption class="cinder-table__caption">{dataTableCaption ?? label}</caption>
       <thead class="cinder-table__header"
-        ><tr><th scope="col">Category</th><th scope="col">Series</th><th scope="col">Value</th></tr
+        ><tr class="cinder-table__row"
+          ><th class="cinder-table__header-cell" scope="col">Category</th><th
+            class="cinder-table__header-cell"
+            scope="col">Series</th
+          ><th class="cinder-table__header-cell" scope="col">Value</th></tr
         ></thead
       >
       <tbody>
         {#each model.tableRows as row (row.categoryKey)}
           {#each row.values as value (value.seriesId)}
             <tr class="cinder-table__row"
-              ><th class="cinder-table__header-cell" scope="row">{row.categoryLabel}</th><td
+              ><th class="cinder-table__cell" scope="row">{row.categoryLabel}</th><td
                 class="cinder-table__cell">{value.seriesLabel}</td
               ><td class="cinder-table__cell">{value.valueLabel}</td></tr
             >

--- a/packages/components/src/components/line-chart/line-chart.css
+++ b/packages/components/src/components/line-chart/line-chart.css
@@ -1,4 +1,5 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../table/table.css';
 @layer cinder.components {
   .cinder-line-chart {
     display: grid;

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -31,6 +31,7 @@
     createPointFocusRingGeometry,
   } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
+  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import type { LineChartProps } from './line-chart.types.ts';
 
@@ -391,29 +392,17 @@
   {/if}
 
   {#if hasDataTable}
-    <table
-      class={classNames('cinder-table', dataTableClass(dataTableVisibility))}
-      aria-describedby={guidanceId}
-    >
-      <caption class="cinder-table__caption">{dataTableCaption ?? label}</caption>
-      <thead class="cinder-table__header">
-        <tr class="cinder-table__row"
-          ><th class="cinder-table__header-cell" scope="col">Series</th><th
-            class="cinder-table__header-cell"
-            scope="col">X</th
-          ><th class="cinder-table__header-cell" scope="col">Value</th></tr
-        >
-      </thead>
-      <tbody class="cinder-table__body">
-        {#each model.tableRows as row (row.id)}
-          <tr class="cinder-table__row"
-            ><th class="cinder-table__cell" scope="row">{row.seriesLabel}</th><td
-              class="cinder-table__cell">{row.xLabel}</td
-            ><td class="cinder-table__cell">{row.valueLabel}</td></tr
-          >
-        {/each}
-      </tbody>
-    </table>
+    <ChartDataTable
+      caption={dataTableCaption ?? label}
+      headers={['Series', 'X', 'Value']}
+      rows={model.tableRows.map((row) => ({
+        id: row.id,
+        header: row.seriesLabel,
+        cells: [row.xLabel, row.valueLabel],
+      }))}
+      visibilityClass={dataTableClass(dataTableVisibility)}
+      describedBy={guidanceId}
+    />
   {/if}
 
   {#if legendVisible(legendPosition, series.length) && legendPosition === 'bottom'}

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -392,18 +392,24 @@
 
   {#if hasDataTable}
     <table
-      class={`cinder-table ${dataTableClass(dataTableVisibility)}`}
+      class={classNames('cinder-table', dataTableClass(dataTableVisibility))}
       aria-describedby={guidanceId}
     >
-      <caption>{dataTableCaption ?? label}</caption>
-      <thead
-        ><tr><th scope="col">Series</th><th scope="col">X</th><th scope="col">Value</th></tr></thead
-      >
+      <caption class="cinder-table__caption">{dataTableCaption ?? label}</caption>
+      <thead class="cinder-table__header">
+        <tr class="cinder-table__row"
+          ><th class="cinder-table__header-cell" scope="col">Series</th><th
+            class="cinder-table__header-cell"
+            scope="col">X</th
+          ><th class="cinder-table__header-cell" scope="col">Value</th></tr
+        >
+      </thead>
       <tbody>
         {#each model.tableRows as row (row.id)}
-          <tr
-            ><th scope="row">{row.seriesLabel}</th><td>{row.xLabel}</td><td>{row.valueLabel}</td
-            ></tr
+          <tr class="cinder-table__row"
+            ><th class="cinder-table__header-cell" scope="row">{row.seriesLabel}</th><td
+              class="cinder-table__cell">{row.xLabel}</td
+            ><td class="cinder-table__cell">{row.valueLabel}</td></tr
           >
         {/each}
       </tbody>

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -391,7 +391,10 @@
   {/if}
 
   {#if hasDataTable}
-    <table class={dataTableClass(dataTableVisibility)} aria-describedby={guidanceId}>
+    <table
+      class={`cinder-table ${dataTableClass(dataTableVisibility)}`}
+      aria-describedby={guidanceId}
+    >
       <caption>{dataTableCaption ?? label}</caption>
       <thead
         ><tr><th scope="col">Series</th><th scope="col">X</th><th scope="col">Value</th></tr></thead

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -404,7 +404,7 @@
           ><th class="cinder-table__header-cell" scope="col">Value</th></tr
         >
       </thead>
-      <tbody>
+      <tbody class="cinder-table__body">
         {#each model.tableRows as row (row.id)}
           <tr class="cinder-table__row"
             ><th class="cinder-table__cell" scope="row">{row.seriesLabel}</th><td

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -407,7 +407,7 @@
       <tbody>
         {#each model.tableRows as row (row.id)}
           <tr class="cinder-table__row"
-            ><th class="cinder-table__header-cell" scope="row">{row.seriesLabel}</th><td
+            ><th class="cinder-table__cell" scope="row">{row.seriesLabel}</th><td
               class="cinder-table__cell">{row.xLabel}</td
             ><td class="cinder-table__cell">{row.valueLabel}</td></tr
           >

--- a/packages/components/src/components/line-chart/line-chart.svelte
+++ b/packages/components/src/components/line-chart/line-chart.svelte
@@ -31,7 +31,7 @@
     createPointFocusRingGeometry,
   } from '../../_internal/chart/chart-focus-ring.ts';
   import { ChartInteraction } from '../../_internal/chart/chart-interaction.svelte.ts';
-  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
+  import ChartDataTable from '../_internal/chart-data-table.svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import type { LineChartProps } from './line-chart.types.ts';
 

--- a/packages/components/src/components/line-chart/line-chart.test.ts
+++ b/packages/components/src/components/line-chart/line-chart.test.ts
@@ -50,6 +50,12 @@ describe('LineChart', () => {
     });
 
     expect(container.querySelector('table caption')?.textContent).toBe('Monthly revenue');
+    expect(container.querySelector('table.cinder-table')).not.toBeNull();
+    expect(container.querySelector('thead.cinder-table__header')).not.toBeNull();
+    expect(container.querySelector('tbody.cinder-table__body')).not.toBeNull();
+    expect(container.querySelector('tr.cinder-table__row')).not.toBeNull();
+    expect(container.querySelector('th.cinder-table__header-cell')).not.toBeNull();
+    expect(container.querySelector('td.cinder-table__cell')).not.toBeNull();
     expect(container.querySelector('table')?.className).not.toContain('cinder-sr-only');
   });
 

--- a/packages/components/src/components/matrix-chart/matrix-chart.css
+++ b/packages/components/src/components/matrix-chart/matrix-chart.css
@@ -1,4 +1,5 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../table/table.css';
 @layer cinder.components {
   .cinder-matrix-chart {
     display: grid;

--- a/packages/components/src/components/matrix-chart/matrix-chart.svelte
+++ b/packages/components/src/components/matrix-chart/matrix-chart.svelte
@@ -19,7 +19,7 @@
 
 <script lang="ts">
   import { dataTableClass } from '../../_internal/chart/chart-utilities.ts';
-  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
+  import ChartDataTable from '../_internal/chart-data-table.svelte';
   import {
     heatmapCellFill,
     heatmapDomain,

--- a/packages/components/src/components/matrix-chart/matrix-chart.svelte
+++ b/packages/components/src/components/matrix-chart/matrix-chart.svelte
@@ -19,6 +19,7 @@
 
 <script lang="ts">
   import { dataTableClass } from '../../_internal/chart/chart-utilities.ts';
+  import ChartDataTable from '../../_internal/chart/chart-data-table.svelte';
   import {
     heatmapCellFill,
     heatmapDomain,
@@ -315,26 +316,15 @@
     </svg>
   </div>
   {#if hasDataTable}
-    <table class={dataTableClass(dataTableVisibility)}>
-      <caption>{dataTableCaption ?? label}</caption>
-      <thead>
-        <tr>
-          <th scope="col">{yField}</th>
-          {#each xLabels as xLabel (xLabel)}
-            <th scope="col">{xLabel}</th>
-          {/each}
-        </tr>
-      </thead>
-      <tbody>
-        {#each tableRows as row (row.yLabel)}
-          <tr>
-            <th scope="row">{row.yLabel}</th>
-            {#each row.values as cell (cell.xLabel)}
-              <td>{cell.value !== null ? formatValue(cell.value) : '—'}</td>
-            {/each}
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+    <ChartDataTable
+      caption={dataTableCaption ?? label}
+      headers={[yField, ...xLabels]}
+      rows={tableRows.map((row) => ({
+        id: row.yLabel,
+        header: row.yLabel,
+        cells: row.values.map((cell) => (cell.value !== null ? formatValue(cell.value) : '—')),
+      }))}
+      visibilityClass={dataTableClass(dataTableVisibility)}
+    />
   {/if}
 </figure>


### PR DESCRIPTION
Closes #947

Chart data-table fallbacks now share one internal ChartDataTable implementation composed from Cinder Table primitives. Line, area, bar, and matrix charts preserve caption and scoped-header semantics while using the shared row, header, body, and cell styles for consistent dividers. Regression coverage asserts the shared table classes on the line-chart fallback.