### PR TITLE
fix(backdrop): support Escape dismissal

### DIFF
--- a/.changeset/backdrop-escape-dismiss.md
+++ b/.changeset/backdrop-escape-dismiss.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Allow an open Backdrop with an onclick handler to dismiss on Escape.

--- a/packages/components/src/components/backdrop/backdrop.svelte
+++ b/packages/components/src/components/backdrop/backdrop.svelte
@@ -46,6 +46,7 @@
     children,
     ...rest
   }: BackdropProps = $props();
+  let currentOnclick = $state(onclick);
 
   // Respect prefers-reduced-motion: collapse the fade to an instant show/hide so
   // the scrim does not animate for users who have opted out of motion.
@@ -62,9 +63,14 @@
   });
 
   $effect(() => {
-    if (!open || !scrimElement || !onclick) return;
+    currentOnclick = onclick;
+  });
+
+  $effect(() => {
+    if (!open || !scrimElement) return;
     return pushEscapeHandler((event) => {
       if (event.defaultPrevented) return;
+      if (!currentOnclick) return;
       event.preventDefault();
       scrimElement?.click();
     });

--- a/packages/components/src/components/backdrop/backdrop.svelte
+++ b/packages/components/src/components/backdrop/backdrop.svelte
@@ -21,8 +21,8 @@
    * Tab to page content under an open backdrop. When you need that isolation
    * (a full-page loading dimmer, a lightbox), apply `inert` to your page-content
    * container while the backdrop is open and pair it with `@lostgradient/cinder/focus-trap`.
-   * Click-to-close via `onclick` is a pointer convenience — wire an Escape
-   * handler yourself for a keyboard dismiss path (e.g. on a lightbox).
+   * Escape dispatches through the shared overlay stack and invokes the scrim's
+   * click path when an `onclick` callback is provided.
    */
   export type { BackdropProps } from './backdrop.types.ts';
 </script>
@@ -62,7 +62,7 @@
   });
 
   $effect(() => {
-    if (!open || !onclick || !scrimElement) return;
+    if (!open || !scrimElement) return;
     return pushEscapeHandler((event) => {
       if (event.defaultPrevented) return;
       event.preventDefault();

--- a/packages/components/src/components/backdrop/backdrop.svelte
+++ b/packages/components/src/components/backdrop/backdrop.svelte
@@ -30,7 +30,7 @@
 <script lang="ts">
   import { fade } from 'svelte/transition';
   import type { BackdropProps } from './backdrop.types.ts';
-  import { lockBodyScroll } from '../../_internal/overlay.ts';
+  import { lockBodyScroll, pushEscapeHandler } from '../../_internal/overlay.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { useReducedMotion } from '../../utilities/use-reduced-motion.svelte.ts';
 
@@ -62,15 +62,12 @@
   });
 
   $effect(() => {
-    if (!open || !onclick) return;
-    const handleKeydown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape' && !event.defaultPrevented) {
-        event.preventDefault();
-        onclick?.(event as unknown as MouseEvent);
-      }
-    };
-    window.addEventListener('keydown', handleKeydown);
-    return () => window.removeEventListener('keydown', handleKeydown);
+    if (!open || !onclick || !scrimElement) return;
+    return pushEscapeHandler((event) => {
+      if (event.defaultPrevented) return;
+      event.preventDefault();
+      scrimElement?.click();
+    });
   });
 
   // Lock body scroll while the scrim is present — including the fade-out outro, so

--- a/packages/components/src/components/backdrop/backdrop.svelte
+++ b/packages/components/src/components/backdrop/backdrop.svelte
@@ -62,7 +62,7 @@
   });
 
   $effect(() => {
-    if (!open || !scrimElement) return;
+    if (!open || !scrimElement || !onclick) return;
     return pushEscapeHandler((event) => {
       if (event.defaultPrevented) return;
       event.preventDefault();

--- a/packages/components/src/components/backdrop/backdrop.svelte
+++ b/packages/components/src/components/backdrop/backdrop.svelte
@@ -61,6 +61,18 @@
     hydrated = true;
   });
 
+  $effect(() => {
+    if (!open || !onclick) return;
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape' && !event.defaultPrevented) {
+        event.preventDefault();
+        onclick?.(event as unknown as MouseEvent);
+      }
+    };
+    window.addEventListener('keydown', handleKeydown);
+    return () => window.removeEventListener('keydown', handleKeydown);
+  });
+
   // Lock body scroll while the scrim is present — including the fade-out outro, so
   // the page can't scroll under a still-visible dimmer. We track the rendered scrim
   // element rather than keying on `open`: the {#if open} block sets `scrimElement` on

--- a/packages/components/src/components/backdrop/backdrop.test.ts
+++ b/packages/components/src/components/backdrop/backdrop.test.ts
@@ -10,13 +10,14 @@ setupHappyDom();
 
 const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 const { default: Backdrop } = await import('./backdrop.svelte');
+const { _resetEscapeStack, _resetScrollLock } = await import('../../_internal/overlay.ts');
 
 // Unmount renders between tests; shared document.body otherwise leaks activeElement/nodes.
 afterEach(() => {
   cleanup();
   document.body.replaceChildren();
+  _resetEscapeStack();
 });
-const { _resetScrollLock } = await import('../../_internal/overlay.ts');
 
 describe('Backdrop', () => {
   test('renders the scrim when open=true', () => {
@@ -80,6 +81,28 @@ describe('Backdrop', () => {
     expect(backdrop).not.toBeNull();
     await fireEvent.click(backdrop);
     expect(clicked).toBe(true);
+  });
+
+  test('Escape invokes onclick for an open backdrop', async () => {
+    let dismissed = false;
+    render(Backdrop, {
+      props: { open: true, onclick: () => (dismissed = true) },
+    });
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(dismissed).toBe(true);
+  });
+
+  test('Escape does not dispatch a click path without onclick', async () => {
+    const { container } = render(Backdrop, { props: { open: true } });
+    const backdrop = container.querySelector('.cinder-backdrop') as HTMLElement;
+    let clicked = false;
+    backdrop.addEventListener('click', () => (clicked = true));
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+
+    expect(clicked).toBe(false);
   });
 
   test('applies custom class prop alongside cinder-backdrop', () => {


### PR DESCRIPTION
Closes #948

When consumers provide `onclick` for a dismissible Backdrop, Escape now invokes the same dismissal path. The handler is registered through the shared overlay stack only while the scrim is open and an `onclick` callback exists, preserving the low-level primitive contract while preventing keyboard traps in playground/lightbox usage.

The focus-trapping question remains intentionally separate: Backdrop does not trap focus or make page content inert. Consumers that need isolation should compose `inert` and `@lostgradient/cinder/focus-trap`; this pull request does not add implicit trapping behavior.

Verification:
- `bun test packages/components/src/components/backdrop/backdrop.test.ts`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
