### PR TITLE
fix(color-field): mark swatch decorative

### DIFF
--- a/.changeset/noninteractive-color-field-swatch.md
+++ b/.changeset/noninteractive-color-field-swatch.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Mark ColorField's decorative swatch as non-interactive to match its text-input contract.

--- a/.changeset/stable-chat-history.md
+++ b/.changeset/stable-chat-history.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Preserve deferred history anchors across expected restoration scrolls.

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -258,7 +258,7 @@
   let deferredNonVirtualHistoryStabilization: PendingHistoryScroll | null = null;
   let isHistoryRestorationUserScrolling = false;
   let historyLoadRequestId = 0;
-  let historyRestorationExpectedScrollTop: number | null = null;
+  let historyRestorationScrollPending = false;
   let historyRestorationUserScrollObserved = false;
   let historyRestorationUserScrollResetRaf: number | undefined;
   let deferredHistoryTriggerFocus = $state<
@@ -735,7 +735,7 @@
         anchorCorrection === null
           ? pending.previousScrollTop + (viewport.scrollHeight - pending.previousScrollHeight)
           : viewport.scrollTop + anchorCorrection;
-      historyRestorationExpectedScrollTop = targetScrollTop;
+      historyRestorationScrollPending = true;
       viewport.scrollTo({
         top: targetScrollTop,
         behavior: 'instant',
@@ -877,7 +877,7 @@
   function resetHistoryRestorationUserScrolling(): void {
     cancelHistoryRestorationUserScrollReset();
     deferredNonVirtualHistoryStabilization = null;
-    historyRestorationExpectedScrollTop = null;
+    historyRestorationScrollPending = false;
     isHistoryRestorationUserScrolling = false;
     historyRestorationUserScrollObserved = false;
   }
@@ -1090,24 +1090,28 @@
   const historyAnchorScrollAttachment: Attachment<HTMLElement> = (node) => {
     const handleScroll = () => {
       clearHistoryAnchorAfterScroll(node.scrollTop);
-      const isExpectedRestorationScroll =
-        historyRestorationExpectedScrollTop !== null &&
-        Math.abs(node.scrollTop - historyRestorationExpectedScrollTop) < 1;
-      if (historyRestorationExpectedScrollTop !== null) {
-        historyRestorationExpectedScrollTop = null;
-      }
+      const isExpectedRestorationScroll = historyRestorationScrollPending;
+      historyRestorationScrollPending = false;
       if (isHistoryRestorationUserScrolling && !isExpectedRestorationScroll) {
         historyRestorationUserScrollObserved = true;
         deferredNonVirtualHistoryStabilization = null;
         cancelHistoryRestorationUserScrollReset();
       }
-      if (isHistoryRestorationUserScrolling && pendingHistoryScroll === null) {
+      if (
+        isHistoryRestorationUserScrolling &&
+        historyRestorationUserScrollObserved &&
+        pendingHistoryScroll === null
+      ) {
         cancelNonVirtualHistoryAnchorStabilization();
       }
       schedulePendingHistoryAnchorRecapture();
     };
     const handleScrollEnd = () => {
-      if (isHistoryRestorationUserScrolling && pendingHistoryScroll === null) {
+      if (
+        isHistoryRestorationUserScrolling &&
+        historyRestorationUserScrollObserved &&
+        pendingHistoryScroll === null
+      ) {
         cancelNonVirtualHistoryAnchorStabilization();
       }
       isHistoryRestorationUserScrolling = false;

--- a/packages/components/src/components/color-field/color-field.css
+++ b/packages/components/src/components/color-field/color-field.css
@@ -16,6 +16,8 @@
     background-color: var(--cinder-color-field-swatch, transparent);
     border: 1px solid var(--cinder-border);
     vertical-align: middle;
+    pointer-events: none;
+    cursor: default;
   }
 
   .cinder-color-field__swatch[data-cinder-empty] {

--- a/packages/components/src/components/color-field/color-field.test.ts
+++ b/packages/components/src/components/color-field/color-field.test.ts
@@ -1,5 +1,8 @@
 /// <reference lib="dom" />
+import { readFileSync } from 'node:fs';
+
 import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { parse } from 'postcss';
 import type { ComponentProps } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -13,6 +16,7 @@ const { default: ColorFieldFormFixture } =
   await import('../../test/fixtures/color-field-form-fixture.svelte');
 const { default: ColorFieldFormFieldFixture } =
   await import('../../test/fixtures/color-field-form-field-fixture.svelte');
+const colorFieldCss = readFileSync(new URL('./color-field.css', import.meta.url), 'utf8');
 
 afterEach(() => {
   cleanup();
@@ -41,11 +45,36 @@ function getInput(container: ParentNode, id = 'color'): HTMLInputElement {
   return q<HTMLInputElement>(container, `#${id}`);
 }
 
+function getCssDeclaration(selector: string, property: string): string | undefined {
+  let value: string | undefined;
+  parse(colorFieldCss).walkRules((rule) => {
+    if (rule.selector !== selector) return;
+    rule.walkDecls(property, (declaration) => {
+      value = declaration.value;
+    });
+  });
+  return value;
+}
+
 async function typeAndBlur(input: HTMLInputElement, text: string): Promise<void> {
   await fireEvent.input(input, { target: { value: text } });
   await fireEvent.blur(input);
   await tick();
 }
+
+describe('ColorField — decorative swatch', () => {
+  test('stays hidden from assistive technology and ignores pointer interaction', () => {
+    const { container } = render(ColorField, { id: 'color', name: 'color' });
+    const swatch = q<HTMLElement>(container, '.cinder-color-field__swatch');
+
+    expect(swatch.tagName).toBe('SPAN');
+    expect(swatch.getAttribute('aria-hidden')).toBe('true');
+    expect(swatch.hasAttribute('role')).toBe(false);
+    expect(swatch.tabIndex).toBe(-1);
+    expect(getCssDeclaration('.cinder-color-field__swatch', 'pointer-events')).toBe('none');
+    expect(getCssDeclaration('.cinder-color-field__swatch', 'cursor')).toBe('default');
+  });
+});
 
 describe('ColorField — parse round-trips', () => {
   const cases = [

--- a/packages/playground/src/snapshot-mode.test.ts
+++ b/packages/playground/src/snapshot-mode.test.ts
@@ -117,6 +117,11 @@ describe('snapshotModeStyleTag', () => {
     expect(tag).toContain('transition-delay: 0s');
   });
 
+  it('forces offscreen content to render for complete accessibility and screenshot capture', () => {
+    const tag = snapshotModeStyleTag(true);
+    expect(tag).toContain('content-visibility: visible !important');
+  });
+
   it('scopes rules to [data-snapshot-mode] so normal pages are unaffected', () => {
     const tag = snapshotModeStyleTag(true);
     expect(tag).toContain('[data-snapshot-mode]');

--- a/packages/playground/src/snapshot-mode.ts
+++ b/packages/playground/src/snapshot-mode.ts
@@ -41,14 +41,16 @@ export function isSnapshotMode(search: URLSearchParams): boolean {
  * receiving `data-preserve-motion` on themselves or a containing ancestor.
  */
 export const SNAPSHOT_MODE_CSS = `
-  /* Snapshot mode: zero all animation/transition durations so screenshots
-     are stable. Elements with data-preserve-motion (or inside such an
-     ancestor) are exempted — they render their own deterministic end state. */
+  /* Snapshot mode: freeze motion and fully render offscreen content so
+     screenshots and accessibility scans see one complete, stable tree.
+     Elements with data-preserve-motion (or inside such an ancestor) keep
+     their own deterministic motion state. */
   [data-snapshot-mode] *:not([data-preserve-motion]):not([data-preserve-motion] *) {
     animation-duration: 0s !important;
     animation-delay: 0s !important;
     transition-duration: 0s !important;
     transition-delay: 0s !important;
+    content-visibility: visible !important;
   }
 
   /* Hide text insertion carets globally. Prevents cursor-blink diffs between


### PR DESCRIPTION
Closes #949

ColorField’s swatch is decorative by design; make that contract explicit with pointer-events none and a default cursor while preserving aria-hidden. ColorSwatchPicker remains interactive as the dedicated picker primitive.

Exact-head CI after rebasing exposed two independent Chat/test-harness defects, both fixed at their shared causes:

- Treat the scroll event emitted by a programmatic history restoration as expected by construction, instead of comparing a browser-normalized scrollTop to the requested pixel value. This preserves deferred anchor stabilization while still cancelling on observed user scrolls.
- Force content-visibility: visible in snapshot mode so axe and screenshots fully render offscreen component examples instead of sampling skipped Chat message paint as transparent.

Focused verification:

- ColorField unit suite: 50 passed
- Chat history anchor stress: 12 passed across two workers
- Chat component axe matrix: 18 passed across two workers and three repetitions; zero violations
- Snapshot-mode unit suite: 23 passed
- Chat, playground, and testing TypeScript checks: passed