### PR TITLE
fix(phone-input): constrain country selector width

### DIFF
--- a/.changeset/compact-phone-country-control.md
+++ b/.changeset/compact-phone-country-control.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep PhoneInput's country selector compact instead of sizing it to the longest country name.

--- a/packages/components/src/components/phone-input/phone-input.a11y.md
+++ b/packages/components/src/components/phone-input/phone-input.a11y.md
@@ -4,11 +4,11 @@
 
 - The outer container is a `role="group"` that owns the component's group accessible name. The accessible name source is, in order: the `label` prop, a wrapping `<FormField>` label, `aria-labelledby`, then `aria-label`. Development builds warn when none of these are present.
 - The component renders **two** native controls with their own accessible names:
-  - a `<select>` with the accessible name `Country code` (sourced from a visually hidden span via `aria-labelledby`)
-  - an `<input type="tel">` with the accessible name `Phone number` (also via a visually hidden span)
+  - a `<select>` whose name combines the group label with the selected country and calling code, such as `Phone Country: United States, +1`
+  - an `<input type="tel">` whose name combines the group label with `Phone number`, such as `Phone Phone number`
 - Both controls share the same `aria-describedby` value so the same description or error follows whichever control has focus.
 - `error` sets `aria-invalid="true"` on both controls and the group; CSS uses the attribute to draw the invalid border so the state is communicated by both attribute and color.
-- `required` is announced via `aria-required="true"` on the group and on the national-number input.
+- `required` is announced on the group and is applied to both the country select and national-number input.
 
 ## Keyboard Interactions
 

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -41,7 +41,7 @@
     }
   }
 
-  .cinder-phone-input__country,
+  .cinder-phone-input__country .cinder-select,
   .cinder-phone-input__national {
     min-height: 2.25rem;
     padding: var(--cinder-space-1-5) var(--cinder-space-3);
@@ -59,7 +59,7 @@
       box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
-  .cinder-phone-input__country {
+  .cinder-phone-input__country .cinder-select {
     cursor: pointer;
     padding-inline-end: var(--cinder-space-6);
     background-image:
@@ -74,32 +74,32 @@
     background-repeat: no-repeat;
   }
 
-  .cinder-phone-input__country::-ms-expand {
+  .cinder-phone-input__country .cinder-select::-ms-expand {
     display: none;
   }
 
   @media (hover: hover) {
-    .cinder-phone-input__country:hover:not(:disabled),
+    .cinder-phone-input__country .cinder-select:hover:not(:disabled),
     .cinder-phone-input__national:hover:not(:disabled) {
       border-color: var(--cinder-border-strong);
     }
   }
 
-  .cinder-phone-input__country:focus-visible,
+  .cinder-phone-input__country .cinder-select:focus-visible,
   .cinder-phone-input__national:focus-visible {
     outline: var(--cinder-ring-width) solid transparent;
     box-shadow: var(--_cinder-focus-ring-shadow);
     border-color: var(--cinder-border-strong);
   }
 
-  .cinder-phone-input__country[aria-invalid='true'],
+  .cinder-phone-input__country .cinder-select[aria-invalid='true'],
   .cinder-phone-input__national[aria-invalid='true'],
-  .cinder-phone-input[aria-invalid='true'] .cinder-phone-input__country,
+  .cinder-phone-input[aria-invalid='true'] .cinder-phone-input__country .cinder-select,
   .cinder-phone-input[aria-invalid='true'] .cinder-phone-input__national {
     border-color: var(--cinder-danger);
   }
 
-  .cinder-phone-input__country:disabled,
+  .cinder-phone-input__country .cinder-select:disabled,
   .cinder-phone-input__national:disabled {
     cursor: not-allowed;
     color: var(--cinder-text-disabled);
@@ -107,7 +107,7 @@
   }
 
   @media (forced-colors: active) {
-    .cinder-phone-input__country:focus-visible,
+    .cinder-phone-input__country .cinder-select:focus-visible,
     .cinder-phone-input__national:focus-visible {
       outline: var(--cinder-ring-width) solid Highlight;
     }

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -1,4 +1,6 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../input/input.css';
+@import '../select/select.css';
 @layer cinder.components {
   /* ========================================
  * PHONE INPUT
@@ -61,7 +63,7 @@
   .cinder-phone-input__country-summary {
     position: absolute;
     z-index: 1;
-    inset-block-start: calc(var(--cinder-control-height, 2.25rem) / 2);
+    inset-block-start: 50%;
     inset-inline-start: var(--cinder-space-3);
     max-inline-size: calc(100% - var(--cinder-space-10));
     overflow: hidden;
@@ -76,6 +78,10 @@
 
   .cinder-phone-input__country[data-disabled] .cinder-phone-input__country-summary {
     color: var(--cinder-text-disabled);
+  }
+
+  .cinder-phone-input__country[data-disabled] .cinder-select:disabled {
+    color: transparent;
   }
 
   .cinder-phone-input-field__description {

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -88,6 +88,10 @@
     .cinder-phone-input__country .cinder-select {
       text-indent: -9999px;
     }
+
+    .cinder-phone-input__country .cinder-select option {
+      text-indent: 0;
+    }
   }
 
   .cinder-phone-input-field__description {

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -84,6 +84,12 @@
     color: transparent;
   }
 
+  @media (forced-colors: active) {
+    .cinder-phone-input__country .cinder-select {
+      text-indent: -9999px;
+    }
+  }
+
   .cinder-phone-input-field__description {
     margin: 0;
     font-size: var(--cinder-text-xs);

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -41,76 +41,41 @@
     }
   }
 
-  .cinder-phone-input__country .cinder-select,
-  .cinder-phone-input__national {
-    min-height: 2.25rem;
-    padding: var(--cinder-space-1-5) var(--cinder-space-3);
-    font-family: inherit;
-    font-size: var(--cinder-text-sm);
-    line-height: var(--cinder-leading-normal);
-    color: var(--cinder-text);
-    background: var(--cinder-surface-raised);
-    border: 1px solid var(--cinder-border);
-    border-radius: var(--cinder-radius-md);
-    appearance: none;
+  .cinder-phone-input__country {
+    position: relative;
+    min-inline-size: 0;
+  }
 
-    transition:
-      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
+  .cinder-phone-input__country .cinder-select-field {
+    inline-size: 100%;
   }
 
   .cinder-phone-input__country .cinder-select {
-    cursor: pointer;
-    padding-inline-end: var(--cinder-space-6);
-    background-image:
-      linear-gradient(45deg, transparent 50%, currentColor 50%),
-      linear-gradient(135deg, currentColor 50%, transparent 50%);
-    background-position:
-      calc(100% - 18px) 50%,
-      calc(100% - 12px) 50%;
-    background-size:
-      6px 6px,
-      6px 6px;
-    background-repeat: no-repeat;
+    color: transparent;
   }
 
-  .cinder-phone-input__country .cinder-select::-ms-expand {
-    display: none;
+  .cinder-phone-input__country .cinder-select option {
+    color: var(--cinder-text);
   }
 
-  @media (hover: hover) {
-    .cinder-phone-input__country .cinder-select:hover:not(:disabled),
-    .cinder-phone-input__national:hover:not(:disabled) {
-      border-color: var(--cinder-border-strong);
-    }
+  .cinder-phone-input__country-summary {
+    position: absolute;
+    z-index: 1;
+    inset-block-start: calc(var(--cinder-control-height, 2.25rem) / 2);
+    inset-inline-start: var(--cinder-space-3);
+    max-inline-size: calc(100% - var(--cinder-space-10));
+    overflow: hidden;
+    color: var(--cinder-text);
+    font-size: var(--cinder-text-sm);
+    line-height: 1;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    pointer-events: none;
+    transform: translateY(-50%);
   }
 
-  .cinder-phone-input__country .cinder-select:focus-visible,
-  .cinder-phone-input__national:focus-visible {
-    outline: var(--cinder-ring-width) solid transparent;
-    box-shadow: var(--_cinder-focus-ring-shadow);
-    border-color: var(--cinder-border-strong);
-  }
-
-  .cinder-phone-input__country .cinder-select[aria-invalid='true'],
-  .cinder-phone-input__national[aria-invalid='true'],
-  .cinder-phone-input[aria-invalid='true'] .cinder-phone-input__country .cinder-select,
-  .cinder-phone-input[aria-invalid='true'] .cinder-phone-input__national {
-    border-color: var(--cinder-danger);
-  }
-
-  .cinder-phone-input__country .cinder-select:disabled,
-  .cinder-phone-input__national:disabled {
-    cursor: not-allowed;
+  .cinder-phone-input__country[data-disabled] .cinder-phone-input__country-summary {
     color: var(--cinder-text-disabled);
-    background-color: var(--cinder-surface-inset);
-  }
-
-  @media (forced-colors: active) {
-    .cinder-phone-input__country .cinder-select:focus-visible,
-    .cinder-phone-input__national:focus-visible {
-      outline: var(--cinder-ring-width) solid Highlight;
-    }
   }
 
   .cinder-phone-input-field__description {

--- a/packages/components/src/components/phone-input/phone-input.css
+++ b/packages/components/src/components/phone-input/phone-input.css
@@ -30,7 +30,7 @@
 
   .cinder-phone-input {
     display: grid;
-    grid-template-columns: minmax(7rem, max-content) 1fr;
+    grid-template-columns: minmax(7rem, 10rem) minmax(0, 1fr);
     gap: var(--cinder-space-2);
     align-items: stretch;
   }

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -27,6 +27,8 @@
     PhoneInputCountryOption,
     PhoneInputProps,
   } from './phone-input.types.ts';
+  import Input from '../input/input.svelte';
+  import Select from '../select/select.svelte';
   import { devWarn } from '../../utilities/dev-warn.ts';
 
   import {
@@ -102,6 +104,9 @@
         label: `${displayName} +${callingCode}`,
       };
     }),
+  );
+  const selectOptions = $derived(
+    countryOptions.map((option) => ({ value: option.code, label: option.label })),
   );
 
   function isAllowed(code: PhoneInputCountryCode): boolean {
@@ -342,9 +347,15 @@
 
   const groupLabelId = $derived(label ? `${id}-label` : undefined);
   const countrySelectId = $derived(`${id}-country`);
-  const countryLabelId = $derived(`${id}-country-label`);
   const nationalInputId = $derived(id);
-  const nationalLabelId = $derived(`${id}-national-label`);
+  const selectedCountryOption = $derived(
+    countryOptions.find((option) => option.code === country) ?? countryOptions[0],
+  );
+  const countryAccessibleLabel = $derived(
+    selectedCountryOption
+      ? `Country: ${selectedCountryOption.displayName}, +${selectedCountryOption.callingCode}`
+      : 'Country',
+  );
 
   const defaultDescriptionId = $derived(describeId(id, !!description));
   const defaultErrorId = $derived(buildErrorId(id, !!error));
@@ -373,18 +384,6 @@
   const groupAriaLabel = $derived(
     !resolvedGroupLabelledBy && !ariaLabelledBy ? ariaLabel : undefined,
   );
-
-  /**
-   * Compose the per-control accessible-name reference. Prefix the group label
-   * (when present) so screen readers announce the consumer's "Phone number"
-   * alongside the inner control's role-specific label ("Country code",
-   * "Phone number").
-   */
-  function controlLabelledBy(controlLabelId: string): string {
-    if (resolvedGroupLabelledBy) return `${resolvedGroupLabelledBy} ${controlLabelId}`;
-    if (ariaLabelledBy) return `${ariaLabelledBy} ${controlLabelId}`;
-    return controlLabelId;
-  }
 
   const hasGroupAccessibleName = $derived(
     !!label || !!context?.labelId || !!ariaLabelledBy || !!ariaLabel,
@@ -455,36 +454,33 @@
     aria-required={resolvedRequired || undefined}
     aria-disabled={resolvedDisabled || undefined}
   >
-    <span id={countryLabelId} class="cinder-sr-only">Country code</span>
-    <select
+    <Select
       id={countrySelectId}
       class="cinder-phone-input__country"
-      aria-labelledby={controlLabelledBy(countryLabelId)}
+      label={countryAccessibleLabel}
+      hideLabel
+      options={selectOptions}
+      value={isAllowed(country) ? country : selectOptions[0]?.value}
       aria-describedby={describedBy}
       aria-invalid={resolvedAriaInvalid}
       disabled={resolvedDisabled}
-      value={country}
       onchange={handleCountryChange}
-    >
-      {#each countryOptions as option (option.code)}
-        <option value={option.code}>{option.label}</option>
-      {/each}
-    </select>
+    />
 
-    <span id={nationalLabelId} class="cinder-sr-only">Phone number</span>
-    <input
+    <Input
       id={nationalInputId}
       class="cinder-phone-input__national"
+      label="Phone number"
+      hideLabel
       type="tel"
       inputmode="tel"
       autocomplete="tel-national"
-      aria-labelledby={controlLabelledBy(nationalLabelId)}
+      value={nationalDisplay}
       aria-describedby={describedBy}
       aria-invalid={resolvedAriaInvalid}
       aria-required={resolvedRequired || undefined}
       disabled={resolvedDisabled}
       required={resolvedRequired}
-      value={nationalDisplay}
       oninput={handleNationalInput}
     />
   </div>

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -27,8 +27,8 @@
     PhoneInputCountryOption,
     PhoneInputProps,
   } from './phone-input.types.ts';
-  import Input from '../input/index.ts';
-  import Select from '../select/index.ts';
+  import Input from '@lostgradient/cinder/input';
+  import Select from '@lostgradient/cinder/select';
   import { devWarn } from '../../utilities/dev-warn.ts';
 
   import {
@@ -148,6 +148,7 @@
   let knownValue: string | null = null;
   let knownCountry: PhoneInputCountryCode | null = null;
   let knownAllowList: readonly PhoneInputCountryCode[] = [];
+  let fieldRoot = $state<HTMLElement>();
 
   /**
    * Synchronise to external `value` changes. Covers initial hydration too
@@ -345,6 +346,26 @@
     });
   }
 
+  function handleFormReset(): void {
+    queueMicrotask(() =>
+      queueMicrotask(() => {
+        const rawCountry = fieldRoot?.querySelector<HTMLSelectElement>('select')?.value;
+        if (!rawCountry || !isCountryCode(rawCountry)) return;
+        country = rawCountry;
+        knownCountry = rawCountry;
+      }),
+    );
+  }
+
+  $effect(() => {
+    const handleReset = (event: Event) => {
+      if (event.target instanceof HTMLFormElement && fieldRoot?.closest('form') === event.target)
+        handleFormReset();
+    };
+    window.addEventListener('reset', handleReset, true);
+    return () => window.removeEventListener('reset', handleReset, true);
+  });
+
   const groupLabelId = $derived(label ? `${id}-label` : undefined);
   const countrySelectId = $derived(`${id}-country`);
   const countryLabelId = $derived(`${id}-country-label`);
@@ -437,6 +458,7 @@
 </script>
 
 <div
+  bind:this={fieldRoot}
   class={classNames('cinder-phone-input-field', className)}
   data-cinder-disabled={resolvedDisabled || undefined}
 >

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -372,6 +372,9 @@
         knownCountry = resetCountry;
         value = initialValue;
         knownValue = initialValue;
+        const countrySelect = fieldRoot?.querySelector<HTMLSelectElement>('select');
+        if (countrySelect && countrySelect.value !== resetCountry)
+          countrySelect.value = resetCountry;
         nationalDisplay = initialParsedCountryAllowed
           ? initialParsed.formatted
           : initialParsed

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -435,16 +435,24 @@
   const resolvedAriaInvalid = $derived(error ? ariaInvalid(true) : context?.invalid);
   const resolvedRequired = $derived(required ?? context?.required ?? false);
   const resolvedDisabled = $derived(disabled ?? context?.disabled ?? false);
+  const resolvedAriaLabel = $derived(
+    typeof ariaLabel === 'string' && ariaLabel.trim().length > 0 ? ariaLabel : undefined,
+  );
+  const resolvedAriaLabelledBy = $derived(
+    typeof ariaLabelledBy === 'string' && ariaLabelledBy.trim().length > 0
+      ? ariaLabelledBy
+      : undefined,
+  );
 
   const resolvedGroupLabelledBy = $derived.by(() => {
     if (groupLabelId) return groupLabelId;
     if (context?.labelId) return context.labelId;
-    if (ariaLabelledBy) return ariaLabelledBy;
+    if (resolvedAriaLabelledBy) return resolvedAriaLabelledBy;
     return undefined;
   });
 
   const groupAriaLabel = $derived(
-    !resolvedGroupLabelledBy && !ariaLabelledBy ? ariaLabel : undefined,
+    !resolvedGroupLabelledBy && !resolvedAriaLabelledBy ? resolvedAriaLabel : undefined,
   );
 
   function controlLabelledBy(controlLabelId: string): string | undefined {
@@ -458,7 +466,7 @@
   }
 
   const hasGroupAccessibleName = $derived(
-    !!label || !!context?.labelId || !!ariaLabelledBy || !!ariaLabel,
+    !!label || !!context?.labelId || !!resolvedAriaLabelledBy || !!resolvedAriaLabel,
   );
 
   $effect(() => {

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -535,11 +535,7 @@
     aria-required={resolvedRequired || undefined}
     aria-disabled={resolvedDisabled || undefined}
   >
-    <div
-      class="cinder-phone-input__country"
-      data-disabled={resolvedDisabled || undefined}
-      data-invalid={resolvedAriaInvalid === 'true' || undefined}
-    >
+    <div class="cinder-phone-input__country" data-disabled={resolvedDisabled || undefined}>
       <span id={countryLabelId} class="cinder-sr-only">{countryAccessibleLabel}</span>
       <Select
         id={countrySelectId}

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -69,6 +69,9 @@
     onchange,
   }: PhoneInputProps = $props();
 
+  const initialCountry = country;
+  const initialValue = value;
+
   const context = getFormFieldContext();
   const localeContext = getLocaleContext();
 
@@ -351,8 +354,13 @@
       queueMicrotask(() => {
         const rawCountry = fieldRoot?.querySelector<HTMLSelectElement>('select')?.value;
         if (!rawCountry || !isCountryCode(rawCountry)) return;
-        country = rawCountry;
-        knownCountry = rawCountry;
+        const resetCountry = isCountryCode(initialCountry) ? initialCountry : rawCountry;
+        country = resetCountry;
+        knownCountry = resetCountry;
+        value = initialValue;
+        knownValue = initialValue;
+        const parsed = parseE164Value(initialValue);
+        nationalDisplay = parsed?.formatted ?? initialValue;
       }),
     );
   }

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -354,13 +354,18 @@
       queueMicrotask(() => {
         const rawCountry = fieldRoot?.querySelector<HTMLSelectElement>('select')?.value;
         if (!rawCountry || !isCountryCode(rawCountry)) return;
-        const resetCountry = isCountryCode(initialCountry) ? initialCountry : rawCountry;
+        const initialParsed = parseE164Value(initialValue);
+        const resetCountry =
+          initialParsed && isCountryCode(initialParsed.country)
+            ? initialParsed.country
+            : isCountryCode(initialCountry)
+              ? initialCountry
+              : rawCountry;
         country = resetCountry;
         knownCountry = resetCountry;
         value = initialValue;
         knownValue = initialValue;
-        const parsed = parseE164Value(initialValue);
-        nationalDisplay = parsed?.formatted ?? initialValue;
+        nationalDisplay = initialParsed?.formatted ?? initialValue;
       }),
     );
   }

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -375,11 +375,17 @@
         const countrySelect = fieldRoot?.querySelector<HTMLSelectElement>('select');
         if (countrySelect && countrySelect.value !== resetCountry)
           countrySelect.value = resetCountry;
-        nationalDisplay = initialParsedCountryAllowed
+        const resetDisplay = initialParsedCountryAllowed
           ? initialParsed.formatted
           : initialParsed
             ? initialValue
             : formatNationalAsYouType(resetCountry, digitsOnly(initialValue));
+        nationalDisplay = resetDisplay;
+        const nationalInput = fieldRoot?.querySelector<HTMLInputElement>(
+          'input:not([type="hidden"])',
+        );
+        if (nationalInput && nationalInput.value !== resetDisplay)
+          nationalInput.value = resetDisplay;
       }),
     );
   }

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -350,9 +350,12 @@
   }
 
   function handleFormReset(event: Event): void {
+    const valueAtReset = value;
+    const countryAtReset = country;
     queueMicrotask(() =>
       queueMicrotask(() => {
         if (event.defaultPrevented) return;
+        if (value !== valueAtReset || country !== countryAtReset) return;
         const rawCountry = fieldRoot?.querySelector<HTMLSelectElement>('select')?.value;
         if (!rawCountry || !isCountryCode(rawCountry)) return;
         const initialParsed = parseE164Value(initialValue);

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -369,7 +369,11 @@
         knownCountry = resetCountry;
         value = initialValue;
         knownValue = initialValue;
-        nationalDisplay = initialParsedCountryAllowed ? initialParsed.formatted : initialValue;
+        nationalDisplay = initialParsedCountryAllowed
+          ? initialParsed.formatted
+          : initialParsed
+            ? initialValue
+            : formatNationalAsYouType(resetCountry, digitsOnly(initialValue));
       }),
     );
   }

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -358,8 +358,10 @@
         const initialParsed = parseE164Value(initialValue);
         const initialParsedCountryAllowed =
           initialParsed !== null && isCountryCode(initialParsed.country);
-        const resetCountry = initialParsedCountryAllowed
-          ? initialParsed.country
+        const resetCountry = initialParsed
+          ? initialParsedCountryAllowed
+            ? initialParsed.country
+            : fallbackCountry()
           : isCountryCode(initialCountry)
             ? initialCountry
             : rawCountry;

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -349,34 +349,35 @@
     });
   }
 
-  function handleFormReset(): void {
+  function handleFormReset(event: Event): void {
     queueMicrotask(() =>
       queueMicrotask(() => {
+        if (event.defaultPrevented) return;
         const rawCountry = fieldRoot?.querySelector<HTMLSelectElement>('select')?.value;
         if (!rawCountry || !isCountryCode(rawCountry)) return;
         const initialParsed = parseE164Value(initialValue);
-        const resetCountry =
-          initialParsed && isCountryCode(initialParsed.country)
-            ? initialParsed.country
-            : isCountryCode(initialCountry)
-              ? initialCountry
-              : rawCountry;
+        const initialParsedCountryAllowed =
+          initialParsed !== null && isCountryCode(initialParsed.country);
+        const resetCountry = initialParsedCountryAllowed
+          ? initialParsed.country
+          : isCountryCode(initialCountry)
+            ? initialCountry
+            : rawCountry;
         country = resetCountry;
         knownCountry = resetCountry;
         value = initialValue;
         knownValue = initialValue;
-        nationalDisplay = initialParsed?.formatted ?? initialValue;
+        nationalDisplay = initialParsedCountryAllowed ? initialParsed.formatted : initialValue;
       }),
     );
   }
 
   $effect(() => {
-    const handleReset = (event: Event) => {
-      if (event.target instanceof HTMLFormElement && fieldRoot?.closest('form') === event.target)
-        handleFormReset();
-    };
-    window.addEventListener('reset', handleReset, true);
-    return () => window.removeEventListener('reset', handleReset, true);
+    const form = fieldRoot?.closest('form');
+    if (!form) return;
+    const handleReset = (event: Event) => handleFormReset(event);
+    form.addEventListener('reset', handleReset);
+    return () => form.removeEventListener('reset', handleReset);
   });
 
   const groupLabelId = $derived(label ? `${id}-label` : undefined);

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -460,7 +460,7 @@
       label={countryAccessibleLabel}
       hideLabel
       options={selectOptions}
-      value={isAllowed(country) ? country : selectOptions[0]?.value}
+      value={isAllowed(country) ? country : fallbackCountry()}
       aria-describedby={describedBy}
       aria-invalid={resolvedAriaInvalid}
       disabled={resolvedDisabled}

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -27,8 +27,8 @@
     PhoneInputCountryOption,
     PhoneInputProps,
   } from './phone-input.types.ts';
-  import Input from '../input/input.svelte';
-  import Select from '../select/select.svelte';
+  import Input from '../input/index.ts';
+  import Select from '../select/index.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
 
   import {
@@ -347,7 +347,9 @@
 
   const groupLabelId = $derived(label ? `${id}-label` : undefined);
   const countrySelectId = $derived(`${id}-country`);
+  const countryLabelId = $derived(`${id}-country-label`);
   const nationalInputId = $derived(id);
+  const nationalLabelId = $derived(`${id}-national-label`);
   const selectedCountryOption = $derived(
     countryOptions.find((option) => option.code === country) ?? countryOptions[0],
   );
@@ -355,6 +357,11 @@
     selectedCountryOption
       ? `Country: ${selectedCountryOption.displayName}, +${selectedCountryOption.callingCode}`
       : 'Country',
+  );
+  const countrySummary = $derived(
+    selectedCountryOption
+      ? `${selectedCountryOption.code} +${selectedCountryOption.callingCode}`
+      : country,
   );
 
   const defaultDescriptionId = $derived(describeId(id, !!description));
@@ -384,6 +391,16 @@
   const groupAriaLabel = $derived(
     !resolvedGroupLabelledBy && !ariaLabelledBy ? ariaLabel : undefined,
   );
+
+  function controlLabelledBy(controlLabelId: string): string | undefined {
+    if (resolvedGroupLabelledBy) return `${resolvedGroupLabelledBy} ${controlLabelId}`;
+    if (groupAriaLabel) return undefined;
+    return controlLabelId;
+  }
+
+  function controlAriaLabel(controlLabel: string): string | undefined {
+    return groupAriaLabel ? `${groupAriaLabel} ${controlLabel}` : undefined;
+  }
 
   const hasGroupAccessibleName = $derived(
     !!label || !!context?.labelId || !!ariaLabelledBy || !!ariaLabel,
@@ -454,28 +471,39 @@
     aria-required={resolvedRequired || undefined}
     aria-disabled={resolvedDisabled || undefined}
   >
-    <Select
-      id={countrySelectId}
+    <div
       class="cinder-phone-input__country"
-      label={countryAccessibleLabel}
-      hideLabel
-      options={selectOptions}
-      value={isAllowed(country) ? country : fallbackCountry()}
-      aria-describedby={describedBy}
-      aria-invalid={resolvedAriaInvalid}
-      disabled={resolvedDisabled}
-      onchange={handleCountryChange}
-    />
+      data-disabled={resolvedDisabled || undefined}
+      data-invalid={resolvedAriaInvalid === 'true' || undefined}
+    >
+      <span id={countryLabelId} class="cinder-sr-only">{countryAccessibleLabel}</span>
+      <Select
+        id={countrySelectId}
+        options={selectOptions}
+        value={isAllowed(country) ? country : fallbackCountry()}
+        aria-label={controlAriaLabel(countryAccessibleLabel)}
+        aria-labelledby={controlLabelledBy(countryLabelId)}
+        aria-describedby={describedBy}
+        aria-invalid={resolvedAriaInvalid}
+        disabled={resolvedDisabled}
+        required={resolvedRequired}
+        onchange={handleCountryChange}
+      />
+      <span class="cinder-phone-input__country-summary" aria-hidden="true">
+        {countrySummary}
+      </span>
+    </div>
 
+    <span id={nationalLabelId} class="cinder-sr-only">Phone number</span>
     <Input
       id={nationalInputId}
       class="cinder-phone-input__national"
-      label="Phone number"
-      hideLabel
       type="tel"
       inputmode="tel"
       autocomplete="tel-national"
       value={nationalDisplay}
+      aria-label={controlAriaLabel('Phone number')}
+      aria-labelledby={controlLabelledBy(nationalLabelId)}
       aria-describedby={describedBy}
       aria-invalid={resolvedAriaInvalid}
       aria-required={resolvedRequired || undefined}

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -360,7 +360,7 @@
         if (!rawCountry || !isCountryCode(rawCountry)) return;
         const initialParsed = parseE164Value(initialValue);
         const initialParsedCountryAllowed =
-          initialParsed !== null && isCountryCode(initialParsed.country);
+          initialParsed !== null && isAllowed(initialParsed.country);
         const resetCountry = initialParsed
           ? initialParsedCountryAllowed
             ? initialParsed.country

--- a/packages/components/src/components/phone-input/phone-input.svelte
+++ b/packages/components/src/components/phone-input/phone-input.svelte
@@ -379,7 +379,9 @@
           ? initialParsed.formatted
           : initialParsed
             ? initialValue
-            : formatNationalAsYouType(resetCountry, digitsOnly(initialValue));
+            : initialValue === digitsOnly(initialValue)
+              ? formatNationalAsYouType(resetCountry, initialValue)
+              : initialValue;
         nationalDisplay = resetDisplay;
         const nationalInput = fieldRoot?.querySelector<HTMLInputElement>(
           'input:not([type="hidden"])',

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -40,6 +40,18 @@ describe('PhoneInput rendering', () => {
     expect(getByRole('combobox', { name: 'Phone Country: United States, +1' })).not.toBeNull();
   });
 
+  test('ignores whitespace-only ARIA names and preserves control fallbacks', () => {
+    const { container, getByRole } = render(PhoneInput, {
+      props: { id: 'p', 'aria-label': '   ', 'aria-labelledby': '\t' },
+    });
+    const group = container.querySelector('[role="group"]')!;
+
+    expect(group.hasAttribute('aria-label')).toBe(false);
+    expect(group.hasAttribute('aria-labelledby')).toBe(false);
+    expect(getByRole('combobox', { name: 'Country: United States, +1' })).not.toBeNull();
+    expect(getByRole('textbox', { name: 'Phone number' })).not.toBeNull();
+  });
+
   test('visible country summary stays compact while options retain full names', () => {
     const { container } = render(PhoneInput, {
       props: { id: 'p', label: 'Phone', country: 'AE', countries: ['US', 'AE'] },

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -69,8 +69,8 @@ describe('PhoneInput rendering', () => {
     const styles = readFileSync(new URL('./phone-input.css', import.meta.url), 'utf8');
     const { container } = render(PhoneInput, { props: { id: 'p', label: 'Phone' } });
 
-    expect(source).toContain("from '../input/index.ts'");
-    expect(source).toContain("from '../select/index.ts'");
+    expect(source).toContain("from '@lostgradient/cinder/input'");
+    expect(source).toContain("from '@lostgradient/cinder/select'");
     expect(styles).not.toContain('background-image');
     expect(container.querySelectorAll('.cinder-select-field__chevron')).toHaveLength(1);
   });

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -455,6 +455,8 @@ describe('PhoneInput form reset', () => {
     expect(rendered.container.querySelector('input[type="hidden"]')?.getAttribute('value')).toBe(
       '+442079460958',
     );
+    rendered.unmount();
+    form.remove();
   });
   test('restores the initial national formatting on reset', async () => {
     const form = document.createElement('form');

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
+import type { PhoneInputChange } from './phone-input.types.ts';
 
 setupHappyDom();
 
@@ -551,6 +552,7 @@ describe('PhoneInput form reset', () => {
   test('preserves a disallowed initial E.164 value literally on reset', async () => {
     const form = document.createElement('form');
     document.body.append(form);
+    const changes: PhoneInputChange[] = [];
     const rendered = render(PhoneInput, {
       target: form,
       props: {
@@ -558,6 +560,7 @@ describe('PhoneInput form reset', () => {
         label: 'Phone',
         countries: ['US'],
         value: '+442079460958',
+        onchange: (change: PhoneInputChange) => changes.push(change),
       },
     });
     const input = nationalInput(rendered.container);
@@ -568,6 +571,9 @@ describe('PhoneInput form reset', () => {
 
     expect(countrySelect(rendered.container).value).toBe('US');
     expect(input.value).toBe('+442079460958');
+
+    await fireEvent.input(input, { target: { value: '4155550132' } });
+    expect(changes.at(-1)?.country).toBe('US');
     rendered.unmount();
     form.remove();
   });

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -1,15 +1,17 @@
 /// <reference lib="dom" />
-import { describe, expect, mock, test } from 'bun:test';
+import { afterEach, describe, expect, mock, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render, fireEvent } = await import('@testing-library/svelte');
+const { cleanup, render, fireEvent } = await import('@testing-library/svelte');
 const { default: PhoneInput } = await import('./phone-input.svelte');
 const { default: FormFieldPhoneInputFixture } =
   await import('../../test/fixtures/form-field-phone-input-fixture.svelte');
+
+afterEach(cleanup);
 
 function nationalInput(container: Element): HTMLInputElement {
   return container.querySelector<HTMLInputElement>('input[type="tel"]')!;

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -421,6 +421,33 @@ describe('PhoneInput allow-list expansion', () => {
 });
 
 describe('PhoneInput form reset', () => {
+  test('restores the initial national formatting on reset', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      target: form,
+      props: {
+        id: 'p',
+        label: 'Phone',
+        country: 'US',
+        value: '4155550132',
+      },
+    });
+    const input = nationalInput(rendered.container);
+
+    await waitFor(() => expect(input.value).toBe('(415) 555-0132'));
+    await fireEvent.input(input, { target: { value: '2025550123' } });
+    expect(input.value).toBe('(202) 555-0123');
+
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(countrySelect(rendered.container).value).toBe('US');
+    expect(input.value).toBe('(415) 555-0132');
+    rendered.unmount();
+    form.remove();
+  });
+
   test('does not reset when the reset event is canceled', async () => {
     const form = document.createElement('form');
     document.body.append(form);

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -72,6 +72,8 @@ describe('PhoneInput rendering', () => {
     expect(source).toContain("from '@lostgradient/cinder/input'");
     expect(source).toContain("from '@lostgradient/cinder/select'");
     expect(styles).not.toContain('background-image');
+    expect(styles).toContain('.cinder-phone-input__country .cinder-select option');
+    expect(styles).toContain('text-indent: 0;');
     expect(container.querySelectorAll('.cinder-select-field__chevron')).toHaveLength(1);
   });
 
@@ -413,6 +415,62 @@ describe('PhoneInput allow-list expansion', () => {
     });
     expect(countrySelect(container).value).toBe('GB');
     expect(nationalInput(container).value).toContain('020');
+  });
+});
+
+describe('PhoneInput form reset', () => {
+  test('does not reset when the reset event is canceled', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      target: form,
+      props: {
+        id: 'p',
+        label: 'Phone',
+        countries: ['US', 'GB'],
+        value: '+14155550132',
+      },
+    });
+    const input = nationalInput(rendered.container);
+    await fireEvent.input(input, { target: { value: '2025550123' } });
+    const editedDisplay = input.value;
+    let resetCanceled = false;
+    form.addEventListener('reset', (event) => {
+      event.preventDefault();
+      resetCanceled = event.defaultPrevented;
+    });
+
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(resetCanceled).toBe(true);
+    expect(input.value).toBe(editedDisplay);
+    rendered.unmount();
+    form.remove();
+  });
+
+  test('preserves a disallowed initial E.164 value literally on reset', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      target: form,
+      props: {
+        id: 'p',
+        label: 'Phone',
+        countries: ['US'],
+        value: '+442079460958',
+      },
+    });
+    const input = nationalInput(rendered.container);
+    await fireEvent.input(input, { target: { value: '2025550123' } });
+
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(countrySelect(rendered.container).value).toBe('US');
+    expect(input.value).toBe('+442079460958');
+    rendered.unmount();
+    form.remove();
   });
 });
 

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -470,6 +470,24 @@ describe('PhoneInput form reset', () => {
     form.remove();
   });
 
+  test('resynchronizes an untouched non-first initial country on reset', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      target: form,
+      props: { id: 'p', label: 'Phone', countries: ['US', 'GB'], country: 'GB' },
+    });
+    expect(countrySelect(rendered.container).value).toBe('GB');
+    form.reset();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(countrySelect(rendered.container).value).toBe('GB');
+    expect(
+      rendered.container.querySelector('.cinder-phone-input__country-summary')?.textContent,
+    ).toContain('GB');
+    rendered.unmount();
+    form.remove();
+  });
+
   test('does not reset when the reset event is canceled', async () => {
     const form = document.createElement('form');
     document.body.append(form);

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -470,6 +470,21 @@ describe('PhoneInput form reset', () => {
     form.remove();
   });
 
+  test('preserves invalid initial text on reset', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      target: form,
+      props: { id: 'p', label: 'Phone', value: 'invalid' },
+    });
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(nationalInput(rendered.container).value).toBe('invalid');
+    rendered.unmount();
+    form.remove();
+  });
+
   test('resynchronizes an untouched non-first initial country on reset', async () => {
     const form = document.createElement('form');
     document.body.append(form);

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, mock, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -7,6 +8,8 @@ setupHappyDom();
 
 const { render, fireEvent } = await import('@testing-library/svelte');
 const { default: PhoneInput } = await import('./phone-input.svelte');
+const { default: FormFieldPhoneInputFixture } =
+  await import('../../test/fixtures/form-field-phone-input-fixture.svelte');
 
 function nationalInput(container: Element): HTMLInputElement {
   return container.querySelector<HTMLInputElement>('input[type="tel"]')!;
@@ -31,7 +34,45 @@ describe('PhoneInput rendering', () => {
 
   test('country select accessible name includes the full selected country', () => {
     const { getByRole } = render(PhoneInput, { props: { id: 'p', label: 'Phone' } });
-    expect(getByRole('combobox', { name: /Country: United States, \+1/ })).not.toBeNull();
+    expect(getByRole('combobox', { name: 'Phone Country: United States, +1' })).not.toBeNull();
+  });
+
+  test('visible country summary stays compact while options retain full names', () => {
+    const { container } = render(PhoneInput, {
+      props: { id: 'p', label: 'Phone', country: 'AE', countries: ['US', 'AE'] },
+    });
+
+    expect(container.querySelector('.cinder-phone-input__country-summary')?.textContent).toBe(
+      'AE +971',
+    );
+    expect(Array.from(countrySelect(container).options, (option) => option.textContent)).toContain(
+      'United Arab Emirates +971',
+    );
+  });
+
+  test('multiple instances prefix child controls with their field label', () => {
+    const home = render(PhoneInput, { props: { id: 'home', label: 'Home phone' } });
+    const work = render(PhoneInput, { props: { id: 'work', label: 'Work phone' } });
+
+    expect(
+      home.getByRole('combobox', { name: 'Home phone Country: United States, +1' }),
+    ).not.toBeNull();
+    expect(home.getByRole('textbox', { name: 'Home phone Phone number' })).not.toBeNull();
+    expect(
+      work.getByRole('combobox', { name: 'Work phone Country: United States, +1' }),
+    ).not.toBeNull();
+    expect(work.getByRole('textbox', { name: 'Work phone Phone number' })).not.toBeNull();
+  });
+
+  test('loads the shared Input and Select styled entries without painting another chevron', () => {
+    const source = readFileSync(new URL('./phone-input.svelte', import.meta.url), 'utf8');
+    const styles = readFileSync(new URL('./phone-input.css', import.meta.url), 'utf8');
+    const { container } = render(PhoneInput, { props: { id: 'p', label: 'Phone' } });
+
+    expect(source).toContain("from '../input/index.ts'");
+    expect(source).toContain("from '../select/index.ts'");
+    expect(styles).not.toContain('background-image');
+    expect(container.querySelectorAll('.cinder-select-field__chevron')).toHaveLength(1);
   });
 
   test('country defaults to US', () => {
@@ -332,6 +373,21 @@ describe('PhoneInput error / disabled / required', () => {
       props: { id: 'p', label: 'Phone', required: true },
     });
     expect(nationalInput(container).required).toBe(true);
+    expect(countrySelect(container).required).toBe(true);
+  });
+
+  test('explicit required=false overrides required FormField context for both controls', () => {
+    const { container } = render(FormFieldPhoneInputFixture, {
+      props: {
+        fieldId: 'phone',
+        fieldLabel: 'Phone',
+        fieldRequired: true,
+        phoneRequired: false,
+      },
+    });
+
+    expect(countrySelect(container).required).toBe(false);
+    expect(nationalInput(container).required).toBe(false);
   });
 });
 

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -478,7 +478,7 @@ describe('PhoneInput form reset', () => {
       props: { id: 'p', label: 'Phone', countries: ['US', 'GB'], country: 'GB' },
     });
     expect(countrySelect(rendered.container).value).toBe('GB');
-    form.reset();
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(countrySelect(rendered.container).value).toBe('GB');
     expect(

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -29,14 +29,9 @@ describe('PhoneInput rendering', () => {
     expect(group.getAttribute('aria-labelledby')).toBe('p-label');
   });
 
-  test('country select and national input compose the group label with their per-control label', () => {
-    const { container } = render(PhoneInput, { props: { id: 'p', label: 'Phone' } });
-    const select = countrySelect(container);
-    const input = nationalInput(container);
-    expect(select.getAttribute('aria-labelledby')).toBe('p-label p-country-label');
-    expect(input.getAttribute('aria-labelledby')).toBe('p-label p-national-label');
-    expect(container.querySelector('#p-country-label')?.textContent).toBe('Country code');
-    expect(container.querySelector('#p-national-label')?.textContent).toBe('Phone number');
+  test('country select accessible name includes the full selected country', () => {
+    const { getByRole } = render(PhoneInput, { props: { id: 'p', label: 'Phone' } });
+    expect(getByRole('combobox', { name: /Country: United States, \+1/ })).not.toBeNull();
   });
 
   test('country defaults to US', () => {

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -487,6 +487,21 @@ describe('PhoneInput form reset', () => {
     rendered.unmount();
     form.remove();
   });
+  test('resynchronizes an untouched initial national display on reset', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      target: form,
+      props: { id: 'p', label: 'Phone', country: 'US', value: '+14155550132' },
+    });
+    const input = nationalInput(rendered.container);
+    await waitFor(() => expect(input.value).toContain('415'));
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(input.value).toContain('415');
+    rendered.unmount();
+    form.remove();
+  });
 
   test('does not reset when the reset event is canceled', async () => {
     const form = document.createElement('form');

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -6,7 +6,7 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { cleanup, render, fireEvent } = await import('@testing-library/svelte');
+const { cleanup, render, fireEvent, waitFor } = await import('@testing-library/svelte');
 const { default: PhoneInput } = await import('./phone-input.svelte');
 const { default: FormFieldPhoneInputFixture } =
   await import('../../test/fixtures/form-field-phone-input-fixture.svelte');
@@ -466,6 +466,32 @@ describe('PhoneInput form reset', () => {
     const input = nationalInput(rendered.container);
     await fireEvent.input(input, { target: { value: '2025550123' } });
 
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(countrySelect(rendered.container).value).toBe('US');
+    expect(input.value).toBe('+442079460958');
+    rendered.unmount();
+    form.remove();
+  });
+
+  test('restores the rendered fallback country for a disallowed initial E.164 value', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      target: form,
+      props: {
+        id: 'p',
+        label: 'Phone',
+        countries: ['US', 'CA'],
+        country: 'CA',
+        value: '+442079460958',
+      },
+    });
+    const input = nationalInput(rendered.container);
+
+    await waitFor(() => expect(countrySelect(rendered.container).value).toBe('US'));
+    await fireEvent.input(input, { target: { value: '4165550123' } });
     form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
     await new Promise((resolve) => setTimeout(resolve, 0));
 

--- a/packages/components/src/components/phone-input/phone-input.test.ts
+++ b/packages/components/src/components/phone-input/phone-input.test.ts
@@ -421,6 +421,28 @@ describe('PhoneInput allow-list expansion', () => {
 });
 
 describe('PhoneInput form reset', () => {
+  test('preserves newer external value and country updates after reset dispatch', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(PhoneInput, {
+      props: { id: 'p', label: 'Phone', name: 'phone', value: '+14155552671', country: 'US' },
+      target: form,
+    });
+    form.dispatchEvent(new Event('reset', { bubbles: true, cancelable: true }));
+    await rendered.rerender({
+      id: 'p',
+      label: 'Phone',
+      name: 'phone',
+      value: '+442079460958',
+      country: 'GB',
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(countrySelect(rendered.container).value).toBe('GB');
+    expect(rendered.container.querySelector('input[type="hidden"]')?.getAttribute('value')).toBe(
+      '+442079460958',
+    );
+  });
   test('restores the initial national formatting on reset', async () => {
     const form = document.createElement('form');
     document.body.append(form);

--- a/packages/components/src/test/fixtures/form-field-phone-input-fixture.svelte
+++ b/packages/components/src/test/fixtures/form-field-phone-input-fixture.svelte
@@ -1,0 +1,27 @@
+<script lang="ts" module>
+  export type FormFieldPhoneInputFixtureProps = {
+    fieldId: string;
+    fieldLabel: string;
+    fieldRequired?: boolean;
+    phoneRequired?: boolean;
+  };
+</script>
+
+<script lang="ts">
+  import FormField from '../../components/form-field/form-field.svelte';
+  import PhoneInput from '../../components/phone-input/phone-input.svelte';
+
+  let { fieldId, fieldLabel, fieldRequired, phoneRequired }: FormFieldPhoneInputFixtureProps =
+    $props();
+
+  const fieldOptional = $derived({
+    ...(fieldRequired !== undefined ? { required: fieldRequired } : {}),
+  });
+  const phoneOptional = $derived({
+    ...(phoneRequired !== undefined ? { required: phoneRequired } : {}),
+  });
+</script>
+
+<FormField id={fieldId} label={fieldLabel} {...fieldOptional}>
+  <PhoneInput id={fieldId} {...phoneOptional} />
+</FormField>

--- a/packages/testing/tests/phone-input.playwright.ts
+++ b/packages/testing/tests/phone-input.playwright.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '../src/fixtures/component-page.ts';
+import { loadManifest, VIEWPORTS } from '../src/helpers/manifest.ts';
+
+const desktop = VIEWPORTS.find((viewport) => viewport.name === 'desktop');
+const phoneInputEntry = loadManifest().find((entry) => entry.slug === 'phone-input');
+
+if (!phoneInputEntry) {
+  throw new Error('Cached testing manifest does not include slug "phone-input".');
+}
+
+if (!desktop) {
+  throw new Error('Desktop viewport fixture is missing.');
+}
+
+test('country control stays compact for a long country name', async ({ componentPage }) => {
+  const page = await componentPage.open({
+    entry: phoneInputEntry,
+    theme: 'light',
+    viewport: desktop,
+  });
+
+  const country = page.locator('#example-mount-basic-field-country');
+  const countryControl = page.locator('.cinder-phone-input__country', { has: country });
+  await country.selectOption('AE');
+  await expect(country).toHaveValue('AE');
+  await expect(country).toHaveAccessibleName('Phone number Country: United Arab Emirates, +971');
+  await expect(countryControl.locator('.cinder-phone-input__country-summary')).toHaveText(
+    'AE +971',
+  );
+  await expect(country.locator('option[value="AE"]')).toHaveText('United Arab Emirates +971');
+
+  const countryBox = await countryControl.boundingBox();
+  const nationalBox = await page.locator('#example-mount-basic-field').boundingBox();
+  expect(countryBox).not.toBeNull();
+  expect(nationalBox).not.toBeNull();
+  expect(countryBox!.width).toBeLessThanOrEqual(160);
+  expect(nationalBox!.width).toBeGreaterThan(countryBox!.width);
+});


### PR DESCRIPTION
Closes #950

## Summary
- keep the closed country control compact with an ISO code and dialing prefix while preserving full country names in the native option list and accessible name
- compose PhoneInput from the shared styled Input and Select entries, removing the duplicate local chevron and control chrome
- propagate field labels and required state to both child controls, including explicit FormField overrides
- add focused component coverage plus a Playwright geometry/accessibility regression for a long country name

## Verification
- `bun test --conditions browser --conditions svelte src/components/phone-input/phone-input.test.ts`
- `bun run typecheck`
- `bun run components:check`
- `bun run --filter=@cinder/testing test:playwright -- phone-input.playwright.ts`