### PR TITLE
fix(playground): label icon controls with tooltips

### DIFF
--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -155,6 +155,21 @@ afterEach(() => {
 });
 
 describe('component-page single-scroll layout', () => {
+  test('groups standalone page actions and exposes focus-visible tooltips', async () => {
+    const { container, unmount } = render(ComponentPage);
+    await tick();
+
+    const toolbar = container.querySelector('[role="toolbar"][aria-label="Page controls"]');
+    expect(toolbar).not.toBeNull();
+    expect(toolbar?.querySelector('[data-tooltip="View source on GitHub"]')).not.toBeNull();
+    expect(toolbar?.querySelector('[data-tooltip="Preview theme: switch to dark"]')).not.toBeNull();
+    expect(toolbar?.querySelectorAll('button[aria-label^="Preview theme: switch to"]').length).toBe(
+      1,
+    );
+
+    unmount();
+  });
+
   test('reads documentation synchronously without an initial fetch', async () => {
     const originalFetch = globalThis.fetch;
     const fetchSpy = mock(async () => new Response('unexpected request', { status: 500 }));

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -607,6 +607,7 @@
             target="_blank"
             rel="noreferrer"
             aria-label="View source on GitHub"
+            title="View source on GitHub"
           >
             <Github size={17} strokeWidth={1.5} aria-hidden="true" />
           </a>
@@ -615,6 +616,7 @@
             class="dx-iconbtn"
             onclick={toggleTheme}
             aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
+            title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
           >
             {#if theme === 'dark'}
               <Sun size={17} strokeWidth={1.5} aria-hidden="true" />

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -122,6 +122,9 @@
     return document.documentElement.dataset['cinderTheme'] === 'dark' ? 'dark' : 'light';
   }
   let theme: 'light' | 'dark' = $state(readInitialTheme());
+  let themeToggleLabel = $derived(
+    theme === 'dark' ? 'Preview theme: switch to light' : 'Preview theme: switch to dark',
+  );
 
   function toggleTheme(): void {
     theme = theme === 'dark' ? 'light' : 'dark';
@@ -600,30 +603,32 @@
             >
           {/if}
         </nav>
-        <div class="dx-topbar__actions">
-          <a
-            class="dx-iconbtn"
-            href="https://github.com/stevekinney/cinder"
-            target="_blank"
-            rel="noreferrer"
-            aria-label="View source on GitHub"
-            title="View source on GitHub"
-          >
-            <Github size={17} strokeWidth={1.5} aria-hidden="true" />
-          </a>
-          <button
-            type="button"
-            class="dx-iconbtn"
-            onclick={toggleTheme}
-            aria-label={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-            title={theme === 'dark' ? 'Switch to light theme' : 'Switch to dark theme'}
-          >
-            {#if theme === 'dark'}
-              <Sun size={17} strokeWidth={1.5} aria-hidden="true" />
-            {:else}
-              <Moon size={17} strokeWidth={1.5} aria-hidden="true" />
-            {/if}
-          </button>
+        <div class="dx-topbar__actions" role="toolbar" aria-label="Page controls">
+          <Tooltip text="View source on GitHub" placement="bottom">
+            <a
+              class="dx-iconbtn"
+              href="https://github.com/stevekinney/cinder"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="View source on GitHub"
+            >
+              <Github size={17} strokeWidth={1.5} aria-hidden="true" />
+            </a>
+          </Tooltip>
+          <Tooltip text={themeToggleLabel} placement="bottom">
+            <button
+              type="button"
+              class="dx-iconbtn"
+              onclick={toggleTheme}
+              aria-label={themeToggleLabel}
+            >
+              {#if theme === 'dark'}
+                <Sun size={17} strokeWidth={1.5} aria-hidden="true" />
+              {:else}
+                <Moon size={17} strokeWidth={1.5} aria-hidden="true" />
+              {/if}
+            </button>
+          </Tooltip>
         </div>
       </div>
     </header>

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -31,6 +31,7 @@ import { isComponentDocumentationPayload } from './component-documentation-refer
 import { COMPOSE_ONLY_COMPONENTS } from './discover.ts';
 import {
   PORT,
+  configureRequestIdleTimeout,
   createHttpServerOnAvailablePort,
   createSharedDisposer,
   fallbackToLastGood,
@@ -91,6 +92,23 @@ afterEach(async () => {
 function req(path: string, options?: RequestInit): Request {
   return new Request(`http://localhost:${PORT}${path}`, options);
 }
+
+describe('request idle timeout configuration', () => {
+  it('disables the idle timeout only for the long-lived SSE route', () => {
+    const calls: Array<{ request: Request; seconds: number }> = [];
+    const server = {
+      timeout(request: Request, seconds: number) {
+        calls.push({ request, seconds });
+      },
+    };
+    const eventsRequest = req('/events');
+
+    configureRequestIdleTimeout(eventsRequest, server);
+    configureRequestIdleTimeout(req('/ping'), server);
+
+    expect(calls).toEqual([{ request: eventsRequest, seconds: 0 }]);
+  });
+});
 
 function cssImportUrlsFrom(cssUrl: string, css: string): string[] {
   const urls = new Set<string>();

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2198,6 +2198,23 @@ type PlaygroundHttpServer = {
   server: BunServer;
   port: number;
 };
+type RequestIdleTimeoutController = {
+  timeout: (request: Request, seconds: number) => unknown;
+};
+
+/**
+ * Keep the live-reload event stream open between edits without weakening the
+ * timeout for ordinary HTTP requests. Bun applies its default ten-second idle
+ * timeout to streaming responses unless the request opts out explicitly.
+ */
+export function configureRequestIdleTimeout(
+  request: Request,
+  server: RequestIdleTimeoutController,
+): void {
+  if (new URL(request.url).pathname === '/events') {
+    server.timeout(request, 0);
+  }
+}
 
 function isAddressInUseError(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
@@ -2214,7 +2231,10 @@ export function createHttpServerOnAvailablePort(
     try {
       const server = Bun.serve({
         port,
-        fetch: fetchHandler,
+        fetch(request, server) {
+          configureRequestIdleTimeout(request, server);
+          return fetchHandler(request);
+        },
       });
       return { server, port };
     } catch (error) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2231,8 +2231,8 @@ export function createHttpServerOnAvailablePort(
     try {
       const server = Bun.serve({
         port,
-        fetch(request, server) {
-          configureRequestIdleTimeout(request, server);
+        fetch(request, requestServer) {
+          configureRequestIdleTimeout(request, requestServer);
           return fetchHandler(request);
         },
       });

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -12,6 +12,7 @@
     Segment,
     SegmentedControl,
     Toolbar,
+    Tooltip,
   } from '../../../components/src/index.ts';
 
   const store = getPreviewStore();
@@ -116,7 +117,7 @@
   function selectTheme(value: ThemeChoice): void {
     store.setTheme(value);
     const option = THEME_OPTIONS.find((o) => o.value === value);
-    announce(`Color scheme: ${option?.announce ?? value}`);
+    announce(`Preview theme: ${option?.announce ?? value}`);
   }
 
   // ── Sidebar drawer (narrow viewports) ──────────────────────────────────────
@@ -223,7 +224,7 @@
     <Toolbar.Group>
       <SegmentedControl
         id="theme-preset"
-        label="Color scheme"
+        label="Preview theme"
         hideLabel
         density="toolbar"
         value={store.theme}
@@ -238,90 +239,100 @@
     <Toolbar.Spacer />
 
     <Toolbar.Group>
-      <Button
-        variant="ghost"
-        size="sm"
-        iconOnly={true}
-        aria-label="Open GitHub repository"
-        href={GITHUB_REPOSITORY_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <svg
-          class="toolbar-icon"
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="M4 6.5A2.5 2.5 0 0 1 6.5 4H20v14H6.5A2.5 2.5 0 0 0 4 20.5z" />
-          <path d="M8 4v16" />
-          <path d="M12 8h4" />
-          <path d="M12 12h3" />
-        </svg>
-      </Button>
-
-      <Button
-        variant="ghost"
-        size="sm"
-        iconOnly={true}
-        aria-label="Open npm package"
-        href={NPM_PACKAGE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <svg
-          class="toolbar-icon"
-          aria-hidden="true"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          stroke-width="2"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-        >
-          <path d="m12 3 8 4.5v9L12 21l-8-4.5v-9z" />
-          <path d="M12 12 4 7.5" />
-          <path d="m12 12 8-4.5" />
-          <path d="M12 12v9" />
-        </svg>
-      </Button>
-
-      <Button
-        variant="ghost"
-        size="sm"
-        aria-label="Color token panel"
-        aria-expanded={store.isColorTokenPanelOpen}
-        aria-controls="color-token-panel"
-        data-testid="color-token-panel-toggle"
-        onclick={toggleColorTokenPanel}
-      >
-        <span aria-hidden="true">◐</span>
-      </Button>
-
-      {#if store.currentComponent !== ''}
+      <Tooltip text="Open GitHub repository" placement="bottom">
         <Button
           variant="ghost"
           size="sm"
-          aria-label="Open preview in new tab"
-          onclick={openInNewTab}
+          iconOnly={true}
+          aria-label="Open GitHub repository"
+          href={GITHUB_REPOSITORY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
         >
-          <span aria-hidden="true">↗</span>
+          <svg
+            class="toolbar-icon"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="M4 6.5A2.5 2.5 0 0 1 6.5 4H20v14H6.5A2.5 2.5 0 0 0 4 20.5z" />
+            <path d="M8 4v16" />
+            <path d="M12 8h4" />
+            <path d="M12 12h3" />
+          </svg>
         </Button>
+      </Tooltip>
+
+      <Tooltip text="Open npm package" placement="bottom">
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly={true}
+          aria-label="Open npm package"
+          href={NPM_PACKAGE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <svg
+            class="toolbar-icon"
+            aria-hidden="true"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          >
+            <path d="m12 3 8 4.5v9L12 21l-8-4.5v-9z" />
+            <path d="M12 12 4 7.5" />
+            <path d="m12 12 8-4.5" />
+            <path d="M12 12v9" />
+          </svg>
+        </Button>
+      </Tooltip>
+
+      <Tooltip text="Color token panel" placement="bottom">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Color token panel"
+          aria-expanded={store.isColorTokenPanelOpen}
+          aria-controls="color-token-panel"
+          data-testid="color-token-panel-toggle"
+          onclick={toggleColorTokenPanel}
+        >
+          <span aria-hidden="true">◐</span>
+        </Button>
+      </Tooltip>
+
+      {#if store.currentComponent !== ''}
+        <Tooltip text="Open preview in new tab" placement="bottom">
+          <Button
+            variant="ghost"
+            size="sm"
+            aria-label="Open preview in new tab"
+            onclick={openInNewTab}
+          >
+            <span aria-hidden="true">↗</span>
+          </Button>
+        </Tooltip>
       {/if}
 
-      <Button
-        variant="ghost"
-        size="sm"
-        aria-pressed={store.isFocusMode}
-        aria-label="Focus mode — hide sidebar and toolbar (press Escape to exit)"
-        onclick={toggleFocusMode}
-      >
-        <span aria-hidden="true">⛶</span>
-      </Button>
+      <Tooltip text="Focus mode" placement="bottom">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-pressed={store.isFocusMode}
+          aria-label="Focus mode — hide sidebar and toolbar (press Escape to exit)"
+          onclick={toggleFocusMode}
+        >
+          <span aria-hidden="true">⛶</span>
+        </Button>
+      </Tooltip>
     </Toolbar.Group>
   </Toolbar>
 </header>

--- a/packages/playground/src/shell-app/top-bar.test.ts
+++ b/packages/playground/src/shell-app/top-bar.test.ts
@@ -107,6 +107,14 @@ function liveRegion(container: HTMLElement): HTMLElement {
   return region;
 }
 
+function tooltipTextFor(control: HTMLElement): string | null {
+  const tooltipId = control.getAttribute('aria-describedby');
+  if (tooltipId === null) return null;
+  const tooltip = document.getElementById(tooltipId);
+  if (tooltip?.getAttribute('role') !== 'tooltip') return null;
+  return tooltip.textContent?.trim() ?? null;
+}
+
 describe('top-bar open-in-new-tab button', () => {
   test('renders the public toolbar controls', async () => {
     const store = new PreviewStore('button');
@@ -125,6 +133,35 @@ describe('top-bar open-in-new-tab button', () => {
       ),
     ).not.toBeNull();
     expect(toolbar.querySelector('input')).not.toBeNull();
+
+    unmount();
+  });
+
+  test('labels the preview theme and gives every icon-only action a visible tooltip', async () => {
+    const { container, unmount } = render(TopBarFixture, { currentComponent: 'button' });
+    await tick();
+
+    const themeGroup = container.querySelector('[role="radiogroup"]#theme-preset');
+    expect(themeGroup).not.toBeNull();
+    const themeLabelId = themeGroup?.getAttribute('aria-labelledby');
+    expect(themeLabelId).not.toBeNull();
+    expect(document.getElementById(themeLabelId ?? '')?.textContent?.trim()).toBe('Preview theme');
+
+    const expectedTooltips = new Map<string, string>([
+      ['Open GitHub repository', 'Open GitHub repository'],
+      ['Open npm package', 'Open npm package'],
+      ['Color token panel', 'Color token panel'],
+      ['Open preview in new tab', 'Open preview in new tab'],
+      ['Focus mode — hide sidebar and toolbar (press Escape to exit)', 'Focus mode'],
+    ]);
+    for (const [label, tooltip] of expectedTooltips) {
+      const control =
+        container.querySelector<HTMLElement>(`[aria-label="${label}"]`) ??
+        document.querySelector<HTMLElement>(`[aria-label="${label}"]`);
+      expect(control).not.toBeNull();
+      if (control === null) throw new Error(`No control with aria-label "${label}"`);
+      expect(tooltipTextFor(control)).toBe(tooltip);
+    }
 
     unmount();
   });


### PR DESCRIPTION
Closes #953

## What changed

- Keep one consolidated toolbar per route: the shell owns `/c/*` controls, while `/page/*` owns its standalone page controls.
- Use Cinder `Tooltip` for every icon-only shell action and both standalone page actions so labels appear on hover and keyboard focus.
- Scope the theme control and announcement as `Preview theme` instead of the ambiguous `Color scheme`.
- Mark the standalone control group as a `Page controls` toolbar.
- Disable Bun request idle timeouts only for the playground live-reload `/events` SSE stream. Ordinary HTTP requests retain the default timeout.

## Root cause

The toolbar controls had accessible names but no visible hover/focus labels, and the generic theme label did not identify the preview scope. Separately, Bun applied its default request idle timeout to the intentionally long-lived SSE response, producing a server timeout warning after ten seconds. The request boundary now opts only `/events` out with `server.timeout(request, 0)`.

## Verification

- `bun test --conditions browser --conditions svelte src/shell-app/top-bar.test.ts` (13 pass)
- `bun test --conditions browser --conditions svelte src/component-page-documentation.test.ts` (18 pass)
- `bun test --conditions browser --conditions svelte -t "request idle timeout configuration" src/playground-server.test.ts` (1 pass)
- `bun run typecheck` in `packages/playground` (0 errors)
- Browser-verified `/c/button`: one preview-theme group, five labeled tooltips, and a focus-visible Color token panel tooltip.
- Browser-verified `/page/button`: one Page controls toolbar, one preview-theme control, and a visible scoped theme tooltip.
- Held `/events` open for twelve seconds: the stream stayed connected without a Bun idle-timeout warning.