### PR TITLE
Fix static playground documentation delivery

### DIFF
--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -24,6 +24,7 @@ describe('static export', () => {
       expect(indexHtml).toContain('/styles/shell.css');
       expect(indexHtml).not.toContain('http-equiv="refresh"');
       expect(rendered.has('/shell-bundle/shell.js')).toBe(true);
+      expect(indexHtml).not.toContain('data-canonical-documentation');
       expect(rendered.has('/styles/shell.css')).toBe(true);
     } finally {
       await rm(outputDirectory, { recursive: true, force: true });
@@ -66,6 +67,13 @@ describe('static export', () => {
 
       expect(pageHtml).toContain('/page-bundle/chat.js');
       expect(pageHtml).toContain('/package-components/chat/chat/chat.css');
+      expect(pageHtml).toContain('id="cinder-documentation"');
+      expect(pageHtml).toContain('\\u003cp');
+
+      const canonicalHtml = await Bun.file(join(outputDirectory, 'c', 'chat', 'index.html')).text();
+      expect(canonicalHtml).toContain('data-canonical-documentation');
+      expect(canonicalHtml).toMatch(/<h1[^>]*>.*Chat.*<\/h1>/s);
+      expect(canonicalHtml).toContain('src="/page/chat?preview=1"');
       expect(chatStyles).toContain('.cinder-chat');
       expect(composerStyles).toContain("@import '/components/command-menu/command-menu.css';");
       expect(headerStyles).toContain("@import '/components/dropdown/dropdown.css';");

--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -4,7 +4,15 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
-import { runStaticExport } from './static-export.ts';
+import { assetUrlsFromHtml, runStaticExport } from './static-export.ts';
+
+test('HTML asset discovery normalizes query-configured routes to one static path', () => {
+  expect(
+    assetUrlsFromHtml(
+      '<iframe src="/page/button?preview=1"></iframe><a href="/page/button">Button</a>',
+    ),
+  ).toEqual(['/page/button']);
+});
 
 describe('static export', () => {
   test('writes the root landing shell instead of a redirect', async () => {
@@ -74,6 +82,7 @@ describe('static export', () => {
       expect(canonicalHtml).toContain('data-canonical-documentation');
       expect(canonicalHtml).toMatch(/<h1[^>]*>.*Chat.*<\/h1>/s);
       expect(canonicalHtml).toContain('src="/page/chat?preview=1"');
+      expect(rendered.has('/page/chat?preview=1')).toBe(false);
       expect(chatStyles).toContain('.cinder-chat');
       expect(composerStyles).toContain("@import '/components/command-menu/command-menu.css';");
       expect(headerStyles).toContain("@import '/components/dropdown/dropdown.css';");

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -111,7 +111,7 @@ async function writeFile(path: string, contents: string): Promise<void> {
  * Pull every same-origin asset URL the given HTML references — the `<script
  * src>` bundles and `<link href>` stylesheets — as root-relative paths.
  */
-function assetUrlsFromHtml(html: string): string[] {
+export function assetUrlsFromHtml(html: string): string[] {
   const urls = new Set<string>();
   const attribute = /\b(?:src|href)="(\/[^"]+)"/g;
   let match: RegExpExecArray | null;
@@ -119,7 +119,10 @@ function assetUrlsFromHtml(html: string): string[] {
     const url = match[1]!;
     // Only crawlable GET routes — skip in-page anchors and the SSE stream.
     if (url === '/events' || url.startsWith('#')) continue;
-    urls.add(url);
+    // Queries configure browser behavior but do not identify a second static
+    // file. Materialize `/page/button?preview=1` at the already-exported
+    // `/page/button` path instead of creating a literal `?preview=1` directory.
+    urls.add(new URL(url, ORIGIN).pathname);
   }
   return [...urls];
 }

--- a/packages/playground/src/component-documentation-reference.ts
+++ b/packages/playground/src/component-documentation-reference.ts
@@ -7,6 +7,8 @@ import type {
 } from './component-documentation-types.ts';
 import { isComponentManifest } from './manifest-reference.ts';
 
+export const COMPONENT_DOCUMENTATION_DATA_ISLAND_ID = 'cinder-documentation';
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -117,6 +119,28 @@ export function isComponentDocumentationPayload(
     (readProperty(value, 'examples') === null || isJsonValue(readProperty(value, 'examples'))) &&
     isRawArtifacts(readProperty(value, 'rawArtifacts'))
   );
+}
+
+export function readComponentDocumentationDataIsland(
+  root: Pick<Document, 'getElementById'> = document,
+): ComponentDocumentationPayload {
+  const node = root.getElementById(COMPONENT_DOCUMENTATION_DATA_ISLAND_ID);
+  if (node === null) {
+    throw new Error(
+      `Documentation data island #${COMPONENT_DOCUMENTATION_DATA_ISLAND_ID} was not found`,
+    );
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(node.textContent ?? '');
+  } catch {
+    throw new Error('Documentation data island did not contain valid JSON');
+  }
+  if (!isComponentDocumentationPayload(value)) {
+    throw new Error('Documentation data island was not a valid ComponentDocumentationPayload');
+  }
+  return value;
 }
 
 export function variablesList(value: JsonValue): string[] {

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -16,7 +16,6 @@ const { default: CalloutMock } = await import('./component-page-callout-mock.sve
 const { default: CodeBlockMock } = await import('./component-page-code-block-mock.svelte');
 const { default: CollapsibleMock } = await import('./component-page-collapsible-mock.svelte');
 const { default: KbdMock } = await import('./component-page-kbd-mock.svelte');
-const { default: SkeletonMock } = await import('./component-page-skeleton-mock.svelte');
 const { default: StatusDotMock } = await import('./component-page-status-dot-mock.svelte');
 const { default: ToggleMock } = await import('./component-page-toggle-mock.svelte');
 const { default: TooltipMock } = await import('./component-page-tooltip-mock.svelte');
@@ -56,7 +55,6 @@ mock.module('@lostgradient/cinder/callout', () => ({ Callout: CalloutMock }));
 mock.module('@lostgradient/cinder/code-block', () => ({ CodeBlock: CodeBlockMock }));
 mock.module('@lostgradient/cinder/collapsible', () => ({ Collapsible: CollapsibleMock }));
 mock.module('@lostgradient/cinder/kbd', () => ({ Kbd: KbdMock }));
-mock.module('@lostgradient/cinder/skeleton', () => ({ Skeleton: SkeletonMock }));
 mock.module('@lostgradient/cinder/status-dot', () => ({ StatusDot: StatusDotMock }));
 mock.module('@lostgradient/cinder/table', () => ({ Table: TableMock }));
 mock.module('@lostgradient/cinder/toggle', () => ({ Toggle: ToggleMock }));
@@ -133,19 +131,13 @@ function baseFixture(): ComponentDocumentationPayload {
   };
 }
 
-const originalFetch = globalThis.fetch;
-
-function installDocumentationFetch(fixture: ComponentDocumentationPayload): void {
-  globalThis.fetch = (async (url: string | URL | Request) => {
-    const href = url instanceof Request ? url.url : String(url);
-    if (href === '/api/documentation/button') {
-      return new Response(JSON.stringify(fixture), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json' },
-      });
-    }
-    return new Response('not found', { status: 404, statusText: 'Not Found' });
-  }) as typeof fetch;
+function installDocumentationDataIsland(fixture: ComponentDocumentationPayload): void {
+  const existing = document.getElementById('cinder-documentation');
+  const node = (existing ?? document.createElement('script')) as HTMLScriptElement;
+  node.type = 'application/json';
+  node.id = 'cinder-documentation';
+  node.textContent = JSON.stringify(fixture);
+  if (existing === null) document.body.append(node);
 }
 
 beforeEach(() => {
@@ -154,16 +146,32 @@ beforeEach(() => {
   happyWindow.happyDOM.setURL('http://localhost/page/button');
   Reflect.set(window, '__CINDER_EXAMPLES__', []);
   Reflect.set(window, '__CINDER_SCENARIOS__', {});
-  installDocumentationFetch(baseFixture());
+  installDocumentationDataIsland(baseFixture());
 });
 
 afterEach(() => {
   resetLedgers();
-  globalThis.fetch = originalFetch;
   document.body.innerHTML = '';
 });
 
 describe('component-page single-scroll layout', () => {
+  test('reads documentation synchronously without an initial fetch', async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchSpy = mock(async () => new Response('unexpected request', { status: 500 }));
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    try {
+      const { unmount } = render(ComponentPage);
+
+      expect(screen.getByRole('heading', { level: 1, name: 'Button' })).toBeTruthy();
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      unmount();
+      await tick();
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test('renders the hero, spec card, and section anchors from a fixture', async () => {
     const { unmount } = render(ComponentPage);
 
@@ -203,7 +211,7 @@ describe('component-page single-scroll layout', () => {
   test('maps a non-stable status to a non-success badge variant', async () => {
     const beta = baseFixture();
     beta.component.status = 'beta';
-    installDocumentationFetch(beta);
+    installDocumentationDataIsland(beta);
 
     const { unmount } = render(ComponentPage);
     const statusBadge = await screen.findByText('beta');
@@ -263,7 +271,7 @@ describe('component-page single-scroll layout', () => {
       keyboard: [{ keys: 'Enter / Space', action: 'Activates the button.' }],
       notes: ['Uses a native button element.'],
     };
-    installDocumentationFetch(withA11y);
+    installDocumentationDataIsland(withA11y);
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
@@ -299,7 +307,7 @@ describe('component-page single-scroll layout', () => {
         defaultValue: 'alpha',
       },
     ];
-    installDocumentationFetch(fixture);
+    installDocumentationDataIsland(fixture);
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
@@ -329,7 +337,7 @@ describe('component-page single-scroll layout', () => {
   test('omits the Related section when there are no related components', async () => {
     const noRelated = baseFixture();
     noRelated.component.related = [];
-    installDocumentationFetch(noRelated);
+    installDocumentationDataIsland(noRelated);
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
@@ -342,7 +350,7 @@ describe('component-page single-scroll layout', () => {
     const noGuidance = baseFixture();
     noGuidance.component.useWhen = [];
     noGuidance.component.avoidWhen = [];
-    installDocumentationFetch(noGuidance);
+    installDocumentationDataIsland(noGuidance);
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
@@ -381,7 +389,7 @@ describe('component-page single-scroll layout', () => {
         optional: false,
       },
     ];
-    installDocumentationFetch(required);
+    installDocumentationDataIsland(required);
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
@@ -428,7 +436,7 @@ describe('component-page single-scroll layout', () => {
         },
       ],
     };
-    installDocumentationFetch(exampleOnly);
+    installDocumentationDataIsland(exampleOnly);
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Autocomplete' });
@@ -453,7 +461,7 @@ describe('component-page single-scroll layout', () => {
         optional: false,
       },
     ];
-    installDocumentationFetch(required);
+    installDocumentationDataIsland(required);
 
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
@@ -471,9 +479,9 @@ describe('component-page single-scroll layout', () => {
   // `window.__CINDER_EXAMPLES__` into a module-level const at import time — before
   // this file's `beforeEach` can set it — so the examples list is empty here.
 
-  test('surfaces a documentation fetch failure', async () => {
-    globalThis.fetch = (async (_url: string | URL | Request) =>
-      new Response('boom', { status: 500, statusText: 'Server Error' })) as typeof fetch;
+  test('surfaces an invalid documentation data island', async () => {
+    const node = document.getElementById('cinder-documentation');
+    if (node !== null) node.textContent = '{not-json';
 
     const { unmount } = render(ComponentPage);
     await waitFor(() => {

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1,4 +1,4 @@
-<!-- dev-only playground scaffold; window.__CINDER_EXAMPLES__ is injected server-side -->
+<!-- dev-only playground scaffold; immutable page data is injected server-side -->
 <script lang="ts">
   import { mount, unmount } from 'svelte';
   import { Accordion } from '@lostgradient/cinder/accordion';
@@ -10,7 +10,6 @@
   import { CodeBlock } from '@lostgradient/cinder/code-block';
   import { Collapsible } from '@lostgradient/cinder/collapsible';
   import { Kbd } from '@lostgradient/cinder/kbd';
-  import { Skeleton } from '@lostgradient/cinder/skeleton';
   import { StatusDot } from '@lostgradient/cinder/status-dot';
   import { Table } from '@lostgradient/cinder/table';
   import { Toggle } from '@lostgradient/cinder/toggle';
@@ -32,7 +31,7 @@
     type MountErrorDetail,
     type SourceErrorDetail,
   } from './example-error.ts';
-  import { fetchComponentDocumentation } from './component-documentation-reference.ts';
+  import { readComponentDocumentationDataIsland } from './component-documentation-reference.ts';
   import type {
     ComponentDocumentationPayload,
     JsonValue,
@@ -72,7 +71,10 @@
   // from a `window` global so the live preview (#405) is wired explicitly to the
   // bundle that mounted it — no out-of-band global to go stale against the page.
   // Defaults to `undefined` for the no-prop mount paths (tests, SSR render).
-  let { bareComponentModule }: { bareComponentModule?: unknown } = $props();
+  let {
+    bareComponentModule,
+    previewOnly = false,
+  }: { bareComponentModule?: unknown; previewOnly?: boolean } = $props();
 
   // Height of the sticky top bar, in pixels — used for scroll-spy activation
   // and smooth-scroll offset so anchored sections clear the bar.
@@ -278,12 +280,18 @@
     return () => observer.disconnect();
   }
 
-  // --- Documentation payload (fetched once) -----------------------------
-  let documentation = $state<ComponentDocumentationPayload | null>(null);
-  let documentationLoading = $state(true);
+  // --- Documentation payload --------------------------------------------
+  // Documentation is immutable for a deployed build, so the server embeds it
+  // in the page HTML and the client reads it synchronously before first render.
+  let documentation: ComponentDocumentationPayload | null = $state(null);
   let documentationError: string | null = $state(null);
+  try {
+    documentation = readComponentDocumentationDataIsland();
+  } catch (error) {
+    documentationError =
+      error instanceof Error ? error.message : 'Failed to read component documentation.';
+  }
 
-  const skeletonRowCount = 5;
   const propRows = $derived(
     documentation === null ? [] : toPropReferenceRows(documentation.propsManifest),
   );
@@ -321,30 +329,6 @@
         return 'neutral';
     }
   }
-
-  $effect(() => {
-    if (componentName === '') {
-      documentationLoading = false;
-      return;
-    }
-    let cancelled = false;
-    fetchComponentDocumentation(componentName)
-      .then((payload) => {
-        if (!cancelled) documentation = payload;
-      })
-      .catch((error: unknown) => {
-        if (!cancelled) {
-          documentationError =
-            error instanceof Error ? error.message : 'Failed to load documentation.';
-        }
-      })
-      .finally(() => {
-        if (!cancelled) documentationLoading = false;
-      });
-    return () => {
-      cancelled = true;
-    };
-  });
 
   // --- Import line copy --------------------------------------------------
   let importCopied = $state(false);
@@ -563,7 +547,19 @@
   }
 </script>
 
-{#if snapshotMode}
+{#if previewOnly}
+  <div class="canonical-preview" data-component-preview>
+    {#if overviewExample === undefined}
+      <h1 class="snapshot-empty-heading">{humanizeId(componentName)}</h1>
+    {:else}
+      <div
+        class="example-preview"
+        id="canonical-preview-mount-{overviewExample.scenario}"
+        {@attach mountScenario(overviewExample.scenario)}
+      ></div>
+    {/if}
+  </div>
+{:else if snapshotMode}
   <!-- Snapshot mode (`?snapshot=1`): the visual-regression / a11y test harness
        loads this route and screenshots / axe-scans the page, expecting a clean
        single mount of each example with no docs chrome (matching the prior
@@ -630,13 +626,7 @@
       </div>
     </header>
 
-    {#if documentationLoading}
-      <div class="dx__inner dx-loading" aria-hidden="true">
-        {#each Array.from({ length: skeletonRowCount }, (_, index) => index) as row (row)}
-          <Skeleton height="2rem" radius="var(--cinder-radius-sm)" />
-        {/each}
-      </div>
-    {:else if documentationError !== null}
+    {#if documentationError !== null}
       <div class="dx__inner dx-error-region">
         <Alert variant="danger">
           Could not load documentation: {documentationError}
@@ -1447,12 +1437,6 @@
     }
   }
 
-  .dx-loading {
-    display: flex;
-    flex-direction: column;
-    gap: var(--cinder-space-3);
-    padding-block: var(--cinder-space-8);
-  }
   .dx-error-region {
     padding-block: var(--cinder-space-8);
   }

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -33,6 +33,7 @@ import {
   PORT,
   createHttpServerOnAvailablePort,
   createSharedDisposer,
+  fallbackToLastGood,
   handleRequest,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
@@ -69,6 +70,18 @@ beforeAll(async () => {
 });
 
 const temporaryServers: ReturnType<typeof Bun.serve>[] = [];
+
+describe('last-good rebuild fallback', () => {
+  it('keeps a successful renderer available through a transient rebuild failure', () => {
+    const renderer = () => ({ body: '<main>last good</main>', head: '' });
+    expect(fallbackToLastGood(renderer, new Error('transient compile failure'))).toBe(renderer);
+  });
+
+  it('preserves the original failure when no successful renderer exists yet', () => {
+    const error = new Error('initial compile failure');
+    expect(() => fallbackToLastGood(null, error)).toThrow(error);
+  });
+});
 
 afterEach(async () => {
   const servers = temporaryServers.splice(0);

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -349,6 +349,18 @@ describe('/c/:name', () => {
     expect(html).toContain('/shell-bundle/shell.js');
   });
 
+  it('server-renders crawlable documentation and scopes the iframe to the live preview', async () => {
+    const response = await handleRequest(req('/c/button'));
+    const html = await response.text();
+
+    expect(html).toContain('data-canonical-documentation');
+    expect(html).toMatch(/<h1[^>]*>.*Button.*<\/h1>/s);
+    expect(html).toContain('Overview');
+    expect(html).toContain('Props');
+    expect(html).toContain('src="/page/button?preview=1"');
+    expect(html.match(/data-canonical-documentation/g)).toHaveLength(1);
+  });
+
   it('embeds the active component name in the cinder-initial data island', async () => {
     const response = await handleRequest(req('/c/button'));
     const html = await response.text();
@@ -360,6 +372,7 @@ describe('/c/:name', () => {
     expect(payload.component).toBe('button');
     expect(payload.components).toContain('button');
     expect(payload.components).toContain('avatar');
+    expect(payload).toHaveProperty('documentation.component.id', 'button');
   });
 
   it('loads the shell CSS bundle so Cinder shell chrome is styled', async () => {
@@ -812,6 +825,21 @@ describe('/page/:name', () => {
     const html = await response.text();
     expect(html).toContain('<!DOCTYPE html>');
     expect(html).toContain('id="app"');
+  });
+
+  it('embeds the validated documentation payload in a JSON data island', async () => {
+    const response = await handleRequest(req(`/page/${FIXTURE_COMPONENT}`));
+    const html = await response.text();
+    const match =
+      /<script type="application\/json" id="cinder-documentation">([^<]+)<\/script>/.exec(html);
+
+    expect(match).not.toBeNull();
+    const documentation: unknown = JSON.parse(match![1]!);
+    expect(isComponentDocumentationPayload(documentation)).toBe(true);
+    if (isComponentDocumentationPayload(documentation)) {
+      expect(documentation.component.id).toBe(FIXTURE_COMPONENT);
+      expect(documentation.component.purpose).not.toBe('');
+    }
   });
 
   it('returns 404 for an unknown component', async () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -358,7 +358,25 @@ describe('/c/:name', () => {
     expect(html).toContain('Overview');
     expect(html).toContain('Props');
     expect(html).toContain('src="/page/button?preview=1"');
+    expect(html).toContain('href="/page/button"');
     expect(html.match(/data-canonical-documentation/g)).toHaveLength(1);
+  });
+
+  it('seeds SSR and hydration from the same toolbar query', async () => {
+    const response = await handleRequest(req('/c/button?w=768&focus=1'));
+    const html = await response.text();
+
+    expect(html).toContain('id="viewport-width-input"');
+    expect(html).toContain('value="768"');
+    expect(html).toContain('"initialSearch":"?w=768\\u0026focus=1"');
+    expect(html).toMatch(/class="shell [^"]*focus-mode"/);
+  });
+
+  it('includes server-rendered scoped shell styles for no-JavaScript rendering', async () => {
+    const response = await handleRequest(req('/c/button'));
+    const html = await response.text();
+
+    expect(html).toMatch(/<style[^>]*>[\s\S]*\.documentation/);
   });
 
   it('embeds the active component name in the cinder-initial data island', async () => {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -3,8 +3,8 @@
  *
  * Runs at http://localhost:5555 by default, or the next available port. Routes:
  *   GET /              → shell HTML with README landing content
- *   GET /c/:name       → shell HTML (sidebar + iframe pointing at /page/:name)
- *   GET /page/:name    → component page HTML (the iframe target — lists examples)
+ *   GET /c/:name       → server-rendered canonical documentation + isolated preview iframe
+ *   GET /page/:name    → standalone component documentation or preview-only iframe page
  *   GET /page-bundle/:name.js → page-bundle entry OR a hashed code-split chunk.
  *                              Entry URLs are bare component names (e.g. chat.js);
  *                              chunk URLs are hashed (e.g. core-abc123.js). Both
@@ -28,6 +28,7 @@
 import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync, watch, type FSWatcher } from 'node:fs';
 import { dirname, isAbsolute, join, relative as relativePath, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import { initializeHighlighter, renderMarkdown } from '@lostgradient/markdown/rendering';
 import type { BuildArtifact } from 'bun';
@@ -86,6 +87,7 @@ import {
 import { humanizeComponentName } from './shell-app/humanize.ts';
 
 import { stripExampleHarness } from '../../components/scripts/lib/strip-example-harness.ts';
+import type { ComponentDocumentationPayload } from './component-documentation-types.ts';
 import {
   isSnapshotMode,
   snapshotModeHtmlAttribute,
@@ -179,6 +181,14 @@ const fixtureArtifactByPath = new Map<string, string>();
 const pageBuildPromiseByKey = new Map<string, Promise<string | null>>();
 const scenarioBuildPromiseByKey = new Map<string, Promise<string | null>>();
 let shellBuildPromise: Promise<string | null> | null = null;
+let shellServerRendererPromise: Promise<
+  (props: {
+    initialComponent: string;
+    components: string[];
+    readmeHtml: string;
+    documentation: ComponentDocumentationPayload | null;
+  }) => string
+> | null = null;
 const fixtureBuildPromiseByKey = new Map<string, Promise<string | null>>();
 
 /**
@@ -286,6 +296,7 @@ const SHA256_HEX_PATTERN = /^[a-f0-9]{64}$/;
 let manifestCache: ComponentManifest[] | null = null;
 /** In-flight analyzeAll() promise — prevents duplicate concurrent analyses. */
 let manifestPromise: Promise<ComponentManifest[]> | null = null;
+const componentManifestCache = new Map<string, ComponentManifest>();
 
 /**
  * Invalidation generation. Bumped synchronously by `invalidateCachesForChange`
@@ -390,6 +401,7 @@ function invalidateCachesForChange(scope: ChangeScope): void {
   invalidateDiscoveryCache();
   manifestCache = null;
   manifestPromise = null;
+  componentManifestCache.clear();
   // Dispose the shared ts-morph project so the next analyzeAll() rebuilds
   // from fresh compiler state rather than reusing sources from before this
   // change.
@@ -450,6 +462,7 @@ function invalidateCachesForChange(scope: ChangeScope): void {
   // above — a post-invalidation request must not join a pre-edit build.
   shellStale = true;
   shellBuildPromise = null;
+  shellServerRendererPromise = null;
 
   triggerReload(scope.kind === 'shell' ? 'shell-reload' : 'reload');
 }
@@ -882,7 +895,11 @@ if (target === null) {
 // back to the default export — the whole namespace is handed over so both
 // resolve. Threaded as a prop (not a \`window\` global) so the live preview is
 // wired explicitly to the bundle that mounted the page.
-mount(ComponentPage, { target, props: { bareComponentModule: BareComponentModule } });
+const previewOnly = new URLSearchParams(window.location.search).get('preview') === '1';
+mount(ComponentPage, {
+  target,
+  props: { bareComponentModule: BareComponentModule, previewOnly },
+});
 `;
 
   try {
@@ -1166,6 +1183,56 @@ async function compileShellBundleArtifacts(): Promise<{
   }
 }
 
+async function loadShellServerRenderer(): Promise<
+  (props: {
+    initialComponent: string;
+    components: string[];
+    readmeHtml: string;
+    documentation: ComponentDocumentationPayload | null;
+  }) => string
+> {
+  if (shellServerRendererPromise !== null) return shellServerRendererPromise;
+
+  shellServerRendererPromise = (async () => {
+    const result = await Bun.build({
+      entrypoints: [join(PLAYGROUND_ROOT, 'src', 'shell-app', 'shell-server-entry.ts')],
+      plugins: [sveltePlugin({ generate: 'server' })],
+      target: 'bun',
+      format: 'esm',
+      conditions: ['bun', 'svelte'],
+      splitting: false,
+    });
+    if (!result.success || result.outputs[0] === undefined) {
+      throw new Error(`Shell server bundle failed:\n${result.logs.join('\n')}`);
+    }
+
+    const serverBundleDirectory = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+    const serverBundlePath = join(serverBundleDirectory, 'shell-server.js');
+    let loaded: unknown;
+    try {
+      await Bun.write(serverBundlePath, await result.outputs[0].text());
+      loaded = await import(pathToFileURL(serverBundlePath).href);
+    } finally {
+      rmSync(serverBundleDirectory, { recursive: true, force: true });
+    }
+    if (
+      typeof loaded !== 'object' ||
+      loaded === null ||
+      typeof Reflect.get(loaded, 'renderShellBody') !== 'function'
+    ) {
+      throw new Error('Shell server bundle did not export renderShellBody');
+    }
+    return Reflect.get(loaded, 'renderShellBody') as (props: {
+      initialComponent: string;
+      components: string[];
+      readmeHtml: string;
+      documentation: ComponentDocumentationPayload | null;
+    }) => string;
+  })();
+
+  return shellServerRendererPromise;
+}
+
 /**
  * Lazy-build wrapper: compile the shell bundle and publish into shared
  * caches. Used by `/shell-bundle/shell.js` as a fallback when the shell
@@ -1255,6 +1322,9 @@ async function getManifests(): Promise<ComponentManifest[]> {
     // `invalidateCachesForChange` cleared it.
     if (generationAtStart === rebuildGeneration) {
       manifestCache = manifests;
+      for (const manifest of manifests) {
+        componentManifestCache.set(manifest.kebabName, manifest);
+      }
     }
     return manifests;
   } finally {
@@ -1263,6 +1333,22 @@ async function getManifests(): Promise<ComponentManifest[]> {
     // clobbering a newer call's in-flight promise.
     if (manifestPromise === inFlight) manifestPromise = null;
   }
+}
+
+async function getComponentManifest(componentName: string): Promise<ComponentManifest | null> {
+  const cached = componentManifestCache.get(componentName);
+  if (cached !== undefined) return cached;
+  if (manifestCache !== null) {
+    return manifestCache.find((manifest) => manifest.kebabName === componentName) ?? null;
+  }
+
+  const definition = await discoverComponentDefinition(componentName);
+  if (definition === undefined) return null;
+  const manifest = await analyzeComponent(definition.filePath, {
+    importPath: definition.importPath,
+  });
+  componentManifestCache.set(componentName, manifest);
+  return manifest;
 }
 
 /**
@@ -1423,6 +1509,14 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
   // line/paragraph separators so a `</script>` in an example title/description
   // cannot terminate this inline script early or inject markup.
   const examplesJson = jsonForScriptTag(examples);
+  const documentation = await buildValidatedComponentDocumentation(componentName);
+  if (documentation === null) {
+    throw new ComponentDocumentationError(
+      'unknown-component',
+      `Documentation for "${componentName}" not found`,
+    );
+  }
+  const documentationJson = jsonForScriptTag(documentation);
   const htmlAttribute = snapshotModeHtmlAttribute(snapshotMode);
   const styleTag = snapshotModeStyleTag(snapshotMode);
   const humanName = escapeHtml(humanizeComponentName(componentName));
@@ -1468,11 +1562,37 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
     ${renderPreviewMessageBridgeScript()}
   </head>
   <body>
+    <script type="application/json" id="cinder-documentation">${documentationJson}</script>
     <script>window.__CINDER_EXAMPLES__ = ${examplesJson};</script>
     <div id="app"></div>
     <script type="module" src="/page-bundle/${componentName}.js"></script>
   </body>
 </html>`;
+}
+
+async function buildValidatedComponentDocumentation(
+  componentName: string,
+): Promise<ComponentDocumentationPayload | null> {
+  const manifest = await getComponentManifest(componentName);
+  if (manifest === null) return null;
+
+  const componentDefinition = await discoverComponentDefinition(componentName);
+  if (componentDefinition === undefined) return null;
+
+  const documentation = await buildComponentDocumentation(
+    componentName,
+    manifest,
+    undefined,
+    componentDefinition.source,
+  );
+  const validationErrors = validateComponentDocumentationPayload(documentation);
+  if (validationErrors.length > 0) {
+    throw new Error(
+      `Documentation payload for "${componentName}" failed validation:\n` +
+        validationErrors.map((validationError) => `  - ${validationError}`).join('\n'),
+    );
+  }
+  return documentation;
 }
 
 function renderFixturePageHtml(
@@ -1926,29 +2046,11 @@ export async function handleRequest(request: Request): Promise<Response> {
   if (apiDocumentationMatch) {
     const componentName = apiDocumentationMatch[1]!;
     if (!isSafeSegment(componentName)) return notFound();
-    const manifests = await getManifests();
-    const manifest = manifests.find((m) => m.kebabName === componentName);
-    if (manifest === undefined) {
-      return notFound(`Documentation for "${componentName}" not found`);
-    }
-    const componentDefinition = await discoverComponentDefinition(componentName);
-    if (componentDefinition === undefined) {
-      return notFound(`Documentation for "${componentName}" not found`);
-    }
 
     try {
-      const documentation = await buildComponentDocumentation(
-        componentName,
-        manifest,
-        undefined,
-        componentDefinition.source,
-      );
-      const validationErrors = validateComponentDocumentationPayload(documentation);
-      if (validationErrors.length > 0) {
-        throw new Error(
-          `Documentation payload for "${componentName}" failed validation:\n` +
-            validationErrors.map((validationError) => `  - ${validationError}`).join('\n'),
-        );
+      const documentation = await buildValidatedComponentDocumentation(componentName);
+      if (documentation === null) {
+        return notFound(`Documentation for "${componentName}" not found`);
       }
       return new Response(JSON.stringify(documentation), {
         headers: { 'Content-Type': 'application/json' },
@@ -2026,15 +2128,35 @@ export async function handleRequest(request: Request): Promise<Response> {
     if (!allComponents.includes(componentName))
       return notFound(`Component "${componentName}" not found`);
     const sidebarComponents = await discoverSidebarComponents();
-    const html = renderShell(componentName, sidebarComponents);
+    const documentation = await buildValidatedComponentDocumentation(componentName);
+    if (documentation === null) {
+      return notFound(`Documentation for "${componentName}" not found`);
+    }
+    const renderShellBody = await loadShellServerRenderer();
+    const shellBody = renderShellBody({
+      initialComponent: componentName,
+      components: sidebarComponents,
+      readmeHtml: '',
+      documentation,
+    });
+    const html = renderShell(componentName, sidebarComponents, { documentation, shellBody });
     return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 
   // GET / → README-backed landing shell
   if (pathname === '/') {
-    const sidebarComponents = await discoverSidebarComponents();
-    const readmeHtml = await renderLandingReadmeHtml();
-    const html = renderShell(null, sidebarComponents, { readmeHtml });
+    const [sidebarComponents, readmeHtml] = await Promise.all([
+      discoverSidebarComponents(),
+      renderLandingReadmeHtml(),
+    ]);
+    const renderShellBody = await loadShellServerRenderer();
+    const shellBody = renderShellBody({
+      initialComponent: '',
+      components: sidebarComponents,
+      readmeHtml,
+      documentation: null,
+    });
+    const html = renderShell(null, sidebarComponents, { readmeHtml, shellBody });
     return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -187,7 +187,8 @@ let shellServerRendererPromise: Promise<
     components: string[];
     readmeHtml: string;
     documentation: ComponentDocumentationPayload | null;
-  }) => string
+    initialSearch: string;
+  }) => { body: string; head: string }
 > | null = null;
 const fixtureBuildPromiseByKey = new Map<string, Promise<string | null>>();
 
@@ -447,11 +448,11 @@ function invalidateCachesForChange(scope: ChangeScope): void {
   // component barrel (`../../../components/src/index.ts`), so a
   // components-package change can affect the shell's own compiled output,
   // not just page bundles. The only difference between the two scopes is
-  // which SSE event to emit: `shell-reload` forces a live browser reload
-  // (needed when shell-app sources themselves changed); `reload` doesn't
-  // (a components-only change still leaves the shell CACHE fresh for
-  // whenever a real reload next happens, without disrupting the current
-  // session on every component edit).
+  // which files caused the invalidation. Both tiers emit `shell-reload`: the
+  // canonical shell now owns README and prop metadata as well as the preview,
+  // so reloading only the iframe would leave that outer documentation stale.
+  // Session-only shell state is persisted before navigation, so the document
+  // refresh does not discard filters or color-token overrides.
   pageEntryByName.clear();
   pageArtifactByPath.clear();
   pageBuildPromiseByKey.clear();
@@ -464,7 +465,7 @@ function invalidateCachesForChange(scope: ChangeScope): void {
   shellBuildPromise = null;
   shellServerRendererPromise = null;
 
-  triggerReload(scope.kind === 'shell' ? 'shell-reload' : 'reload');
+  triggerReload('shell-reload');
 }
 
 /** Set of active SSE stream controllers. */
@@ -1189,7 +1190,8 @@ async function loadShellServerRenderer(): Promise<
     components: string[];
     readmeHtml: string;
     documentation: ComponentDocumentationPayload | null;
-  }) => string
+    initialSearch: string;
+  }) => { body: string; head: string }
 > {
   if (shellServerRendererPromise !== null) return shellServerRendererPromise;
 
@@ -1227,7 +1229,8 @@ async function loadShellServerRenderer(): Promise<
       components: string[];
       readmeHtml: string;
       documentation: ComponentDocumentationPayload | null;
-    }) => string;
+      initialSearch: string;
+    }) => { body: string; head: string };
   })();
 
   return shellServerRendererPromise;
@@ -1344,10 +1347,13 @@ async function getComponentManifest(componentName: string): Promise<ComponentMan
 
   const definition = await discoverComponentDefinition(componentName);
   if (definition === undefined) return null;
+  const generationAtStart = rebuildGeneration;
   const manifest = await analyzeComponent(definition.filePath, {
     importPath: definition.importPath,
   });
-  componentManifestCache.set(componentName, manifest);
+  if (generationAtStart === rebuildGeneration) {
+    componentManifestCache.set(componentName, manifest);
+  }
   return manifest;
 }
 
@@ -2133,13 +2139,19 @@ export async function handleRequest(request: Request): Promise<Response> {
       return notFound(`Documentation for "${componentName}" not found`);
     }
     const renderShellBody = await loadShellServerRenderer();
-    const shellBody = renderShellBody({
+    const renderedShell = renderShellBody({
       initialComponent: componentName,
       components: sidebarComponents,
       readmeHtml: '',
       documentation,
+      initialSearch: url.search,
     });
-    const html = renderShell(componentName, sidebarComponents, { documentation, shellBody });
+    const html = renderShell(componentName, sidebarComponents, {
+      documentation,
+      shellBody: renderedShell.body,
+      shellHead: renderedShell.head,
+      initialSearch: url.search,
+    });
     return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 
@@ -2150,13 +2162,19 @@ export async function handleRequest(request: Request): Promise<Response> {
       renderLandingReadmeHtml(),
     ]);
     const renderShellBody = await loadShellServerRenderer();
-    const shellBody = renderShellBody({
+    const renderedShell = renderShellBody({
       initialComponent: '',
       components: sidebarComponents,
       readmeHtml,
       documentation: null,
+      initialSearch: url.search,
     });
-    const html = renderShell(null, sidebarComponents, { readmeHtml, shellBody });
+    const html = renderShell(null, sidebarComponents, {
+      readmeHtml,
+      shellBody: renderedShell.body,
+      shellHead: renderedShell.head,
+      initialSearch: url.search,
+    });
     return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -181,15 +181,15 @@ const fixtureArtifactByPath = new Map<string, string>();
 const pageBuildPromiseByKey = new Map<string, Promise<string | null>>();
 const scenarioBuildPromiseByKey = new Map<string, Promise<string | null>>();
 let shellBuildPromise: Promise<string | null> | null = null;
-let shellServerRendererPromise: Promise<
-  (props: {
-    initialComponent: string;
-    components: string[];
-    readmeHtml: string;
-    documentation: ComponentDocumentationPayload | null;
-    initialSearch: string;
-  }) => { body: string; head: string }
-> | null = null;
+type ShellServerRenderer = (props: {
+  initialComponent: string;
+  components: string[];
+  readmeHtml: string;
+  documentation: ComponentDocumentationPayload | null;
+  initialSearch: string;
+}) => { body: string; head: string };
+let shellServerRendererPromise: Promise<ShellServerRenderer> | null = null;
+let lastGoodShellServerRenderer: ShellServerRenderer | null = null;
 const fixtureBuildPromiseByKey = new Map<string, Promise<string | null>>();
 
 /**
@@ -1184,53 +1184,58 @@ async function compileShellBundleArtifacts(): Promise<{
   }
 }
 
-async function loadShellServerRenderer(): Promise<
-  (props: {
-    initialComponent: string;
-    components: string[];
-    readmeHtml: string;
-    documentation: ComponentDocumentationPayload | null;
-    initialSearch: string;
-  }) => { body: string; head: string }
-> {
+/** Return the last-good value after a failed rebuild, or preserve the original failure. */
+export function fallbackToLastGood<T>(lastGood: T | null, error: unknown): T {
+  if (lastGood === null) throw error;
+  return lastGood;
+}
+
+async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
   if (shellServerRendererPromise !== null) return shellServerRendererPromise;
 
   shellServerRendererPromise = (async () => {
-    const result = await Bun.build({
-      entrypoints: [join(PLAYGROUND_ROOT, 'src', 'shell-app', 'shell-server-entry.ts')],
-      plugins: [sveltePlugin({ generate: 'server' })],
-      target: 'bun',
-      format: 'esm',
-      conditions: ['bun', 'svelte'],
-      splitting: false,
-    });
-    if (!result.success || result.outputs[0] === undefined) {
-      throw new Error(`Shell server bundle failed:\n${result.logs.join('\n')}`);
-    }
-
-    const serverBundleDirectory = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
-    const serverBundlePath = join(serverBundleDirectory, 'shell-server.js');
-    let loaded: unknown;
     try {
-      await Bun.write(serverBundlePath, await result.outputs[0].text());
-      loaded = await import(pathToFileURL(serverBundlePath).href);
-    } finally {
-      rmSync(serverBundleDirectory, { recursive: true, force: true });
+      const generationAtStart = rebuildGeneration;
+      const result = await Bun.build({
+        entrypoints: [join(PLAYGROUND_ROOT, 'src', 'shell-app', 'shell-server-entry.ts')],
+        plugins: [sveltePlugin({ generate: 'server' })],
+        target: 'bun',
+        format: 'esm',
+        conditions: ['bun', 'svelte'],
+        splitting: false,
+      });
+      if (!result.success || result.outputs[0] === undefined) {
+        throw new Error(`Shell server bundle failed:\n${result.logs.join('\n')}`);
+      }
+
+      const serverBundleDirectory = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+      const serverBundlePath = join(serverBundleDirectory, 'shell-server.js');
+      let loaded: unknown;
+      try {
+        await Bun.write(serverBundlePath, await result.outputs[0].text());
+        loaded = await import(pathToFileURL(serverBundlePath).href);
+      } finally {
+        rmSync(serverBundleDirectory, { recursive: true, force: true });
+      }
+      if (
+        typeof loaded !== 'object' ||
+        loaded === null ||
+        typeof Reflect.get(loaded, 'renderShellBody') !== 'function'
+      ) {
+        throw new Error('Shell server bundle did not export renderShellBody');
+      }
+      const renderer = Reflect.get(loaded, 'renderShellBody') as ShellServerRenderer;
+      if (generationAtStart === rebuildGeneration) {
+        lastGoodShellServerRenderer = renderer;
+      }
+      return renderer;
+    } catch (error) {
+      console.error(
+        '[playground] shell server rebuild failed; serving the last-good renderer:',
+        error,
+      );
+      return fallbackToLastGood(lastGoodShellServerRenderer, error);
     }
-    if (
-      typeof loaded !== 'object' ||
-      loaded === null ||
-      typeof Reflect.get(loaded, 'renderShellBody') !== 'function'
-    ) {
-      throw new Error('Shell server bundle did not export renderShellBody');
-    }
-    return Reflect.get(loaded, 'renderShellBody') as (props: {
-      initialComponent: string;
-      components: string[];
-      readmeHtml: string;
-      documentation: ComponentDocumentationPayload | null;
-      initialSearch: string;
-    }) => { body: string; head: string };
   })();
 
   return shellServerRendererPromise;

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -136,6 +136,10 @@ export type RenderShellOptions = {
    * Server-rendered Shell markup. The client hydrates this exact tree.
    */
   shellBody?: string;
+  /** Server-rendered Svelte head output, including scoped component styles. */
+  shellHead?: string;
+  /** Request query used to seed identical server and client toolbar state. */
+  initialSearch?: string;
 };
 
 /**
@@ -200,6 +204,7 @@ export function renderShell(
     components,
     readmeHtml: options.readmeHtml ?? '',
     documentation: options.documentation ?? null,
+    initialSearch: options.initialSearch ?? '',
   };
 
   return `<!DOCTYPE html>
@@ -209,6 +214,7 @@ export function renderShell(
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${title}</title>
     ${meta}
+    ${options.shellHead ?? ''}
     <script>${PRE_PAINT_THEME_SCRIPT}</script>
     <style>
       /* Register cinder.reset as the FIRST layer (least priority) so the universal

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -1,11 +1,10 @@
 /**
- * Renders the minimal HTML scaffold for the cinder playground shell.
+ * Renders the HTML document around the cinder playground shell.
  *
- * The scaffold is intentionally tiny: it sets up a `#shell-root` mount point,
- * embeds initial data via a `<script type="application/json">` data island,
- * and loads the compiled shell-app bundle. Everything else — sidebar, top
- * control bar, iframe — is rendered by the Svelte 5 SPA that boots from
- * `shell-app/shell-entry.ts`.
+ * Canonical component routes place server-rendered shell and documentation
+ * markup inside `#shell-root`; the client bundle hydrates that exact tree.
+ * Initial props travel through a `<script type="application/json">` data
+ * island so hydration does not repeat any documentation work.
  *
  * The data-island pattern (instead of `window.__GLOBAL__ = JSON.stringify(...)`)
  * eliminates `</script>` injection vectors and is the standard SSR-hydration
@@ -14,6 +13,7 @@
  * terminate a script body in some parsers.
  */
 
+import type { ComponentDocumentationPayload } from './component-documentation-types.ts';
 import { humanizeComponentName } from './shell-app/humanize.ts';
 
 const LINE_SEPARATOR = String.fromCharCode(0x2028);
@@ -128,6 +128,14 @@ export type RenderShellOptions = {
    * root shell route, where the Svelte shell renders it as landing-page prose.
    */
   readmeHtml?: string;
+  /**
+   * Validated documentation embedded for the canonical component route.
+   */
+  documentation?: ComponentDocumentationPayload | null;
+  /**
+   * Server-rendered Shell markup. The client hydrates this exact tree.
+   */
+  shellBody?: string;
 };
 
 /**
@@ -191,6 +199,7 @@ export function renderShell(
     component: activeComponent ?? '',
     components,
     readmeHtml: options.readmeHtml ?? '',
+    documentation: options.documentation ?? null,
   };
 
   return `<!DOCTYPE html>
@@ -253,7 +262,7 @@ export function renderShell(
   </head>
   <body>
     <script type="application/json" id="cinder-initial">${jsonForScriptTag(initialData)}</script>
-    <div id="shell-root"></div>
+    <div id="shell-root">${options.shellBody ?? ''}</div>
     <script type="module" src="/shell-bundle/shell.js"></script>
   </body>
 </html>`;

--- a/packages/playground/src/shell-app/component-documentation.svelte
+++ b/packages/playground/src/shell-app/component-documentation.svelte
@@ -41,7 +41,7 @@
 
   <section aria-labelledby="overview-heading">
     <h2 id="overview-heading">Overview</h2>
-    <div class="readme-content">{@html documentation.readme.html}</div>
+    <div class="readme-content cinder-markdown-content">{@html documentation.readme.html}</div>
   </section>
 
   {#if propRows.length > 0}

--- a/packages/playground/src/shell-app/component-documentation.svelte
+++ b/packages/playground/src/shell-app/component-documentation.svelte
@@ -1,0 +1,159 @@
+<script lang="ts">
+  import type { ComponentDocumentationPayload } from '../component-documentation-types.ts';
+  import { toPropReferenceRows } from '../manifest-reference.ts';
+  import PreviewFrame, { type PreviewFrameHandle } from './preview-frame.svelte';
+
+  type Props = {
+    componentName: string;
+    documentation: ComponentDocumentationPayload;
+  };
+
+  let { componentName, documentation }: Props = $props();
+  let previewFrame = $state<PreviewFrameHandle | null>(null);
+
+  const propRows = $derived(toPropReferenceRows(documentation.propsManifest));
+  const importStatement = $derived(
+    `import { ${documentation.component.exportName} } from '${documentation.component.importSpecifier}';`,
+  );
+
+  export function reloadPreview(): void {
+    previewFrame?.reload();
+  }
+</script>
+
+<article class="documentation" data-canonical-documentation>
+  <header class="hero">
+    <p class="eyebrow">{documentation.component.categoryLabel}</p>
+    <h1>{documentation.component.name}</h1>
+    <p class="purpose">{documentation.component.purpose}</p>
+    <code>{importStatement}</code>
+  </header>
+
+  <section aria-labelledby="preview-heading">
+    <h2 id="preview-heading">Live preview</h2>
+    <div class="preview">
+      <PreviewFrame bind:this={previewFrame} {componentName} previewOnly />
+    </div>
+  </section>
+
+  <section aria-labelledby="overview-heading">
+    <h2 id="overview-heading">Overview</h2>
+    <div class="readme-content">{@html documentation.readme.html}</div>
+  </section>
+
+  {#if propRows.length > 0}
+    <section aria-labelledby="props-heading">
+      <h2 id="props-heading">Props</h2>
+      <div class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th scope="col">Name</th>
+              <th scope="col">Type</th>
+              <th scope="col">Default</th>
+              <th scope="col">Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each propRows as row (row.name)}
+              <tr>
+                <th scope="row"><code>{row.name}</code></th>
+                <td><code>{row.type}</code></td>
+                <td><code>{row.defaultValue ?? '—'}</code></td>
+                <td>{row.description}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  {/if}
+</article>
+
+<style>
+  .documentation {
+    width: min(100%, 1120px);
+    margin: 0 auto;
+    padding: var(--cinder-space-8);
+  }
+
+  .hero,
+  section {
+    margin-block-end: var(--cinder-space-10);
+  }
+
+  .eyebrow {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-semibold);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  h1 {
+    margin-block: var(--cinder-space-2);
+    font-size: clamp(2rem, 5vw, 4rem);
+    line-height: 1;
+  }
+
+  h2 {
+    margin-block-end: var(--cinder-space-4);
+    font-size: var(--cinder-text-2xl);
+  }
+
+  .purpose {
+    max-width: 70ch;
+    margin-block-end: var(--cinder-space-4);
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-lg);
+  }
+
+  .hero > code {
+    display: inline-block;
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface);
+  }
+
+  .preview {
+    display: flex;
+    height: 360px;
+    overflow: hidden;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-lg);
+    background: var(--cinder-bg);
+  }
+
+  .readme-content {
+    max-width: 80ch;
+  }
+
+  .table-scroll {
+    overflow-x: auto;
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: start;
+  }
+
+  th,
+  td {
+    padding: var(--cinder-space-3);
+    border-block-end: 1px solid var(--cinder-border);
+    vertical-align: top;
+  }
+
+  thead th {
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+  }
+
+  @media (max-width: 720px) {
+    .documentation {
+      padding: var(--cinder-space-5);
+    }
+  }
+</style>

--- a/packages/playground/src/shell-app/component-documentation.svelte
+++ b/packages/playground/src/shell-app/component-documentation.svelte
@@ -27,9 +27,12 @@
     <h1>{documentation.component.name}</h1>
     <p class="purpose">{documentation.component.purpose}</p>
     <code>{importStatement}</code>
+    <a class="full-documentation-link" href="/page/{componentName}">
+      Open interactive documentation
+    </a>
   </header>
 
-  <section aria-labelledby="preview-heading">
+  <section class="preview-section" aria-labelledby="preview-heading">
     <h2 id="preview-heading">Live preview</h2>
     <div class="preview">
       <PreviewFrame bind:this={previewFrame} {componentName} previewOnly />
@@ -116,6 +119,14 @@
     background: var(--cinder-surface);
   }
 
+  .full-documentation-link {
+    display: block;
+    width: fit-content;
+    margin-block-start: var(--cinder-space-4);
+    color: var(--cinder-accent);
+    font-weight: var(--cinder-font-semibold);
+  }
+
   .preview {
     display: flex;
     height: 360px;
@@ -137,6 +148,35 @@
     width: 100%;
     border-collapse: collapse;
     text-align: start;
+  }
+
+  :global(.shell.focus-mode) .documentation {
+    width: 100%;
+    max-width: none;
+    height: 100%;
+    padding: 0;
+  }
+
+  :global(.shell.focus-mode) .documentation > :not(.preview-section) {
+    display: none;
+  }
+
+  :global(.shell.focus-mode) .preview-section {
+    display: flex;
+    height: 100%;
+    margin: 0;
+    flex-direction: column;
+  }
+
+  :global(.shell.focus-mode) .preview-section > h2 {
+    display: none;
+  }
+
+  :global(.shell.focus-mode) .preview {
+    flex: 1;
+    height: auto;
+    border: 0;
+    border-radius: 0;
   }
 
   th,

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -18,16 +18,19 @@
 
   type Props = {
     componentName: string;
+    previewOnly?: boolean;
   };
 
-  let { componentName }: Props = $props();
+  let { componentName, previewOnly = false }: Props = $props();
 
   const store = getPreviewStore();
 
   let iframeEl = $state<HTMLIFrameElement | null>(null);
   let lastSyncedTheme: ThemeChoice | null = null;
 
-  let src = $derived(buildIframeSrc(componentName));
+  let src = $derived(
+    previewOnly ? `${buildIframeSrc(componentName)}?preview=1` : buildIframeSrc(componentName),
+  );
 
   // The src whose document has finished painting, set in `handleLoad`. Loading
   // is then a pure derivation: we're loading whenever the current `src` hasn't

--- a/packages/playground/src/shell-app/preview-frame.svelte
+++ b/packages/playground/src/shell-app/preview-frame.svelte
@@ -115,6 +115,18 @@
     const element = iframeEl;
     if (element === null) return;
     element.addEventListener('load', handleLoad);
+    // SSR emits the iframe before the hydration bundle. A cached preview can
+    // finish before this listener attaches, so recognize that exact completed
+    // document immediately. Do not mistake the initial about:blank document
+    // for readiness: its URL will not equal the requested preview URL.
+    const documentUrl = element.contentDocument?.URL;
+    if (element.contentDocument?.readyState === 'complete' && documentUrl) {
+      const expectedUrl = new URL(src, 'http://cinder.local');
+      const loadedUrl = new URL(documentUrl, 'http://cinder.local');
+      if (loadedUrl.pathname === expectedUrl.pathname && loadedUrl.search === expectedUrl.search) {
+        handleLoad();
+      }
+    }
     return () => {
       element.removeEventListener('load', handleLoad);
     };

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -36,6 +36,7 @@ const PREVIEW_STORE_KEY = Symbol('cinder-preview-store');
 
 /** Persisted theme key — must match `PRE_PAINT_THEME_SCRIPT` in render-shell.ts. */
 export const THEME_STORAGE_KEY = 'cinder-playground-theme';
+export const COLOR_TOKEN_SESSION_KEY = 'cinder-playground-color-token-overrides';
 
 const THEME_VALUES: ReadonlySet<ThemeChoice> = new Set(['light', 'dark']);
 
@@ -61,6 +62,39 @@ export function readPersistedTheme(): ThemeChoice | null {
 export function writePersistedTheme(value: ThemeChoice): void {
   try {
     localStorage.setItem(THEME_STORAGE_KEY, value);
+  } catch {
+    /* ignore — degraded but functional */
+  }
+}
+
+function readSessionColorTokenOverrides(): ColorTokenOverrideState {
+  const empty: ColorTokenOverrideState = { light: {}, dark: {} };
+  try {
+    const parsed: unknown = JSON.parse(sessionStorage.getItem(COLOR_TOKEN_SESSION_KEY) ?? 'null');
+    if (typeof parsed !== 'object' || parsed === null) return empty;
+    const result: ColorTokenOverrideState = { light: {}, dark: {} };
+    for (const theme of THEME_VALUES) {
+      const entries = Reflect.get(parsed, theme);
+      if (typeof entries !== 'object' || entries === null) continue;
+      for (const [tokenName, value] of Object.entries(entries)) {
+        if (
+          isColorTokenName(tokenName) &&
+          typeof value === 'string' &&
+          isSafeColorTokenValue(value)
+        ) {
+          result[theme][tokenName] = value.trim();
+        }
+      }
+    }
+    return result;
+  } catch {
+    return empty;
+  }
+}
+
+function writeSessionColorTokenOverrides(overrides: ColorTokenOverrideState): void {
+  try {
+    sessionStorage.setItem(COLOR_TOKEN_SESSION_KEY, JSON.stringify(overrides));
   } catch {
     /* ignore — degraded but functional */
   }
@@ -146,6 +180,9 @@ export class PreviewStore {
     this.#isFocusMode = initialState.isFocusMode ?? false;
     this.#override = initialState.theme ?? null;
     this.#previewWidth = initialState.previewWidth ?? null;
+    if (typeof window !== 'undefined') {
+      this.colorTokenOverrides = readSessionColorTokenOverrides();
+    }
   }
 
   get isFocusMode(): boolean {
@@ -258,6 +295,7 @@ export class PreviewStore {
         [tokenName]: value.trim(),
       },
     };
+    writeSessionColorTokenOverrides(this.colorTokenOverrides);
 
     if (theme === this.theme && typeof document !== 'undefined') {
       this.applyActiveColorTokenOverridesToDocument(document);
@@ -272,6 +310,7 @@ export class PreviewStore {
       ...this.colorTokenOverrides,
       [theme]: nextThemeOverrides,
     };
+    writeSessionColorTokenOverrides(this.colorTokenOverrides);
 
     if (theme === this.theme && typeof document !== 'undefined') {
       this.applyActiveColorTokenOverridesToDocument(document);
@@ -283,6 +322,7 @@ export class PreviewStore {
       ...this.colorTokenOverrides,
       [theme]: {},
     };
+    writeSessionColorTokenOverrides(this.colorTokenOverrides);
 
     if (theme === this.theme && typeof document !== 'undefined') {
       this.applyActiveColorTokenOverridesToDocument(document);

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -151,15 +151,15 @@ export class PreviewStore {
   #isFocusMode = $state<boolean>(false);
   /**
    * The explicit theme override, or `null` when the user has made no choice and
-   * the playground should follow the browser. `#browserPrefersDark` tracks the
-   * live `prefers-color-scheme` so the resolved {@link theme} updates the moment
-   * the OS setting flips while no override is active.
+   * the playground should follow the browser. `#browserThemeQuery` tracks the
+   * live `prefers-color-scheme` after hydration so the resolved {@link theme}
+   * updates the moment the OS setting flips while no override is active.
    */
   #override = $state<ThemeChoice | null>(null);
-  // Fallback `false` keeps the resolved theme deterministic on the server (where
-  // there's no `matchMedia`): with no override the playground resolves to light
-  // until the client hydrates and the real preference takes over.
-  #browserPrefersDark = new MediaQuery('(prefers-color-scheme: dark)', false);
+  // Keep browser media state absent through hydration so both the server and
+  // client begin from the same deterministic light fallback. Shell enables the
+  // live query in `onMount`, after Svelte has reconciled the server tree.
+  #browserThemeQuery = $state<MediaQuery | null>(null);
   #previewWidth = $state<number | null>(null);
 
   colorTokenOverrides = $state<ColorTokenOverrideState>({ light: {}, dark: {} });
@@ -215,9 +215,15 @@ export class PreviewStore {
     return this.#override;
   }
 
+  /** Begin resolving the OS color scheme after hydration has completed. */
+  enableBrowserThemeResolution(): void {
+    if (typeof window === 'undefined' || this.#browserThemeQuery !== null) return;
+    this.#browserThemeQuery = new MediaQuery('(prefers-color-scheme: dark)', false);
+  }
+
   /** Map the live `prefers-color-scheme` media query to a concrete theme. */
   #resolvedBrowserTheme(): ThemeChoice {
-    return this.#browserPrefersDark.current ? 'dark' : 'light';
+    return this.#browserThemeQuery?.current ? 'dark' : 'light';
   }
 
   /** null = full / unconstrained width. Number = pixel width applied to the iframe. */

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -248,10 +248,11 @@ export class PreviewStore {
   }
 
   /**
-   * Re-seed every toolbar cell from the current URL. Called by the SPA on
-   * `popstate` so back/forward navigation updates the UI. The theme override
-   * falls back to localStorage when the URL has no `theme=` param; when neither
-   * carries an override the playground follows the browser preference.
+   * Re-seed every toolbar cell from the current URL. Called after hydration so
+   * a persisted theme can be restored without changing the server-known
+   * initial tree. The theme override falls back to localStorage when the URL
+   * has no `theme=` param; when neither carries an override the playground
+   * follows the browser preference.
    */
   syncFromUrl(): void {
     if (typeof window === 'undefined') return;

--- a/packages/playground/src/shell-app/preview-store.test.ts
+++ b/packages/playground/src/shell-app/preview-store.test.ts
@@ -105,12 +105,12 @@ function createMatchMedia(matches = false): Window['matchMedia'] {
   }) as Window['matchMedia'];
 }
 
-function installWindow(href: string): void {
+function installWindow(href: string, prefersDark = false): void {
   Object.defineProperty(globalThis, 'window', {
     configurable: true,
     value: {
       location: { href },
-      matchMedia: createMatchMedia(),
+      matchMedia: createMatchMedia(prefersDark),
     } as unknown as Window,
     writable: true,
   });
@@ -223,6 +223,18 @@ describe('writePersistedTheme', () => {
   it('does not throw when localStorage is undefined', () => {
     installLocalStorage(undefined);
     expect(() => writePersistedTheme('light')).not.toThrow();
+  });
+});
+
+describe('browser theme hydration', () => {
+  it('keeps the server fallback until browser resolution is enabled after hydration', () => {
+    installWindow('https://example.com/c/button', true);
+
+    const store = new PreviewStore('button');
+
+    expect(store.theme).toBe('light');
+    store.enableBrowserThemeResolution();
+    expect(store.theme).toBe('dark');
   });
 });
 

--- a/packages/playground/src/shell-app/preview-store.test.ts
+++ b/packages/playground/src/shell-app/preview-store.test.ts
@@ -32,6 +32,7 @@ type MatchMediaListener =
   | ((this: MediaQueryList, event: MediaQueryListEvent) => void);
 
 const originalLocalStorage = (globalThis as { localStorage?: Storage }).localStorage;
+const originalSessionStorage = (globalThis as { sessionStorage?: Storage }).sessionStorage;
 const originalWindow = (globalThis as { window?: Window }).window;
 const originalHistory = (globalThis as { history?: History }).history;
 
@@ -48,6 +49,17 @@ function installLocalStorage(stub: LocalStorageStub | undefined): void {
   Object.defineProperty(globalThis, 'localStorage', {
     configurable: true,
     value: stub as unknown as Storage,
+    writable: true,
+  });
+}
+
+function installSessionStorage(values = new Map<string, string>()): void {
+  Object.defineProperty(globalThis, 'sessionStorage', {
+    configurable: true,
+    value: {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    } as unknown as Storage,
     writable: true,
   });
 }
@@ -120,6 +132,15 @@ afterEach(() => {
     Object.defineProperty(globalThis, 'window', {
       configurable: true,
       value: originalWindow,
+      writable: true,
+    });
+  }
+  if (originalSessionStorage === undefined) {
+    delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+  } else {
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      value: originalSessionStorage,
       writable: true,
     });
   }
@@ -317,6 +338,19 @@ describe('color token overrides', () => {
     expect(store.colorTokenOverrides.light['--cinder-accent']).toBe('oklch(60% 0.2 195)');
     expect(store.colorTokenOverrides.dark['--cinder-accent']).toBe('oklch(78% 0.16 195)');
     expect(store.getActiveColorTokenOverrides()).toEqual({
+      '--cinder-accent': 'oklch(60% 0.2 195)',
+    });
+  });
+
+  it('restores validated color overrides across full-page shell navigation', () => {
+    installWindow('https://playground.example/c/button');
+    installSessionStorage();
+
+    const firstPageStore = new PreviewStore('button', { theme: 'light' });
+    firstPageStore.setColorTokenOverride('light', '--cinder-accent', 'oklch(60% 0.2 195)');
+
+    const nextPageStore = new PreviewStore('card', { theme: 'light' });
+    expect(nextPageStore.colorTokenOverrides.light).toEqual({
       '--cinder-accent': 'oklch(60% 0.2 195)',
     });
   });

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -18,7 +18,14 @@ import Shell from './shell.svelte';
 
 function readInitialData(): InitialData {
   const node = document.getElementById('cinder-initial');
-  if (!node) return { component: '', components: [], readmeHtml: '', documentation: null };
+  if (!node)
+    return {
+      component: '',
+      components: [],
+      readmeHtml: '',
+      documentation: null,
+      initialSearch: '',
+    };
   try {
     const parsed: unknown = JSON.parse(node.textContent ?? '{}');
     const initialData = parseInitialData(parsed);
@@ -26,7 +33,13 @@ function readInitialData(): InitialData {
   } catch (error) {
     console.error('[cinder playground] failed to parse #cinder-initial:', error);
   }
-  return { component: '', components: [], readmeHtml: '', documentation: null };
+  return {
+    component: '',
+    components: [],
+    readmeHtml: '',
+    documentation: null,
+    initialSearch: '',
+  };
 }
 
 const initial = readInitialData();
@@ -43,5 +56,6 @@ hydrate(Shell, {
     components: initial.components,
     readmeHtml: initial.readmeHtml,
     documentation: initial.documentation,
+    initialSearch: initial.initialSearch,
   },
 });

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -3,21 +3,22 @@
  *
  * Reads the `<script type="application/json" id="cinder-initial">` data island
  * embedded by `render-shell.ts` to get the initial component name and the
- * full sidebar component list, then mounts the Svelte shell into `#shell-root`.
+ * full sidebar component list, then hydrates the server-rendered Svelte shell
+ * in `#shell-root`.
  *
  * The data-island pattern is used instead of a `window.__GLOBAL__` to avoid
  * any risk of `</script>` injection through the embedded payload, even though
  * payload values are filesystem-derived and kebab-case-validated server-side.
  */
 
-import { mount } from 'svelte';
+import { hydrate } from 'svelte';
 
 import { parseInitialData, type InitialData } from './shell-initial-data.ts';
 import Shell from './shell.svelte';
 
 function readInitialData(): InitialData {
   const node = document.getElementById('cinder-initial');
-  if (!node) return { component: '', components: [], readmeHtml: '' };
+  if (!node) return { component: '', components: [], readmeHtml: '', documentation: null };
   try {
     const parsed: unknown = JSON.parse(node.textContent ?? '{}');
     const initialData = parseInitialData(parsed);
@@ -25,7 +26,7 @@ function readInitialData(): InitialData {
   } catch (error) {
     console.error('[cinder playground] failed to parse #cinder-initial:', error);
   }
-  return { component: '', components: [], readmeHtml: '' };
+  return { component: '', components: [], readmeHtml: '', documentation: null };
 }
 
 const initial = readInitialData();
@@ -35,11 +36,12 @@ if (target === null) {
   throw new Error('[cinder playground] #shell-root target not found');
 }
 
-mount(Shell, {
+hydrate(Shell, {
   target,
   props: {
     initialComponent: initial.component,
     components: initial.components,
     readmeHtml: initial.readmeHtml,
+    documentation: initial.documentation,
   },
 });

--- a/packages/playground/src/shell-app/shell-initial-data.test.ts
+++ b/packages/playground/src/shell-app/shell-initial-data.test.ts
@@ -8,6 +8,7 @@ describe('parseInitialData', () => {
       component: 'button',
       components: ['button', 'card'],
       readmeHtml: '',
+      documentation: null,
     });
   });
 
@@ -18,6 +19,7 @@ describe('parseInitialData', () => {
       component: '',
       components: ['button'],
       readmeHtml: '<h1>cinder</h1>',
+      documentation: null,
     });
   });
 

--- a/packages/playground/src/shell-app/shell-initial-data.test.ts
+++ b/packages/playground/src/shell-app/shell-initial-data.test.ts
@@ -9,6 +9,7 @@ describe('parseInitialData', () => {
       components: ['button', 'card'],
       readmeHtml: '',
       documentation: null,
+      initialSearch: '',
     });
   });
 
@@ -20,7 +21,18 @@ describe('parseInitialData', () => {
       components: ['button'],
       readmeHtml: '<h1>cinder</h1>',
       documentation: null,
+      initialSearch: '',
     });
+  });
+
+  test('keeps the request search used to seed SSR toolbar state', () => {
+    expect(
+      parseInitialData({
+        component: 'button',
+        components: ['button'],
+        initialSearch: '?w=768&focus=1',
+      }),
+    ).toHaveProperty('initialSearch', '?w=768&focus=1');
   });
 
   test('rejects malformed component names', () => {

--- a/packages/playground/src/shell-app/shell-initial-data.ts
+++ b/packages/playground/src/shell-app/shell-initial-data.ts
@@ -1,4 +1,12 @@
-export type InitialData = { component: string; components: string[]; readmeHtml: string };
+import { isComponentDocumentationPayload } from '../component-documentation-reference.ts';
+import type { ComponentDocumentationPayload } from '../component-documentation-types.ts';
+
+export type InitialData = {
+  component: string;
+  components: string[];
+  readmeHtml: string;
+  documentation: ComponentDocumentationPayload | null;
+};
 
 function getOwnProperty(value: object, key: string): unknown {
   return Object.getOwnPropertyDescriptor(value, key)?.value;
@@ -14,9 +22,17 @@ export function parseInitialData(value: unknown): InitialData | null {
   const component = getOwnProperty(value, 'component');
   const components = getOwnProperty(value, 'components');
   const readmeHtml = getOwnProperty(value, 'readmeHtml');
+  const documentation = getOwnProperty(value, 'documentation');
   if (typeof component !== 'string') return null;
   if (!Array.isArray(components)) return null;
   if (readmeHtml !== undefined && typeof readmeHtml !== 'string') return null;
+  if (
+    documentation !== undefined &&
+    documentation !== null &&
+    !isComponentDocumentationPayload(documentation)
+  ) {
+    return null;
+  }
   const componentNamePattern = /^[a-z0-9][a-z0-9-]*$/;
   // The active component can legitimately be absent from `components`: the
   // server lists only sidebar-eligible components there (those with at least
@@ -32,5 +48,6 @@ export function parseInitialData(value: unknown): InitialData | null {
     component,
     components,
     readmeHtml: readmeHtml ?? '',
+    documentation: documentation ?? null,
   };
 }

--- a/packages/playground/src/shell-app/shell-initial-data.ts
+++ b/packages/playground/src/shell-app/shell-initial-data.ts
@@ -6,6 +6,7 @@ export type InitialData = {
   components: string[];
   readmeHtml: string;
   documentation: ComponentDocumentationPayload | null;
+  initialSearch: string;
 };
 
 function getOwnProperty(value: object, key: string): unknown {
@@ -23,9 +24,11 @@ export function parseInitialData(value: unknown): InitialData | null {
   const components = getOwnProperty(value, 'components');
   const readmeHtml = getOwnProperty(value, 'readmeHtml');
   const documentation = getOwnProperty(value, 'documentation');
+  const initialSearch = getOwnProperty(value, 'initialSearch');
   if (typeof component !== 'string') return null;
   if (!Array.isArray(components)) return null;
   if (readmeHtml !== undefined && typeof readmeHtml !== 'string') return null;
+  if (initialSearch !== undefined && typeof initialSearch !== 'string') return null;
   if (
     documentation !== undefined &&
     documentation !== null &&
@@ -49,5 +52,6 @@ export function parseInitialData(value: unknown): InitialData | null {
     components,
     readmeHtml: readmeHtml ?? '',
     documentation: documentation ?? null,
+    initialSearch: initialSearch ?? '',
   };
 }

--- a/packages/playground/src/shell-app/shell-server-entry.ts
+++ b/packages/playground/src/shell-app/shell-server-entry.ts
@@ -1,0 +1,15 @@
+import { render } from 'svelte/server';
+
+import type { ComponentDocumentationPayload } from '../component-documentation-types.ts';
+import Shell from './shell.svelte';
+
+export type ShellServerProps = {
+  initialComponent: string;
+  components: string[];
+  readmeHtml: string;
+  documentation: ComponentDocumentationPayload | null;
+};
+
+export function renderShellBody(props: ShellServerProps): string {
+  return render(Shell, { props }).body;
+}

--- a/packages/playground/src/shell-app/shell-server-entry.ts
+++ b/packages/playground/src/shell-app/shell-server-entry.ts
@@ -8,8 +8,15 @@ export type ShellServerProps = {
   components: string[];
   readmeHtml: string;
   documentation: ComponentDocumentationPayload | null;
+  initialSearch: string;
 };
 
-export function renderShellBody(props: ShellServerProps): string {
-  return render(Shell, { props }).body;
+export type RenderedShell = {
+  body: string;
+  head: string;
+};
+
+export function renderShellBody(props: ShellServerProps): RenderedShell {
+  const rendered = render(Shell, { props });
+  return { body: rendered.body, head: rendered.head };
 }

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -3,12 +3,7 @@
   import { MediaQuery } from 'svelte/reactivity';
 
   import Announcer from './announcer.svelte';
-  import {
-    announceLandingNavigation,
-    announceNavigation,
-    Announcer as AnnouncerStore,
-    setAnnouncer,
-  } from './announcer.svelte.ts';
+  import { Announcer as AnnouncerStore, setAnnouncer } from './announcer.svelte.ts';
   import { createEventSource } from './event-source.svelte.ts';
   import type { ComponentDocumentationPayload } from '../component-documentation-types.ts';
   import ComponentDocumentation from './component-documentation.svelte';
@@ -18,7 +13,7 @@
     readPersistedTheme,
     setPreviewStore,
   } from './preview-store.svelte.ts';
-  import { buildShellHref, parseComponentFromPath, readToolbarStateFromSearch } from './routing.ts';
+  import { buildShellHref, readToolbarStateFromSearch } from './routing.ts';
   import ColorTokenPanel from './color-token-panel.svelte';
   import LandingPage from './landing-page.svelte';
   import Sidebar, { type SidebarHandle } from './sidebar.svelte';
@@ -29,9 +24,10 @@
     components: string[];
     readmeHtml: string;
     documentation: ComponentDocumentationPayload | null;
+    initialSearch: string;
   };
 
-  let { initialComponent, components, readmeHtml, documentation }: Props = $props();
+  let { initialComponent, components, readmeHtml, documentation, initialSearch }: Props = $props();
 
   // Bound to the Sidebar instance so the `/` shortcut can focus its filter.
   let sidebar = $state<SidebarHandle | null>(null);
@@ -43,11 +39,8 @@
   // Seed the toolbar from the URL (shareable, survives reload). When the URL
   // is silent about theme, fall back to the localStorage preference so the
   // next visit honors the user's last choice.
-  const initialSearch =
-    typeof window === 'undefined'
-      ? new URLSearchParams()
-      : new URL(window.location.href).searchParams;
-  const initialUrlState = readToolbarStateFromSearch(initialSearch);
+  const initialSearchValue = untrack(() => initialSearch);
+  const initialUrlState = readToolbarStateFromSearch(new URLSearchParams(initialSearchValue));
   const initialTheme = initialUrlState.theme ?? readPersistedTheme();
   const initialComponentName = untrack(() => initialComponent);
   const store = new PreviewStore(initialComponentName, {
@@ -56,9 +49,8 @@
   });
   setPreviewStore(store);
 
-  // Single shared polite live region for the shell. The top bar pushes
-  // toolbar feedback through it; client-side navigation (below) announces the
-  // newly-viewed component. One instance keeps exactly one live region in the
+  // Single shared polite live region for the shell. The top bar pushes toolbar
+  // feedback through it. One instance keeps exactly one live region in the
   // document (two would double-read every message).
   const announcer = new AnnouncerStore();
   setAnnouncer(announcer);
@@ -71,8 +63,7 @@
   // pure lifecycle cleanup that never tracks reactive state.
   onDestroy(() => announcer.cancel());
 
-  // `<main>` is programmatically focusable (tabindex="-1") so keyboard focus
-  // can move to the freshly-rendered content after client-side navigation.
+  // `<main>` is bound so the narrow sidebar can make background content inert.
   let mainEl = $state<HTMLElement | null>(null);
 
   // True below the responsive breakpoint, where the sidebar is a modal-style
@@ -155,26 +146,6 @@
     if (name === store.currentComponent) return;
     const { search, hash } = window.location;
     window.location.assign(`${buildShellHref(name)}${search}${hash}`);
-  }
-
-  async function handlePopState(): Promise<void> {
-    const parsed = parseComponentFromPath(window.location.pathname);
-    const isRootPath = window.location.pathname === '/';
-    if (parsed !== null) {
-      store.currentComponent = parsed;
-    } else if (isRootPath) {
-      store.currentComponent = '';
-    }
-    // Re-sync the toolbar (theme/viewport/focus mode) from the URL *before*
-    // announcing so the toolbar reflects the restored state by the time focus
-    // lands on <main>.
-    store.syncFromUrl();
-    // Browser back/forward is client-side navigation too: apply the same
-    // title + live-region + focus side effects as selectComponent (WCAG
-    // 2.4.2 / 4.1.3 / 2.4.3). Guard on a resolved component, mirroring the
-    // null check above.
-    if (parsed !== null) await announceNavigation(announcer, parsed, () => mainEl);
-    else if (isRootPath) await announceLandingNavigation(announcer, () => mainEl);
   }
 
   /**
@@ -270,7 +241,7 @@
   }
 </script>
 
-<svelte:window onpopstate={handlePopState} onkeydown={handleKeydown} />
+<svelte:window onkeydown={handleKeydown} />
 
 <!--
   Layout overview

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import { MediaQuery } from 'svelte/reactivity';
 
   import Announcer from './announcer.svelte';
@@ -10,7 +10,8 @@
     setAnnouncer,
   } from './announcer.svelte.ts';
   import { createEventSource } from './event-source.svelte.ts';
-  import PreviewFrame, { type PreviewFrameHandle } from './preview-frame.svelte';
+  import type { ComponentDocumentationPayload } from '../component-documentation-types.ts';
+  import ComponentDocumentation from './component-documentation.svelte';
   import {
     applyThemeToDocument,
     PreviewStore,
@@ -27,16 +28,17 @@
     initialComponent: string;
     components: string[];
     readmeHtml: string;
+    documentation: ComponentDocumentationPayload | null;
   };
 
-  let { initialComponent, components, readmeHtml }: Props = $props();
+  let { initialComponent, components, readmeHtml, documentation }: Props = $props();
 
   // Bound to the Sidebar instance so the `/` shortcut can focus its filter.
   let sidebar = $state<SidebarHandle | null>(null);
 
   // Bound to the PreviewFrame so live-reload events reload through it (re-arming
   // the loading overlay) instead of poking the raw iframe.
-  let previewFrame = $state<PreviewFrameHandle | null>(null);
+  let componentDocumentation = $state<ComponentDocumentation | null>(null);
 
   // Seed the toolbar from the URL (shareable, survives reload). When the URL
   // is silent about theme, fall back to the localStorage preference so the
@@ -47,7 +49,8 @@
       : new URL(window.location.href).searchParams;
   const initialUrlState = readToolbarStateFromSearch(initialSearch);
   const initialTheme = initialUrlState.theme ?? readPersistedTheme();
-  const store = new PreviewStore(initialComponent, {
+  const initialComponentName = untrack(() => initialComponent);
+  const store = new PreviewStore(initialComponentName, {
     ...initialUrlState,
     theme: initialTheme,
   });
@@ -143,23 +146,15 @@
     store.applyActiveColorTokenOverridesToDocument(document);
   });
 
-  async function selectComponent(name: string): Promise<void> {
+  function selectComponent(name: string): void {
     // Selecting from the off-canvas drawer (narrow viewports) should always
     // dismiss it so the preview is visible — including when the user taps the
     // already-active component, which short-circuits below. Harmless on wide
     // viewports where the drawer is the static sidebar.
     store.isSidebarOpen = false;
     if (name === store.currentComponent) return;
-    store.currentComponent = name;
-    // Preserve the current query string (e.g. ?focus=1) and hash when
-    // navigating between components.
     const { search, hash } = window.location;
-    history.pushState({}, '', `${buildShellHref(name)}${search}${hash}`);
-
-    // Title (2.4.2) + live-region announcement (4.1.3) + focus move to the
-    // freshly-rendered <main> (2.4.3). Centralized in announceNavigation so the
-    // shell and its tests exercise the same code path.
-    await announceNavigation(announcer, name, () => mainEl);
+    window.location.assign(`${buildShellHref(name)}${search}${hash}`);
   }
 
   async function handlePopState(): Promise<void> {
@@ -267,7 +262,7 @@
     // Reload through the PreviewFrame handle (not the raw iframe) so the loading
     // overlay re-arms during hot reload — a direct contentWindow.reload() keeps
     // the same src, so the overlay would otherwise never show.
-    previewFrame?.reload();
+    componentDocumentation?.reloadPreview();
   }
 
   function handleShellReloadEvent(): void {
@@ -332,8 +327,12 @@
         firstComponent={components[0] ?? ''}
         onBrowseComponent={selectComponent}
       />
-    {:else}
-      <PreviewFrame bind:this={previewFrame} componentName={store.currentComponent} />
+    {:else if documentation !== null}
+      <ComponentDocumentation
+        bind:this={componentDocumentation}
+        componentName={store.currentComponent}
+        {documentation}
+      />
     {/if}
   </main>
   <Announcer />

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, untrack } from 'svelte';
+  import { onDestroy, onMount, untrack } from 'svelte';
   import { MediaQuery } from 'svelte/reactivity';
 
   import Announcer from './announcer.svelte';
@@ -7,12 +7,7 @@
   import { createEventSource } from './event-source.svelte.ts';
   import type { ComponentDocumentationPayload } from '../component-documentation-types.ts';
   import ComponentDocumentation from './component-documentation.svelte';
-  import {
-    applyThemeToDocument,
-    PreviewStore,
-    readPersistedTheme,
-    setPreviewStore,
-  } from './preview-store.svelte.ts';
+  import { applyThemeToDocument, PreviewStore, setPreviewStore } from './preview-store.svelte.ts';
   import { buildShellHref, readToolbarStateFromSearch } from './routing.ts';
   import ColorTokenPanel from './color-token-panel.svelte';
   import LandingPage from './landing-page.svelte';
@@ -41,13 +36,18 @@
   // next visit honors the user's last choice.
   const initialSearchValue = untrack(() => initialSearch);
   const initialUrlState = readToolbarStateFromSearch(new URLSearchParams(initialSearchValue));
-  const initialTheme = initialUrlState.theme ?? readPersistedTheme();
   const initialComponentName = untrack(() => initialComponent);
   const store = new PreviewStore(initialComponentName, {
     ...initialUrlState,
-    theme: initialTheme,
   });
   setPreviewStore(store);
+
+  // Server rendering cannot read localStorage. Keep the hydration tree seeded
+  // exclusively from request data, then restore the persisted preference once
+  // hydration has completed so the server and client markup stay identical.
+  onMount(() => {
+    if (initialUrlState.theme === null) store.syncFromUrl();
+  });
 
   // Single shared polite live region for the shell. The top bar pushes toolbar
   // feedback through it. One instance keeps exactly one live region in the

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -31,9 +31,7 @@
   // the loading overlay) instead of poking the raw iframe.
   let componentDocumentation = $state<ComponentDocumentation | null>(null);
 
-  // Seed the toolbar from the URL (shareable, survives reload). When the URL
-  // is silent about theme, fall back to the localStorage preference so the
-  // next visit honors the user's last choice.
+  // Seed the hydration tree exclusively from shareable, server-known URL state.
   const initialSearchValue = untrack(() => initialSearch);
   const initialUrlState = readToolbarStateFromSearch(new URLSearchParams(initialSearchValue));
   const initialComponentName = untrack(() => initialComponent);
@@ -46,6 +44,7 @@
   // exclusively from request data, then restore the persisted preference once
   // hydration has completed so the server and client markup stay identical.
   onMount(() => {
+    store.enableBrowserThemeResolution();
     if (initialUrlState.theme === null) store.syncFromUrl();
   });
 

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -9,6 +9,7 @@
 </script>
 
 <script lang="ts">
+  import { onMount } from 'svelte';
   import {
     Input,
     SideNavigation,
@@ -40,6 +41,26 @@
   let { components, currentComponent, onSelect, isOpen = false, onClose }: Props = $props();
 
   let filter = $state('');
+  let restoredSessionFilter = $state(false);
+  const FILTER_SESSION_KEY = 'cinder-playground-sidebar-filter';
+
+  onMount(() => {
+    try {
+      filter = sessionStorage.getItem(FILTER_SESSION_KEY) ?? '';
+    } catch {
+      filter = '';
+    }
+    restoredSessionFilter = true;
+  });
+
+  $effect(() => {
+    if (!restoredSessionFilter) return;
+    try {
+      sessionStorage.setItem(FILTER_SESSION_KEY, filter);
+    } catch {
+      /* ignore — degraded but functional */
+    }
+  });
 
   // The cinder Input owns its native <input> and does not forward a ref, so
   // the focus handle resolves the element by its stable id. The id is unique
@@ -71,7 +92,7 @@
     `${visibleComponents.length} component${visibleComponents.length === 1 ? '' : 's'} shown`,
   );
 
-  // A "plain" left-click is the only gesture we hijack for SPA navigation.
+  // A "plain" left-click is the only gesture we handle through `onSelect`.
   // Modified clicks (cmd/ctrl/shift/alt) and middle-clicks fall through to
   // native browser behavior so open-in-new-tab, "Copy Link Address", and
   // status-bar URL preview all keep working like regular anchor semantics.
@@ -84,19 +105,15 @@
     if (!isPlainLeftClick(event)) return;
     // Belt-and-suspenders: the capture-phase handler below normally fires first
     // and has already preventDefaulted + routed this exact click. Bailing on an
-    // already-handled event keeps onSelect from firing twice (which would push a
-    // duplicate history entry). If the capture handler somehow didn't run, this
-    // bubble-phase path still selects — so the SPA navigation never silently
-    // falls through to a native page load.
+    // already-handled event keeps onSelect from firing twice. If the capture
+    // handler somehow didn't run, this bubble-phase path still selects.
     if (event.defaultPrevented) return;
     event.preventDefault();
     onSelect(componentName);
   }
 
-  // Capture-phase delegation on the nav container. This is the GUARANTEE that a
-  // plain left-click never triggers the default anchor navigation (which would
-  // be a full page load to `/c/<name>` — a route the SPA owns but the static
-  // server does not, landing the user on a "page that doesn't exist").
+  // Capture-phase delegation on the nav container guarantees that a plain
+  // left-click delegates selection exactly once through `onSelect`.
   //
   // The per-item `onclick` below forwards through cinder's NavigationItem and
   // already calls preventDefault, but it runs in the BUBBLE phase and depends on

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -37,6 +37,7 @@ const { tick } = await import('svelte');
 // the whole suite runs in one process.
 afterEach(() => {
   cleanup();
+  sessionStorage.clear();
 });
 
 const COMPONENTS = ['button', 'tag-input', 'json-schema-editor', 'card'];

--- a/packages/testing/tests/playground-color-token-panel.playwright.ts
+++ b/packages/testing/tests/playground-color-token-panel.playwright.ts
@@ -709,8 +709,8 @@ test.describe('playground color token panel', () => {
 
     await page.reload({ waitUntil: 'load' });
     await waitForPlayground(page);
-    await expect.poll(() => shellTokenValue(page, TOKEN_NAME)).not.toBe(LIGHT_ADVANCED_OVERRIDE);
-    await expect.poll(() => iframeTokenValue(page, TOKEN_NAME)).not.toBe(LIGHT_ADVANCED_OVERRIDE);
+    await expect.poll(() => shellTokenValue(page, TOKEN_NAME)).toBe(LIGHT_ADVANCED_OVERRIDE);
+    await expect.poll(() => iframeTokenValue(page, TOKEN_NAME)).toBe(LIGHT_ADVANCED_OVERRIDE);
   });
 
   test('keeps token row actions and value input usable at narrow widths', async ({ page }) => {

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -17,6 +17,9 @@ test.describe('playground component documentation', () => {
       if (message.type() === 'error') errors.push(message.text());
     });
     page.on('pageerror', (error) => errors.push(error.message));
+    await page.addInitScript(() => {
+      localStorage.setItem('cinder-playground-theme', 'dark');
+    });
 
     await page.goto('/c/button?w=768', { waitUntil: 'load' });
     const documentation = page.locator('[data-canonical-documentation]');
@@ -29,6 +32,7 @@ test.describe('playground component documentation', () => {
       '/page/button?preview=1',
     );
     await expect(page.locator('#viewport-width-input')).toHaveValue('768');
+    await expect(page.getByRole('radio', { name: 'Dark' })).toBeChecked();
     await expect(
       page.getByRole('link', { name: 'Open interactive documentation' }),
     ).toHaveAttribute('href', '/page/button');

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -9,35 +9,26 @@ import { expect, test } from '@playwright/test';
  * open.
  */
 test.describe('playground component documentation', () => {
-  test('button exposes single-scroll sections and generated raw artifacts', async ({ page }) => {
+  test('button hydrates server-rendered canonical documentation without replacing it', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') errors.push(message.text());
+    });
+    page.on('pageerror', (error) => errors.push(error.message));
+
     await page.goto('/c/button', { waitUntil: 'load' });
-    const preview = page.frameLocator('iframe[data-cinder-preview]');
-
-    // The hero shows the component name as the page title, and the content
-    // sections render as headings on one scrolling page — no tabs.
-    await expect(preview.getByRole('heading', { level: 1, name: 'Button' })).toBeVisible();
-    for (const section of ['Overview', 'When to use', 'Examples', 'Props', 'Related']) {
-      await expect(preview.getByRole('heading', { name: section })).toBeVisible();
-    }
-    // The removed tabs no longer exist anywhere on the page.
-    await expect(preview.getByRole('tab')).toHaveCount(0);
-
-    // Each example renders inline with a lazy "Show code" disclosure.
-    await expect(preview.locator('.dx-example').first()).toBeVisible();
-    await expect(
-      preview.locator('.dx-example').first().getByRole('button', { name: 'Show code' }),
-    ).toBeVisible();
-
-    // Generated artifacts live in the collapsed "Raw artifacts" section. Opening
-    // it renders the manifest entry and schema as highlighted code blocks.
-    const rawArtifacts = preview.getByRole('button', { name: 'Raw artifacts' });
-    await expect(rawArtifacts).toHaveAttribute('aria-expanded', 'false');
-    await rawArtifacts.click();
-
-    await expect(preview.getByRole('heading', { name: 'Manifest entry' })).toBeVisible();
-    await expect(preview.getByRole('heading', { name: 'Schema' })).toBeVisible();
-    await expect(preview.getByText('"id": "button"')).toBeVisible();
-    await expect(preview.locator('.cinder-code-block__highlighted .shiki').first()).toBeVisible();
+    const documentation = page.locator('[data-canonical-documentation]');
+    await expect(documentation).toHaveCount(1);
+    await expect(documentation.getByRole('heading', { level: 1, name: 'Button' })).toBeVisible();
+    await expect(documentation.getByRole('heading', { name: 'Overview' })).toBeVisible();
+    await expect(documentation.getByRole('heading', { name: 'Props' })).toBeVisible();
+    await expect(page.locator('iframe[data-cinder-preview]')).toHaveAttribute(
+      'src',
+      '/page/button?preview=1',
+    );
+    expect(errors).toEqual([]);
   });
 
   test('playground preview re-renders live as a prop control changes (#405)', async ({ page }) => {
@@ -46,8 +37,8 @@ test.describe('playground component documentation', () => {
     // can't fill, so `showGeneratedPlayground` is true and the live mount
     // appears. Button requires an accessible name with no default, which flags
     // `hasUnsatisfiedRequired` and suppresses the generated playground entirely.
-    await page.goto('/c/toggle', { waitUntil: 'load' });
-    const preview = page.frameLocator('iframe[data-cinder-preview]');
+    await page.goto('/page/toggle', { waitUntil: 'load' });
+    const preview = page;
 
     // The Playground section mounts the BARE component live with the synthesized
     // prop values, labelled "Live preview" — not the static "Featured example".
@@ -73,8 +64,8 @@ test.describe('playground component documentation', () => {
   });
 
   test('avatar-group exposes its styling variables in the raw artifacts', async ({ page }) => {
-    await page.goto('/c/avatar-group', { waitUntil: 'load' });
-    const preview = page.frameLocator('iframe[data-cinder-preview]');
+    await page.goto('/page/avatar-group', { waitUntil: 'load' });
+    const preview = page;
 
     // Styling variables are part of the generated raw artifacts, collapsed by
     // default. Open the section, then assert the variables artifact rendered.

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -18,7 +18,7 @@ test.describe('playground component documentation', () => {
     });
     page.on('pageerror', (error) => errors.push(error.message));
 
-    await page.goto('/c/button', { waitUntil: 'load' });
+    await page.goto('/c/button?w=768', { waitUntil: 'load' });
     const documentation = page.locator('[data-canonical-documentation]');
     await expect(documentation).toHaveCount(1);
     await expect(documentation.getByRole('heading', { level: 1, name: 'Button' })).toBeVisible();
@@ -28,6 +28,11 @@ test.describe('playground component documentation', () => {
       'src',
       '/page/button?preview=1',
     );
+    await expect(page.locator('#viewport-width-input')).toHaveValue('768');
+    await expect(
+      page.getByRole('link', { name: 'Open interactive documentation' }),
+    ).toHaveAttribute('href', '/page/button');
+    await expect(page.getByTestId('preview-loading-overlay')).toHaveCount(0);
     expect(errors).toEqual([]);
   });
 

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -17,9 +17,7 @@ test.describe('playground component documentation', () => {
       if (message.type() === 'error') errors.push(message.text());
     });
     page.on('pageerror', (error) => errors.push(error.message));
-    await page.addInitScript(() => {
-      localStorage.setItem('cinder-playground-theme', 'dark');
-    });
+    await page.emulateMedia({ colorScheme: 'dark' });
 
     await page.goto('/c/button?w=768', { waitUntil: 'load' });
     const documentation = page.locator('[data-canonical-documentation]');
@@ -27,6 +25,16 @@ test.describe('playground component documentation', () => {
     await expect(documentation.getByRole('heading', { level: 1, name: 'Button' })).toBeVisible();
     await expect(documentation.getByRole('heading', { name: 'Overview' })).toBeVisible();
     await expect(documentation.getByRole('heading', { name: 'Props' })).toBeVisible();
+    const readme = documentation.locator('.cinder-markdown-content');
+    await expect(readme).toBeVisible();
+    expect(
+      await readme
+        .locator('p')
+        .first()
+        .evaluate((paragraph) => {
+          return Number.parseFloat(getComputedStyle(paragraph).marginBlockEnd);
+        }),
+    ).toBeGreaterThan(0);
     await expect(page.locator('iframe[data-cinder-preview]')).toHaveAttribute(
       'src',
       '/page/button?preview=1',
@@ -37,6 +45,24 @@ test.describe('playground component documentation', () => {
       page.getByRole('link', { name: 'Open interactive documentation' }),
     ).toHaveAttribute('href', '/page/button');
     await expect(page.getByTestId('preview-loading-overlay')).toHaveCount(0);
+    expect(errors).toEqual([]);
+  });
+
+  test('restores a persisted theme after hydration without changing the server tree', async ({
+    page,
+  }) => {
+    const errors: string[] = [];
+    page.on('console', (message) => {
+      if (message.type() === 'error') errors.push(message.text());
+    });
+    page.on('pageerror', (error) => errors.push(error.message));
+    await page.addInitScript(() => {
+      localStorage.setItem('cinder-playground-theme', 'dark');
+    });
+
+    await page.goto('/c/button', { waitUntil: 'load' });
+
+    await expect(page.getByRole('radio', { name: 'Dark' })).toBeChecked();
     expect(errors).toEqual([]);
   });
 

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -24,9 +24,7 @@ test.describe('playground landing page', () => {
     );
   }
 
-  test('renders README content at the root and returns to it with browser history', async ({
-    page,
-  }) => {
+  test('renders README content and uses full-page canonical browser history', async ({ page }) => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
@@ -42,12 +40,16 @@ test.describe('playground landing page', () => {
 
     await page.getByRole('link', { name: 'Browse components' }).click();
     await expect(page).toHaveURL(/\/c\/[^/]+$/);
-    await expect.poll(() => readShellMarker(page)).toBe('mounted');
-    await expect(page.locator('iframe')).toHaveAttribute('src', /\/page\/[^/]+$/);
+    await expect.poll(() => readShellMarker(page)).toBeUndefined();
+    await expect(page.locator('iframe')).toHaveAttribute('src', /\/page\/[^/?]+\?preview=1$/);
+
+    await page.evaluate(() => {
+      (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker = 'mounted';
+    });
 
     await page.goBack();
     await expect(page).toHaveURL(/\/$/);
-    await expect.poll(() => readShellMarker(page)).toBe('mounted');
+    await expect.poll(() => readShellMarker(page)).toBeUndefined();
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -37,11 +37,13 @@ test.describe('playground landing page', () => {
     await page.evaluate(() => {
       (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker = 'mounted';
     });
+    await page.locator('#sidebar-filter').fill('button');
 
     await page.getByRole('link', { name: 'Browse components' }).click();
     await expect(page).toHaveURL(/\/c\/[^/]+$/);
     await expect.poll(() => readShellMarker(page)).toBeUndefined();
     await expect(page.locator('iframe')).toHaveAttribute('src', /\/page\/[^/?]+\?preview=1$/);
+    await expect(page.locator('#sidebar-filter')).toHaveValue('button');
 
     await page.evaluate(() => {
       (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker = 'mounted';
@@ -50,6 +52,7 @@ test.describe('playground landing page', () => {
     await page.goBack();
     await expect(page).toHaveURL(/\/$/);
     await expect.poll(() => readShellMarker(page)).toBeUndefined();
+    await expect(page.locator('#sidebar-filter')).toHaveValue('button');
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);

--- a/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
+++ b/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
@@ -155,21 +155,13 @@ function expectInsetFocusPaint(paint: FocusPaint, label: string): void {
 }
 
 async function openButtonDocumentationPage(page: Page): Promise<Frame> {
-  await page.goto('/c/button', { waitUntil: 'load' });
+  await page.goto('/page/button', { waitUntil: 'load' });
   await page.waitForLoadState('networkidle');
-
-  const previewFrameElement = page.locator('iframe[data-cinder-preview]');
-  await expect(previewFrameElement).toBeVisible();
-  const previewFrameHandle = await previewFrameElement.elementHandle();
-  const previewFrame = await previewFrameHandle?.contentFrame();
-  if (previewFrame === null || previewFrame === undefined) {
-    throw new Error('/c/button did not expose the component documentation preview frame.');
-  }
 
   // The single-scroll page renders every section at once; the hero heading is a
   // stable readiness signal that the documentation payload has hydrated.
-  await expect(previewFrame.getByRole('heading', { level: 1, name: 'Button' })).toBeVisible();
-  return previewFrame;
+  await expect(page.getByRole('heading', { level: 1, name: 'Button' })).toBeVisible();
+  return page.mainFrame();
 }
 
 /**

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -83,10 +83,8 @@ test.describe('playground shell styles', () => {
     expect(filterMetrics.borderRadius).toBeGreaterThan(0);
     expect(filterMetrics.height).toBeGreaterThan(30);
 
-    const previewPage = page.frameLocator('iframe[data-cinder-preview]').locator('.dx');
-    await expect(previewPage).toBeVisible();
-    const previewPageMetrics = await computedMetrics(previewPage);
-    expect(previewPageMetrics.borderBlockStartWidth).toBeGreaterThan(0);
+    await expect(page.locator('[data-canonical-documentation]')).toBeVisible();
+    await expect(page.locator('iframe[data-cinder-preview]')).toBeVisible();
 
     await page.getByRole('radio', { name: 'Tablet (768 pixels)' }).click();
     await expect(viewportControl.locator('[data-cinder-selected]')).toContainText('Tablet');

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -116,6 +116,15 @@ test.describe('playground shell styles', () => {
     const focusModeButton = page.getByRole('button', { name: /Focus mode/ });
     await focusModeButton.click();
     await expect(page.locator('.shell')).toHaveClass(/focus-mode/);
+    await expect(page.locator('.documentation .hero')).toBeHidden();
+    const focusPreviewMetrics = await computedMetrics(page.locator('.documentation .preview'));
+    const focusMainMetrics = await computedMetrics(page.locator('main'));
+    expect(Math.abs(focusPreviewMetrics.height - focusMainMetrics.height)).toBeLessThanOrEqual(
+      PIXEL_TOLERANCE,
+    );
+    expect(Math.abs(focusPreviewMetrics.width - focusMainMetrics.width)).toBeLessThanOrEqual(
+      PIXEL_TOLERANCE,
+    );
     await page.keyboard.press('Escape');
     await expect(page.locator('.shell')).not.toHaveClass(/focus-mode/);
 


### PR DESCRIPTION
Closes #951.

## Summary

- inline validated documentation data into standalone component pages so initial rendering makes no documentation fetch and has no skeleton state
- server-render canonical `/c/<name>` documentation and hydrate the exact markup on the client
- constrain the iframe and loading overlay to the live preview surface at `/page/<name>?preview=1`
- analyze a single component manifest for cold canonical requests instead of scanning the full catalog
- add static-export, SSR, hydration, and browser regression coverage

## Verification

- `bun run --filter=@cinder/playground typecheck`
- `bun test packages/playground/scripts/static-export.test.ts`
- `bun test packages/playground/src/playground-server.test.ts`
- `bun test packages/playground/src/component-page-documentation.test.ts`
- `bun run --filter=@cinder/testing typecheck`
- focused Playwright: playground documentation, shell styles, and page chrome focus rings (7 passed)
- `bun run --filter=@cinder/playground lint`
- `git diff --check`