### PR TITLE
fix: enforce resting-state component contracts

### DIFF
--- a/.changeset/resting-state-contracts.md
+++ b/.changeset/resting-state-contracts.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix command-menu dismissal, load-more sentinel throttling, and resting layouts for sortable lists, logo clouds, and cards.

--- a/packages/components/src/components/card/card.css
+++ b/packages/components/src/components/card/card.css
@@ -95,11 +95,6 @@
     padding: 0;
   }
 
-  .cinder-card[data-cinder-padding='none'] > .cinder-card__header,
-  .cinder-card[data-cinder-padding='none'] > .cinder-card__footer {
-    padding: 0;
-  }
-
   .cinder-card[data-cinder-variant='well'] > .cinder-card__body {
     background: var(--cinder-surface-inset);
   }

--- a/packages/components/src/components/card/card.test.ts
+++ b/packages/components/src/components/card/card.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { createRawSnippet } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -27,6 +28,16 @@ const emptySnippet = createRawSnippet(() => ({
 }));
 
 describe('Card', () => {
+  test('keeps header and footer padding when body padding is none', () => {
+    const stylesheet = readFileSync(new URL('./card.css', import.meta.url), 'utf8');
+    expect(stylesheet).not.toContain(
+      ".cinder-card[data-cinder-padding='none'] > .cinder-card__header",
+    );
+    expect(stylesheet).not.toContain(
+      ".cinder-card[data-cinder-padding='none'] > .cinder-card__footer",
+    );
+  });
+
   test('renders a basic card without a generated header', () => {
     const { container } = render(Card, {
       props: {

--- a/packages/components/src/components/command-menu/command-menu.svelte
+++ b/packages/components/src/components/command-menu/command-menu.svelte
@@ -60,6 +60,11 @@
 
   let mounted = $state(false);
   let listElement: HTMLElement | undefined = $state();
+  let dismissedTrigger: {
+    anchor: HTMLInputElement | HTMLTextAreaElement;
+    value: string;
+    caretIndex: number;
+  } | null = $state(null);
   const commandList = createCommandListState(() => listboxId);
 
   const showEmpty = $derived(
@@ -101,6 +106,28 @@
   });
 
   $effect(() => {
+    const currentAnchor = anchor;
+    const currentValue = currentAnchor?.value;
+    if (
+      dismissedTrigger &&
+      (dismissedTrigger.anchor !== currentAnchor ||
+        dismissedTrigger.value !== currentValue ||
+        dismissedTrigger.caretIndex !== caretIndex)
+    ) {
+      dismissedTrigger = null;
+    }
+    if (
+      open &&
+      dismissedTrigger &&
+      dismissedTrigger.anchor === currentAnchor &&
+      dismissedTrigger.value === currentValue &&
+      dismissedTrigger.caretIndex === caretIndex
+    ) {
+      open = false;
+    }
+  });
+
+  $effect(() => {
     if (!open) {
       commandList.resetActiveItem();
       return;
@@ -135,6 +162,9 @@
 
   function dismiss() {
     if (!open) return;
+    if (anchor) {
+      dismissedTrigger = { anchor, value: anchor.value, caretIndex };
+    }
     open = false;
     onDismiss?.();
   }

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -189,6 +189,27 @@ describe('CommandMenu', () => {
     expect(dismissCount).toBe(1);
   });
 
+  test('Escape keeps the menu closed while the dismissed trigger remains unchanged', async () => {
+    const dismissed = mock(() => {});
+    const { getByTestId } = render(CommandMenuHostFixture, { onDismissed: dismissed });
+    const host = getByTestId('host') as HTMLTextAreaElement;
+
+    await fireEvent.input(host, { target: { value: '/a' } });
+    host.setSelectionRange(2, 2);
+    await fireEvent.keyUp(host, { key: 'a' });
+    await waitFor(() => expect(queryMenu()).not.toBeNull());
+
+    await fireEvent.keyDown(host, { key: 'Escape' });
+    await waitFor(() => expect(queryMenu()).toBeNull());
+    expect(dismissed).toHaveBeenCalledTimes(1);
+
+    // A host can run trigger detection again on the same key event. The
+    // dismissal must remain stable until the user changes the trigger text.
+    await fireEvent.keyUp(host, { key: 'Escape' });
+    await settleCommandMenu();
+    expect(queryMenu()).toBeNull();
+  });
+
   test('outside pointerdown dismisses the menu', async () => {
     let dismissCount = 0;
     const { getByTestId } = render(CommandMenuFixture, {

--- a/packages/components/src/components/load-more/load-more.svelte
+++ b/packages/components/src/components/load-more/load-more.svelte
@@ -37,15 +37,16 @@
   let requestInFlight = $state(false);
   let errorState = $state(false);
   let retryCount = $state(0);
+  let autoLoadCount = $state(0);
   // Tracks the last `hasMore` value the component reconciled against so a
-  // parent-driven false -> true flip (new page of data arrived) can clear the
-  // retry budget and error latch exactly once per transition.
+  // parent-driven false -> true flip (new page of data arrived) can clear both
+  // sentinel and error budgets exactly once per transition.
   let previousHasMore = hasMore;
 
   const mergedClassName = $derived(classNames('cinder-load-more', customClassName));
   const busy = $derived(loading || requestInFlight);
   const sentinelEnabled = $derived(
-    hasMore && !loading && !errorState && !requestInFlight && retryCount < maxRetries,
+    hasMore && !loading && !errorState && !requestInFlight && autoLoadCount < maxRetries,
   );
   // `enabled` is a getter, so `useIntersection`'s own `$effect` re-evaluates
   // `sentinelEnabled` reactively and toggles the observer in place. Constructing
@@ -69,6 +70,7 @@
   $effect(() => {
     if (!previousHasMore && hasMore) {
       retryCount = 0;
+      autoLoadCount = 0;
       errorState = false;
     }
     previousHasMore = hasMore;
@@ -79,12 +81,12 @@
       return;
     }
 
-    if (source === 'sentinel' && (errorState || retryCount >= maxRetries)) {
+    if (source === 'sentinel' && (errorState || autoLoadCount >= maxRetries)) {
       return;
     }
 
     if (source === 'sentinel') {
-      retryCount += 1;
+      autoLoadCount += 1;
     }
 
     requestInFlight = true;
@@ -94,6 +96,7 @@
       await onLoadMore();
       if (source === 'button') {
         retryCount = 0;
+        autoLoadCount = 0;
       }
     } catch (error) {
       errorState = true;

--- a/packages/components/src/components/load-more/load-more.test.ts
+++ b/packages/components/src/components/load-more/load-more.test.ts
@@ -151,6 +151,34 @@ describe('LoadMore', () => {
     });
   });
 
+  test('caps repeated sentinel callbacks independently from the error retry count', async () => {
+    let calls = 0;
+    const rendered = render(LoadMore, {
+      props: {
+        maxRetries: 2,
+        onloadmore: () => {
+          calls += 1;
+        },
+      },
+    });
+
+    const sentinel = rendered.container.querySelector('.cinder-load-more__sentinel') as Element;
+    const [record] = FakeIntersectionObserver.records;
+    const entry = createEntry(sentinel, true);
+
+    record?.callback([entry], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(1));
+    await waitFor(() =>
+      expect(rendered.container.firstElementChild?.getAttribute('aria-busy')).toBe('false'),
+    );
+    record?.callback([entry], {} as IntersectionObserver);
+    await waitFor(() => expect(calls).toBe(2));
+    record?.callback([entry], {} as IntersectionObserver);
+    await Promise.resolve();
+
+    expect(calls).toBe(2);
+  });
+
   test('ignores stale sentinel callbacks while loading or after an error', async () => {
     let calls = 0;
     let rejectNextRequest = false;

--- a/packages/components/src/components/logo-cloud/logo-cloud.css
+++ b/packages/components/src/components/logo-cloud/logo-cloud.css
@@ -36,19 +36,19 @@
   }
 
   .cinder-logo-cloud[data-cinder-columns='3'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud[data-cinder-columns='4'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud__item {

--- a/packages/components/src/components/logo-cloud/logo-cloud.test.ts
+++ b/packages/components/src/components/logo-cloud/logo-cloud.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -23,6 +24,15 @@ const logos = [
 ];
 
 describe('LogoCloud', () => {
+  test('maps each columns value to its matching grid track count', () => {
+    const stylesheet = readFileSync(new URL('./logo-cloud.css', import.meta.url), 'utf8');
+    for (const columns of [3, 4, 5, 6]) {
+      expect(stylesheet).toContain(
+        `.cinder-logo-cloud[data-cinder-columns='${columns}'] .cinder-logo-cloud__list {\n    grid-template-columns: repeat(${columns}, minmax(0, 1fr));`,
+      );
+    }
+  });
+
   test('renders logo images and optional links', () => {
     const { container } = render(LogoCloud, {
       props: {

--- a/packages/components/src/components/sortable-list/sortable-list.css
+++ b/packages/components/src/components/sortable-list/sortable-list.css
@@ -11,6 +11,9 @@
   }
 
   .cinder-sortable-item {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
     position: relative;
     cursor: default;
     user-select: none;

--- a/packages/components/src/components/sortable-list/sortable-list.test.ts
+++ b/packages/components/src/components/sortable-list/sortable-list.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck — test file; noUncheckedIndexedAccess and bun:test types disabled per project convention
 /// <reference lib="dom" />
 import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 import { createRawSnippet, tick } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
@@ -64,6 +65,13 @@ function renderList(overrides?: Record<string, unknown>) {
 // ---------------------------------------------------------------------------
 
 describe('SortableController', () => {
+  test('resting items provide an inline handle-and-label layout', () => {
+    const stylesheet = readFileSync(new URL('./sortable-list.css', import.meta.url), 'utf8');
+    expect(stylesheet).toContain(
+      '.cinder-sortable-item {\n    display: flex;\n    align-items: center;\n    gap: var(--cinder-space-2);',
+    );
+  });
+
   test('lift sets phase, key, from/to, liftedLabel, and calls announce', () => {
     const announce = mock();
     const controller = new SortableController({ announce });


### PR DESCRIPTION
Refs #931

Fix the concrete transition and resting-state regressions identified in the epic:

- Keep CommandMenu dismissed while the host trigger text and caret remain unchanged after Escape.
- Track LoadMore sentinel auto-loads separately from the error retry budget and stop repeated callbacks at the configured cap.
- Restore the SortableList resting flex layout and make LogoCloud column values map to their declared track counts.
- Keep Card header and footer padding when `padding="none"` is used (the body remains edge-to-edge).

Regression tests cover the steady states and CSS contracts. Existing visual-regression capture/diff infrastructure remains documented under `docs/visual-regression/`; this PR does not regenerate the repository-wide PNG matrix.

Focused verification:
- `bun test packages/components/src/components/card/card.test.ts packages/components/src/components/command-menu/command-menu.test.ts packages/components/src/components/load-more/load-more.test.ts packages/components/src/components/logo-cloud/logo-cloud.test.ts packages/components/src/components/sortable-list/sortable-list.test.ts`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
