### PR TITLE
fix(playground): keep build temp files out of src

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -323,6 +323,9 @@ jobs:
             bunx turbo run test --filter=@cinder/playground
           fi
 
+      - name: Check Playground source temporary directories
+        run: bun run --filter=@cinder/playground check:source-temp
+
       - name: Run component unit tests (scoped)
         # Scopes the `@lostgradient/cinder` (components) package to the changed components and
         # their dependents. `@lostgradient/markdown`/`@lostgradient/editor`

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,7 @@ packages/playground/public/
 scripts/playground/.controls-*.svelte
 # Per-build UUID temp dirs created by buildBundle/buildPageBundle.
 **/.tmp-*/
+packages/playground/.tmp/
 # Import-graph leanness test scratch dirs.
 **/.import-graph-*/
 

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "check:source-temp": "bun run scripts/check-source-temp.ts",
+    "clean": "bun run scripts/clean.ts",
     "dev": "bun run --filter='@lostgradient/markdown' build && bun run --filter='@lostgradient/cinder' build && bun run --filter='@lostgradient/editor' build && bun run --filter='@lostgradient/chat' build && bun --watch run src/playground-server.ts",
     "examples:audit": "bun run scripts/check-raw-native-controls.ts",
     "lint": "oxlint src/ scripts/",

--- a/packages/playground/scripts/check-source-temp.ts
+++ b/packages/playground/scripts/check-source-temp.ts
@@ -2,6 +2,12 @@ import { readdir } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 import { PLAYGROUND_TEMP_ROOT } from '../src/playground-paths.ts';
 
+const serverSource = await Bun.file(join(import.meta.dir, '..', 'src', 'playground-server.ts')).text();
+if (serverSource.includes("join(PLAYGROUND_ROOT, 'src', `.tmp-")) {
+  console.error('Page server renderer must write temporary bundles under PLAYGROUND_TEMP_ROOT.');
+  process.exit(1);
+}
+
 const sourceDirectory = join(import.meta.dir, '..', 'src');
 const tempRootRelativeToSource = relative(sourceDirectory, PLAYGROUND_TEMP_ROOT);
 if (

--- a/packages/playground/scripts/check-source-temp.ts
+++ b/packages/playground/scripts/check-source-temp.ts
@@ -1,7 +1,19 @@
 import { readdir } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, relative, sep } from 'node:path';
+import { PLAYGROUND_TEMP_ROOT } from '../src/playground-paths.ts';
 
 const sourceDirectory = join(import.meta.dir, '..', 'src');
+const tempRootRelativeToSource = relative(sourceDirectory, PLAYGROUND_TEMP_ROOT);
+if (
+  tempRootRelativeToSource !== '..' &&
+  !tempRootRelativeToSource.startsWith(`..${sep}`)
+) {
+  console.error(
+    `Playground build temporary root must stay outside packages/playground/src: ${PLAYGROUND_TEMP_ROOT}`,
+  );
+  process.exit(1);
+}
+
 const entries = await readdir(sourceDirectory, { withFileTypes: true });
 const stragglers = entries.filter((entry) => entry.isDirectory() && entry.name.startsWith('.tmp-'));
 

--- a/packages/playground/scripts/check-source-temp.ts
+++ b/packages/playground/scripts/check-source-temp.ts
@@ -1,0 +1,14 @@
+import { readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const sourceDirectory = join(import.meta.dir, '..', 'src');
+const entries = await readdir(sourceDirectory, { withFileTypes: true });
+const stragglers = entries.filter((entry) => entry.isDirectory() && entry.name.startsWith('.tmp-'));
+
+if (stragglers.length > 0) {
+  console.error(`Found ${stragglers.length} temporary directories under packages/playground/src:`);
+  for (const entry of stragglers) console.error(`- ${entry.name}`);
+  process.exit(1);
+}
+
+console.log('No temporary directories found under packages/playground/src.');

--- a/packages/playground/scripts/clean.ts
+++ b/packages/playground/scripts/clean.ts
@@ -1,0 +1,15 @@
+import { readdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const playgroundRoot = join(import.meta.dir, '..');
+await rm(join(playgroundRoot, '.tmp'), { recursive: true, force: true });
+
+const sourceDirectory = join(playgroundRoot, 'src');
+const sourceEntries = (await readdir(sourceDirectory, { withFileTypes: true }))
+  .filter((entry) => entry.isDirectory() && entry.name.startsWith('.tmp-'))
+  .map((entry) => entry.name);
+await Promise.all(
+  sourceEntries.map((entry) =>
+    rm(join(playgroundRoot, 'src', entry), { recursive: true, force: true }),
+  ),
+);

--- a/packages/playground/scripts/clean.ts
+++ b/packages/playground/scripts/clean.ts
@@ -5,7 +5,8 @@ const playgroundRoot = join(import.meta.dir, '..');
 await rm(join(playgroundRoot, '.tmp'), { recursive: true, force: true });
 
 const sourceDirectory = join(playgroundRoot, 'src');
-const sourceEntries = (await readdir(sourceDirectory, { withFileTypes: true }))
+const sourceDirectoryEntries = await readdir(sourceDirectory, { withFileTypes: true });
+const sourceEntries = sourceDirectoryEntries
   .filter((entry) => entry.isDirectory() && entry.name.startsWith('.tmp-'))
   .map((entry) => entry.name);
 await Promise.all(

--- a/packages/playground/src/playground-paths.ts
+++ b/packages/playground/src/playground-paths.ts
@@ -1,0 +1,4 @@
+import { dirname, join } from 'node:path';
+
+export const PLAYGROUND_ROOT = dirname(import.meta.dirname);
+export const PLAYGROUND_TEMP_ROOT = join(PLAYGROUND_ROOT, '.tmp');

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -27,7 +27,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { existsSync, rmSync, watch, type FSWatcher } from 'node:fs';
-import { dirname, isAbsolute, join, relative as relativePath, sep } from 'node:path';
+import { isAbsolute, join, relative as relativePath, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 import { initializeHighlighter, renderMarkdown } from '@lostgradient/markdown/rendering';
@@ -88,6 +88,7 @@ import { humanizeComponentName } from './shell-app/humanize.ts';
 
 import { stripExampleHarness } from '../../components/scripts/lib/strip-example-harness.ts';
 import type { ComponentDocumentationPayload } from './component-documentation-types.ts';
+import { PLAYGROUND_ROOT, PLAYGROUND_TEMP_ROOT } from './playground-paths.ts';
 import {
   isSnapshotMode,
   snapshotModeHtmlAttribute,
@@ -115,9 +116,6 @@ export function resolvePreferredPort(): number {
 
 export const PORT = resolvePreferredPort();
 const MAX_PORT_SCAN_ATTEMPTS = 100;
-// import.meta.dirname is packages/playground/src/
-const PLAYGROUND_ROOT = dirname(import.meta.dirname); // packages/playground/
-const PLAYGROUND_TEMP_ROOT = join(PLAYGROUND_ROOT, '.tmp');
 const COMPONENTS_ROOT = CINDER_COMPONENT_SOURCE.packageRoot; // packages/components/
 const REPO_ROOT = join(PLAYGROUND_ROOT, '..', '..'); // repo root
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -117,6 +117,7 @@ export const PORT = resolvePreferredPort();
 const MAX_PORT_SCAN_ATTEMPTS = 100;
 // import.meta.dirname is packages/playground/src/
 const PLAYGROUND_ROOT = dirname(import.meta.dirname); // packages/playground/
+const PLAYGROUND_TEMP_ROOT = join(PLAYGROUND_ROOT, '.tmp');
 const COMPONENTS_ROOT = CINDER_COMPONENT_SOURCE.packageRoot; // packages/components/
 const REPO_ROOT = join(PLAYGROUND_ROOT, '..', '..'); // repo root
 
@@ -777,9 +778,9 @@ async function buildBundleUncached(
   // other on disk; the basename itself stays stable so Bun's `[name]`
   // resolves predictably.
   const entryBasename = `bundle-${componentName}-${scenario}`;
-  const entryTempDir = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+  const entryTempDir = join(PLAYGROUND_TEMP_ROOT, randomUUID());
   const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
-  const shim = `export { default } from '../examples/${componentName}/${scenario}.example.svelte';\n`;
+  const shim = `export { default } from '../../src/examples/${componentName}/${scenario}.example.svelte';\n`;
 
   try {
     // Bun.write auto-creates parent directories. We keep the write inside
@@ -878,13 +879,13 @@ async function compilePageBundleArtifacts(
   // which renders a "No examples found" fallback.
 
   const entryBasename = `page-${componentName}`;
-  const entryTempDir = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+  const entryTempDir = join(PLAYGROUND_TEMP_ROOT, randomUUID());
   const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
 
   const scenarioImports = scenarios
     .map(
       (scenario, index) =>
-        `import Scenario_${index} from '../examples/${componentName}/${scenario}.example.svelte';`,
+        `import Scenario_${index} from '../../src/examples/${componentName}/${scenario}.example.svelte';`,
     )
     .join('\n');
   const scenarioRegistrations = scenarios
@@ -893,7 +894,7 @@ async function compilePageBundleArtifacts(
 
   const entrySource = `import { hydrate, mount } from 'svelte';
 
-import ComponentPage from '../component-page.svelte';
+import ComponentPage from '../../src/component-page.svelte';
 import * as BareComponentModule from ${JSON.stringify(componentDefinition.importPath)};
 ${scenarioImports}
 const scenarios: Record<string, unknown> = {
@@ -1072,7 +1073,7 @@ async function compileFixtureBundleArtifacts(
   componentOrHostPath: string,
 ): Promise<{ entryPath: string; entryCode: string; artifacts: Map<string, string> } | null> {
   const entryBasename = fixtureEntryKey(componentName, fixture.name, fixtureContentHash);
-  const entryTempDir = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+  const entryTempDir = join(PLAYGROUND_TEMP_ROOT, randomUUID());
   const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
   const propsTempPath = join(entryTempDir, `${entryBasename}-props.ts`);
   const componentImport = relativeImportSpecifier(entryTempDir, componentOrHostPath);
@@ -1201,13 +1202,13 @@ async function compileShellBundleArtifacts(): Promise<{
   artifacts: Map<string, string>;
 } | null> {
   const entryBasename = 'shell-shell';
-  const entryTempDir = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+  const entryTempDir = join(PLAYGROUND_TEMP_ROOT, randomUUID());
   const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
   // Side-effect import: `shell-entry.ts` calls `mount(Shell, ...)` at module
   // top level and exports nothing. `export {} from` is a re-export of named
   // bindings and is eligible for tree-shaking when the source exports no
   // names; a bare side-effect import preserves the module's evaluation.
-  const shim = `import '../shell-app/shell-entry.ts';\n`;
+  const shim = `import '../../src/shell-app/shell-entry.ts';\n`;
 
   try {
     await Bun.write(entryTempPath, shim);
@@ -1259,7 +1260,7 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
         throw new Error(`Shell server bundle failed:\n${result.logs.join('\n')}`);
       }
 
-      const serverBundleDirectory = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+      const serverBundleDirectory = join(PLAYGROUND_TEMP_ROOT, randomUUID());
       const serverBundlePath = join(serverBundleDirectory, 'shell-server.js');
       let loaded: unknown;
       try {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1318,7 +1318,7 @@ async function loadPageServerRenderer(): Promise<PageServerRenderer> {
         throw new Error(`Page server bundle failed:\n${result.logs.join('\n')}`);
       }
 
-      const serverBundleDirectory = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+      const serverBundleDirectory = join(PLAYGROUND_TEMP_ROOT, randomUUID());
       const serverBundlePath = join(serverBundleDirectory, 'page-server.js');
       let loaded: unknown;
       try {


### PR DESCRIPTION
## Summary
- move playground build scratch files from `packages/playground/src` to `packages/playground/.tmp`
- add cleanup and source-temp guard scripts
- run the guard in playground CI

## Verification
- `bun run --filter=@cinder/playground lint`
- `bun run --filter=@cinder/playground check:source-temp`
- clean/guard regression (creates a straggler, verifies failure, cleans it)
- `bun run --filter=@cinder/playground typecheck`

Closes #952