### PR TITLE
fix(playground): compact viewport toolbar controls

### DIFF
--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -485,6 +485,17 @@
     box-shadow: inset 0 -2px 0 var(--cinder-accent);
   }
 
+  @media (forced-colors: active) {
+    .top-bar :global(.cinder-segmented-control-option[data-cinder-selected]),
+    .top-bar :global(.cinder-segmented-control-option[data-cinder-current]),
+    .top-bar :global(.cinder-segmented-control-option[data-cinder-pressed]) {
+      background: Canvas;
+      color: CanvasText;
+      border-block-end: 2px solid Highlight;
+      forced-color-adjust: none;
+    }
+  }
+
   /*
    * Keep compact segmented-control labels on a single line. Cinder's
    * toolbar-density segments have no `white-space: nowrap`, so a tightened

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -53,7 +53,7 @@
 
   const VIEWPORT_SEGMENTED_OPTIONS = VIEWPORT_PRESETS.map((preset) => ({
     value: preset.key,
-    label: preset.value !== null ? `${preset.label} (${preset.value} pixels)` : preset.label,
+    label: preset.value !== null ? `${preset.value}px` : preset.label,
   }));
 
   // Derive the SegmentedControl value from store.previewWidth. When no preset
@@ -221,7 +221,7 @@
       </Toolbar.Group>
     {/if}
 
-    <Toolbar.Group>
+    <Toolbar.Group class="theme-controls">
       <SegmentedControl
         id="theme-preset"
         label="Preview theme"
@@ -455,12 +455,40 @@
     min-width: 0;
   }
 
+  /* Keep viewport sizing and theme selection legible as two related but
+   * distinct groups instead of one continuous block of controls. */
+  .top-bar :global(.viewport-size-controls) {
+    gap: var(--cinder-space-2);
+    padding-inline-end: var(--cinder-space-3);
+    margin-inline-end: var(--cinder-space-3);
+    border-inline-end: 1px solid var(--cinder-border-muted);
+  }
+
+  /* Toolbar controls use a compact, quiet treatment so the preview remains
+   * the visual focus. Keep the shared control contract while reducing the
+   * saturated selected-state chrome locally to this shell toolbar. */
+  .top-bar :global(.cinder-segmented-control) {
+    border-radius: var(--cinder-radius-sm);
+    background: transparent;
+  }
+
+  .top-bar :global(.cinder-segmented-control-option) {
+    min-block-size: 1.875rem;
+    border-radius: calc(var(--cinder-radius-sm) - 2px);
+  }
+
+  .top-bar :global(.cinder-segmented-control-option[data-cinder-selected]),
+  .top-bar :global(.cinder-segmented-control-option[data-cinder-current]),
+  .top-bar :global(.cinder-segmented-control-option[data-cinder-pressed]) {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 84%);
+    color: var(--cinder-text);
+    box-shadow: none;
+  }
+
   /*
-   * Keep segmented-control labels on a single line. Cinder's toolbar-density
-   * segments have no `white-space: nowrap`, so a long label ("Mobile (375
-   * pixels)") wraps to two/three cramped lines the moment the row tightens —
-   * which is exactly what mangled the toolbar when a viewport preset was
-   * selected. Force single-line segments.
+   * Keep compact segmented-control labels on a single line. Cinder's
+   * toolbar-density segments have no `white-space: nowrap`, so a tightened
+   * toolbar can otherwise wrap even short viewport labels.
    */
   .top-bar :global(.cinder-segmented-control-option) {
     white-space: nowrap;

--- a/packages/playground/src/shell-app/top-bar.svelte
+++ b/packages/playground/src/shell-app/top-bar.svelte
@@ -477,12 +477,12 @@
     border-radius: calc(var(--cinder-radius-sm) - 2px);
   }
 
-  .top-bar :global(.cinder-segmented-control-option[data-cinder-selected]),
-  .top-bar :global(.cinder-segmented-control-option[data-cinder-current]),
-  .top-bar :global(.cinder-segmented-control-option[data-cinder-pressed]) {
-    background: color-mix(in oklch, var(--cinder-accent), transparent 84%);
+  .top-bar :global(.cinder-segmented-control-option[data-cinder-selected]:not(:focus-visible)),
+  .top-bar :global(.cinder-segmented-control-option[data-cinder-current]:not(:focus-visible)),
+  .top-bar :global(.cinder-segmented-control-option[data-cinder-pressed]:not(:focus-visible)) {
+    background: color-mix(in oklch, var(--cinder-accent), transparent 55%);
     color: var(--cinder-text);
-    box-shadow: none;
+    box-shadow: inset 0 -2px 0 var(--cinder-accent);
   }
 
   /*

--- a/packages/playground/src/shell-app/top-bar.test.ts
+++ b/packages/playground/src/shell-app/top-bar.test.ts
@@ -303,6 +303,30 @@ describe('top-bar theme selection', () => {
   });
 });
 
+describe('top-bar viewport selection', () => {
+  test('uses compact preset labels and preserves every viewport width', async () => {
+    const store = new PreviewStore('button');
+    const { container } = render(TopBarFixture, { store });
+    await tick();
+
+    for (const [label, width] of [
+      ['375px', 375],
+      ['768px', 768],
+      ['1280px', 1280],
+    ] as const) {
+      const button = buttonByText(container, label);
+      expect(button).not.toBeNull();
+      button.click();
+      await tick();
+      expect(store.previewWidth).toBe(width);
+    }
+
+    buttonByText(container, 'Full').click();
+    await tick();
+    expect(store.previewWidth).toBeNull();
+  });
+});
+
 describe('top-bar announcements', () => {
   test('aria-live region is empty until the 50 ms gap elapses, then carries the message', async () => {
     const store = new PreviewStore('button');

--- a/packages/playground/src/shell-app/top-bar.test.ts
+++ b/packages/playground/src/shell-app/top-bar.test.ts
@@ -19,6 +19,7 @@
  * refactors of `top-bar.svelte` don't break them.
  */
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { readFile } from 'node:fs/promises';
 
 import { setupHappyDom } from '../../../components/src/test/happy-dom.ts';
 
@@ -114,6 +115,24 @@ function tooltipTextFor(control: HTMLElement): string | null {
   if (tooltip?.getAttribute('role') !== 'tooltip') return null;
   return tooltip.textContent?.trim() ?? null;
 }
+
+describe('top-bar selected-state contrast', () => {
+  test('keeps the selected segment visible in forced-colors mode', async () => {
+    const source = await readFile(new URL('./top-bar.svelte', import.meta.url), 'utf8');
+    const mediaQueryStart = source.indexOf('@media (forced-colors: active)');
+    const mediaQueryEnd = source.indexOf('\n  }', mediaQueryStart);
+
+    expect(mediaQueryStart).toBeGreaterThan(-1);
+    expect(mediaQueryEnd).toBeGreaterThan(mediaQueryStart);
+
+    const forcedColorsRule = source.slice(mediaQueryStart, mediaQueryEnd);
+    expect(forcedColorsRule).toContain('[data-cinder-selected]');
+    expect(forcedColorsRule).toContain('[data-cinder-current]');
+    expect(forcedColorsRule).toContain('[data-cinder-pressed]');
+    expect(forcedColorsRule).toContain('border-block-end: 2px solid Highlight');
+    expect(forcedColorsRule).toContain('forced-color-adjust: none');
+  });
+});
 
 describe('top-bar open-in-new-tab button', () => {
   test('renders the public toolbar controls', async () => {

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -86,8 +86,8 @@ test.describe('playground shell styles', () => {
     await expect(page.locator('[data-canonical-documentation]')).toBeVisible();
     await expect(page.locator('iframe[data-cinder-preview]')).toBeVisible();
 
-    await page.getByRole('radio', { name: 'Tablet (768 pixels)' }).click();
-    await expect(viewportControl.locator('[data-cinder-selected]')).toContainText('Tablet');
+    await page.getByRole('radio', { name: '768px' }).click();
+    await expect(viewportControl.locator('[data-cinder-selected]')).toContainText('768px');
 
     // The custom-width field is cinder's Input with type="number" (a native
     // number input), so it renders as `.cinder-input`, not `.cinder-number-input`.


### PR DESCRIPTION
## Summary
- shorten viewport presets to 375px, 768px, and 1280px
- reduce segmented-control chrome and separate viewport/theme groups
- add regression coverage for all viewport presets and Full

## Verification
- `git diff --check`
- `bunx prettier --check .../top-bar.svelte .../top-bar.test.ts`
- Svelte compiler check
- focused Bun test is blocked in the isolated worktree because `bun install --frozen-lockfile` did not materialize `node_modules`; the same existing test file passes from the main checkout

Closes #954