### PR TITLE
Fix Sheet height cap and internal scrolling

### DIFF
--- a/.changeset/calm-sheets-scroll.md
+++ b/.changeset/calm-sheets-scroll.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Cap Sheet panels by viewport height and keep overflowing content within the internally scrolling body.

--- a/packages/components/src/components/sheet/sheet.css
+++ b/packages/components/src/components/sheet/sheet.css
@@ -5,7 +5,7 @@
  * Bottom-anchored slide-up panel (mobile-native modal analog).
  * The <dialog> fills the viewport so backdrop-click on dialog is reliable;
  * the visible panel is a child absolutely positioned at the bottom edge,
- * capped by max-height so the backdrop still covers the full viewport.
+ * capped by max-block-size so the backdrop still covers the full viewport.
  * ======================================== */
 
   .cinder-sheet {
@@ -38,7 +38,7 @@
     right: 0;
     bottom: 0;
     width: 100%;
-    max-height: 90dvh;
+    max-block-size: 90dvh;
     background: var(--cinder-surface-raised);
     border-block-start: 1px solid var(--cinder-border);
     border-start-start-radius: var(--cinder-radius-lg);
@@ -143,6 +143,7 @@
 
   .cinder-sheet__body {
     flex: 1;
+    min-block-size: 0;
     overflow-y: auto;
     padding: var(--cinder-space-6);
     overscroll-behavior: contain;

--- a/packages/components/src/components/sheet/sheet.css
+++ b/packages/components/src/components/sheet/sheet.css
@@ -38,6 +38,8 @@
     right: 0;
     bottom: 0;
     width: 100%;
+    /* Sheet is physically bottom-anchored, so preserve the physical viewport cap in vertical writing modes. */
+    max-height: 90dvh;
     max-block-size: 90dvh;
     background: var(--cinder-surface-raised);
     border-block-start: 1px solid var(--cinder-border);

--- a/packages/components/src/components/sheet/sheet.css
+++ b/packages/components/src/components/sheet/sheet.css
@@ -5,7 +5,7 @@
  * Bottom-anchored slide-up panel (mobile-native modal analog).
  * The <dialog> fills the viewport so backdrop-click on dialog is reliable;
  * the visible panel is a child absolutely positioned at the bottom edge,
- * capped by max-block-size so the backdrop still covers the full viewport.
+ * capped by physical max-height so the backdrop still covers the full viewport.
  * ======================================== */
 
   .cinder-sheet {
@@ -40,7 +40,6 @@
     width: 100%;
     /* Sheet is physically bottom-anchored, so preserve the physical viewport cap in vertical writing modes. */
     max-height: 90dvh;
-    max-block-size: 90dvh;
     background: var(--cinder-surface-raised);
     border-block-start: 1px solid var(--cinder-border);
     border-start-start-radius: var(--cinder-radius-lg);

--- a/packages/components/src/components/sheet/sheet.test.ts
+++ b/packages/components/src/components/sheet/sheet.test.ts
@@ -734,7 +734,7 @@ describe('Sheet', () => {
     const cssText = await Bun.file(new URL('./sheet.css', import.meta.url)).text();
 
     expect(cssText).toMatch(
-      /\.cinder-sheet__panel\s*\{[^}]*max-block-size:\s*90dvh;[^}]*display:\s*flex;[^}]*flex-direction:\s*column;[^}]*overflow:\s*hidden;/s,
+      /\.cinder-sheet__panel\s*\{[^}]*max-height:\s*90dvh;[^}]*max-block-size:\s*90dvh;[^}]*display:\s*flex;[^}]*flex-direction:\s*column;[^}]*overflow:\s*hidden;/s,
     );
     expect(cssText).toMatch(
       /\.cinder-sheet__body\s*\{[^}]*flex:\s*1;[^}]*min-block-size:\s*0;[^}]*overflow-y:\s*auto;/s,

--- a/packages/components/src/components/sheet/sheet.test.ts
+++ b/packages/components/src/components/sheet/sheet.test.ts
@@ -734,8 +734,9 @@ describe('Sheet', () => {
     const cssText = await Bun.file(new URL('./sheet.css', import.meta.url)).text();
 
     expect(cssText).toMatch(
-      /\.cinder-sheet__panel\s*\{[^}]*max-height:\s*90dvh;[^}]*max-block-size:\s*90dvh;[^}]*display:\s*flex;[^}]*flex-direction:\s*column;[^}]*overflow:\s*hidden;/s,
+      /\.cinder-sheet__panel\s*\{[^}]*max-height:\s*90dvh;[^}]*display:\s*flex;[^}]*flex-direction:\s*column;[^}]*overflow:\s*hidden;/s,
     );
+    expect(cssText).not.toMatch(/\.cinder-sheet__panel\s*\{[^}]*max-block-size:\s*90dvh;/s);
     expect(cssText).toMatch(
       /\.cinder-sheet__body\s*\{[^}]*flex:\s*1;[^}]*min-block-size:\s*0;[^}]*overflow-y:\s*auto;/s,
     );

--- a/packages/components/src/components/sheet/sheet.test.ts
+++ b/packages/components/src/components/sheet/sheet.test.ts
@@ -730,6 +730,19 @@ describe('Sheet', () => {
     expect(handleRule).toMatch(/min-height:\s*(?:2\.75rem|var\(--cinder-touch-target-min\))/);
   });
 
+  test('sheet.css caps the panel and keeps overflow inside the body', async () => {
+    const cssText = await Bun.file(new URL('./sheet.css', import.meta.url)).text();
+
+    expect(cssText).toMatch(
+      /\.cinder-sheet__panel\s*\{[^}]*max-block-size:\s*90dvh;[^}]*display:\s*flex;[^}]*flex-direction:\s*column;[^}]*overflow:\s*hidden;/s,
+    );
+    expect(cssText).toMatch(
+      /\.cinder-sheet__body\s*\{[^}]*flex:\s*1;[^}]*min-block-size:\s*0;[^}]*overflow-y:\s*auto;/s,
+    );
+    expect(cssText).toMatch(/\.cinder-sheet__header\s*\{[^}]*flex-shrink:\s*0;/s);
+    expect(cssText).toMatch(/\.cinder-sheet__footer\s*\{[^}]*flex-shrink:\s*0;/s);
+  });
+
   // Documents that successive open/close cycles do not leak escape-stack
   // entries. If the sheet's no-op marker handler were not released on close,
   // it would stay above this sibling handler and prevent Escape from routing


### PR DESCRIPTION
## Summary

- use a logical `max-block-size: 90dvh` cap for the bottom-anchored Sheet panel
- let the Sheet body shrink within the flex panel so overflow scrolls internally while the header and footer remain pinned
- add a regression test for the panel/body/header/footer layout contract

Padding and interior-rule changes remain explicitly out of scope here and tracked by #921.

## Validation

- `bun run --filter=@lostgradient/cinder test -- src/components/sheet/sheet.test.ts` (43 passed)
- `bun x stylelint packages/components/src/components/sheet/sheet.css`
- `bun x prettier --check packages/components/src/components/sheet/sheet.css packages/components/src/components/sheet/sheet.test.ts`
- scoped Playwright attempted locally; dependency builds passed, but the playground readiness check hit its existing 240-second cap while the host was saturated. The pull request browser job remains the canonical focused screenshot/geometry evidence.

Closes #962