### PR TITLE
fix(event-timeline): prevent label collisions and cap dense lanes

### DIFF
--- a/.changeset/event-timeline-collision.md
+++ b/.changeset/event-timeline-collision.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix EventTimeline label collisions with measured container sizing, leader-line offsets, and accessible clustered events.

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -14,6 +14,7 @@ export type AnchoredOverlayOptions = {
   arrowPadding?: () => number;
   arrowVisible?: () => boolean;
   widthMode?: () => AnchoredOverlayWidthMode;
+  strategy?: () => 'fixed' | 'absolute';
 };
 
 const DEFAULT_PLACEMENT: Placement = 'bottom-start';
@@ -115,6 +116,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     const arrow = options.arrow?.();
     const arrowVisible = options.arrowVisible?.() ?? Boolean(arrow);
     const widthMode = options.widthMode?.() ?? 'content';
+    const strategy = options.strategy?.() ?? 'fixed';
     let cancelled = false;
     let generation = 0;
     let stopAutoUpdate: (() => void) | undefined;
@@ -148,7 +150,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
           result = await computePosition(anchor, panel, {
             placement,
             middleware,
-            strategy: 'fixed',
+            strategy,
           });
         } catch {
           if (cancelled || currentGeneration !== generation) return;
@@ -162,7 +164,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
 
         const widthStyle = getAnchoredOverlayWidthStyle(widthMode, anchor.getBoundingClientRect());
         positionStyle = [
-          'position: fixed;',
+          `position: ${strategy};`,
           `left: ${result.x}px;`,
           `top: ${result.y}px;`,
           widthStyle,

--- a/packages/components/src/components/event-timeline/event-timeline-modal.ts
+++ b/packages/components/src/components/event-timeline/event-timeline-modal.ts
@@ -13,3 +13,33 @@ export function setEventTimelineModalPredicate(predicate: (element: HTMLElement)
 export function isEventTimelineModal(element: HTMLElement): boolean {
   return modalPredicate(element);
 }
+
+function hasContainingBlockStyle(style: CSSStyleDeclaration): boolean {
+  return (
+    style.transform !== 'none' ||
+    style.translate !== 'none' ||
+    style.scale !== 'none' ||
+    style.rotate !== 'none' ||
+    style.filter !== 'none' ||
+    style.contain !== 'none'
+  );
+}
+
+export function hasFixedPositionContainingBlock(element: HTMLElement): boolean {
+  for (let current: HTMLElement | null = element; current; current = current.parentElement) {
+    if (hasContainingBlockStyle(getComputedStyle(current))) return true;
+  }
+  return false;
+}
+
+export function observeEventTimelineDirection(node: HTMLElement, callback: () => void): () => void {
+  const observer = new MutationObserver(callback);
+  const options: MutationObserverInit = {
+    attributes: true,
+    attributeFilter: ['class', 'dir', 'style'],
+  };
+  for (let current: HTMLElement | null = node; current; current = current.parentElement) {
+    observer.observe(current, options);
+  }
+  return () => observer.disconnect();
+}

--- a/packages/components/src/components/event-timeline/event-timeline-modal.ts
+++ b/packages/components/src/components/event-timeline/event-timeline-modal.ts
@@ -23,6 +23,13 @@ function createsContainingBlock(value: string | undefined): boolean {
   return value !== undefined && value !== '' && value !== 'none';
 }
 
+const CONTAINING_BLOCK_WILL_CHANGE_VALUES = ['transform', 'perspective', 'filter'];
+
+function willChangeCreatesContainingBlock(willChange: string | undefined): boolean {
+  if (!willChange) return false;
+  return CONTAINING_BLOCK_WILL_CHANGE_VALUES.some((value) => willChange.includes(value));
+}
+
 function hasContainingBlockStyle(style: CSSStyleDeclaration): boolean {
   return (
     createsContainingBlock(style.transform) ||
@@ -30,7 +37,10 @@ function hasContainingBlockStyle(style: CSSStyleDeclaration): boolean {
     createsContainingBlock(style.scale) ||
     createsContainingBlock(style.rotate) ||
     createsContainingBlock(style.filter) ||
-    createsContainingBlock(style.contain)
+    createsContainingBlock(style.contain) ||
+    createsContainingBlock(style.perspective) ||
+    createsContainingBlock(style.backdropFilter) ||
+    willChangeCreatesContainingBlock(style.willChange)
   );
 }
 

--- a/packages/components/src/components/event-timeline/event-timeline-modal.ts
+++ b/packages/components/src/components/event-timeline/event-timeline-modal.ts
@@ -1,0 +1,15 @@
+let modalPredicate: (element: HTMLElement) => boolean = (element) => {
+  try {
+    return element.matches(':modal');
+  } catch {
+    return false;
+  }
+};
+
+export function setEventTimelineModalPredicate(predicate: (element: HTMLElement) => boolean): void {
+  modalPredicate = predicate;
+}
+
+export function isEventTimelineModal(element: HTMLElement): boolean {
+  return modalPredicate(element);
+}

--- a/packages/components/src/components/event-timeline/event-timeline-modal.ts
+++ b/packages/components/src/components/event-timeline/event-timeline-modal.ts
@@ -1,27 +1,36 @@
-let modalPredicate: (element: HTMLElement) => boolean = (element) => {
+const defaultModalPredicate = (element: HTMLElement): boolean => {
   try {
     return element.matches(':modal');
   } catch {
     return false;
   }
 };
+let modalPredicate: (element: HTMLElement) => boolean = defaultModalPredicate;
 
 export function setEventTimelineModalPredicate(predicate: (element: HTMLElement) => boolean): void {
   modalPredicate = predicate;
+}
+
+export function resetEventTimelineModalPredicate(): void {
+  modalPredicate = defaultModalPredicate;
 }
 
 export function isEventTimelineModal(element: HTMLElement): boolean {
   return modalPredicate(element);
 }
 
+function createsContainingBlock(value: string | undefined): boolean {
+  return value !== undefined && value !== '' && value !== 'none';
+}
+
 function hasContainingBlockStyle(style: CSSStyleDeclaration): boolean {
   return (
-    style.transform !== 'none' ||
-    style.translate !== 'none' ||
-    style.scale !== 'none' ||
-    style.rotate !== 'none' ||
-    style.filter !== 'none' ||
-    style.contain !== 'none'
+    createsContainingBlock(style.transform) ||
+    createsContainingBlock(style.translate) ||
+    createsContainingBlock(style.scale) ||
+    createsContainingBlock(style.rotate) ||
+    createsContainingBlock(style.filter) ||
+    createsContainingBlock(style.contain)
   );
 }
 

--- a/packages/components/src/components/event-timeline/event-timeline.a11y.md
+++ b/packages/components/src/components/event-timeline/event-timeline.a11y.md
@@ -15,10 +15,11 @@ Purpose: Proportional schedule strip with fired and upcoming event states, a vis
 
 - Presenting a vertical activity history or audit log — use timeline.
 - Showing step-by-step run execution — use run-step-timeline.
+- Showing a dense event stream that cannot fit within the supported label lanes — use timeline.
 
 ## Keyboard and focus
 
-EventTimeline is non-interactive and does not enter the tab order by default. Do not make timeline dots clickable unless the composition uses native controls or links with visible focus indicators and clear accessible names.
+EventTimeline is non-interactive and does not enter the tab order by default. Timeline dots and labels are decorative list content, not controls. When density exceeds the supported label lanes, the component exposes a native `+N` cluster button. The button enters the tab order, has an accessible count-and-range name, opens the hidden events in a floating surface, and closes on Escape while returning focus to the button.
 
 ## Names, roles, and state
 

--- a/packages/components/src/components/event-timeline/event-timeline.a11y.md
+++ b/packages/components/src/components/event-timeline/event-timeline.a11y.md
@@ -23,7 +23,7 @@ EventTimeline is non-interactive and does not enter the tab order by default. Ti
 
 ## Names, roles, and state
 
-EventTimeline renders a named `role="list"` and one `role="listitem"` per valid event. Event labels are rendered with `time` elements; the visual now marker is hidden from assistive technologies because it is decorative unless the surrounding content explains current time.
+EventTimeline renders a named `role="list"` containing one `role="listitem"` for each visible event and aggregate cluster item. Dense regions replace hidden events with a cluster list item, so the list count is the visible event count plus any cluster summaries. Event labels are rendered with `time` elements; the visual now marker is hidden from assistive technologies because it is decorative unless the surrounding content explains current time.
 
 State color is supplemental. Keep labels and sublabels descriptive enough that users do not need color to understand the event.
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -83,6 +83,16 @@
     text-align: end;
   }
 
+  .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='start'] {
+    justify-items: end;
+    text-align: end;
+  }
+
+  .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='end'] {
+    justify-items: start;
+    text-align: start;
+  }
+
   .cinder-event-timeline__item[data-cinder-edge='start'] .cinder-event-timeline__leader,
   .cinder-event-timeline__item[data-cinder-edge='end'] .cinder-event-timeline__leader {
     display: none;

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -116,17 +116,17 @@
   }
 
   .cinder-event-timeline__item[data-cinder-lane-parity='even'] .cinder-event-timeline__leader {
-    inset-inline-start: 50%;
-    border-inline-end: 1px solid var(--cinder-border-muted);
-    transform: skewY(-24deg);
-    transform-origin: top left;
-  }
-
-  .cinder-event-timeline__item[data-cinder-lane-parity='odd'] .cinder-event-timeline__leader {
     inset-inline-end: 50%;
     border-inline-start: 1px solid var(--cinder-border-muted);
     transform: skewY(24deg);
     transform-origin: top right;
+  }
+
+  .cinder-event-timeline__item[data-cinder-lane-parity='odd'] .cinder-event-timeline__leader {
+    inset-inline-start: 50%;
+    border-inline-end: 1px solid var(--cinder-border-muted);
+    transform: skewY(-24deg);
+    transform-origin: top left;
   }
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-lane-parity='even'] {

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -157,6 +157,10 @@
     transform: translateX(-100%);
   }
 
+  .cinder-event-timeline__cluster[data-cinder-open] {
+    z-index: 2;
+  }
+
   .cinder-event-timeline__cluster[data-cinder-edge='start']
     .cinder-event-timeline__cluster-surface {
     left: 0;

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -83,6 +83,11 @@
     text-align: end;
   }
 
+  .cinder-event-timeline__item[data-cinder-edge='start'] .cinder-event-timeline__leader,
+  .cinder-event-timeline__item[data-cinder-edge='end'] .cinder-event-timeline__leader {
+    display: none;
+  }
+
   .cinder-event-timeline__leader {
     position: absolute;
     inset-block-start: 0.625rem;
@@ -104,6 +109,36 @@
     border-inline-start: 1px solid var(--cinder-border-muted);
     transform: skewY(24deg);
     transform-origin: top right;
+  }
+
+  .cinder-event-timeline[dir='rtl'] .cinder-event-timeline__item[data-cinder-lane-parity='even'] {
+    --_cinder-event-timeline-label-offset: 4.5rem;
+  }
+
+  .cinder-event-timeline[dir='rtl'] .cinder-event-timeline__item[data-cinder-lane-parity='odd'] {
+    --_cinder-event-timeline-label-offset: -4.5rem;
+  }
+
+  .cinder-event-timeline[dir='rtl']
+    .cinder-event-timeline__item[data-cinder-lane-parity='even']
+    .cinder-event-timeline__leader {
+    inset-inline-start: auto;
+    inset-inline-end: 50%;
+    border-inline-end: 0;
+    border-inline-start: 1px solid var(--cinder-border-muted);
+    transform: skewY(24deg);
+    transform-origin: top right;
+  }
+
+  .cinder-event-timeline[dir='rtl']
+    .cinder-event-timeline__item[data-cinder-lane-parity='odd']
+    .cinder-event-timeline__leader {
+    inset-inline-end: auto;
+    inset-inline-start: 50%;
+    border-inline-start: 0;
+    border-inline-end: 1px solid var(--cinder-border-muted);
+    transform: skewY(-24deg);
+    transform-origin: top left;
   }
 
   .cinder-event-timeline__cluster {
@@ -152,6 +187,8 @@
     background: var(--cinder-surface);
     box-shadow: var(--cinder-shadow-md);
     text-align: start;
+    max-block-size: min(24rem, calc(100vh - 4rem));
+    overflow: auto;
   }
 
   .cinder-event-timeline__cluster-surface ul {

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -205,14 +205,14 @@
   }
 
   .cinder-event-timeline__cluster-trigger:focus-visible {
-    outline: 2px solid transparent;
+    outline: var(--cinder-ring-width) solid transparent;
     outline-offset: 2px;
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   @media (forced-colors: active) {
     .cinder-event-timeline__cluster-trigger:focus-visible {
-      outline: 2px solid CanvasText;
+      outline: var(--cinder-ring-width) solid CanvasText;
       outline-offset: 2px;
     }
   }

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -62,11 +62,11 @@
   }
 
   .cinder-event-timeline__item[data-cinder-lane-parity='even'] {
-    --_cinder-event-timeline-label-offset: -4.5rem;
+    --_cinder-event-timeline-label-offset: -6rem;
   }
 
   .cinder-event-timeline__item[data-cinder-lane-parity='odd'] {
-    --_cinder-event-timeline-label-offset: 4.5rem;
+    --_cinder-event-timeline-label-offset: 6rem;
   }
 
   .cinder-event-timeline__item[data-cinder-edge='start'] {
@@ -112,11 +112,11 @@
   }
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-lane-parity='even'] {
-    --_cinder-event-timeline-label-offset: 4.5rem;
+    --_cinder-event-timeline-label-offset: 6rem;
   }
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-lane-parity='odd'] {
-    --_cinder-event-timeline-label-offset: -4.5rem;
+    --_cinder-event-timeline-label-offset: -6rem;
   }
 
   .cinder-event-timeline:dir(rtl)
@@ -155,6 +155,15 @@
 
   .cinder-event-timeline__cluster[data-cinder-edge='end'] {
     transform: translateX(-100%);
+  }
+
+  .cinder-event-timeline__cluster[data-cinder-edge='start']
+    .cinder-event-timeline__cluster-surface {
+    inset-inline-start: 0;
+  }
+
+  .cinder-event-timeline__cluster[data-cinder-edge='end'] .cinder-event-timeline__cluster-surface {
+    inset-inline-end: 0;
   }
 
   .cinder-event-timeline__cluster-trigger {

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -87,6 +87,10 @@
     --_cinder-event-timeline-label-offset: 0px;
   }
 
+  .cinder-event-timeline__item[data-cinder-centered] .cinder-event-timeline__leader {
+    display: none;
+  }
+
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='start'] {
     justify-items: end;
     text-align: end;
@@ -131,6 +135,10 @@
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-lane-parity='odd'] {
     --_cinder-event-timeline-label-offset: -6rem;
+  }
+
+  .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-centered] {
+    --_cinder-event-timeline-label-offset: 0px;
   }
 
   .cinder-event-timeline:dir(rtl)

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -229,7 +229,7 @@
     background: var(--cinder-surface);
     box-shadow: var(--cinder-shadow-md);
     text-align: start;
-    max-block-size: min(24rem, calc(100vh - 4rem));
+    max-block-size: min(24rem, calc(100% - 4rem), calc(100vh - 4rem));
     overflow: auto;
   }
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -111,15 +111,15 @@
     transform-origin: top right;
   }
 
-  .cinder-event-timeline[dir='rtl'] .cinder-event-timeline__item[data-cinder-lane-parity='even'] {
+  .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-lane-parity='even'] {
     --_cinder-event-timeline-label-offset: 4.5rem;
   }
 
-  .cinder-event-timeline[dir='rtl'] .cinder-event-timeline__item[data-cinder-lane-parity='odd'] {
+  .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-lane-parity='odd'] {
     --_cinder-event-timeline-label-offset: -4.5rem;
   }
 
-  .cinder-event-timeline[dir='rtl']
+  .cinder-event-timeline:dir(rtl)
     .cinder-event-timeline__item[data-cinder-lane-parity='even']
     .cinder-event-timeline__leader {
     inset-inline-start: auto;
@@ -130,7 +130,7 @@
     transform-origin: top right;
   }
 
-  .cinder-event-timeline[dir='rtl']
+  .cinder-event-timeline:dir(rtl)
     .cinder-event-timeline__item[data-cinder-lane-parity='odd']
     .cinder-event-timeline__leader {
     inset-inline-end: auto;

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -92,12 +92,10 @@
   }
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='start'] {
-    justify-items: end;
     text-align: end;
   }
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='end'] {
-    justify-items: start;
     text-align: start;
   }
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -45,13 +45,13 @@
   .cinder-event-timeline__items {
     block-size: max(
       6rem,
-      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2rem + 1.5rem)
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2.5rem + 1.5rem)
     );
   }
 
   .cinder-event-timeline__item {
     position: absolute;
-    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2rem);
+    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2.5rem);
     display: grid;
     justify-items: center;
     gap: 0.25rem;

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -205,6 +205,8 @@
   }
 
   .cinder-event-timeline__cluster-trigger:focus-visible {
+    outline: 2px solid transparent;
+    outline-offset: 2px;
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
@@ -216,8 +218,6 @@
   }
 
   .cinder-event-timeline__cluster-surface {
-    position: absolute;
-    z-index: var(--cinder-z-popover, 1100);
     inset-block-start: 2.25rem;
     min-inline-size: 10rem;
     padding: var(--cinder-space-2);

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -57,7 +57,7 @@
     gap: 0.25rem;
     inline-size: max-content;
     max-inline-size: 9rem;
-    transform: translateX(calc(-50% + var(--_cinder-event-timeline-label-offset, 0px)));
+    transform: translateX(-50%);
     text-align: center;
   }
 
@@ -238,6 +238,11 @@
     padding-inline-start: 1.25rem;
   }
 
+  .cinder-event-timeline__cluster-surface[data-cinder-position-ready='false'] {
+    visibility: hidden;
+    pointer-events: none;
+  }
+
   .cinder-event-timeline__cluster-item-details {
     display: block;
     color: var(--cinder-text-muted);
@@ -258,6 +263,7 @@
     display: grid;
     gap: 0.0625rem;
     min-inline-size: 0;
+    transform: translateX(var(--_cinder-event-timeline-label-offset, 0px));
   }
 
   .cinder-event-timeline__item-label,

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -93,17 +93,17 @@
   }
 
   .cinder-event-timeline__item[data-cinder-lane-parity='even'] .cinder-event-timeline__leader {
-    inset-inline-end: 50%;
-    border-inline-start: 1px solid var(--cinder-border-muted);
+    inset-inline-start: 50%;
+    border-inline-end: 1px solid var(--cinder-border-muted);
     transform: skewY(-24deg);
-    transform-origin: top right;
+    transform-origin: top left;
   }
 
   .cinder-event-timeline__item[data-cinder-lane-parity='odd'] .cinder-event-timeline__leader {
-    inset-inline-start: 50%;
-    border-inline-end: 1px solid var(--cinder-border-muted);
+    inset-inline-end: 50%;
+    border-inline-start: 1px solid var(--cinder-border-muted);
     transform: skewY(24deg);
-    transform-origin: top left;
+    transform-origin: top right;
   }
 
   .cinder-event-timeline__cluster {
@@ -112,6 +112,14 @@
     display: grid;
     justify-items: center;
     transform: translateX(-50%);
+  }
+
+  .cinder-event-timeline__cluster[data-cinder-edge='start'] {
+    transform: translateX(0);
+  }
+
+  .cinder-event-timeline__cluster[data-cinder-edge='end'] {
+    transform: translateX(-100%);
   }
 
   .cinder-event-timeline__cluster-trigger {
@@ -149,6 +157,12 @@
   .cinder-event-timeline__cluster-surface ul {
     margin: var(--cinder-space-2) 0 0;
     padding-inline-start: 1.25rem;
+  }
+
+  .cinder-event-timeline__cluster-item-details {
+    display: block;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-2xs);
   }
 
   .cinder-event-timeline__dot {

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -43,7 +43,10 @@
   }
 
   .cinder-event-timeline__items {
-    block-size: max(6rem, calc(var(--_cinder-event-timeline-lane-count, 3) * 1.45rem + 1.5rem));
+    block-size: max(
+      6rem,
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 1.45rem + 1.5rem)
+    );
   }
 
   .cinder-event-timeline__item {
@@ -54,20 +57,98 @@
     gap: 0.25rem;
     inline-size: max-content;
     max-inline-size: 9rem;
-    transform: translateX(-50%);
+    transform: translateX(calc(-50% + var(--_cinder-event-timeline-label-offset, 0px)));
     text-align: center;
   }
 
+  .cinder-event-timeline__item[data-cinder-lane-parity='even'] {
+    --_cinder-event-timeline-label-offset: -4.5rem;
+  }
+
+  .cinder-event-timeline__item[data-cinder-lane-parity='odd'] {
+    --_cinder-event-timeline-label-offset: 4.5rem;
+  }
+
   .cinder-event-timeline__item[data-cinder-edge='start'] {
+    --_cinder-event-timeline-label-offset: 0px;
     justify-items: start;
-    transform: translateX(0);
+    transform: translateX(var(--_cinder-event-timeline-label-offset, 0px));
     text-align: start;
   }
 
   .cinder-event-timeline__item[data-cinder-edge='end'] {
+    --_cinder-event-timeline-label-offset: 0px;
     justify-items: end;
-    transform: translateX(-100%);
+    transform: translateX(calc(-100% + var(--_cinder-event-timeline-label-offset, 0px)));
     text-align: end;
+  }
+
+  .cinder-event-timeline__leader {
+    position: absolute;
+    inset-block-start: 0.625rem;
+    block-size: 1rem;
+    inline-size: 4rem;
+    border-block-start: 1px solid var(--cinder-border-muted);
+    pointer-events: none;
+  }
+
+  .cinder-event-timeline__item[data-cinder-lane-parity='even'] .cinder-event-timeline__leader {
+    inset-inline-end: 50%;
+    border-inline-start: 1px solid var(--cinder-border-muted);
+    transform: skewY(-24deg);
+    transform-origin: top right;
+  }
+
+  .cinder-event-timeline__item[data-cinder-lane-parity='odd'] .cinder-event-timeline__leader {
+    inset-inline-start: 50%;
+    border-inline-end: 1px solid var(--cinder-border-muted);
+    transform: skewY(24deg);
+    transform-origin: top left;
+  }
+
+  .cinder-event-timeline__cluster {
+    position: absolute;
+    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 1.45rem);
+    display: grid;
+    justify-items: center;
+    transform: translateX(-50%);
+  }
+
+  .cinder-event-timeline__cluster-trigger {
+    min-inline-size: 2.25rem;
+    min-block-size: 1.75rem;
+    padding: 0.125rem 0.375rem;
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-full);
+    color: var(--cinder-text);
+    background: var(--cinder-surface-raised);
+    font: inherit;
+    font-size: var(--cinder-text-xs);
+    font-weight: var(--cinder-font-medium);
+    cursor: pointer;
+  }
+
+  .cinder-event-timeline__cluster-trigger:focus-visible {
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  .cinder-event-timeline__cluster-surface {
+    position: absolute;
+    z-index: 1;
+    inset-block-start: 2.25rem;
+    min-inline-size: 10rem;
+    padding: var(--cinder-space-2);
+    border: 1px solid var(--cinder-border-muted);
+    border-radius: var(--cinder-radius-md);
+    color: var(--cinder-text);
+    background: var(--cinder-surface);
+    box-shadow: var(--cinder-shadow-md);
+    text-align: start;
+  }
+
+  .cinder-event-timeline__cluster-surface ul {
+    margin: var(--cinder-space-2) 0 0;
+    padding-inline-start: 1.25rem;
   }
 
   .cinder-event-timeline__dot {
@@ -117,7 +198,10 @@
   }
 
   .cinder-event-timeline[data-cinder-size='sm'] .cinder-event-timeline__items {
-    block-size: max(5.25rem, calc(var(--_cinder-event-timeline-lane-count, 3) * 1.45rem + 1.25rem));
+    block-size: max(
+      5.25rem,
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 1.45rem + 1.25rem)
+    );
   }
 
   .cinder-event-timeline[data-cinder-size='sm'] .cinder-event-timeline__item {

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -45,13 +45,13 @@
   .cinder-event-timeline__items {
     block-size: max(
       6rem,
-      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 1.45rem + 1.5rem)
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2rem + 1.5rem)
     );
   }
 
   .cinder-event-timeline__item {
     position: absolute;
-    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 1.45rem);
+    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2rem);
     display: grid;
     justify-items: center;
     gap: 0.25rem;
@@ -200,7 +200,7 @@
 
   .cinder-event-timeline__cluster-surface {
     position: absolute;
-    z-index: 1;
+    z-index: var(--cinder-z-popover, 1100);
     inset-block-start: 2.25rem;
     min-inline-size: 10rem;
     padding: var(--cinder-space-2);

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -92,7 +92,7 @@
     position: absolute;
     inset-block-start: 0.625rem;
     block-size: 1rem;
-    inline-size: 4rem;
+    inline-size: 6rem;
     border-block-start: 1px solid var(--cinder-border-muted);
     pointer-events: none;
   }
@@ -159,11 +159,11 @@
 
   .cinder-event-timeline__cluster[data-cinder-edge='start']
     .cinder-event-timeline__cluster-surface {
-    inset-inline-start: 0;
+    left: 0;
   }
 
   .cinder-event-timeline__cluster[data-cinder-edge='end'] .cinder-event-timeline__cluster-surface {
-    inset-inline-end: 0;
+    right: 0;
   }
 
   .cinder-event-timeline__cluster-trigger {

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -153,7 +153,7 @@
 
   .cinder-event-timeline__cluster {
     position: absolute;
-    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 1.45rem);
+    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2rem);
     display: grid;
     justify-items: center;
     transform: translateX(-50%);
@@ -274,7 +274,7 @@
   .cinder-event-timeline[data-cinder-size='sm'] .cinder-event-timeline__items {
     block-size: max(
       5.25rem,
-      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 1.45rem + 1.25rem)
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2rem + 1.25rem)
     );
   }
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -45,13 +45,13 @@
   .cinder-event-timeline__items {
     block-size: max(
       6rem,
-      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2.5rem + 1.5rem)
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 3.25rem + 1.5rem)
     );
   }
 
   .cinder-event-timeline__item {
     position: absolute;
-    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2.5rem);
+    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 3.25rem);
     display: grid;
     justify-items: center;
     gap: 0.25rem;
@@ -165,7 +165,7 @@
 
   .cinder-event-timeline__cluster {
     position: absolute;
-    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2.5rem);
+    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 3.25rem);
     display: grid;
     justify-items: center;
     transform: translateX(-50%);
@@ -293,7 +293,7 @@
   .cinder-event-timeline[data-cinder-size='sm'] .cinder-event-timeline__items {
     block-size: max(
       5.25rem,
-      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2.5rem + 1.25rem)
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 3.25rem + 1.25rem)
     );
   }
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -92,10 +92,12 @@
   }
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='start'] {
+    justify-items: end;
     text-align: end;
   }
 
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='end'] {
+    justify-items: start;
     text-align: start;
   }
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -165,7 +165,7 @@
 
   .cinder-event-timeline__cluster {
     position: absolute;
-    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2rem);
+    inset-block-start: calc(var(--_cinder-event-timeline-lane, 0) * 2.5rem);
     display: grid;
     justify-items: center;
     transform: translateX(-50%);
@@ -293,7 +293,7 @@
   .cinder-event-timeline[data-cinder-size='sm'] .cinder-event-timeline__items {
     block-size: max(
       5.25rem,
-      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2rem + 1.25rem)
+      calc(min(var(--_cinder-event-timeline-lane-count, 3), 5) * 2.5rem + 1.25rem)
     );
   }
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -83,6 +83,10 @@
     text-align: end;
   }
 
+  .cinder-event-timeline__item[data-cinder-centered] {
+    --_cinder-event-timeline-label-offset: 0px;
+  }
+
   .cinder-event-timeline:dir(rtl) .cinder-event-timeline__item[data-cinder-edge='start'] {
     justify-items: end;
     text-align: end;
@@ -196,6 +200,13 @@
 
   .cinder-event-timeline__cluster-trigger:focus-visible {
     box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-event-timeline__cluster-trigger:focus-visible {
+      outline: 2px solid CanvasText;
+      outline-offset: 2px;
+    }
   }
 
   .cinder-event-timeline__cluster-surface {

--- a/packages/components/src/components/event-timeline/event-timeline.examples.json
+++ b/packages/components/src/components/event-timeline/event-timeline.examples.json
@@ -10,6 +10,12 @@
       "code": "<script lang=\"ts\">\n  import { EventTimeline } from '@lostgradient/cinder/event-timeline';\n</script>\n\n<EventTimeline\n  label=\"Next 24 hours\"\n  start=\"2026-07-03T00:00:00.000Z\"\n  end=\"2026-07-04T00:00:00.000Z\"\n  now=\"2026-07-03T10:30:00.000Z\"\n  items={[\n    { at: '2026-07-03T02:00:00.000Z', label: 'Digest', sublabel: '02:00', state: 'done' },\n    { at: '2026-07-03T10:00:00.000Z', label: 'Retry', sublabel: '10:00', state: 'failed' },\n    { at: '2026-07-03T16:00:00.000Z', label: 'Deploy', sublabel: '16:00' },\n    { at: '2026-07-03T22:00:00.000Z', label: 'Archive', sublabel: '22:00' },\n  ]}\n/>\n"
     },
     {
+      "id": "cluster",
+      "title": "Dense cluster",
+      "description": "Excess overlapping events collapse into a keyboard-accessible cluster.",
+      "code": "<script lang=\"ts\">\n  import { EventTimeline } from '@lostgradient/cinder/event-timeline';\n</script>\n\n<EventTimeline\n  ariaLabel=\"Dense incident timeline\"\n  start=\"2026-07-03T12:00:00.000Z\"\n  end=\"2026-07-03T18:00:00.000Z\"\n  items={[\n    { at: '2026-07-03T13:00:00.000Z', label: 'Queued', sublabel: '13:00' },\n    { at: '2026-07-03T13:02:00.000Z', label: 'Started', sublabel: '13:02' },\n    { at: '2026-07-03T13:04:00.000Z', label: 'Checked', sublabel: '13:04' },\n    { at: '2026-07-03T13:06:00.000Z', label: 'Retried', sublabel: '13:06' },\n    { at: '2026-07-03T13:08:00.000Z', label: 'Escalated', sublabel: '13:08' },\n    { at: '2026-07-03T13:10:00.000Z', label: 'Paged', sublabel: '13:10' },\n    { at: '2026-07-03T13:12:00.000Z', label: 'Acknowledged', sublabel: '13:12' },\n    { at: '2026-07-03T13:14:00.000Z', label: 'Mitigated', sublabel: '13:14' },\n  ]}\n/>\n"
+    },
+    {
       "id": "overlap",
       "title": "Overlapping labels",
       "description": "Nearby events are nudged into separate label lanes.",

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -1,5 +1,11 @@
 <script lang="ts" module>
-  let modalPredicate: (element: HTMLElement) => boolean = (element) => element.matches(':modal');
+  let modalPredicate: (element: HTMLElement) => boolean = (element) => {
+    try {
+      return element.matches(':modal');
+    } catch {
+      return false;
+    }
+  };
   export function __setEventTimelineModalPredicate(predicate: (element: HTMLElement) => boolean) {
     modalPredicate = predicate;
   }
@@ -129,7 +135,14 @@
       const owner = portalOwner();
       if (!owner) return 'fixed';
       const style = getComputedStyle(owner);
-      return style.transform !== 'none' || style.translate !== 'none' ? 'absolute' : 'fixed';
+      return style.transform !== 'none' ||
+        style.translate !== 'none' ||
+        style.scale !== 'none' ||
+        style.rotate !== 'none' ||
+        style.filter !== 'none' ||
+        style.contain !== 'none'
+        ? 'absolute'
+        : 'fixed';
     },
   });
 

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -1,14 +1,4 @@
 <script lang="ts" module>
-  let modalPredicate: (element: HTMLElement) => boolean = (element) => {
-    try {
-      return element.matches(':modal');
-    } catch {
-      return false;
-    }
-  };
-  export function __setEventTimelineModalPredicate(predicate: (element: HTMLElement) => boolean) {
-    modalPredicate = predicate;
-  }
   /**
    * @cinder
    * @category data-display
@@ -35,6 +25,7 @@
   import { classNames } from '../../utilities/class-names.ts';
   import { createClickOutside } from '../../utilities/attachments.ts';
   import { createPortalAttachment } from '../portal/index.ts';
+  import { isEventTimelineModal } from './event-timeline-modal.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
   import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
@@ -109,7 +100,7 @@
       if (focusTrapRoot) return focusTrapRoot;
       const dialog = trigger.closest<HTMLElement>('dialog');
       return (
-        (dialog && modalPredicate(dialog) ? dialog : null) ??
+        (dialog && isEventTimelineModal(dialog) ? dialog : null) ??
         (typeof CSS !== 'undefined' && CSS.supports?.('selector(:popover-open)')
           ? trigger.closest<HTMLElement>('[popover]:popover-open')
           : null)

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -114,6 +114,13 @@
       return null;
     }
   }
+
+  function clusterSurfaceMaxInlineSize(): string {
+    const owner = portalOwner();
+    if (!owner) return '28rem';
+    const width = owner.getBoundingClientRect().width;
+    return width > 0 ? `min(28rem, ${width}px)` : '28rem';
+  }
   const clusterPortalAttachment = createPortalAttachment({
     // Anchored overlay coordinates are viewport-relative (fixed strategy). Keep the
     // surface in the document top layer so transformed dialog containers cannot
@@ -553,6 +560,7 @@
               data-cinder-position-ready={anchoredClusterSurface.positionReady}
               aria-hidden={anchoredClusterSurface.positionReady ? undefined : 'true'}
               style={anchoredClusterSurface.positionStyle}
+              style:max-inline-size={clusterSurfaceMaxInlineSize()}
               {@attach dismissOnOutsidePointerdown}
             >
               <strong>{cluster.accessibleLabel}</strong>

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -117,7 +117,7 @@
 
   function clusterSurfaceMaxInlineSize(): string {
     const owner = portalOwner();
-    if (!owner) return '28rem';
+    if (!owner) return 'min(28rem, calc(100vw - var(--cinder-space-4)))';
     const width = owner.getBoundingClientRect().width;
     return width > 0 ? `min(28rem, ${width}px)` : '28rem';
   }
@@ -392,7 +392,9 @@
         count: overflowGroup.length,
         edge: edgeForPosition(first.position, collisionThresholdPercent),
         endTime,
-        key: `cluster-${startTime}-${endTime}-${JSON.stringify(chronologicalItems.map((item) => item.id ?? item.key))}`,
+        key: `cluster-${startTime}-${endTime}-${JSON.stringify(
+          chronologicalItems.map((item) => item.id ?? item.key).sort(),
+        )}`,
         lane: MAX_VISIBLE_LANES,
         position: first.position,
         startTime,

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -92,7 +92,13 @@
     // Anchored overlay coordinates are viewport-relative (fixed strategy). Keep the
     // surface in the document top layer so transformed dialog containers cannot
     // become a competing fixed-position containing block.
-    target: () => document.body,
+    target: () => {
+      const owner = clusterTrigger?.closest<HTMLElement>('dialog[open], [popover]:popover-open');
+      // A transformed dialog becomes a fixed-position containing block; keep
+      // viewport-relative Floating UI coordinates rooted at body in that case.
+      if (owner && getComputedStyle(owner).transform === 'none') return owner;
+      return document.body;
+    },
     inheritAttributes: true,
     source: () => clusterTrigger,
   });

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -106,9 +106,13 @@
     return `${item.id ?? `${item.label}-${new Date(timestamp).toISOString()}`}-${index}`;
   }
 
-  function edgeForPosition(position: number): PositionedEventTimelineItem['edge'] {
-    if (position <= 10) return 'start';
-    if (position >= 90) return 'end';
+  function edgeForPosition(
+    position: number,
+    thresholdPercent = FALLBACK_COLLISION_THRESHOLD_PERCENT,
+  ): PositionedEventTimelineItem['edge'] {
+    const edgeThreshold = Math.min(25, Math.max(10, thresholdPercent / 2));
+    if (position <= edgeThreshold) return 'start';
+    if (position >= 100 - edgeThreshold) return 'end';
     return 'middle';
   }
 
@@ -217,7 +221,7 @@
         const positionedItem = {
           ...item,
           accessibleLabel: `${item.label}, ${timeLabel}, ${stateLabel}`,
-          edge: edgeForPosition(position),
+          edge: edgeForPosition(position, collisionThresholdPercent),
           key: keyForItem(item, index, timestamp),
           lane,
           position,
@@ -250,21 +254,22 @@
     }
 
     const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup) => {
-      const first = overflowGroup[0]!;
-      const last = overflowGroup.at(-1)!;
+      const chronologicalItems = overflowGroup.toSorted((a, b) => a.timestamp - b.timestamp);
+      const first = chronologicalItems[0]!;
+      const last = chronologicalItems.at(-1)!;
       const startTime = first.isoDatetime;
       const endTime = last.isoDatetime;
       const countLabel = overflowGroup.length === 1 ? 'event' : 'events';
       return {
         accessibleLabel: `${overflowGroup.length} ${countLabel} between ${startTime} and ${endTime}`,
         count: overflowGroup.length,
-        edge: edgeForPosition(first.position),
+        edge: edgeForPosition(first.position, collisionThresholdPercent),
         endTime,
-        key: `cluster-${first.key}`,
+        key: `cluster-${chronologicalItems.map((item) => item.id ?? item.key.split('-').slice(0, -1).join('-')).join('|')}`,
         lane: MAX_VISIBLE_LANES,
         position: first.position,
         startTime,
-        items: overflowGroup,
+        items: chronologicalItems,
       };
     });
 

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -406,9 +406,7 @@
         count: overflowGroup.length,
         edge: edgeForPosition(first.position, collisionThresholdPercent),
         endTime,
-        key: `cluster-${startTime}-${endTime}-${JSON.stringify(
-          chronologicalItems.map((item) => item.id ?? item.key).sort(),
-        )}`,
+        key: `cluster-${startTime}-${endTime}-${overflowGroup.length}`,
         lane: MAX_VISIBLE_LANES,
         position: first.position,
         startTime,

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -137,9 +137,8 @@
     return usableWidth > 0 ? `min(28rem, ${usableWidth}px)` : '28rem';
   }
   const clusterPortalAttachment = createPortalAttachment({
-    // Anchored overlay coordinates are viewport-relative (fixed strategy). Keep the
-    // surface in the document top layer so transformed dialog containers cannot
-    // become a competing fixed-position containing block.
+    // Keep the surface attached to the nearest overlay owner so its positioning
+    // strategy can account for transformed dialog or popover containers.
     target: () => {
       return portalOwner() ?? document.body;
     },
@@ -308,7 +307,7 @@
       })
       .filter((item): item is NonNullable<typeof item> => item !== undefined)
       .sort((a, b) => a.position - b.position)
-      .map(({ item, index, timestamp, position }) => {
+      .forEach(({ item, index, timestamp, position }) => {
         const offsetPercent =
           measuredWidth > 0
             ? ((6 * rootFontSize) / measuredWidth) * 100
@@ -585,7 +584,7 @@
             tabindex="0"
             aria-expanded={openClusterKey === cluster.key}
             aria-haspopup="dialog"
-            aria-controls={clusterId}
+            aria-controls={openClusterKey === cluster.key ? clusterId : undefined}
             aria-label={cluster.accessibleLabel}
             onclick={(event) => {
               clusterTrigger = event.currentTarget as HTMLButtonElement;

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -74,7 +74,8 @@
   const MAX_VISIBLE_LANES = 4;
   const LABEL_MAX_WIDTH_REM = { sm: 7, md: 9 } as const;
   const FALLBACK_ROOT_FONT_SIZE_PX = 16;
-  const FALLBACK_COLLISION_THRESHOLD_PERCENT = 10;
+  const FALLBACK_LAYOUT_WIDTH_PX = 320;
+  const CLUSTER_SHIFT_PADDING_PX = 8;
 
   let {
     start,
@@ -92,24 +93,36 @@
   let rootFontSize = $state(FALLBACK_ROOT_FONT_SIZE_PX);
   let openClusterKey = $state<string | null>(null);
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
+  let clusterFocusPending = $state(false);
   let clusterSurface = $state<HTMLDivElement | null>(null);
+  let portalOwnerWidth = $state(0);
   let isRtl = $state(false);
   const instanceId = $props.id();
   function portalOwner(): HTMLElement | null {
     const trigger = clusterTrigger;
     if (!trigger) return null;
     try {
-      const focusTrapRoot = trigger.closest<HTMLElement>(
-        '.cinder-modal__panel, .cinder-sheet__panel, .cinder-drawer__panel, .cinder-popover',
-      );
-      if (focusTrapRoot) return focusTrapRoot;
-      const dialog = trigger.closest<HTMLElement>('dialog');
-      return (
-        (dialog && isEventTimelineModal(dialog) ? dialog : null) ??
-        (typeof CSS !== 'undefined' && CSS.supports?.('selector(:popover-open)')
-          ? trigger.closest<HTMLElement>('[popover]:popover-open')
-          : null)
-      );
+      for (
+        let current: HTMLElement | null = trigger.parentElement;
+        current;
+        current = current.parentElement
+      ) {
+        if (
+          current.matches(
+            '.cinder-modal__panel, .cinder-sheet__panel, .cinder-drawer__panel, .cinder-popover',
+          )
+        )
+          return current;
+        if (current.matches('dialog') && isEventTimelineModal(current)) return current;
+        if (
+          current.hasAttribute('popover') &&
+          typeof CSS !== 'undefined' &&
+          CSS.supports?.('selector(:popover-open)') &&
+          current.matches(':popover-open')
+        )
+          return current;
+      }
+      return null;
     } catch {
       return null;
     }
@@ -118,8 +131,9 @@
   function clusterSurfaceMaxInlineSize(): string {
     const owner = portalOwner();
     if (!owner) return 'min(28rem, calc(100vw - var(--cinder-space-4)))';
-    const width = owner.getBoundingClientRect().width;
-    return width > 0 ? `min(28rem, ${width}px)` : '28rem';
+    const width = portalOwnerWidth || owner.getBoundingClientRect().width;
+    const usableWidth = width - CLUSTER_SHIFT_PADDING_PX * 2;
+    return usableWidth > 0 ? `min(28rem, ${usableWidth}px)` : '28rem';
   }
   const clusterPortalAttachment = createPortalAttachment({
     // Anchored overlay coordinates are viewport-relative (fixed strategy). Keep the
@@ -168,7 +182,7 @@
 
   function edgeForPosition(
     position: number,
-    thresholdPercent = FALLBACK_COLLISION_THRESHOLD_PERCENT,
+    thresholdPercent = collisionThresholdPercent,
     offsetPercent = 0,
   ): PositionedEventTimelineItem['edge'] {
     const edgeThreshold = Math.max(10, thresholdPercent / 2 + offsetPercent);
@@ -253,7 +267,7 @@
   const collisionThresholdPercent = $derived(
     measuredWidth > 0
       ? (getLabelMaxWidthPx() / measuredWidth) * 100
-      : FALLBACK_COLLISION_THRESHOLD_PERCENT,
+      : (LABEL_MAX_WIDTH_REM[size] * FALLBACK_ROOT_FONT_SIZE_PX * 100) / FALLBACK_LAYOUT_WIDTH_PX,
   );
 
   const range = $derived.by(() => {
@@ -446,6 +460,7 @@
 
   function closeCluster(restoreFocus = false): void {
     openClusterKey = null;
+    clusterFocusPending = false;
     if (restoreFocus) void tick().then(() => clusterTrigger?.focus());
   }
 
@@ -461,6 +476,7 @@
   $effect(() => {
     if (openClusterKey !== null && !clusters.some((cluster) => cluster.key === openClusterKey)) {
       openClusterKey = null;
+      clusterFocusPending = false;
       clusterTrigger = null;
     }
   });
@@ -474,7 +490,22 @@
   });
 
   $effect(() => {
-    if (openClusterKey !== null && anchoredClusterSurface.positionReady) {
+    if (openClusterKey === null || typeof ResizeObserver === 'undefined') return;
+    const owner = portalOwner();
+    if (!owner) return;
+    portalOwnerWidth = 0;
+    const observer = new ResizeObserver(([entry]) => {
+      const inlineSize = entry?.borderBoxSize?.[0]?.inlineSize;
+      portalOwnerWidth =
+        inlineSize ?? entry?.contentRect.width ?? owner.getBoundingClientRect().width;
+    });
+    observer.observe(owner);
+    return () => observer.disconnect();
+  });
+
+  $effect(() => {
+    if (openClusterKey !== null && anchoredClusterSurface.positionReady && clusterFocusPending) {
+      clusterFocusPending = false;
       clusterSurface?.focus();
     }
   });
@@ -547,7 +578,12 @@
             aria-label={cluster.accessibleLabel}
             onclick={(event) => {
               clusterTrigger = event.currentTarget as HTMLButtonElement;
-              openClusterKey = openClusterKey === cluster.key ? null : cluster.key;
+              const isOpen = openClusterKey === cluster.key;
+              clusterFocusPending = !isOpen;
+              openClusterKey = isOpen ? null : cluster.key;
+            }}
+            onfocusout={() => {
+              clusterFocusPending = false;
             }}>+{cluster.count}</button
           >
           {#if openClusterKey === cluster.key}
@@ -571,7 +607,10 @@
                   <li>
                     <span>{hiddenItem.label}</span>
                     <span class="cinder-event-timeline__cluster-item-details">
-                      {hiddenItem.sublabel ?? hiddenItem.isoDatetime} · {hiddenItem.stateLabel}
+                      <time datetime={hiddenItem.isoDatetime}>
+                        {hiddenItem.sublabel ?? hiddenItem.isoDatetime}
+                      </time>
+                      · {hiddenItem.stateLabel}
                     </span>
                   </li>
                 {/each}

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -25,7 +25,11 @@
   import { classNames } from '../../utilities/class-names.ts';
   import { createClickOutside } from '../../utilities/attachments.ts';
   import { createPortalAttachment } from '../portal/index.ts';
-  import { isEventTimelineModal } from './event-timeline-modal.ts';
+  import {
+    hasFixedPositionContainingBlock,
+    isEventTimelineModal,
+    observeEventTimelineDirection,
+  } from './event-timeline-modal.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
   import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
@@ -131,15 +135,7 @@
     strategy: () => {
       const owner = portalOwner();
       if (!owner) return 'fixed';
-      const style = getComputedStyle(owner);
-      return style.transform !== 'none' ||
-        style.translate !== 'none' ||
-        style.scale !== 'none' ||
-        style.rotate !== 'none' ||
-        style.filter !== 'none' ||
-        style.contain !== 'none'
-        ? 'absolute'
-        : 'fixed';
+      return hasFixedPositionContainingBlock(owner) ? 'absolute' : 'fixed';
     },
   });
 
@@ -220,15 +216,10 @@
     };
     updateMeasuredWidth(node.getBoundingClientRect().width);
     updateDirection();
-    const directionObserver = new MutationObserver(updateDirection);
-    directionObserver.observe(node.ownerDocument.documentElement, {
-      attributes: true,
-      attributeFilter: ['class', 'dir', 'style'],
-      subtree: true,
-    });
+    const stopDirectionObserver = observeEventTimelineDirection(node, updateDirection);
     const stopResizeObserver = observeResize(node);
     return () => {
-      directionObserver.disconnect();
+      stopDirectionObserver();
       stopResizeObserver?.();
     };
   };

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -116,6 +116,23 @@
     return 'middle';
   }
 
+  function transformedLabelBounds(
+    position: number,
+    lane: number,
+    edge: PositionedEventTimelineItem['edge'],
+    labelWidthPercent: number,
+    offsetPercent: number,
+  ): { start: number; end: number } {
+    if (edge === 'start') return { start: position, end: position + labelWidthPercent };
+    if (edge === 'end') return { start: position - labelWidthPercent, end: position };
+
+    const center = position + (lane % 2 === 0 ? -offsetPercent : offsetPercent);
+    return {
+      start: center - labelWidthPercent / 2,
+      end: center + labelWidthPercent / 2,
+    };
+  }
+
   function getLabelMaxWidthPx(): number {
     return LABEL_MAX_WIDTH_REM[size] * rootFontSize;
   }
@@ -185,7 +202,7 @@
     clusters: EventTimelineCluster[];
     items: PositionedEventTimelineItem[];
   }>(() => {
-    const lanePositions: number[] = [];
+    const laneBounds: Array<{ end: number }> = [];
     const visibleItems: PositionedEventTimelineItem[] = [];
     const overflowItems: PositionedEventTimelineItem[] = [];
 
@@ -204,13 +221,34 @@
       .filter((item): item is NonNullable<typeof item> => item !== undefined)
       .sort((a, b) => a.position - b.position)
       .map(({ item, index, timestamp, position }) => {
-        const availableLane = lanePositions.findIndex(
-          (lastPosition) => position - lastPosition >= collisionThresholdPercent,
-        );
-        const nextLane = availableLane === -1 ? lanePositions.length : availableLane;
+        const edge = edgeForPosition(position, collisionThresholdPercent);
+        const offsetPercent =
+          measuredWidth > 0
+            ? ((6 * rootFontSize) / measuredWidth) * 100
+            : (6 / LABEL_MAX_WIDTH_REM[size]) * collisionThresholdPercent;
+        const availableLane = laneBounds.findIndex((bounds, lane) => {
+          const candidate = transformedLabelBounds(
+            position,
+            lane,
+            edge,
+            collisionThresholdPercent,
+            offsetPercent,
+          );
+          return candidate.start >= bounds.end;
+        });
+        const nextLane = availableLane === -1 ? laneBounds.length : availableLane;
         const isOverflow = availableLane === -1 && nextLane >= MAX_VISIBLE_LANES;
         const lane = isOverflow ? MAX_VISIBLE_LANES : nextLane;
-        if (!isOverflow) lanePositions[lane] = position;
+        if (!isOverflow) {
+          const bounds = transformedLabelBounds(
+            position,
+            lane,
+            edge,
+            collisionThresholdPercent,
+            offsetPercent,
+          );
+          laneBounds[lane] = { end: bounds.end };
+        }
 
         const isoDatetime = new Date(timestamp).toISOString();
         const state = item.state ?? 'upcoming';
@@ -221,7 +259,7 @@
         const positionedItem = {
           ...item,
           accessibleLabel: `${item.label}, ${timeLabel}, ${stateLabel}`,
-          edge: edgeForPosition(position, collisionThresholdPercent),
+          edge,
           key: keyForItem(item, index, timestamp),
           lane,
           position,

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -59,9 +59,14 @@
     items: PositionedEventTimelineItem[];
   };
 
+  type EventTimelineRenderItem =
+    | { kind: 'item'; key: string; position: number; item: PositionedEventTimelineItem }
+    | { kind: 'cluster'; key: string; position: number; cluster: EventTimelineCluster };
+
   const MAX_VISIBLE_LANES = 4;
   const LABEL_MAX_WIDTH_REM = { sm: 7, md: 9 } as const;
   const FALLBACK_ROOT_FONT_SIZE_PX = 16;
+  const FALLBACK_COLLISION_THRESHOLD_PERCENT = 10;
 
   let {
     start,
@@ -76,6 +81,7 @@
   }: EventTimelineProps = $props();
 
   let measuredWidth = $state(0);
+  let rootFontSize = $state(FALLBACK_ROOT_FONT_SIZE_PX);
   let openClusterKey = $state<string | null>(null);
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
@@ -101,20 +107,13 @@
   }
 
   function edgeForPosition(position: number): PositionedEventTimelineItem['edge'] {
-    if (position <= 0) return 'start';
-    if (position >= 100) return 'end';
+    if (position <= 10) return 'start';
+    if (position >= 90) return 'end';
     return 'middle';
   }
 
   function getLabelMaxWidthPx(): number {
-    if (typeof window === 'undefined') {
-      return LABEL_MAX_WIDTH_REM[size] * FALLBACK_ROOT_FONT_SIZE_PX;
-    }
-
-    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
-    const baseFontSize =
-      Number.isFinite(rootFontSize) && rootFontSize > 0 ? rootFontSize : FALLBACK_ROOT_FONT_SIZE_PX;
-    return LABEL_MAX_WIDTH_REM[size] * baseFontSize;
+    return LABEL_MAX_WIDTH_REM[size] * rootFontSize;
   }
 
   function getObservedWidth(entry: ResizeObserverEntry): number {
@@ -138,8 +137,29 @@
     return observeResize(node);
   };
 
+  $effect(() => {
+    if (typeof window === 'undefined') return;
+    const updateRootFontSize = () => {
+      const value = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+      if (Number.isFinite(value) && value > 0) rootFontSize = value;
+    };
+    updateRootFontSize();
+    const observer = new MutationObserver(updateRootFontSize);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'style'],
+    });
+    window.addEventListener('resize', updateRootFontSize);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateRootFontSize);
+    };
+  });
+
   const collisionThresholdPercent = $derived(
-    measuredWidth > 0 ? (getLabelMaxWidthPx() / measuredWidth) * 100 : 100,
+    measuredWidth > 0
+      ? (getLabelMaxWidthPx() / measuredWidth) * 100
+      : FALLBACK_COLLISION_THRESHOLD_PERCENT,
   );
 
   const range = $derived.by(() => {
@@ -232,8 +252,8 @@
     const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup) => {
       const first = overflowGroup[0]!;
       const last = overflowGroup.at(-1)!;
-      const startTime = new Date(first.timestamp).toISOString().slice(11, 16);
-      const endTime = new Date(last.timestamp).toISOString().slice(11, 16);
+      const startTime = first.isoDatetime;
+      const endTime = last.isoDatetime;
       const countLabel = overflowGroup.length === 1 ? 'event' : 'events';
       return {
         accessibleLabel: `${overflowGroup.length} ${countLabel} between ${startTime} and ${endTime}`,
@@ -253,6 +273,22 @@
 
   const positionedItems = $derived(positionedLayout.items);
   const clusters = $derived(positionedLayout.clusters);
+  const renderItems = $derived<EventTimelineRenderItem[]>(
+    [
+      ...positionedItems.map((item) => ({
+        kind: 'item' as const,
+        key: item.key,
+        position: item.position,
+        item,
+      })),
+      ...clusters.map((cluster) => ({
+        kind: 'cluster' as const,
+        key: cluster.key,
+        position: cluster.position,
+        cluster,
+      })),
+    ].sort((a, b) => a.position - b.position),
+  );
 
   const laneCount = $derived(
     Math.max(
@@ -285,6 +321,7 @@
       handler: closeCluster,
       enabled: () => openClusterKey !== null,
       eventType: 'pointerdown',
+      ignoreRefs: [() => clusterTrigger],
     }),
   );
 
@@ -320,77 +357,80 @@
     aria-label={accessibleName}
     style:--_cinder-event-timeline-lane-count={laneCount}
   >
-    {#each positionedItems as item (item.key)}
-      <div
-        class="cinder-event-timeline__item"
-        role="listitem"
-        data-cinder-state={item.state}
-        data-cinder-lane={item.lane}
-        data-cinder-lane-parity={item.lane % 2 === 0 ? 'even' : 'odd'}
-        data-cinder-edge={item.edge}
-        aria-label={item.accessibleLabel}
-        style:left="{item.position}%"
-        style:--_cinder-event-timeline-lane={item.lane}
-      >
-        <span class="cinder-event-timeline__dot" aria-hidden="true"></span>
-        <span class="cinder-event-timeline__leader" aria-hidden="true"></span>
-        <span class="cinder-event-timeline__content">
-          <span class="cinder-event-timeline__item-label">{item.label}</span>
-          {#if item.sublabel}
-            <time class="cinder-event-timeline__item-sublabel" datetime={item.isoDatetime}
-              >{item.sublabel}</time
-            >
-          {:else}
-            <time class="cinder-sr-only" datetime={item.isoDatetime}>{item.isoDatetime}</time>
-          {/if}
-          <span class="cinder-sr-only">{item.stateLabel}</span>
-        </span>
-      </div>
-    {/each}
-    {#each clusters as cluster (cluster.key)}
-      <div
-        class="cinder-event-timeline__cluster"
-        role="listitem"
-        data-cinder-edge={cluster.edge}
-        data-cinder-lane={cluster.lane}
-        style:left="{cluster.position}%"
-        style:--_cinder-event-timeline-lane={cluster.lane}
-      >
-        <button
-          class="cinder-event-timeline__cluster-trigger"
-          type="button"
-          tabindex="0"
-          aria-expanded={openClusterKey === cluster.key}
-          aria-label={cluster.accessibleLabel}
-          onclick={(event) => {
-            clusterTrigger = event.currentTarget as HTMLButtonElement;
-            openClusterKey = openClusterKey === cluster.key ? null : cluster.key;
-            if (openClusterKey !== null) void tick().then(() => clusterSurface?.focus());
-          }}>+{cluster.count}</button
+    {#each renderItems as renderItem (renderItem.key)}
+      {#if renderItem.kind === 'item'}
+        {@const item = renderItem.item}
+        <div
+          class="cinder-event-timeline__item"
+          role="listitem"
+          data-cinder-state={item.state}
+          data-cinder-lane={item.lane}
+          data-cinder-lane-parity={item.lane % 2 === 0 ? 'even' : 'odd'}
+          data-cinder-edge={item.edge}
+          aria-label={item.accessibleLabel}
+          style:left="{item.position}%"
+          style:--_cinder-event-timeline-lane={item.lane}
         >
-        {#if openClusterKey === cluster.key}
-          <div
-            class="cinder-_floating-surface cinder-event-timeline__cluster-surface"
-            role="dialog"
+          <span class="cinder-event-timeline__dot" aria-hidden="true"></span>
+          <span class="cinder-event-timeline__leader" aria-hidden="true"></span>
+          <span class="cinder-event-timeline__content">
+            <span class="cinder-event-timeline__item-label">{item.label}</span>
+            {#if item.sublabel}
+              <time class="cinder-event-timeline__item-sublabel" datetime={item.isoDatetime}
+                >{item.sublabel}</time
+              >
+            {:else}
+              <time class="cinder-sr-only" datetime={item.isoDatetime}>{item.isoDatetime}</time>
+            {/if}
+            <span class="cinder-sr-only">{item.stateLabel}</span>
+          </span>
+        </div>
+      {:else}
+        {@const cluster = renderItem.cluster}
+        <div
+          class="cinder-event-timeline__cluster"
+          role="listitem"
+          data-cinder-edge={cluster.edge}
+          data-cinder-lane={cluster.lane}
+          style:left="{cluster.position}%"
+          style:--_cinder-event-timeline-lane={cluster.lane}
+        >
+          <button
+            class="cinder-event-timeline__cluster-trigger"
+            type="button"
+            tabindex="0"
+            aria-expanded={openClusterKey === cluster.key}
             aria-label={cluster.accessibleLabel}
-            bind:this={clusterSurface}
-            tabindex="-1"
-            {@attach dismissOnOutsidePointerdown}
+            onclick={(event) => {
+              clusterTrigger = event.currentTarget as HTMLButtonElement;
+              openClusterKey = openClusterKey === cluster.key ? null : cluster.key;
+              if (openClusterKey !== null) void tick().then(() => clusterSurface?.focus());
+            }}>+{cluster.count}</button
           >
-            <strong>{cluster.accessibleLabel}</strong>
-            <ul>
-              {#each cluster.items as hiddenItem (hiddenItem.key)}
-                <li>
-                  <span>{hiddenItem.label}</span>
-                  <span class="cinder-event-timeline__cluster-item-details">
-                    {hiddenItem.sublabel ?? hiddenItem.isoDatetime} · {hiddenItem.stateLabel}
-                  </span>
-                </li>
-              {/each}
-            </ul>
-          </div>
-        {/if}
-      </div>
+          {#if openClusterKey === cluster.key}
+            <div
+              class="cinder-_floating-surface cinder-event-timeline__cluster-surface"
+              role="dialog"
+              aria-label={cluster.accessibleLabel}
+              bind:this={clusterSurface}
+              tabindex="-1"
+              {@attach dismissOnOutsidePointerdown}
+            >
+              <strong>{cluster.accessibleLabel}</strong>
+              <ul>
+                {#each cluster.items as hiddenItem (hiddenItem.key)}
+                  <li>
+                    <span>{hiddenItem.label}</span>
+                    <span class="cinder-event-timeline__cluster-item-details">
+                      {hiddenItem.sublabel ?? hiddenItem.isoDatetime} · {hiddenItem.stateLabel}
+                    </span>
+                  </li>
+                {/each}
+              </ul>
+            </div>
+          {/if}
+        </div>
+      {/if}
     {/each}
   </div>
 </div>

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -26,6 +26,7 @@
   import { createClickOutside } from '../../utilities/attachments.ts';
   import { createPortalAttachment } from '../portal/index.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
+  import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
   import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
   import { tick } from 'svelte';
 
@@ -86,20 +87,20 @@
   let openClusterKey = $state<string | null>(null);
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
-  let clusterSurfaceStyle = $state<string | undefined>();
-
   const clusterPortalAttachment = createPortalAttachment({
-    target: () => document.body,
+    target: () => clusterTrigger?.closest('dialog[open]') ?? document.body,
     inheritAttributes: true,
     source: () => clusterTrigger,
   });
 
-  function positionClusterSurface(): void {
-    const trigger = clusterTrigger;
-    if (!trigger) return;
-    const bounds = trigger.getBoundingClientRect();
-    clusterSurfaceStyle = `position: fixed; left: ${Math.round(bounds.left)}px; top: ${Math.round(bounds.bottom + 8)}px;`;
-  }
+  const anchoredClusterSurface = createAnchoredOverlay({
+    open: () => openClusterKey !== null,
+    anchor: () => clusterTrigger,
+    panel: () => clusterSurface,
+    placement: () => 'bottom-start',
+    offset: () => 8,
+    shiftPadding: () => 8,
+  });
 
   function toTimestamp(value: EventTimelineDate | undefined): number | undefined {
     if (value === undefined) return undefined;
@@ -127,8 +128,11 @@
     offsetPercent = 0,
   ): PositionedEventTimelineItem['edge'] {
     const edgeThreshold = Math.max(10, thresholdPercent / 2 + offsetPercent);
-    if (position <= edgeThreshold) return 'start';
-    if (position >= 100 - edgeThreshold) return 'end';
+    const nearStart = position <= edgeThreshold;
+    const nearEnd = position >= 100 - edgeThreshold;
+    if (nearStart && nearEnd) return position <= 50 ? 'start' : 'end';
+    if (nearStart) return 'start';
+    if (nearEnd) return 'end';
     return 'middle';
   }
 
@@ -247,7 +251,7 @@
             collisionThresholdPercent,
             offsetPercent,
           );
-          return candidate.start >= bounds.end;
+          return candidate.start >= bounds.end + 1;
         });
         const nextLane = availableLane === -1 ? laneBounds.length : availableLane;
         const isOverflow = availableLane === -1 && nextLane >= MAX_VISIBLE_LANES;
@@ -303,7 +307,7 @@
       }
     }
 
-    const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup) => {
+    const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup, groupIndex) => {
       const chronologicalItems = overflowGroup.slice().sort((a, b) => a.timestamp - b.timestamp);
       const first = chronologicalItems[0]!;
       const last = chronologicalItems.at(-1)!;
@@ -315,7 +319,7 @@
         count: overflowGroup.length,
         edge: edgeForPosition(first.position, collisionThresholdPercent),
         endTime,
-        key: `cluster-${JSON.stringify(chronologicalItems.map((item) => item.id ?? item.key))}`,
+        key: `cluster-${groupIndex}-${startTime}-${endTime}-${JSON.stringify(chronologicalItems.map((item) => item.id ?? item.key))}`,
         lane: MAX_VISIBLE_LANES,
         position: first.position,
         startTime,
@@ -462,7 +466,6 @@
               openClusterKey = openClusterKey === cluster.key ? null : cluster.key;
               if (openClusterKey !== null)
                 void tick().then(() => {
-                  positionClusterSurface();
                   clusterSurface?.focus();
                 });
             }}>+{cluster.count}</button
@@ -475,7 +478,9 @@
               bind:this={clusterSurface}
               {@attach clusterPortalAttachment}
               tabindex="-1"
-              style={clusterSurfaceStyle}
+              data-cinder-position-ready={anchoredClusterSurface.positionReady}
+              aria-hidden={anchoredClusterSurface.positionReady ? undefined : 'true'}
+              style={anchoredClusterSurface.positionStyle}
               {@attach dismissOnOutsidePointerdown}
             >
               <strong>{cluster.accessibleLabel}</strong>

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -24,6 +24,7 @@
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
   import { createClickOutside } from '../../utilities/attachments.ts';
+  import { createPortalAttachment } from '../portal/index.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
   import { tick } from 'svelte';
@@ -85,6 +86,20 @@
   let openClusterKey = $state<string | null>(null);
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
+  let clusterSurfaceStyle = $state<string | undefined>();
+
+  const clusterPortalAttachment = createPortalAttachment({
+    target: () => document.body,
+    inheritAttributes: true,
+    source: () => clusterTrigger,
+  });
+
+  function positionClusterSurface(): void {
+    const trigger = clusterTrigger;
+    if (!trigger) return;
+    const bounds = trigger.getBoundingClientRect();
+    clusterSurfaceStyle = `position: fixed; left: ${Math.round(bounds.left)}px; top: ${Math.round(bounds.bottom + 8)}px;`;
+  }
 
   function toTimestamp(value: EventTimelineDate | undefined): number | undefined {
     if (value === undefined) return undefined;
@@ -111,7 +126,7 @@
     thresholdPercent = FALLBACK_COLLISION_THRESHOLD_PERCENT,
     offsetPercent = 0,
   ): PositionedEventTimelineItem['edge'] {
-    const edgeThreshold = Math.min(40, Math.max(10, thresholdPercent / 2 + offsetPercent));
+    const edgeThreshold = Math.max(10, thresholdPercent / 2 + offsetPercent);
     if (position <= edgeThreshold) return 'start';
     if (position >= 100 - edgeThreshold) return 'end';
     return 'middle';
@@ -445,7 +460,11 @@
             onclick={(event) => {
               clusterTrigger = event.currentTarget as HTMLButtonElement;
               openClusterKey = openClusterKey === cluster.key ? null : cluster.key;
-              if (openClusterKey !== null) void tick().then(() => clusterSurface?.focus());
+              if (openClusterKey !== null)
+                void tick().then(() => {
+                  positionClusterSurface();
+                  clusterSurface?.focus();
+                });
             }}>+{cluster.count}</button
           >
           {#if openClusterKey === cluster.key}
@@ -454,7 +473,9 @@
               role="dialog"
               aria-label={cluster.accessibleLabel}
               bind:this={clusterSurface}
+              {@attach clusterPortalAttachment}
               tabindex="-1"
+              style={clusterSurfaceStyle}
               {@attach dismissOnOutsidePointerdown}
             >
               <strong>{cluster.accessibleLabel}</strong>

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -1,4 +1,8 @@
 <script lang="ts" module>
+  let modalPredicate: (element: HTMLElement) => boolean = (element) => element.matches(':modal');
+  export function __setEventTimelineModalPredicate(predicate: (element: HTMLElement) => boolean) {
+    modalPredicate = predicate;
+  }
   /**
    * @cinder
    * @category data-display
@@ -92,9 +96,10 @@
     const trigger = clusterTrigger;
     if (!trigger) return null;
     try {
+      const dialog = trigger.closest<HTMLElement>('dialog');
       return (
-        trigger.closest<HTMLElement>('dialog:modal') ??
-        (CSS.supports('selector(:popover-open)')
+        (dialog && modalPredicate(dialog) ? dialog : null) ??
+        (typeof CSS !== 'undefined' && CSS.supports?.('selector(:popover-open)')
           ? trigger.closest<HTMLElement>('[popover]:popover-open')
           : null)
       );

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -88,7 +88,7 @@
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
   const clusterPortalAttachment = createPortalAttachment({
-    target: () => clusterTrigger?.closest('dialog[open]') ?? document.body,
+    target: () => clusterTrigger?.closest<HTMLElement>('dialog[open]') ?? document.body,
     inheritAttributes: true,
     source: () => clusterTrigger,
   });

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -90,6 +90,7 @@
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
   let isRtl = $state(false);
+  const instanceId = $props.id();
   function portalOwner(): HTMLElement | null {
     const trigger = clusterTrigger;
     if (!trigger) return null;
@@ -214,9 +215,22 @@
   });
 
   const observeItems = (node: HTMLElement) => {
+    const updateDirection = () => {
+      isRtl = getComputedStyle(node).direction === 'rtl';
+    };
     updateMeasuredWidth(node.getBoundingClientRect().width);
-    isRtl = getComputedStyle(node).direction === 'rtl';
-    return observeResize(node);
+    updateDirection();
+    const directionObserver = new MutationObserver(updateDirection);
+    directionObserver.observe(node.ownerDocument.documentElement, {
+      attributes: true,
+      attributeFilter: ['class', 'dir', 'style'],
+      subtree: true,
+    });
+    const stopResizeObserver = observeResize(node);
+    return () => {
+      directionObserver.disconnect();
+      stopResizeObserver?.();
+    };
   };
 
   $effect(() => {
@@ -514,7 +528,7 @@
         </div>
       {:else}
         {@const cluster = renderItem.cluster}
-        {@const clusterId = `cinder-event-timeline-cluster-${cluster.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`}
+        {@const clusterId = `${instanceId}-cluster-${cluster.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`}
         <div
           class="cinder-event-timeline__cluster"
           role="listitem"

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -503,9 +503,7 @@
     if (!owner) return;
     portalOwnerWidth = 0;
     const observer = new ResizeObserver(([entry]) => {
-      const inlineSize = entry?.borderBoxSize?.[0]?.inlineSize;
-      portalOwnerWidth =
-        inlineSize ?? entry?.contentRect.width ?? owner.getBoundingClientRect().width;
+      portalOwnerWidth = entry ? getObservedWidth(entry) : owner.getBoundingClientRect().width;
     });
     observer.observe(owner);
     return () => observer.disconnect();

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -95,6 +95,7 @@
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterFocusPending = $state(false);
   let clusterSurface = $state<HTMLDivElement | null>(null);
+  let itemsElement = $state<HTMLDivElement | null>(null);
   let portalOwnerWidth = $state(0);
   let isRtl = $state(false);
   const instanceId = $props.id();
@@ -473,8 +474,16 @@
     }),
   );
 
-  $effect(() => {
+  $effect.pre(() => {
     if (openClusterKey !== null && !clusters.some((cluster) => cluster.key === openClusterKey)) {
+      if (clusterSurface?.contains(document.activeElement)) {
+        const survivingTrigger = [
+          ...(itemsElement?.querySelectorAll<HTMLButtonElement>(
+            '.cinder-event-timeline__cluster-trigger',
+          ) ?? []),
+        ].find((trigger) => trigger !== clusterTrigger);
+        (survivingTrigger ?? itemsElement)?.focus();
+      }
       openClusterKey = null;
       clusterFocusPending = false;
       clusterTrigger = null;
@@ -522,9 +531,11 @@
   </div>
   <div
     class="cinder-event-timeline__items"
+    bind:this={itemsElement}
     {@attach observeItems}
     role="list"
     aria-label={accessibleName}
+    tabindex="-1"
     style:--_cinder-event-timeline-lane-count={laneCount}
   >
     {#each renderItems as renderItem (renderItem.key)}

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -94,10 +94,7 @@
     // become a competing fixed-position containing block.
     target: () => {
       const owner = clusterTrigger?.closest<HTMLElement>('dialog[open], [popover]:popover-open');
-      // A transformed dialog becomes a fixed-position containing block; keep
-      // viewport-relative Floating UI coordinates rooted at body in that case.
-      if (owner && getComputedStyle(owner).transform === 'none') return owner;
-      return document.body;
+      return owner ?? document.body;
     },
     inheritAttributes: true,
     source: () => clusterTrigger,
@@ -110,6 +107,10 @@
     placement: () => 'bottom-start',
     offset: () => 8,
     shiftPadding: () => 8,
+    strategy: () => {
+      const owner = clusterTrigger?.closest<HTMLElement>('dialog[open], [popover]:popover-open');
+      return owner && getComputedStyle(owner).transform !== 'none' ? 'absolute' : 'fixed';
+    },
   });
 
   function toTimestamp(value: EventTimelineDate | undefined): number | undefined {

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -109,8 +109,9 @@
   function edgeForPosition(
     position: number,
     thresholdPercent = FALLBACK_COLLISION_THRESHOLD_PERCENT,
+    offsetPercent = 0,
   ): PositionedEventTimelineItem['edge'] {
-    const edgeThreshold = Math.min(25, Math.max(10, thresholdPercent / 2));
+    const edgeThreshold = Math.min(40, Math.max(10, thresholdPercent / 2 + offsetPercent));
     if (position <= edgeThreshold) return 'start';
     if (position >= 100 - edgeThreshold) return 'end';
     return 'middle';
@@ -118,7 +119,6 @@
 
   function transformedLabelBounds(
     position: number,
-    lane: number,
     edge: PositionedEventTimelineItem['edge'],
     labelWidthPercent: number,
     offsetPercent: number,
@@ -126,10 +126,9 @@
     if (edge === 'start') return { start: position, end: position + labelWidthPercent };
     if (edge === 'end') return { start: position - labelWidthPercent, end: position };
 
-    const center = position + (lane % 2 === 0 ? -offsetPercent : offsetPercent);
     return {
-      start: center - labelWidthPercent / 2,
-      end: center + labelWidthPercent / 2,
+      start: position - offsetPercent - labelWidthPercent / 2,
+      end: position + offsetPercent + labelWidthPercent / 2,
     };
   }
 
@@ -221,15 +220,14 @@
       .filter((item): item is NonNullable<typeof item> => item !== undefined)
       .sort((a, b) => a.position - b.position)
       .map(({ item, index, timestamp, position }) => {
-        const edge = edgeForPosition(position, collisionThresholdPercent);
         const offsetPercent =
           measuredWidth > 0
             ? ((6 * rootFontSize) / measuredWidth) * 100
             : (6 / LABEL_MAX_WIDTH_REM[size]) * collisionThresholdPercent;
+        const edge = edgeForPosition(position, collisionThresholdPercent, offsetPercent);
         const availableLane = laneBounds.findIndex((bounds, lane) => {
           const candidate = transformedLabelBounds(
             position,
-            lane,
             edge,
             collisionThresholdPercent,
             offsetPercent,
@@ -242,7 +240,6 @@
         if (!isOverflow) {
           const bounds = transformedLabelBounds(
             position,
-            lane,
             edge,
             collisionThresholdPercent,
             offsetPercent,
@@ -434,6 +431,7 @@
           class="cinder-event-timeline__cluster"
           role="listitem"
           data-cinder-edge={cluster.edge}
+          data-cinder-open={openClusterKey === cluster.key ? '' : undefined}
           data-cinder-lane={cluster.lane}
           style:left="{cluster.position}%"
           style:--_cinder-event-timeline-lane={cluster.lane}

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -398,6 +398,12 @@
       closeCluster();
     });
   });
+
+  $effect(() => {
+    if (openClusterKey !== null && anchoredClusterSurface.positionReady) {
+      clusterSurface?.focus();
+    }
+  });
 </script>
 
 <div {...rest} class={classNames('cinder-event-timeline', customClassName)} data-cinder-size={size}>
@@ -464,10 +470,6 @@
             onclick={(event) => {
               clusterTrigger = event.currentTarget as HTMLButtonElement;
               openClusterKey = openClusterKey === cluster.key ? null : cluster.key;
-              if (openClusterKey !== null)
-                void tick().then(() => {
-                  clusterSurface?.focus();
-                });
             }}>+{cluster.count}</button
           >
           {#if openClusterKey === cluster.key}

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -254,7 +254,7 @@
     }
 
     const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup) => {
-      const chronologicalItems = overflowGroup.toSorted((a, b) => a.timestamp - b.timestamp);
+      const chronologicalItems = overflowGroup.slice().sort((a, b) => a.timestamp - b.timestamp);
       const first = chronologicalItems[0]!;
       const last = chronologicalItems.at(-1)!;
       const startTime = first.isoDatetime;
@@ -265,7 +265,7 @@
         count: overflowGroup.length,
         edge: edgeForPosition(first.position, collisionThresholdPercent),
         endTime,
-        key: `cluster-${chronologicalItems.map((item) => item.id ?? item.key.split('-').slice(0, -1).join('-')).join('|')}`,
+        key: `cluster-${JSON.stringify(chronologicalItems.map((item) => item.id ?? item.key))}`,
         lane: MAX_VISIBLE_LANES,
         position: first.position,
         startTime,

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -98,12 +98,13 @@
   let openClusterKey = $state<string | null>(null);
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
+  let isRtl = $state(false);
   function portalOwner(): HTMLElement | null {
     const trigger = clusterTrigger;
     if (!trigger) return null;
     try {
       const focusTrapRoot = trigger.closest<HTMLElement>(
-        '.cinder-modal__panel, .cinder-sheet__panel, .cinder-drawer__panel',
+        '.cinder-modal__panel, .cinder-sheet__panel, .cinder-drawer__panel, .cinder-popover',
       );
       if (focusTrapRoot) return focusTrapRoot;
       const dialog = trigger.closest<HTMLElement>('dialog');
@@ -194,7 +195,7 @@
     if (edge === 'start') return { start: position, end: position + labelWidthPercent };
     if (edge === 'end') return { start: position - labelWidthPercent, end: position };
 
-    const directionalOffset = lane % 2 === 0 ? -offsetPercent : offsetPercent;
+    const directionalOffset = (lane % 2 === 0 ? -offsetPercent : offsetPercent) * (isRtl ? -1 : 1);
     return {
       start: position + directionalOffset - labelWidthPercent / 2,
       end: position + directionalOffset + labelWidthPercent / 2,
@@ -223,6 +224,7 @@
 
   const observeItems = (node: HTMLElement) => {
     updateMeasuredWidth(node.getBoundingClientRect().width);
+    isRtl = getComputedStyle(node).direction === 'rtl';
     return observeResize(node);
   };
 
@@ -521,6 +523,7 @@
         </div>
       {:else}
         {@const cluster = renderItem.cluster}
+        {@const clusterId = `cinder-event-timeline-cluster-${cluster.key.replace(/[^a-zA-Z0-9_-]/g, '-')}`}
         <div
           class="cinder-event-timeline__cluster"
           role="listitem"
@@ -535,6 +538,8 @@
             type="button"
             tabindex="0"
             aria-expanded={openClusterKey === cluster.key}
+            aria-haspopup="dialog"
+            aria-controls={clusterId}
             aria-label={cluster.accessibleLabel}
             onclick={(event) => {
               clusterTrigger = event.currentTarget as HTMLButtonElement;
@@ -544,6 +549,7 @@
           {#if openClusterKey === cluster.key}
             <div
               class="cinder-_floating-surface cinder-event-timeline__cluster-surface"
+              id={clusterId}
               role="dialog"
               aria-label={cluster.accessibleLabel}
               bind:this={clusterSurface}

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -23,6 +23,8 @@
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
+  import { createClickOutside } from '../../utilities/attachments.ts';
+  import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
   import { tick } from 'svelte';
 
@@ -74,8 +76,9 @@
   }: EventTimelineProps = $props();
 
   let measuredWidth = $state(0);
-  let openCluster = $state(false);
+  let openClusterKey = $state<string | null>(null);
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
+  let clusterSurface = $state<HTMLDivElement | null>(null);
 
   function toTimestamp(value: EventTimelineDate | undefined): number | undefined {
     if (value === undefined) return undefined;
@@ -213,25 +216,37 @@
         return positionedItem;
       });
 
-    const clusters: EventTimelineCluster[] = [];
-    if (overflowItems.length > 0) {
-      const first = overflowItems[0]!;
-      const last = overflowItems.at(-1)!;
+    const overflowGroups: PositionedEventTimelineItem[][] = [];
+    for (const item of overflowItems) {
+      const group = overflowGroups.at(-1);
+      if (
+        group === undefined ||
+        item.position - group.at(-1)!.position >= collisionThresholdPercent
+      ) {
+        overflowGroups.push([item]);
+      } else {
+        group.push(item);
+      }
+    }
+
+    const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup) => {
+      const first = overflowGroup[0]!;
+      const last = overflowGroup.at(-1)!;
       const startTime = new Date(first.timestamp).toISOString().slice(11, 16);
       const endTime = new Date(last.timestamp).toISOString().slice(11, 16);
-      const countLabel = overflowItems.length === 1 ? 'event' : 'events';
-      clusters.push({
-        accessibleLabel: `${overflowItems.length} ${countLabel} between ${startTime} and ${endTime}`,
-        count: overflowItems.length,
+      const countLabel = overflowGroup.length === 1 ? 'event' : 'events';
+      return {
+        accessibleLabel: `${overflowGroup.length} ${countLabel} between ${startTime} and ${endTime}`,
+        count: overflowGroup.length,
         edge: edgeForPosition(first.position),
         endTime,
         key: `cluster-${first.key}`,
         lane: MAX_VISIBLE_LANES,
         position: first.position,
         startTime,
-        items: overflowItems,
-      });
-    }
+        items: overflowGroup,
+      };
+    });
 
     return { clusters, items: visibleItems };
   });
@@ -261,18 +276,33 @@
   const accessibleName = $derived(normalizedAriaLabel ?? normalizedLabel ?? 'Event timeline');
 
   function closeCluster(): void {
-    openCluster = false;
+    openClusterKey = null;
     void tick().then(() => clusterTrigger?.focus());
   }
 
-  function handleKeydown(event: KeyboardEvent): void {
-    if (event.key !== 'Escape' || !openCluster) return;
-    event.preventDefault();
-    closeCluster();
-  }
-</script>
+  const dismissOnOutsidePointerdown = $derived(
+    createClickOutside({
+      handler: closeCluster,
+      enabled: () => openClusterKey !== null,
+      eventType: 'pointerdown',
+    }),
+  );
 
-<svelte:window onkeydown={handleKeydown} />
+  $effect(() => {
+    if (openClusterKey !== null && !clusters.some((cluster) => cluster.key === openClusterKey)) {
+      openClusterKey = null;
+      clusterTrigger = null;
+    }
+  });
+
+  $effect(() => {
+    if (openClusterKey === null) return;
+    return pushEscapeHandler((event) => {
+      event.preventDefault();
+      closeCluster();
+    });
+  });
+</script>
 
 <div {...rest} class={classNames('cinder-event-timeline', customClassName)} data-cinder-size={size}>
   {#if normalizedLabel}
@@ -330,23 +360,32 @@
           class="cinder-event-timeline__cluster-trigger"
           type="button"
           tabindex="0"
-          aria-expanded={openCluster}
+          aria-expanded={openClusterKey === cluster.key}
           aria-label={cluster.accessibleLabel}
           onclick={(event) => {
             clusterTrigger = event.currentTarget as HTMLButtonElement;
-            openCluster = !openCluster;
+            openClusterKey = openClusterKey === cluster.key ? null : cluster.key;
+            if (openClusterKey !== null) void tick().then(() => clusterSurface?.focus());
           }}>+{cluster.count}</button
         >
-        {#if openCluster}
+        {#if openClusterKey === cluster.key}
           <div
-            class="cinder-event-timeline__cluster-surface"
+            class="cinder-_floating-surface cinder-event-timeline__cluster-surface"
             role="dialog"
             aria-label={cluster.accessibleLabel}
+            bind:this={clusterSurface}
+            tabindex="-1"
+            {@attach dismissOnOutsidePointerdown}
           >
             <strong>{cluster.accessibleLabel}</strong>
             <ul>
               {#each cluster.items as hiddenItem (hiddenItem.key)}
-                <li>{hiddenItem.label}</li>
+                <li>
+                  <span>{hiddenItem.label}</span>
+                  <span class="cinder-event-timeline__cluster-item-details">
+                    {hiddenItem.sublabel ?? hiddenItem.isoDatetime} · {hiddenItem.stateLabel}
+                  </span>
+                </li>
               {/each}
             </ul>
           </div>

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -88,13 +88,26 @@
   let openClusterKey = $state<string | null>(null);
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
+  function portalOwner(): HTMLElement | null {
+    const trigger = clusterTrigger;
+    if (!trigger) return null;
+    try {
+      return (
+        trigger.closest<HTMLElement>('dialog:modal') ??
+        (CSS.supports('selector(:popover-open)')
+          ? trigger.closest<HTMLElement>('[popover]:popover-open')
+          : null)
+      );
+    } catch {
+      return null;
+    }
+  }
   const clusterPortalAttachment = createPortalAttachment({
     // Anchored overlay coordinates are viewport-relative (fixed strategy). Keep the
     // surface in the document top layer so transformed dialog containers cannot
     // become a competing fixed-position containing block.
     target: () => {
-      const owner = clusterTrigger?.closest<HTMLElement>('dialog[open], [popover]:popover-open');
-      return owner ?? document.body;
+      return portalOwner() ?? document.body;
     },
     inheritAttributes: true,
     source: () => clusterTrigger,
@@ -108,8 +121,10 @@
     offset: () => 8,
     shiftPadding: () => 8,
     strategy: () => {
-      const owner = clusterTrigger?.closest<HTMLElement>('dialog[open], [popover]:popover-open');
-      return owner && getComputedStyle(owner).transform !== 'none' ? 'absolute' : 'fixed';
+      const owner = portalOwner();
+      if (!owner) return 'fixed';
+      const style = getComputedStyle(owner);
+      return style.transform !== 'none' || style.translate !== 'none' ? 'absolute' : 'fixed';
     },
   });
 

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -38,6 +38,7 @@
 
   type PositionedEventTimelineItem = Omit<EventTimelineItem, 'sublabel'> & {
     accessibleLabel: string;
+    centered: boolean;
     edge: 'end' | 'middle' | 'start';
     key: string;
     lane: number;
@@ -88,7 +89,10 @@
   let clusterTrigger = $state<HTMLButtonElement | null>(null);
   let clusterSurface = $state<HTMLDivElement | null>(null);
   const clusterPortalAttachment = createPortalAttachment({
-    target: () => clusterTrigger?.closest<HTMLElement>('dialog[open]') ?? document.body,
+    // Anchored overlay coordinates are viewport-relative (fixed strategy). Keep the
+    // surface in the document top layer so transformed dialog containers cannot
+    // become a competing fixed-position containing block.
+    target: () => document.body,
     inheritAttributes: true,
     source: () => clusterTrigger,
   });
@@ -243,7 +247,22 @@
           measuredWidth > 0
             ? ((6 * rootFontSize) / measuredWidth) * 100
             : (6 / LABEL_MAX_WIDTH_REM[size]) * collisionThresholdPercent;
-        const edge = edgeForPosition(position, collisionThresholdPercent, offsetPercent);
+        const preferredEdge = edgeForPosition(position, collisionThresholdPercent, offsetPercent);
+        let edge = preferredEdge;
+        // On very narrow timelines the edge safety zones can overlap. Prefer an
+        // undisplaced centered label whenever its measured bounds still fit.
+        const centeredBounds = transformedLabelBounds(
+          position,
+          'middle',
+          collisionThresholdPercent,
+          0,
+        );
+        const centered =
+          collisionThresholdPercent > 50 &&
+          preferredEdge !== 'middle' &&
+          centeredBounds.start >= 0 &&
+          centeredBounds.end <= 100;
+        if (centered) edge = 'middle';
         const availableLane = laneBounds.findIndex((bounds) => {
           const candidate = transformedLabelBounds(
             position,
@@ -275,6 +294,7 @@
         const positionedItem = {
           ...item,
           accessibleLabel: `${item.label}, ${timeLabel}, ${stateLabel}`,
+          centered,
           edge,
           key: keyForItem(item, index, timestamp),
           lane,
@@ -432,6 +452,7 @@
           data-cinder-lane={item.lane}
           data-cinder-lane-parity={item.lane % 2 === 0 ? 'even' : 'odd'}
           data-cinder-edge={item.edge}
+          data-cinder-centered={item.centered ? '' : undefined}
           aria-label={item.accessibleLabel}
           style:left="{item.position}%"
           style:--_cinder-event-timeline-lane={item.lane}

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -390,9 +390,9 @@
   const normalizedAriaLabel = $derived(ariaLabel?.trim() || undefined);
   const accessibleName = $derived(normalizedAriaLabel ?? normalizedLabel ?? 'Event timeline');
 
-  function closeCluster(): void {
+  function closeCluster(restoreFocus = false): void {
     openClusterKey = null;
-    void tick().then(() => clusterTrigger?.focus());
+    if (restoreFocus) void tick().then(() => clusterTrigger?.focus());
   }
 
   const dismissOnOutsidePointerdown = $derived(
@@ -415,7 +415,7 @@
     if (openClusterKey === null) return;
     return pushEscapeHandler((event) => {
       event.preventDefault();
-      closeCluster();
+      closeCluster(true);
     });
   });
 

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -327,7 +327,7 @@
       }
     }
 
-    const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup, groupIndex) => {
+    const clusters: EventTimelineCluster[] = overflowGroups.map((overflowGroup) => {
       const chronologicalItems = overflowGroup.slice().sort((a, b) => a.timestamp - b.timestamp);
       const first = chronologicalItems[0]!;
       const last = chronologicalItems.at(-1)!;
@@ -339,7 +339,7 @@
         count: overflowGroup.length,
         edge: edgeForPosition(first.position, collisionThresholdPercent),
         endTime,
-        key: `cluster-${groupIndex}-${startTime}-${endTime}-${JSON.stringify(chronologicalItems.map((item) => item.id ?? item.key))}`,
+        key: `cluster-${startTime}-${endTime}-${JSON.stringify(chronologicalItems.map((item) => item.id ?? item.key))}`,
         lane: MAX_VISIBLE_LANES,
         position: first.position,
         startTime,

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -240,7 +240,7 @@
             ? ((6 * rootFontSize) / measuredWidth) * 100
             : (6 / LABEL_MAX_WIDTH_REM[size]) * collisionThresholdPercent;
         const edge = edgeForPosition(position, collisionThresholdPercent, offsetPercent);
-        const availableLane = laneBounds.findIndex((bounds, lane) => {
+        const availableLane = laneBounds.findIndex((bounds) => {
           const candidate = transformedLabelBounds(
             position,
             edge,

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -312,7 +312,7 @@
             position,
             edge,
             collisionThresholdPercent,
-            offsetPercent,
+            centered ? 0 : offsetPercent,
             lane,
           );
           return candidate.start >= bounds.end + 1;
@@ -325,7 +325,7 @@
             position,
             edge,
             collisionThresholdPercent,
-            offsetPercent,
+            centered ? 0 : offsetPercent,
             lane,
           );
           laneBounds[lane] = { end: bounds.end };
@@ -417,7 +417,6 @@
 
   const laneCount = $derived(
     Math.max(
-      3,
       ...positionedItems.map((item) => item.lane + 1),
       ...clusters.map((cluster) => cluster.lane + 1),
       0,

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -98,6 +98,7 @@
   let itemsElement = $state<HTMLDivElement | null>(null);
   let portalOwnerWidth = $state(0);
   let isRtl = $state(false);
+  let clusterStrategy = $state<'fixed' | 'absolute'>('fixed');
   const instanceId = $props.id();
   function portalOwner(): HTMLElement | null {
     const trigger = clusterTrigger;
@@ -153,11 +154,22 @@
     placement: () => 'bottom-start',
     offset: () => 8,
     shiftPadding: () => 8,
-    strategy: () => {
-      const owner = portalOwner();
-      if (!owner) return 'fixed';
-      return hasFixedPositionContainingBlock(owner) ? 'absolute' : 'fixed';
-    },
+    // Read from state (kept fresh below) rather than recomputing here: `strategy`
+    // is captured once when the anchored overlay's autoUpdate session starts, so
+    // it must be reactive for the session to notice a containing block appearing
+    // on an owner ancestor (e.g. an app-level animation) while the cluster stays open.
+    strategy: () => clusterStrategy,
+  });
+
+  $effect(() => {
+    if (openClusterKey === null) return;
+    const owner = portalOwner();
+    if (!owner) return;
+    const update = () => {
+      clusterStrategy = hasFixedPositionContainingBlock(owner) ? 'absolute' : 'fixed';
+    };
+    update();
+    return observeEventTimelineDirection(owner, update);
   });
 
   function toTimestamp(value: EventTimelineDate | undefined): number | undefined {

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -102,6 +102,10 @@
     const trigger = clusterTrigger;
     if (!trigger) return null;
     try {
+      const focusTrapRoot = trigger.closest<HTMLElement>(
+        '.cinder-modal__panel, .cinder-sheet__panel, .cinder-drawer__panel',
+      );
+      if (focusTrapRoot) return focusTrapRoot;
       const dialog = trigger.closest<HTMLElement>('dialog');
       return (
         (dialog && modalPredicate(dialog) ? dialog : null) ??
@@ -185,13 +189,15 @@
     edge: PositionedEventTimelineItem['edge'],
     labelWidthPercent: number,
     offsetPercent: number,
+    lane = 0,
   ): { start: number; end: number } {
     if (edge === 'start') return { start: position, end: position + labelWidthPercent };
     if (edge === 'end') return { start: position - labelWidthPercent, end: position };
 
+    const directionalOffset = lane % 2 === 0 ? -offsetPercent : offsetPercent;
     return {
-      start: position - offsetPercent - labelWidthPercent / 2,
-      end: position + offsetPercent + labelWidthPercent / 2,
+      start: position + directionalOffset - labelWidthPercent / 2,
+      end: position + directionalOffset + labelWidthPercent / 2,
     };
   }
 
@@ -303,12 +309,13 @@
           centeredBounds.start >= 0 &&
           centeredBounds.end <= 100;
         if (centered) edge = 'middle';
-        const availableLane = laneBounds.findIndex((bounds) => {
+        const availableLane = laneBounds.findIndex((bounds, lane) => {
           const candidate = transformedLabelBounds(
             position,
             edge,
             collisionThresholdPercent,
             offsetPercent,
+            lane,
           );
           return candidate.start >= bounds.end + 1;
         });
@@ -321,6 +328,7 @@
             edge,
             collisionThresholdPercent,
             offsetPercent,
+            lane,
           );
           laneBounds[lane] = { end: bounds.end };
         }

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -378,7 +378,6 @@
         } else {
           visibleItems.push(positionedItem);
         }
-        return positionedItem;
       });
 
     const overflowGroups: PositionedEventTimelineItem[][] = [];

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -579,7 +579,6 @@
           <button
             class="cinder-event-timeline__cluster-trigger"
             type="button"
-            tabindex="0"
             aria-expanded={openClusterKey === cluster.key}
             aria-haspopup="dialog"
             aria-controls={openClusterKey === cluster.key ? clusterId : undefined}

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -23,6 +23,8 @@
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
+  import { useResizeObserver } from '../../utilities/use-resize-observer.svelte.ts';
+  import { tick } from 'svelte';
 
   import type {
     EventTimelineDate,
@@ -36,11 +38,28 @@
     key: string;
     lane: number;
     position: number;
+    timestamp: number;
     isoDatetime: string;
     state: NonNullable<EventTimelineItem['state']>;
     stateLabel: string;
     sublabel: string | undefined;
   };
+
+  type EventTimelineCluster = {
+    accessibleLabel: string;
+    count: number;
+    edge: PositionedEventTimelineItem['edge'];
+    endTime: string;
+    key: string;
+    lane: number;
+    position: number;
+    startTime: string;
+    items: PositionedEventTimelineItem[];
+  };
+
+  const MAX_VISIBLE_LANES = 4;
+  const LABEL_MAX_WIDTH_REM = { sm: 7, md: 9 } as const;
+  const FALLBACK_ROOT_FONT_SIZE_PX = 16;
 
   let {
     start,
@@ -53,6 +72,10 @@
     class: customClassName,
     ...rest
   }: EventTimelineProps = $props();
+
+  let measuredWidth = $state(0);
+  let openCluster = $state(false);
+  let clusterTrigger = $state<HTMLButtonElement | null>(null);
 
   function toTimestamp(value: EventTimelineDate | undefined): number | undefined {
     if (value === undefined) return undefined;
@@ -80,6 +103,42 @@
     return 'middle';
   }
 
+  function getLabelMaxWidthPx(): number {
+    if (typeof window === 'undefined') {
+      return LABEL_MAX_WIDTH_REM[size] * FALLBACK_ROOT_FONT_SIZE_PX;
+    }
+
+    const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+    const baseFontSize =
+      Number.isFinite(rootFontSize) && rootFontSize > 0 ? rootFontSize : FALLBACK_ROOT_FONT_SIZE_PX;
+    return LABEL_MAX_WIDTH_REM[size] * baseFontSize;
+  }
+
+  function getObservedWidth(entry: ResizeObserverEntry): number {
+    const borderBoxSize = Array.isArray(entry.borderBoxSize)
+      ? entry.borderBoxSize[0]
+      : entry.borderBoxSize;
+    return borderBoxSize?.inlineSize ?? entry.contentRect.width;
+  }
+
+  function updateMeasuredWidth(width: number): void {
+    if (Number.isFinite(width) && width > 0) measuredWidth = width;
+  }
+
+  const observeResize = useResizeObserver((entries) => {
+    const entry = entries[0];
+    if (entry) updateMeasuredWidth(getObservedWidth(entry));
+  });
+
+  const observeItems = (node: HTMLElement) => {
+    updateMeasuredWidth(node.getBoundingClientRect().width);
+    return observeResize(node);
+  };
+
+  const collisionThresholdPercent = $derived(
+    measuredWidth > 0 ? (getLabelMaxWidthPx() / measuredWidth) * 100 : 100,
+  );
+
   const range = $derived.by(() => {
     const startTimestamp = toTimestamp(start) ?? 0;
     const endTimestamp = toTimestamp(end);
@@ -95,10 +154,15 @@
     };
   });
 
-  const positionedItems = $derived.by<PositionedEventTimelineItem[]>(() => {
+  const positionedLayout = $derived.by<{
+    clusters: EventTimelineCluster[];
+    items: PositionedEventTimelineItem[];
+  }>(() => {
     const lanePositions: number[] = [];
+    const visibleItems: PositionedEventTimelineItem[] = [];
+    const overflowItems: PositionedEventTimelineItem[] = [];
 
-    return items
+    items
       .map((item, index) => {
         const timestamp = toTimestamp(item.at);
         if (timestamp === undefined) return undefined;
@@ -114,10 +178,12 @@
       .sort((a, b) => a.position - b.position)
       .map(({ item, index, timestamp, position }) => {
         const availableLane = lanePositions.findIndex(
-          (lastPosition) => position - lastPosition >= 12,
+          (lastPosition) => position - lastPosition >= collisionThresholdPercent,
         );
-        const lane = availableLane === -1 ? lanePositions.length : availableLane;
-        lanePositions[lane] = position;
+        const nextLane = availableLane === -1 ? lanePositions.length : availableLane;
+        const isOverflow = availableLane === -1 && nextLane >= MAX_VISIBLE_LANES;
+        const lane = isOverflow ? MAX_VISIBLE_LANES : nextLane;
+        if (!isOverflow) lanePositions[lane] = position;
 
         const isoDatetime = new Date(timestamp).toISOString();
         const state = item.state ?? 'upcoming';
@@ -125,22 +191,62 @@
         const sublabel = item.sublabel?.trim() || undefined;
         const timeLabel = sublabel ?? isoDatetime;
 
-        return {
+        const positionedItem = {
           ...item,
           accessibleLabel: `${item.label}, ${timeLabel}, ${stateLabel}`,
           edge: edgeForPosition(position),
           key: keyForItem(item, index, timestamp),
           lane,
           position,
+          timestamp,
           isoDatetime,
           state,
           stateLabel,
           sublabel,
         };
+
+        if (lane >= MAX_VISIBLE_LANES) {
+          overflowItems.push(positionedItem);
+        } else {
+          visibleItems.push(positionedItem);
+        }
+        return positionedItem;
       });
+
+    const clusters: EventTimelineCluster[] = [];
+    if (overflowItems.length > 0) {
+      const first = overflowItems[0]!;
+      const last = overflowItems.at(-1)!;
+      const startTime = new Date(first.timestamp).toISOString().slice(11, 16);
+      const endTime = new Date(last.timestamp).toISOString().slice(11, 16);
+      const countLabel = overflowItems.length === 1 ? 'event' : 'events';
+      clusters.push({
+        accessibleLabel: `${overflowItems.length} ${countLabel} between ${startTime} and ${endTime}`,
+        count: overflowItems.length,
+        edge: edgeForPosition(first.position),
+        endTime,
+        key: `cluster-${first.key}`,
+        lane: MAX_VISIBLE_LANES,
+        position: first.position,
+        startTime,
+        items: overflowItems,
+      });
+    }
+
+    return { clusters, items: visibleItems };
   });
 
-  const laneCount = $derived(Math.max(3, ...positionedItems.map((item) => item.lane + 1), 0));
+  const positionedItems = $derived(positionedLayout.items);
+  const clusters = $derived(positionedLayout.clusters);
+
+  const laneCount = $derived(
+    Math.max(
+      3,
+      ...positionedItems.map((item) => item.lane + 1),
+      ...clusters.map((cluster) => cluster.lane + 1),
+      0,
+    ),
+  );
 
   const nowPosition = $derived.by(() => {
     const timestamp = toTimestamp(now);
@@ -153,7 +259,20 @@
   const normalizedLabel = $derived(label?.trim() || undefined);
   const normalizedAriaLabel = $derived(ariaLabel?.trim() || undefined);
   const accessibleName = $derived(normalizedAriaLabel ?? normalizedLabel ?? 'Event timeline');
+
+  function closeCluster(): void {
+    openCluster = false;
+    void tick().then(() => clusterTrigger?.focus());
+  }
+
+  function handleKeydown(event: KeyboardEvent): void {
+    if (event.key !== 'Escape' || !openCluster) return;
+    event.preventDefault();
+    closeCluster();
+  }
 </script>
+
+<svelte:window onkeydown={handleKeydown} />
 
 <div {...rest} class={classNames('cinder-event-timeline', customClassName)} data-cinder-size={size}>
   {#if normalizedLabel}
@@ -166,6 +285,7 @@
   </div>
   <div
     class="cinder-event-timeline__items"
+    {@attach observeItems}
     role="list"
     aria-label={accessibleName}
     style:--_cinder-event-timeline-lane-count={laneCount}
@@ -176,12 +296,14 @@
         role="listitem"
         data-cinder-state={item.state}
         data-cinder-lane={item.lane}
+        data-cinder-lane-parity={item.lane % 2 === 0 ? 'even' : 'odd'}
         data-cinder-edge={item.edge}
         aria-label={item.accessibleLabel}
         style:left="{item.position}%"
         style:--_cinder-event-timeline-lane={item.lane}
       >
         <span class="cinder-event-timeline__dot" aria-hidden="true"></span>
+        <span class="cinder-event-timeline__leader" aria-hidden="true"></span>
         <span class="cinder-event-timeline__content">
           <span class="cinder-event-timeline__item-label">{item.label}</span>
           {#if item.sublabel}
@@ -193,6 +315,42 @@
           {/if}
           <span class="cinder-sr-only">{item.stateLabel}</span>
         </span>
+      </div>
+    {/each}
+    {#each clusters as cluster (cluster.key)}
+      <div
+        class="cinder-event-timeline__cluster"
+        role="listitem"
+        data-cinder-edge={cluster.edge}
+        data-cinder-lane={cluster.lane}
+        style:left="{cluster.position}%"
+        style:--_cinder-event-timeline-lane={cluster.lane}
+      >
+        <button
+          class="cinder-event-timeline__cluster-trigger"
+          type="button"
+          tabindex="0"
+          aria-expanded={openCluster}
+          aria-label={cluster.accessibleLabel}
+          onclick={(event) => {
+            clusterTrigger = event.currentTarget as HTMLButtonElement;
+            openCluster = !openCluster;
+          }}>+{cluster.count}</button
+        >
+        {#if openCluster}
+          <div
+            class="cinder-event-timeline__cluster-surface"
+            role="dialog"
+            aria-label={cluster.accessibleLabel}
+          >
+            <strong>{cluster.accessibleLabel}</strong>
+            <ul>
+              {#each cluster.items as hiddenItem (hiddenItem.key)}
+                <li>{hiddenItem.label}</li>
+              {/each}
+            </ul>
+          </div>
+        {/if}
       </div>
     {/each}
   </div>

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -368,6 +368,34 @@ describe('EventTimeline', () => {
     expect(document.activeElement).toBe(cluster);
   });
 
+  test('restores focus to the timeline before removing an open stale cluster', async () => {
+    const denseItems = [0, 1, 2, 3, 4].map((index) => ({
+      at: `2026-07-03T06:0${index}:00.000Z`,
+      label: `Event ${index + 1}`,
+    }));
+    const { container, rerender } = render(EventTimeline, {
+      start,
+      end,
+      items: denseItems,
+    });
+
+    const cluster = container.querySelector<HTMLButtonElement>(
+      '.cinder-event-timeline__cluster-trigger',
+    )!;
+    await fireEvent.click(cluster);
+    const dialog = document.querySelector<HTMLElement>('[role="dialog"]')!;
+    await waitFor(() => expect(document.activeElement).toBe(dialog));
+
+    await rerender({
+      start,
+      end,
+      items: denseItems.slice(0, 1),
+    });
+
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(container.querySelector('[role="list"]'));
+  });
+
   test('keeps cluster surfaces inside a Cinder popover panel', async () => {
     const popover = document.createElement('div');
     popover.className = 'cinder-popover';
@@ -755,5 +783,8 @@ describe('EventTimeline', () => {
     expect(EVENT_TIMELINE_CSS).toContain('cinder-event-timeline__leader');
     expect(EVENT_TIMELINE_CSS).toContain('cinder-event-timeline__cluster-trigger');
     expect(EVENT_TIMELINE_CSS).toContain(':focus-visible');
+    expect(EVENT_TIMELINE_CSS).not.toMatch(
+      /:dir\(rtl\).*data-cinder-edge='(?:start|end)'\][^{]*\{[^}]*justify-items:/s,
+    );
   });
 });

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -288,10 +288,41 @@ describe('EventTimeline', () => {
     expect(document.activeElement).toBe(cluster);
   });
 
-  test('keeps cluster surfaces in the viewport top layer for native dialogs', () => {
-    expect(EVENT_TIMELINE_SOURCE).toContain('return owner ?? document.body');
-    expect(EVENT_TIMELINE_SOURCE).toContain("? 'absolute' : 'fixed'");
-    expect(EVENT_TIMELINE_SOURCE).toContain('closest<HTMLElement>(');
+  test('positions cluster surfaces inside transformed native dialogs', async () => {
+    const dialog = document.createElement('dialog');
+    dialog.open = true;
+    document.body.append(dialog);
+    const original = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = ((element: Element) => {
+      const style = original(element);
+      return element === dialog
+        ? ({ ...style, transform: 'scale(0.98)' } as CSSStyleDeclaration)
+        : style;
+    }) as typeof getComputedStyle;
+    try {
+      const { container } = render(EventTimeline, {
+        start,
+        end,
+        items: [0, 1, 2, 3, 4].map((index) => ({
+          at: `2026-07-03T06:0${index}:00.000Z`,
+          label: `Event ${index + 1}`,
+        })),
+      });
+      dialog.append(container.firstElementChild!);
+      await fireEvent.click(dialog.querySelector('.cinder-event-timeline__cluster-trigger')!);
+      await waitFor(() => {
+        const surface = dialog.querySelector<HTMLElement>('[role="dialog"]');
+        expect(surface).not.toBeNull();
+        expect(surface?.parentElement).toBe(dialog);
+        expect(surface?.style.position).toBe('absolute');
+      });
+      await waitFor(() =>
+        expect(document.activeElement).toBe(dialog.querySelector('[role="dialog"]')),
+      );
+    } finally {
+      globalThis.getComputedStyle = original;
+      dialog.remove();
+    }
   });
 
   test('outside pointer dismissal does not refocus the cluster trigger', async () => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -386,7 +386,7 @@ describe('EventTimeline', () => {
     );
     await fireEvent.keyDown(window, { key: 'Escape' });
     expect(document.querySelector('[role="dialog"]')).toBeNull();
-    expect(document.activeElement).toBe(cluster);
+    await waitFor(() => expect(document.activeElement).toBe(cluster));
   });
 
   test('restores focus to the timeline before removing an open stale cluster', async () => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -804,8 +804,18 @@ describe('EventTimeline', () => {
     expect(EVENT_TIMELINE_CSS).toContain('cinder-event-timeline__leader');
     expect(EVENT_TIMELINE_CSS).toContain('cinder-event-timeline__cluster-trigger');
     expect(EVENT_TIMELINE_CSS).toContain(':focus-visible');
-    expect(EVENT_TIMELINE_CSS).not.toMatch(
-      /:dir\(rtl\).*data-cinder-edge='(?:start|end)'\][^{]*\{[^}]*justify-items:/s,
+  });
+
+  test('anchors edge dots to their physical position under RTL', () => {
+    // `justify-items: start/end` is direction-aware and flips under `dir="rtl"`, but
+    // edge items are positioned with a physical `left` percentage that never flips.
+    // Without a matching RTL override, a wide RTL label would pull the dot away from
+    // its timestamp. Force the opposite logical value so the dot stays physically put.
+    expect(EVENT_TIMELINE_CSS).toMatch(
+      /:dir\(rtl\)\s*\.cinder-event-timeline__item\[data-cinder-edge='start'\]\s*\{[^}]*justify-items:\s*end;/s,
+    );
+    expect(EVENT_TIMELINE_CSS).toMatch(
+      /:dir\(rtl\)\s*\.cinder-event-timeline__item\[data-cinder-edge='end'\]\s*\{[^}]*justify-items:\s*start;/s,
     );
   });
 });

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -235,6 +235,15 @@ describe('EventTimeline', () => {
     );
   });
 
+  test('points collision leaders toward their offset labels', () => {
+    expect(EVENT_TIMELINE_CSS).toContain(
+      "[data-cinder-lane-parity='even'] .cinder-event-timeline__leader {\n    inset-inline-end: 50%;",
+    );
+    expect(EVENT_TIMELINE_CSS).toContain(
+      "[data-cinder-lane-parity='odd'] .cinder-event-timeline__leader {\n    inset-inline-start: 50%;",
+    );
+  });
+
   test('keeps centered fallback bounds out of parity-offset lanes', async () => {
     const { container } = render(EventTimeline, {
       start,

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -150,6 +150,26 @@ describe('EventTimeline', () => {
     ).toEqual(['0', '0']);
   });
 
+  test('accounts for transformed labels when reusing lanes across edge boundaries', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [
+        { at: '2026-07-03T02:24:00.000Z', label: 'Edge event' },
+        { at: '2026-07-03T05:16:48.000Z', label: 'Middle event' },
+      ],
+    });
+
+    await tick();
+    TestResizeObserver.instances[0]?.trigger(1200);
+    await tick();
+    expect(
+      [...container.querySelectorAll('[role="listitem"]')].map((item) =>
+        item.getAttribute('data-cinder-lane'),
+      ),
+    ).toEqual(['0', '1']);
+  });
+
   test('offsets colliding lanes and renders hidden leader lines', () => {
     const { container } = render(EventTimeline, {
       start,

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -288,6 +288,28 @@ describe('EventTimeline', () => {
     expect(document.activeElement).toBe(cluster);
   });
 
+  test('outside pointer dismissal does not refocus the cluster trigger', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [0, 1, 2, 3, 4].map((index) => ({
+        at: `2026-07-03T06:0${index}:00.000Z`,
+        label: `Event ${index + 1}`,
+      })),
+    });
+    const cluster = container.querySelector<HTMLButtonElement>(
+      '.cinder-event-timeline__cluster-trigger',
+    );
+    cluster?.focus();
+    await fireEvent.click(cluster!);
+    const outside = document.createElement('button');
+    document.body.append(outside);
+    outside.focus();
+    await fireEvent.pointerDown(outside);
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(outside);
+  });
+
   test('creates one cluster marker per separated dense region', async () => {
     const { container } = render(EventTimeline, {
       start,

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -8,7 +8,7 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { cleanup, render } = await import('@testing-library/svelte');
+const { cleanup, render, waitFor } = await import('@testing-library/svelte');
 const { default: EventTimeline } = await import('./event-timeline.svelte');
 const { fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
@@ -262,7 +262,7 @@ describe('EventTimeline', () => {
     await fireEvent.click(cluster!);
     const dialog = document.querySelector('[role="dialog"]');
     expect(dialog).not.toBeNull();
-    expect(document.activeElement).toBe(dialog);
+    await waitFor(() => expect(document.activeElement).toBe(dialog));
     expect(dialog?.textContent).toContain('Upcoming');
     await fireEvent.keyDown(window, { key: 'Escape' });
     expect(document.querySelector('[role="dialog"]')).toBeNull();

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -10,8 +10,64 @@ setupHappyDom();
 
 const { render } = await import('@testing-library/svelte');
 const { default: EventTimeline } = await import('./event-timeline.svelte');
+const { fireEvent } = await import('@testing-library/svelte');
+const { tick } = await import('svelte');
 
 const EVENT_TIMELINE_CSS = readFileSync(join(import.meta.dir, 'event-timeline.css'), 'utf8');
+
+class TestResizeObserver implements ResizeObserver {
+  static instances: TestResizeObserver[] = [];
+  readonly callback: ResizeObserverCallback;
+  observed: Element | undefined;
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    TestResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.observed = target;
+  }
+
+  unobserve(): void {}
+
+  disconnect(): void {}
+
+  trigger(width: number): void {
+    this.callback(
+      [
+        {
+          borderBoxSize: [{ inlineSize: width }],
+          contentRect: { width },
+          target: this.observed,
+        } as unknown as ResizeObserverEntry,
+      ],
+      this as unknown as ResizeObserver,
+    );
+  }
+}
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: TestResizeObserver,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  TestResizeObserver.instances = [];
+});
+
+afterAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: originalResizeObserver,
+    writable: true,
+  });
+});
 
 describe('EventTimeline', () => {
   const start = '2026-07-03T00:00:00.000Z';
@@ -63,6 +119,81 @@ describe('EventTimeline', () => {
     const items = [...container.querySelectorAll('[role="listitem"]')];
     expect(items.map((item) => item.getAttribute('data-cinder-lane'))).toEqual(['0', '1', '2']);
     expect(items[2]?.getAttribute('data-cinder-state')).toBe('failed');
+  });
+
+  test('uses the measured pixel width to determine label collisions', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [
+        { at: '2026-07-03T06:00:00.000Z', label: 'A' },
+        { at: '2026-07-03T10:48:00.000Z', label: 'B' },
+      ],
+    });
+
+    await tick();
+    const observer = TestResizeObserver.instances[0];
+    observer?.trigger(400);
+    await tick();
+    expect(
+      [...container.querySelectorAll('[role="listitem"]')].map((item) =>
+        item.getAttribute('data-cinder-lane'),
+      ),
+    ).toEqual(['0', '1']);
+
+    observer?.trigger(1200);
+    await tick();
+    expect(
+      [...container.querySelectorAll('[role="listitem"]')].map((item) =>
+        item.getAttribute('data-cinder-lane'),
+      ),
+    ).toEqual(['0', '0']);
+  });
+
+  test('offsets colliding lanes and renders hidden leader lines', () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [
+        { at: '2026-07-03T06:00:00.000Z', label: 'A' },
+        { at: '2026-07-03T06:15:00.000Z', label: 'B' },
+      ],
+    });
+
+    const items = [...container.querySelectorAll('[role="listitem"]')];
+    expect(items[0]?.getAttribute('data-cinder-lane-parity')).toBe('even');
+    expect(items[1]?.getAttribute('data-cinder-lane-parity')).toBe('odd');
+    expect(container.querySelectorAll('.cinder-event-timeline__leader')).toHaveLength(2);
+    expect(
+      [...container.querySelectorAll('.cinder-event-timeline__leader')].every(
+        (leader) => leader.getAttribute('aria-hidden') === 'true',
+      ),
+    ).toBe(true);
+  });
+
+  test('collapses excess lanes into an accessible cluster button', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [0, 1, 2, 3, 4].map((index) => ({
+        at: `2026-07-03T06:0${index}:00.000Z`,
+        label: `Event ${index + 1}`,
+      })),
+    });
+
+    const cluster = container.querySelector<HTMLButtonElement>(
+      '.cinder-event-timeline__cluster-trigger',
+    );
+    expect(cluster?.textContent).toBe('+1');
+    expect(cluster?.getAttribute('aria-label')).toBe('1 event between 06:04 and 06:04');
+    expect(cluster?.tabIndex).toBe(0);
+
+    cluster?.focus();
+    await fireEvent.click(cluster!);
+    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.activeElement).toBe(cluster);
   });
 
   test('allocates additional lanes for dense clusters without reusing the final lane', () => {
@@ -221,9 +352,16 @@ describe('EventTimeline', () => {
     expect(EVENT_TIMELINE_CSS).toContain('6rem,');
     expect(EVENT_TIMELINE_CSS).toContain('--_cinder-event-timeline-lane-count');
     expect(EVENT_TIMELINE_CSS).toContain("data-cinder-edge='start'");
-    expect(EVENT_TIMELINE_CSS).toContain('transform: translateX(0);');
+    expect(EVENT_TIMELINE_CSS).toContain(
+      'translateX(var(--_cinder-event-timeline-label-offset, 0px))',
+    );
     expect(EVENT_TIMELINE_CSS).toContain("data-cinder-edge='end'");
-    expect(EVENT_TIMELINE_CSS).toContain('transform: translateX(-100%);');
+    expect(EVENT_TIMELINE_CSS).toContain(
+      'translateX(calc(-100% + var(--_cinder-event-timeline-label-offset, 0px)))',
+    );
     expect(EVENT_TIMELINE_CSS).toContain('5.25rem,');
+    expect(EVENT_TIMELINE_CSS).toContain('cinder-event-timeline__leader');
+    expect(EVENT_TIMELINE_CSS).toContain('cinder-event-timeline__cluster-trigger');
+    expect(EVENT_TIMELINE_CSS).toContain(':focus-visible');
   });
 });

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -277,16 +277,41 @@ describe('EventTimeline', () => {
       '1 event between 2026-07-03T06:04:00.000Z and 2026-07-03T06:04:00.000Z',
     );
     expect(cluster?.tabIndex).toBe(0);
+    expect(cluster?.getAttribute('aria-haspopup')).toBe('dialog');
 
     cluster?.focus();
     await fireEvent.click(cluster!);
     const dialog = document.querySelector('[role="dialog"]');
     expect(dialog).not.toBeNull();
+    expect(cluster?.getAttribute('aria-controls')).toBe(dialog?.id);
     await waitFor(() => expect(document.activeElement).toBe(dialog));
     expect(dialog?.textContent).toContain('Upcoming');
     await fireEvent.keyDown(window, { key: 'Escape' });
     expect(document.querySelector('[role="dialog"]')).toBeNull();
     expect(document.activeElement).toBe(cluster);
+  });
+
+  test('keeps cluster surfaces inside a Cinder popover panel', async () => {
+    const popover = document.createElement('div');
+    popover.className = 'cinder-popover';
+    document.body.append(popover);
+    try {
+      const { container } = render(EventTimeline, {
+        start,
+        end,
+        items: [0, 1, 2, 3, 4].map((index) => ({
+          at: `2026-07-03T06:0${index}:00.000Z`,
+          label: `Event ${index + 1}`,
+        })),
+      });
+      popover.append(container.firstElementChild!);
+      await fireEvent.click(popover.querySelector('.cinder-event-timeline__cluster-trigger')!);
+      await waitFor(() =>
+        expect(popover.querySelector('[role="dialog"]')?.parentElement).toBe(popover),
+      );
+    } finally {
+      popover.remove();
+    }
   });
 
   test('positions cluster surfaces inside transformed native dialogs', async () => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -132,6 +132,19 @@ describe('EventTimeline', () => {
     expect(items[2]?.getAttribute('data-cinder-state')).toBe('failed');
   });
 
+  test('uses a narrow-screen-safe fallback before width measurement', () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [20, 32, 44, 56, 68].map((position, index) => ({
+        at: new Date(Date.parse(start) + (position / 100) * (Date.parse(end) - Date.parse(start))),
+        label: `Fallback ${index}`,
+      })),
+    });
+
+    expect(container.querySelector('.cinder-event-timeline__cluster-trigger')).not.toBeNull();
+  });
+
   test('uses the measured pixel width to determine label collisions', async () => {
     const { container } = render(EventTimeline, {
       start,
@@ -328,6 +341,9 @@ describe('EventTimeline', () => {
     expect(cluster?.getAttribute('aria-controls')).toBe(dialog?.id);
     await waitFor(() => expect(document.activeElement).toBe(dialog));
     expect(dialog?.textContent).toContain('Upcoming');
+    expect(dialog?.querySelector('time')?.getAttribute('datetime')).toBe(
+      '2026-07-03T06:04:00.000Z',
+    );
     await fireEvent.keyDown(window, { key: 'Escape' });
     expect(document.querySelector('[role="dialog"]')).toBeNull();
     expect(document.activeElement).toBe(cluster);
@@ -336,6 +352,10 @@ describe('EventTimeline', () => {
   test('keeps cluster surfaces inside a Cinder popover panel', async () => {
     const popover = document.createElement('div');
     popover.className = 'cinder-popover';
+    Object.defineProperty(popover, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ width: 320 }),
+    });
     document.body.append(popover);
     try {
       const { container } = render(EventTimeline, {
@@ -350,6 +370,16 @@ describe('EventTimeline', () => {
       await fireEvent.click(popover.querySelector('.cinder-event-timeline__cluster-trigger')!);
       await waitFor(() =>
         expect(popover.querySelector('[role="dialog"]')?.parentElement).toBe(popover),
+      );
+      expect(popover.querySelector<HTMLElement>('[role="dialog"]')?.style.maxInlineSize).toContain(
+        '304px',
+      );
+      TestResizeObserver.instances
+        .filter((observer) => observer.observed === popover)
+        .forEach((observer) => observer.trigger(200));
+      await tick();
+      expect(popover.querySelector<HTMLElement>('[role="dialog"]')?.style.maxInlineSize).toContain(
+        '184px',
       );
     } finally {
       popover.remove();
@@ -428,6 +458,46 @@ describe('EventTimeline', () => {
     }
   });
 
+  test('keeps cluster surfaces inside the nearest open native popover owner', async () => {
+    const originalCSS = globalThis.CSS;
+    Object.defineProperty(globalThis, 'CSS', {
+      configurable: true,
+      value: { supports: () => true },
+    });
+    const modalPanel = document.createElement('div');
+    modalPanel.className = 'cinder-modal__panel';
+    const nativePopover = document.createElement('div');
+    nativePopover.setAttribute('popover', 'auto');
+    const originalMatches = nativePopover.matches.bind(nativePopover);
+    Object.defineProperty(nativePopover, 'matches', {
+      configurable: true,
+      value: (selector: string) =>
+        selector === ':popover-open' ? true : originalMatches(selector),
+    });
+    modalPanel.append(nativePopover);
+    document.body.append(modalPanel);
+    try {
+      const { container } = render(EventTimeline, {
+        start,
+        end,
+        items: [0, 1, 2, 3, 4].map((index) => ({
+          at: `2026-07-03T06:0${index}:00.000Z`,
+          label: `Event ${index + 1}`,
+        })),
+      });
+      nativePopover.append(container.firstElementChild!);
+      await fireEvent.click(
+        nativePopover.querySelector('.cinder-event-timeline__cluster-trigger')!,
+      );
+      await waitFor(() =>
+        expect(nativePopover.querySelector('[role="dialog"]')?.parentElement).toBe(nativePopover),
+      );
+    } finally {
+      modalPanel.remove();
+      Object.defineProperty(globalThis, 'CSS', { configurable: true, value: originalCSS });
+    }
+  });
+
   test('outside pointer dismissal does not refocus the cluster trigger', async () => {
     const { container } = render(EventTimeline, {
       start,
@@ -448,6 +518,28 @@ describe('EventTimeline', () => {
     await fireEvent.pointerDown(outside);
     expect(document.querySelector('[role="dialog"]')).toBeNull();
     expect(document.activeElement).toBe(outside);
+  });
+
+  test('does not steal focus after the user tabs away while positioning', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [0, 1, 2, 3, 4].map((index) => ({
+        at: `2026-07-03T06:0${index}:00.000Z`,
+        label: `Event ${index + 1}`,
+      })),
+    });
+    const cluster = container.querySelector<HTMLButtonElement>(
+      '.cinder-event-timeline__cluster-trigger',
+    );
+    const outside = document.createElement('button');
+    document.body.append(outside);
+    await fireEvent.click(cluster!);
+    outside.focus();
+    await tick();
+    await tick();
+    expect(document.activeElement).toBe(outside);
+    outside.remove();
   });
 
   test('creates one cluster marker per separated dense region', async () => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -10,8 +10,11 @@ setupHappyDom();
 
 const { cleanup, render, waitFor } = await import('@testing-library/svelte');
 const { default: EventTimeline } = await import('./event-timeline.svelte');
-const { setEventTimelineModalPredicate: __setEventTimelineModalPredicate } =
-  await import('./event-timeline-modal.ts');
+const {
+  hasFixedPositionContainingBlock,
+  resetEventTimelineModalPredicate: __resetEventTimelineModalPredicate,
+  setEventTimelineModalPredicate: __setEventTimelineModalPredicate,
+} = await import('./event-timeline-modal.ts');
 const { fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
 
@@ -309,6 +312,25 @@ describe('EventTimeline', () => {
     expect(EVENT_TIMELINE_MODAL_SOURCE).not.toContain('subtree: true');
   });
 
+  test('does not treat missing individual transform properties as containing blocks', () => {
+    const element = document.createElement('div');
+    const original = globalThis.getComputedStyle;
+    globalThis.getComputedStyle = (() =>
+      ({
+        contain: '',
+        filter: '',
+        rotate: undefined,
+        scale: undefined,
+        transform: '',
+        translate: undefined,
+      }) as unknown as CSSStyleDeclaration) as typeof getComputedStyle;
+    try {
+      expect(hasFixedPositionContainingBlock(element)).toBe(false);
+    } finally {
+      globalThis.getComputedStyle = original;
+    }
+  });
+
   test('offsets colliding lanes and renders hidden leader lines', () => {
     const { container } = render(EventTimeline, {
       start,
@@ -471,7 +493,7 @@ describe('EventTimeline', () => {
         expect(document.activeElement).toBe(panel.querySelector('[role="dialog"]')),
       );
     } finally {
-      __setEventTimelineModalPredicate((element) => element.matches(':modal'));
+      __resetEventTimelineModalPredicate();
       globalThis.getComputedStyle = original;
       dialog.remove();
     }
@@ -500,7 +522,7 @@ describe('EventTimeline', () => {
         expect(panel.querySelector('[role="dialog"]')?.parentElement).toBe(panel),
       );
     } finally {
-      __setEventTimelineModalPredicate((element) => element.matches(':modal'));
+      __resetEventTimelineModalPredicate();
       dialog.remove();
     }
   });

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -190,10 +190,35 @@ describe('EventTimeline', () => {
 
     cluster?.focus();
     await fireEvent.click(cluster!);
-    expect(container.querySelector('[role="dialog"]')).not.toBeNull();
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(document.activeElement).toBe(dialog);
+    expect(dialog?.textContent).toContain('Upcoming');
     await fireEvent.keyDown(window, { key: 'Escape' });
     expect(container.querySelector('[role="dialog"]')).toBeNull();
     expect(document.activeElement).toBe(cluster);
+  });
+
+  test('creates one cluster marker per separated dense region', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [
+        ...[0, 1, 2, 3, 4].map((index) => ({
+          at: `2026-07-03T06:0${index}:00.000Z`,
+          label: `Morning ${index + 1}`,
+        })),
+        ...[0, 1, 2, 3, 4].map((index) => ({
+          at: `2026-07-03T18:0${index}:00.000Z`,
+          label: `Evening ${index + 1}`,
+        })),
+      ],
+    });
+
+    await tick();
+    TestResizeObserver.instances[0]?.trigger(1200);
+    await tick();
+    expect(container.querySelectorAll('.cinder-event-timeline__cluster-trigger')).toHaveLength(2);
   });
 
   test('allocates additional lanes for dense clusters without reusing the final lane', () => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -299,7 +299,8 @@ describe('EventTimeline', () => {
       const style = original(element);
       if (element !== dialog) return style;
       const transformedStyle = Object.create(style) as CSSStyleDeclaration;
-      Object.defineProperty(transformedStyle, 'transform', { value: 'scale(0.98)' });
+      Object.defineProperty(transformedStyle, 'transform', { value: 'none' });
+      Object.defineProperty(transformedStyle, 'scale', { value: '0.98' });
       return transformedStyle;
     }) as typeof getComputedStyle;
     try {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -17,6 +17,10 @@ const { tick } = await import('svelte');
 
 const EVENT_TIMELINE_CSS = readFileSync(join(import.meta.dir, 'event-timeline.css'), 'utf8');
 const EVENT_TIMELINE_SOURCE = readFileSync(join(import.meta.dir, 'event-timeline.svelte'), 'utf8');
+const EVENT_TIMELINE_MODAL_SOURCE = readFileSync(
+  join(import.meta.dir, 'event-timeline-modal.ts'),
+  'utf8',
+);
 
 class TestResizeObserver implements ResizeObserver {
   static instances: TestResizeObserver[] = [];
@@ -239,6 +243,12 @@ describe('EventTimeline', () => {
     expect(EVENT_TIMELINE_SOURCE).toContain('createPortalAttachment');
   });
 
+  test('inspects containing-block ancestors and only observes direction ancestors', () => {
+    expect(EVENT_TIMELINE_MODAL_SOURCE).toContain('current = current.parentElement');
+    expect(EVENT_TIMELINE_MODAL_SOURCE).toContain("attributeFilter: ['class', 'dir', 'style']");
+    expect(EVENT_TIMELINE_MODAL_SOURCE).not.toContain('subtree: true');
+  });
+
   test('offsets colliding lanes and renders hidden leader lines', () => {
     const { container } = render(EventTimeline, {
       start,
@@ -317,6 +327,9 @@ describe('EventTimeline', () => {
 
   test('positions cluster surfaces inside transformed native dialogs', async () => {
     const dialog = document.createElement('dialog');
+    const panel = document.createElement('div');
+    panel.className = 'cinder-modal__panel';
+    dialog.append(panel);
     dialog.open = true;
     document.body.append(dialog);
     __setEventTimelineModalPredicate((element) => element === dialog);
@@ -338,16 +351,16 @@ describe('EventTimeline', () => {
           label: `Event ${index + 1}`,
         })),
       });
-      dialog.append(container.firstElementChild!);
-      await fireEvent.click(dialog.querySelector('.cinder-event-timeline__cluster-trigger')!);
+      panel.append(container.firstElementChild!);
+      await fireEvent.click(panel.querySelector('.cinder-event-timeline__cluster-trigger')!);
       await waitFor(() => {
-        const surface = dialog.querySelector<HTMLElement>('[role="dialog"]');
+        const surface = panel.querySelector<HTMLElement>('[role="dialog"]');
         expect(surface).not.toBeNull();
-        expect(surface?.parentElement).toBe(dialog);
+        expect(surface?.parentElement).toBe(panel);
         expect(surface?.style.position).toBe('absolute');
       });
       await waitFor(() =>
-        expect(document.activeElement).toBe(dialog.querySelector('[role="dialog"]')),
+        expect(document.activeElement).toBe(panel.querySelector('[role="dialog"]')),
       );
     } finally {
       __setEventTimelineModalPredicate((element) => element.matches(':modal'));

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -297,9 +297,10 @@ describe('EventTimeline', () => {
     const original = globalThis.getComputedStyle;
     globalThis.getComputedStyle = ((element: Element) => {
       const style = original(element);
-      return element === dialog
-        ? ({ ...style, transform: 'scale(0.98)' } as CSSStyleDeclaration)
-        : style;
+      if (element !== dialog) return style;
+      const transformedStyle = Object.create(style) as CSSStyleDeclaration;
+      Object.defineProperty(transformedStyle, 'transform', { value: 'scale(0.98)' });
+      return transformedStyle;
     }) as typeof getComputedStyle;
     try {
       const { container } = render(EventTimeline, {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -9,8 +9,9 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 setupHappyDom();
 
 const { cleanup, render, waitFor } = await import('@testing-library/svelte');
-const { default: EventTimeline, __setEventTimelineModalPredicate } =
-  await import('./event-timeline.svelte');
+const { default: EventTimeline } = await import('./event-timeline.svelte');
+const { setEventTimelineModalPredicate: __setEventTimelineModalPredicate } =
+  await import('./event-timeline-modal.ts');
 const { fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
 

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -289,7 +289,8 @@ describe('EventTimeline', () => {
   });
 
   test('keeps cluster surfaces in the viewport top layer for native dialogs', () => {
-    expect(EVENT_TIMELINE_SOURCE).toContain('return document.body');
+    expect(EVENT_TIMELINE_SOURCE).toContain('return owner ?? document.body');
+    expect(EVENT_TIMELINE_SOURCE).toContain("? 'absolute' : 'fixed'");
     expect(EVENT_TIMELINE_SOURCE).toContain('closest<HTMLElement>(');
   });
 

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -306,6 +306,11 @@ describe('EventTimeline', () => {
     expect(container.querySelectorAll('.cinder-event-timeline__cluster-trigger')).toHaveLength(2);
   });
 
+  test('derives stable cluster identity from its items, not array order', () => {
+    expect(EVENT_TIMELINE_SOURCE).not.toContain('cluster-${groupIndex}-');
+    expect(EVENT_TIMELINE_SOURCE).toContain('cluster-${startTime}-${endTime}-');
+  });
+
   test('allocates additional lanes for dense clusters without reusing the final lane', () => {
     const { container } = render(EventTimeline, {
       start,

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -2,13 +2,13 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { render } = await import('@testing-library/svelte');
+const { cleanup, render } = await import('@testing-library/svelte');
 const { default: EventTimeline } = await import('./event-timeline.svelte');
 const { fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
@@ -60,6 +60,10 @@ beforeAll(() => {
 
 beforeEach(() => {
   TestResizeObserver.instances = [];
+});
+
+afterEach(() => {
+  cleanup();
 });
 
 afterAll(() => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -8,14 +8,13 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { cleanup, render, waitFor } = await import('@testing-library/svelte');
+const { cleanup, fireEvent, render, waitFor } = await import('@testing-library/svelte');
 const { default: EventTimeline } = await import('./event-timeline.svelte');
 const {
   hasFixedPositionContainingBlock,
   resetEventTimelineModalPredicate: __resetEventTimelineModalPredicate,
   setEventTimelineModalPredicate: __setEventTimelineModalPredicate,
 } = await import('./event-timeline-modal.ts');
-const { fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
 
 const EVENT_TIMELINE_CSS = readFileSync(join(import.meta.dir, 'event-timeline.css'), 'utf8');
@@ -369,7 +368,7 @@ describe('EventTimeline', () => {
     expect(cluster?.getAttribute('aria-label')).toBe(
       '1 event between 2026-07-03T06:04:00.000Z and 2026-07-03T06:04:00.000Z',
     );
-    expect(cluster?.tabIndex).toBe(0);
+    expect(cluster?.hasAttribute('tabindex')).toBe(false);
     expect(cluster?.getAttribute('aria-haspopup')).toBe('dialog');
 
     cluster?.focus();

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -185,7 +185,9 @@ describe('EventTimeline', () => {
       '.cinder-event-timeline__cluster-trigger',
     );
     expect(cluster?.textContent).toBe('+1');
-    expect(cluster?.getAttribute('aria-label')).toBe('1 event between 06:04 and 06:04');
+    expect(cluster?.getAttribute('aria-label')).toBe(
+      '1 event between 2026-07-03T06:04:00.000Z and 2026-07-03T06:04:00.000Z',
+    );
     expect(cluster?.tabIndex).toBe(0);
 
     cluster?.focus();

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -153,7 +153,7 @@ describe('EventTimeline', () => {
       [...container.querySelectorAll('[role="listitem"]')].map((item) =>
         item.getAttribute('data-cinder-lane'),
       ),
-    ).toEqual(['0', '1']);
+    ).toEqual(['0', '0']);
   });
 
   test('accounts for transformed labels when reusing lanes across edge boundaries', async () => {
@@ -326,6 +326,34 @@ describe('EventTimeline', () => {
     } finally {
       __setEventTimelineModalPredicate((element) => element.matches(':modal'));
       globalThis.getComputedStyle = original;
+      dialog.remove();
+    }
+  });
+
+  test('keeps cluster surfaces inside a modal focus-trap panel', async () => {
+    const dialog = document.createElement('dialog');
+    const panel = document.createElement('div');
+    panel.className = 'cinder-modal__panel';
+    dialog.append(panel);
+    dialog.open = true;
+    document.body.append(dialog);
+    __setEventTimelineModalPredicate((element) => element === dialog);
+    try {
+      const { container } = render(EventTimeline, {
+        start,
+        end,
+        items: [0, 1, 2, 3, 4].map((index) => ({
+          at: `2026-07-03T06:0${index}:00.000Z`,
+          label: `Event ${index + 1}`,
+        })),
+      });
+      panel.append(container.firstElementChild!);
+      await fireEvent.click(panel.querySelector('.cinder-event-timeline__cluster-trigger')!);
+      await waitFor(() =>
+        expect(panel.querySelector('[role="dialog"]')?.parentElement).toBe(panel),
+      );
+    } finally {
+      __setEventTimelineModalPredicate((element) => element.matches(':modal'));
       dialog.remove();
     }
   });

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -190,6 +190,21 @@ describe('EventTimeline', () => {
     );
   });
 
+  test('keeps centered labels centered when narrow timelines overlap edge zones', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [{ at: '2026-07-03T12:00:00.000Z', label: 'Centered event' }],
+    });
+
+    await tick();
+    TestResizeObserver.instances[0]?.trigger(200);
+    await tick();
+    expect(container.querySelector('[role="listitem"]')?.getAttribute('data-cinder-edge')).toBe(
+      'middle',
+    );
+  });
+
   test('reserves lanes for physical RTL bounds', async () => {
     const { container } = render(EventTimeline, {
       start,

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -228,6 +228,13 @@ describe('EventTimeline', () => {
     );
   });
 
+  test('keeps event dots at proportional timestamps while offsetting labels', () => {
+    expect(EVENT_TIMELINE_CSS).toContain('transform: translateX(-50%);');
+    expect(EVENT_TIMELINE_CSS).toContain(
+      'transform: translateX(var(--_cinder-event-timeline-label-offset, 0px));',
+    );
+  });
+
   test('keeps centered fallback bounds out of parity-offset lanes', async () => {
     const { container } = render(EventTimeline, {
       start,
@@ -336,6 +343,9 @@ describe('EventTimeline', () => {
 
     cluster?.focus();
     await fireEvent.click(cluster!);
+    expect(EVENT_TIMELINE_CSS).toContain(
+      ".cinder-event-timeline__cluster-surface[data-cinder-position-ready='false']",
+    );
     const dialog = document.querySelector('[role="dialog"]');
     expect(dialog).not.toBeNull();
     expect(cluster?.getAttribute('aria-controls')).toBe(dialog?.id);

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -203,6 +203,10 @@ describe('EventTimeline', () => {
     expect(container.querySelector('[role="listitem"]')?.getAttribute('data-cinder-edge')).toBe(
       'middle',
     );
+    expect(EVENT_TIMELINE_CSS).toContain('[data-cinder-centered] .cinder-event-timeline__leader');
+    expect(EVENT_TIMELINE_CSS).toContain(
+      ':dir(rtl) .cinder-event-timeline__item[data-cinder-centered]',
+    );
   });
 
   test('reserves lanes for physical RTL bounds', async () => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -147,7 +147,7 @@ describe('EventTimeline', () => {
       [...container.querySelectorAll('[role="listitem"]')].map((item) =>
         item.getAttribute('data-cinder-lane'),
       ),
-    ).toEqual(['0', '0']);
+    ).toEqual(['0', '1']);
   });
 
   test('accounts for transformed labels when reusing lanes across edge boundaries', async () => {
@@ -168,6 +168,47 @@ describe('EventTimeline', () => {
         item.getAttribute('data-cinder-lane'),
       ),
     ).toEqual(['0', '1']);
+  });
+
+  test('moves near-edge labels to edge alignment before their offset can overflow', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [{ at: '2026-07-03T02:38:24.000Z', label: 'Near start' }],
+    });
+
+    await tick();
+    TestResizeObserver.instances[0]?.trigger(1200);
+    await tick();
+    expect(container.querySelector('[role="listitem"]')?.getAttribute('data-cinder-edge')).toBe(
+      'start',
+    );
+  });
+
+  test('reserves lanes for physical RTL bounds', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      dir: 'rtl',
+      items: [
+        { at: '2026-07-03T19:12:00.000Z', label: 'RTL first' },
+        { at: '2026-07-03T21:36:00.000Z', label: 'RTL second' },
+      ],
+    });
+
+    await tick();
+    TestResizeObserver.instances[0]?.trigger(1200);
+    await tick();
+    expect(
+      [...container.querySelectorAll('[role="listitem"]')].map((item) =>
+        item.getAttribute('data-cinder-lane'),
+      ),
+    ).toEqual(['0', '1']);
+  });
+
+  test('keeps adjacent dense parity lanes separated and raises open clusters', () => {
+    expect(EVENT_TIMELINE_CSS).toContain('.cinder-event-timeline__cluster[data-cinder-open]');
+    expect(EVENT_TIMELINE_CSS).toContain('z-index: 2;');
   });
 
   test('offsets colliding lanes and renders hidden leader lines', () => {

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -336,7 +336,7 @@ describe('EventTimeline', () => {
   test('treats perspective, backdrop-filter, and transform-related will-change as containing blocks', () => {
     const element = document.createElement('div');
     const original = globalThis.getComputedStyle;
-    const cases: Array<Partial<CSSStyleDeclaration>> = [
+    const cases: Array<Record<string, string>> = [
       { perspective: '400px' },
       { backdropFilter: 'blur(4px)' },
       { willChange: 'transform' },

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -288,6 +288,11 @@ describe('EventTimeline', () => {
     expect(document.activeElement).toBe(cluster);
   });
 
+  test('keeps cluster surfaces in the viewport top layer for native dialogs', () => {
+    expect(EVENT_TIMELINE_SOURCE).toContain('return document.body');
+    expect(EVENT_TIMELINE_SOURCE).toContain('closest<HTMLElement>(');
+  });
+
   test('outside pointer dismissal does not refocus the cluster trigger', async () => {
     const { container } = render(EventTimeline, {
       start,

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -9,7 +9,8 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 setupHappyDom();
 
 const { cleanup, render, waitFor } = await import('@testing-library/svelte');
-const { default: EventTimeline } = await import('./event-timeline.svelte');
+const { default: EventTimeline, __setEventTimelineModalPredicate } =
+  await import('./event-timeline.svelte');
 const { fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
 
@@ -292,6 +293,7 @@ describe('EventTimeline', () => {
     const dialog = document.createElement('dialog');
     dialog.open = true;
     document.body.append(dialog);
+    __setEventTimelineModalPredicate((element) => element === dialog);
     const original = globalThis.getComputedStyle;
     globalThis.getComputedStyle = ((element: Element) => {
       const style = original(element);
@@ -320,6 +322,7 @@ describe('EventTimeline', () => {
         expect(document.activeElement).toBe(dialog.querySelector('[role="dialog"]')),
       );
     } finally {
+      __setEventTimelineModalPredicate((element) => element.matches(':modal'));
       globalThis.getComputedStyle = original;
       dialog.remove();
     }

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -316,15 +316,50 @@ describe('EventTimeline', () => {
     const original = globalThis.getComputedStyle;
     globalThis.getComputedStyle = (() =>
       ({
+        backdropFilter: '',
         contain: '',
         filter: '',
+        perspective: '',
         rotate: undefined,
         scale: undefined,
         transform: '',
         translate: undefined,
+        willChange: 'auto',
       }) as unknown as CSSStyleDeclaration) as typeof getComputedStyle;
     try {
       expect(hasFixedPositionContainingBlock(element)).toBe(false);
+    } finally {
+      globalThis.getComputedStyle = original;
+    }
+  });
+
+  test('treats perspective, backdrop-filter, and transform-related will-change as containing blocks', () => {
+    const element = document.createElement('div');
+    const original = globalThis.getComputedStyle;
+    const cases: Array<Partial<CSSStyleDeclaration>> = [
+      { perspective: '400px' },
+      { backdropFilter: 'blur(4px)' },
+      { willChange: 'transform' },
+      { willChange: 'perspective' },
+      { willChange: 'filter' },
+    ];
+    try {
+      for (const overrides of cases) {
+        globalThis.getComputedStyle = (() =>
+          ({
+            backdropFilter: '',
+            contain: '',
+            filter: '',
+            perspective: '',
+            rotate: undefined,
+            scale: undefined,
+            transform: '',
+            translate: undefined,
+            willChange: 'auto',
+            ...overrides,
+          }) as unknown as CSSStyleDeclaration) as typeof getComputedStyle;
+        expect(hasFixedPositionContainingBlock(element)).toBe(true);
+      }
     } finally {
       globalThis.getComputedStyle = original;
     }

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -215,6 +215,37 @@ describe('EventTimeline', () => {
     );
   });
 
+  test('keeps centered fallback bounds out of parity-offset lanes', async () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [
+        { at: '2026-07-03T09:36:00.000Z', label: 'Centered fallback with a long label' },
+        { at: '2026-07-03T20:24:00.000Z', label: 'Edge label with a long label' },
+      ],
+    });
+
+    await tick();
+    TestResizeObserver.instances[0]?.trigger(280);
+    await tick();
+    const items = [...container.querySelectorAll('[role="listitem"]')];
+    expect(items[0]?.getAttribute('data-cinder-centered')).toBe('');
+    expect(items.map((item) => item.getAttribute('data-cinder-lane'))).toEqual(['0', '1']);
+  });
+
+  test('uses the occupied lane count while retaining the CSS minimum height', () => {
+    const { container } = render(EventTimeline, {
+      start,
+      end,
+      items: [{ at: '2026-07-03T12:00:00.000Z', label: 'Single event' }],
+    });
+
+    expect(container.querySelector('[role="list"]')?.getAttribute('style')).toContain(
+      '--_cinder-event-timeline-lane-count: 1',
+    );
+    expect(EVENT_TIMELINE_CSS).toContain('block-size: max(');
+  });
+
   test('reserves lanes for physical RTL bounds', async () => {
     const { container } = render(EventTimeline, {
       start,

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -14,6 +14,7 @@ const { fireEvent } = await import('@testing-library/svelte');
 const { tick } = await import('svelte');
 
 const EVENT_TIMELINE_CSS = readFileSync(join(import.meta.dir, 'event-timeline.css'), 'utf8');
+const EVENT_TIMELINE_SOURCE = readFileSync(join(import.meta.dir, 'event-timeline.svelte'), 'utf8');
 
 class TestResizeObserver implements ResizeObserver {
   static instances: TestResizeObserver[] = [];
@@ -209,6 +210,8 @@ describe('EventTimeline', () => {
   test('keeps adjacent dense parity lanes separated and raises open clusters', () => {
     expect(EVENT_TIMELINE_CSS).toContain('.cinder-event-timeline__cluster[data-cinder-open]');
     expect(EVENT_TIMELINE_CSS).toContain('z-index: 2;');
+    expect(EVENT_TIMELINE_CSS).toContain('.cinder-event-timeline:dir(rtl)');
+    expect(EVENT_TIMELINE_SOURCE).toContain('createPortalAttachment');
   });
 
   test('offsets colliding lanes and renders hidden leader lines', () => {
@@ -253,12 +256,12 @@ describe('EventTimeline', () => {
 
     cluster?.focus();
     await fireEvent.click(cluster!);
-    const dialog = container.querySelector('[role="dialog"]');
+    const dialog = document.querySelector('[role="dialog"]');
     expect(dialog).not.toBeNull();
     expect(document.activeElement).toBe(dialog);
     expect(dialog?.textContent).toContain('Upcoming');
     await fireEvent.keyDown(window, { key: 'Escape' });
-    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
     expect(document.activeElement).toBe(cluster);
   });
 

--- a/packages/playground/src/examples/event-timeline/cluster.example.svelte
+++ b/packages/playground/src/examples/event-timeline/cluster.example.svelte
@@ -1,0 +1,25 @@
+<script lang="ts" module>
+  export const title = 'Dense cluster';
+  export const description =
+    'Excess overlapping events collapse into a keyboard-accessible cluster.';
+</script>
+
+<script lang="ts">
+  import { EventTimeline } from '@lostgradient/cinder/event-timeline';
+</script>
+
+<EventTimeline
+  ariaLabel="Dense incident timeline"
+  start="2026-07-03T12:00:00.000Z"
+  end="2026-07-03T18:00:00.000Z"
+  items={[
+    { at: '2026-07-03T13:00:00.000Z', label: 'Queued', sublabel: '13:00' },
+    { at: '2026-07-03T13:02:00.000Z', label: 'Started', sublabel: '13:02' },
+    { at: '2026-07-03T13:04:00.000Z', label: 'Checked', sublabel: '13:04' },
+    { at: '2026-07-03T13:06:00.000Z', label: 'Retried', sublabel: '13:06' },
+    { at: '2026-07-03T13:08:00.000Z', label: 'Escalated', sublabel: '13:08' },
+    { at: '2026-07-03T13:10:00.000Z', label: 'Paged', sublabel: '13:10' },
+    { at: '2026-07-03T13:12:00.000Z', label: 'Acknowledged', sublabel: '13:12' },
+    { at: '2026-07-03T13:14:00.000Z', label: 'Mitigated', sublabel: '13:14' },
+  ]}
+/>

--- a/packages/testing/tests/event-timeline-layout.playwright.ts
+++ b/packages/testing/tests/event-timeline-layout.playwright.ts
@@ -30,6 +30,7 @@ test('overlapping event labels occupy non-intersecting layout boxes', async ({ p
   await root.evaluate((element) => {
     (element as HTMLElement).style.width = '32rem';
   });
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(resolve)));
 
   const labels = timeline.locator('.cinder-event-timeline__content');
   await expect(labels).toHaveCount(4);

--- a/packages/testing/tests/event-timeline-layout.playwright.ts
+++ b/packages/testing/tests/event-timeline-layout.playwright.ts
@@ -1,0 +1,77 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+
+const EVENT_TIMELINE_ROUTE = '/page/event-timeline?snapshot=1';
+
+type Box = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+function boxesOverlap(first: Box, second: Box): boolean {
+  return !(
+    first.x + first.width <= second.x ||
+    second.x + second.width <= first.x ||
+    first.y + first.height <= second.y ||
+    second.y + second.height <= first.y
+  );
+}
+
+async function openOverlapTimeline(page: Page): Promise<Locator> {
+  await page.goto(EVENT_TIMELINE_ROUTE, { waitUntil: 'load' });
+  await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+  return page.getByRole('list', { name: 'Clustered deployment timeline' });
+}
+
+test('overlapping event labels occupy non-intersecting layout boxes', async ({ page }) => {
+  const timeline = await openOverlapTimeline(page);
+  const root = timeline.locator('..');
+  await root.evaluate((element) => {
+    (element as HTMLElement).style.width = '32rem';
+  });
+
+  const labels = timeline.locator('.cinder-event-timeline__content');
+  await expect(labels).toHaveCount(4);
+  const boxes = (await labels.evaluateAll((elements) =>
+    elements.map((element) => {
+      const rect = element.getBoundingClientRect();
+      return { x: rect.x, y: rect.y, width: rect.width, height: rect.height };
+    }),
+  )) as Box[];
+
+  for (let index = 0; index < boxes.length; index += 1) {
+    for (let comparisonIndex = index + 1; comparisonIndex < boxes.length; comparisonIndex += 1) {
+      expect(boxesOverlap(boxes[index]!, boxes[comparisonIndex]!)).toBe(false);
+    }
+  }
+});
+
+test('cluster trigger supports tab entry, Escape dismissal, and focus return', async ({ page }) => {
+  await page.goto(EVENT_TIMELINE_ROUTE, { waitUntil: 'load' });
+  await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+  const timeline = page.getByRole('list', { name: 'Dense incident timeline' });
+
+  const trigger = timeline.locator('.cinder-event-timeline__cluster-trigger').first();
+  await expect(trigger).toBeVisible();
+
+  await page.locator('body').click({ position: { x: 1, y: 1 } });
+  for (let tabIndex = 0; tabIndex < 50; tabIndex += 1) {
+    await page.keyboard.press('Tab');
+    if (await trigger.evaluate((element) => element === document.activeElement)) break;
+  }
+  await expect(trigger).toBeFocused();
+
+  const clusterName = await trigger.getAttribute('aria-label');
+  if (!clusterName) {
+    throw new Error('Event timeline cluster trigger must have an accessible name.');
+  }
+  await page.keyboard.press('Enter');
+  const dialog = page.getByRole('dialog', { name: clusterName });
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toBeFocused();
+
+  await page.keyboard.press('Escape');
+  await expect(dialog).toHaveCount(0);
+  await expect(trigger).toBeFocused();
+});

--- a/packages/testing/tests/event-timeline-layout.playwright.ts
+++ b/packages/testing/tests/event-timeline-layout.playwright.ts
@@ -48,6 +48,37 @@ test('overlapping event labels occupy non-intersecting layout boxes', async ({ p
   }
 });
 
+test('re-resolves the cluster surface strategy when an owner ancestor gains a containing block', async ({
+  page,
+}) => {
+  await page.goto(EVENT_TIMELINE_ROUTE, { waitUntil: 'load' });
+  await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+  const timeline = page.getByRole('list', { name: 'Dense incident timeline' });
+
+  // Wrap the timeline in an element `portalOwner()` recognizes as an overlay
+  // owner, without a transform, so the cluster surface opens `position: fixed`.
+  await timeline.evaluate((element) => {
+    const panel = document.createElement('div');
+    panel.className = 'cinder-modal__panel';
+    element.parentElement?.insertBefore(panel, element);
+    panel.append(element);
+  });
+
+  const trigger = timeline.locator('.cinder-event-timeline__cluster-trigger').first();
+  await trigger.click();
+  const surface = page.locator('.cinder-event-timeline__cluster-surface');
+  await expect(surface).toBeVisible();
+  await expect(surface).toHaveCSS('position', 'fixed');
+
+  // Simulate an ancestor starting a transform-driven animation while the
+  // cluster stays open, without closing and reopening it.
+  await page.locator('.cinder-modal__panel').evaluate((panel) => {
+    (panel as HTMLElement).style.transform = 'scale(0.98)';
+  });
+
+  await expect(surface).toHaveCSS('position', 'absolute');
+});
+
 test('cluster trigger supports tab entry, Escape dismissal, and focus return', async ({ page }) => {
   await page.goto(EVENT_TIMELINE_ROUTE, { waitUntil: 'load' });
   await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });


### PR DESCRIPTION
Closes #959

## Summary
- measure the EventTimeline container with `ResizeObserver` and derive collision thresholds from the CSS label cap
- offset alternating lanes horizontally and draw aria-hidden leader lines to their dots
- cap dense layouts with an accessible `+N` cluster button that opens a floating surface and returns focus on Escape
- document the density boundary and add focused regression coverage

## Verification
- `bun test packages/components/src/components/event-timeline/event-timeline.test.ts`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder typecheck`
- Browser verification at 400px, 800px, and 1200px is pending because the local filesystem is full (`No space left on device` during playground build).
