### PR TITLE
fix(hero-section): size media without a default frame

### DIFF
--- a/.changeset/hero-section-media-contract.md
+++ b/.changeset/hero-section-media-contract.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Give HeroSection media a full-width aspect-ratio contract, remove the default card frame, and enable split layouts from 48rem.

--- a/packages/components/src/components/feature-section/feature-section.css
+++ b/packages/components/src/components/feature-section/feature-section.css
@@ -96,7 +96,7 @@
     }
   }
 
-  @container cinder-feature-section (min-width: 64rem) {
+  @container cinder-feature-section (min-width: 48rem) {
     .cinder-feature-section[data-cinder-layout='split'][data-cinder-has-media]
       .cinder-feature-section__body {
       grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/packages/components/src/components/feature-section/feature-section.css.test.ts
+++ b/packages/components/src/components/feature-section/feature-section.css.test.ts
@@ -7,7 +7,7 @@ describe('FeatureSection responsive layout', () => {
   test('keeps the split breakpoint aligned with HeroSection and bounds media', () => {
     expect(stylesheet).toContain('@container cinder-feature-section (max-width: 48rem)');
     expect(stylesheet).toContain('min-width: 48rem) and (max-width: 64rem)');
-    expect(stylesheet).toContain('@container cinder-feature-section (min-width: 64rem)');
+    expect(stylesheet).toContain('@container cinder-feature-section (min-width: 48rem)');
     expect(stylesheet).toContain('max-block-size: 32rem');
     expect(stylesheet).toContain('overflow: auto');
   });

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -117,6 +117,11 @@
     box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
 
+  .cinder-hero-section__media > .cinder-aspect-ratio > :is(img, video, iframe):focus-visible {
+    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline-offset: calc(-1 * var(--cinder-ring-width));
+  }
+
   @media (forced-colors: active) {
     .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible {
       outline: 2px solid ButtonText;

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -69,7 +69,7 @@
     overflow: hidden;
   }
 
-  .cinder-hero-section__media > .cinder-aspect-ratio > * {
+  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child {
     position: absolute;
     inset: 0;
     display: block;
@@ -78,7 +78,7 @@
     object-fit: cover;
   }
 
-  .cinder-hero-section__media > .cinder-aspect-ratio > picture > img {
+  .cinder-hero-section__media > .cinder-aspect-ratio > picture:only-child > img {
     position: absolute;
     inset: 0;
     display: block;
@@ -89,6 +89,19 @@
 
   .cinder-hero-section__media > .cinder-aspect-ratio > .cinder-image {
     overflow: hidden;
+  }
+
+  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible {
+    /* cinder-focus-ring-owner: parent */
+    outline: none;
+    box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
+  }
+
+  @media (forced-colors: active) {
+    .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible {
+      outline: 2px solid ButtonText;
+      outline-offset: -2px;
+    }
   }
 
   @container cinder-hero-section (min-width: 48rem) {

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -77,7 +77,7 @@
     object-fit: cover;
   }
 
-  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child img {
+  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child > img:only-child {
     display: block;
     inline-size: 100%;
     block-size: 100%;
@@ -99,7 +99,21 @@
 
   .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible {
     /* cinder-focus-ring-owner: parent */
+    /* cinder-focus-ring-owner: parent */
     outline: none;
+  }
+
+  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child::after {
+    content: '';
+    display: none;
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    pointer-events: none;
+  }
+
+  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible::after {
+    display: block;
     box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
 
@@ -107,6 +121,12 @@
     .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible {
       outline: 2px solid ButtonText;
       outline-offset: -2px;
+    }
+
+    .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible::after {
+      outline: 2px solid ButtonText;
+      outline-offset: -2px;
+      box-shadow: inset 0 0 0 2px ButtonText;
     }
   }
 

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -61,12 +61,30 @@
     min-inline-size: 0;
   }
 
+  .cinder-hero-section__media > .cinder-aspect-ratio {
+    display: block;
+    position: relative;
+    inline-size: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+  }
+
   .cinder-hero-section__media > .cinder-aspect-ratio > img,
+  .cinder-hero-section__media > .cinder-aspect-ratio > picture,
   .cinder-hero-section__media > .cinder-aspect-ratio > video,
   .cinder-hero-section__media > .cinder-aspect-ratio > canvas,
   .cinder-hero-section__media > .cinder-aspect-ratio > iframe,
   .cinder-hero-section__media > .cinder-aspect-ratio > svg,
   .cinder-hero-section__media > .cinder-aspect-ratio > .cinder-image {
+    position: absolute;
+    inset: 0;
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+  }
+
+  .cinder-hero-section__media > .cinder-aspect-ratio > picture > img {
     position: absolute;
     inset: 0;
     display: block;

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -118,14 +118,21 @@
   }
 
   .cinder-hero-section__media > .cinder-aspect-ratio > :is(img, video, iframe):focus-visible {
-    outline: var(--cinder-ring-width) solid var(--cinder-ring-color);
+    outline: var(--cinder-ring-width) solid transparent;
     outline-offset: calc(-1 * var(--cinder-ring-width));
+    box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
   @media (forced-colors: active) {
     .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible {
       outline: 2px solid ButtonText;
       outline-offset: -2px;
+    }
+
+    .cinder-hero-section__media > .cinder-aspect-ratio > :is(img, video, iframe):focus-visible {
+      outline: 2px solid ButtonText;
+      outline-offset: -2px;
+      box-shadow: none;
     }
 
     .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible::after {

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -139,7 +139,7 @@
       box-shadow: none;
     }
 
-    .cinder-hero-section__media > .cinder-aspect-ratio:has(> *:only-child:focus-visible)::after {
+    .cinder-hero-section__media > .cinder-aspect-ratio:has(*:focus-visible)::after {
       outline: 2px solid ButtonText;
       outline-offset: -2px;
       box-shadow: inset 0 0 0 2px ButtonText;

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -116,7 +116,7 @@
     pointer-events: none;
   }
 
-  .cinder-hero-section__media > .cinder-aspect-ratio:has(> *:only-child:focus-visible)::after {
+  .cinder-hero-section__media > .cinder-aspect-ratio:has(*:focus-visible)::after {
     display: block;
     box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -65,6 +65,7 @@
   .cinder-hero-section__media > .cinder-aspect-ratio > video,
   .cinder-hero-section__media > .cinder-aspect-ratio > canvas,
   .cinder-hero-section__media > .cinder-aspect-ratio > iframe,
+  .cinder-hero-section__media > .cinder-aspect-ratio > svg,
   .cinder-hero-section__media > .cinder-aspect-ratio > .cinder-image {
     position: absolute;
     inset: 0;

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -58,13 +58,22 @@
   }
 
   .cinder-hero-section__media {
-    border: 1px solid var(--cinder-border-muted);
-    background: var(--cinder-surface-raised);
-    border-radius: var(--cinder-radius-lg);
-    padding: var(--cinder-space-4);
+    min-inline-size: 0;
   }
 
-  @container cinder-hero-section (min-width: 64rem) {
+  .cinder-hero-section__media img,
+  .cinder-hero-section__media video,
+  .cinder-hero-section__media canvas,
+  .cinder-hero-section__media iframe {
+    position: absolute;
+    inset: 0;
+    display: block;
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+  }
+
+  @container cinder-hero-section (min-width: 48rem) {
     .cinder-hero-section[data-cinder-has-media] .cinder-hero-section__inner {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -72,6 +72,12 @@
   .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child {
     position: absolute;
     inset: 0;
+    inline-size: 100%;
+    block-size: 100%;
+    object-fit: cover;
+  }
+
+  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child img {
     display: block;
     inline-size: 100%;
     block-size: 100%;

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -103,7 +103,11 @@
     outline: none;
   }
 
-  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child::after {
+  .cinder-hero-section__media > .cinder-aspect-ratio {
+    position: relative;
+  }
+
+  .cinder-hero-section__media > .cinder-aspect-ratio::after {
     content: '';
     display: none;
     position: absolute;
@@ -112,7 +116,7 @@
     pointer-events: none;
   }
 
-  .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible::after {
+  .cinder-hero-section__media > .cinder-aspect-ratio:has(> *:only-child:focus-visible)::after {
     display: block;
     box-shadow: inset 0 0 0 var(--cinder-ring-width) var(--cinder-ring-color);
   }
@@ -135,7 +139,7 @@
       box-shadow: none;
     }
 
-    .cinder-hero-section__media > .cinder-aspect-ratio > *:only-child:focus-visible::after {
+    .cinder-hero-section__media > .cinder-aspect-ratio:has(> *:only-child:focus-visible)::after {
       outline: 2px solid ButtonText;
       outline-offset: -2px;
       box-shadow: inset 0 0 0 2px ButtonText;

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -69,13 +69,7 @@
     overflow: hidden;
   }
 
-  .cinder-hero-section__media > .cinder-aspect-ratio > img,
-  .cinder-hero-section__media > .cinder-aspect-ratio > picture,
-  .cinder-hero-section__media > .cinder-aspect-ratio > video,
-  .cinder-hero-section__media > .cinder-aspect-ratio > canvas,
-  .cinder-hero-section__media > .cinder-aspect-ratio > iframe,
-  .cinder-hero-section__media > .cinder-aspect-ratio > svg,
-  .cinder-hero-section__media > .cinder-aspect-ratio > .cinder-image {
+  .cinder-hero-section__media > .cinder-aspect-ratio > * {
     position: absolute;
     inset: 0;
     display: block;

--- a/packages/components/src/components/hero-section/hero-section.css
+++ b/packages/components/src/components/hero-section/hero-section.css
@@ -61,16 +61,21 @@
     min-inline-size: 0;
   }
 
-  .cinder-hero-section__media img,
-  .cinder-hero-section__media video,
-  .cinder-hero-section__media canvas,
-  .cinder-hero-section__media iframe {
+  .cinder-hero-section__media > .cinder-aspect-ratio > img,
+  .cinder-hero-section__media > .cinder-aspect-ratio > video,
+  .cinder-hero-section__media > .cinder-aspect-ratio > canvas,
+  .cinder-hero-section__media > .cinder-aspect-ratio > iframe,
+  .cinder-hero-section__media > .cinder-aspect-ratio > .cinder-image {
     position: absolute;
     inset: 0;
     display: block;
     inline-size: 100%;
     block-size: 100%;
     object-fit: cover;
+  }
+
+  .cinder-hero-section__media > .cinder-aspect-ratio > .cinder-image {
+    overflow: hidden;
   }
 
   @container cinder-hero-section (min-width: 48rem) {

--- a/packages/components/src/components/hero-section/hero-section.svelte
+++ b/packages/components/src/components/hero-section/hero-section.svelte
@@ -22,6 +22,7 @@
 
 <script lang="ts">
   import Container from '../container/container.svelte';
+  import AspectRatio from '../aspect-ratio/index.ts';
   import { classNames } from '../../utilities/class-names.ts';
 
   import type { HeroSectionProps } from './hero-section.types.ts';
@@ -73,7 +74,9 @@
       </div>
       {#if media}
         <div class="cinder-hero-section__media">
-          {@render media()}
+          <AspectRatio class="cinder-hero-section__media-ratio">
+            {@render media()}
+          </AspectRatio>
         </div>
       {/if}
     </div>

--- a/packages/components/src/components/hero-section/hero-section.svelte
+++ b/packages/components/src/components/hero-section/hero-section.svelte
@@ -22,6 +22,7 @@
 
 <script lang="ts">
   import Container from '../container/container.svelte';
+  import '@lostgradient/cinder/aspect-ratio/styles';
   import AspectRatio from '../aspect-ratio/index.ts';
   import { classNames } from '../../utilities/class-names.ts';
 

--- a/packages/components/src/components/hero-section/hero-section.svelte
+++ b/packages/components/src/components/hero-section/hero-section.svelte
@@ -22,7 +22,6 @@
 
 <script lang="ts">
   import Container from '../container/container.svelte';
-  import '@lostgradient/cinder/aspect-ratio/styles';
   import AspectRatio from '../aspect-ratio/index.ts';
   import { classNames } from '../../utilities/class-names.ts';
 

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -125,7 +125,7 @@ describe('HeroSection', () => {
   test('preserves multi-root media flow and keeps focused media visible', () => {
     expect(HERO_SECTION_CSS).toContain('> *:only-child');
     expect(HERO_SECTION_CSS).toContain('> *:only-child > img:only-child');
-    expect(HERO_SECTION_CSS).toContain(':has(> *:only-child:focus-visible)::after');
+    expect(HERO_SECTION_CSS).toContain(':has(*:focus-visible)::after');
     expect(HERO_SECTION_CSS).toContain('z-index: 2;');
     expect(HERO_SECTION_CSS).toContain('pointer-events: none;');
     expect(HERO_SECTION_CSS).toContain(':only-child:focus-visible');

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -91,6 +91,7 @@ describe('HeroSection', () => {
     );
     expect(HERO_SECTION_CSS).toContain('inline-size: 100%;');
     expect(HERO_SECTION_CSS).toContain('position: absolute;');
+    expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio > svg');
     expect(HERO_SECTION_CSS).not.toContain('cinder-hero-section__media {\n    border:');
   });
 

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -91,7 +91,7 @@ describe('HeroSection', () => {
     );
     expect(HERO_SECTION_CSS).toContain('inline-size: 100%;');
     expect(HERO_SECTION_CSS).toContain('position: absolute;');
-    expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio > svg');
+    expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio > *');
     expect(HERO_SECTION_CSS).toContain(
       '.cinder-hero-section__media > .cinder-aspect-ratio > picture',
     );

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -124,7 +124,10 @@ describe('HeroSection', () => {
 
   test('preserves multi-root media flow and keeps focused media visible', () => {
     expect(HERO_SECTION_CSS).toContain('> *:only-child');
-    expect(HERO_SECTION_CSS).toContain('> *:only-child img');
+    expect(HERO_SECTION_CSS).toContain('> *:only-child > img:only-child');
+    expect(HERO_SECTION_CSS).toContain(':focus-visible::after');
+    expect(HERO_SECTION_CSS).toContain('z-index: 2;');
+    expect(HERO_SECTION_CSS).toContain('pointer-events: none;');
     expect(HERO_SECTION_CSS).toContain(':only-child:focus-visible');
     expect(HERO_SECTION_CSS).toContain('box-shadow: inset 0 0 0 var(--cinder-ring-width)');
     expect(HERO_SECTION_CSS).toContain('outline-offset: -2px');

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -124,6 +124,7 @@ describe('HeroSection', () => {
 
   test('preserves multi-root media flow and keeps focused media visible', () => {
     expect(HERO_SECTION_CSS).toContain('> *:only-child');
+    expect(HERO_SECTION_CSS).toContain('> *:only-child img');
     expect(HERO_SECTION_CSS).toContain(':only-child:focus-visible');
     expect(HERO_SECTION_CSS).toContain('box-shadow: inset 0 0 0 var(--cinder-ring-width)');
     expect(HERO_SECTION_CSS).toContain('outline-offset: -2px');

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -20,7 +20,6 @@ const runtimePatchSnippet = createRawSnippet(() => ({
 void runtimePatchSnippet;
 
 const HERO_SECTION_CSS = readFileSync(join(import.meta.dir, 'hero-section.css'), 'utf8');
-const HERO_SECTION_SOURCE = readFileSync(join(import.meta.dir, 'hero-section.svelte'), 'utf8');
 
 describe('HeroSection', () => {
   test('renders title and optional description copy', () => {
@@ -93,8 +92,27 @@ describe('HeroSection', () => {
     expect(HERO_SECTION_CSS).toContain('inline-size: 100%;');
     expect(HERO_SECTION_CSS).toContain('position: absolute;');
     expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio > svg');
-    expect(HERO_SECTION_SOURCE).toContain("import '@lostgradient/cinder/aspect-ratio/styles';");
+    expect(HERO_SECTION_CSS).toContain(
+      '.cinder-hero-section__media > .cinder-aspect-ratio > picture',
+    );
+    expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio');
     expect(HERO_SECTION_CSS).not.toContain('cinder-hero-section__media {\n    border:');
+  });
+
+  test('renders responsive picture media inside the aspect-ratio box', () => {
+    const media = createRawSnippet(() => ({
+      render: () =>
+        '<picture><source media="(min-width: 48rem)" srcset="wide.png" /><img src="narrow.png" alt="Product preview" /></picture>',
+    }));
+    const { container } = render(HeroSection, { props: { title: 'Hero', media } });
+
+    expect(container.querySelector('.cinder-hero-section__media picture')).not.toBeNull();
+    expect(
+      container.querySelector('.cinder-hero-section__media picture img')?.getAttribute('alt'),
+    ).toBe('Product preview');
+    expect(HERO_SECTION_CSS).toContain(
+      '.cinder-hero-section__media > .cinder-aspect-ratio > picture > img',
+    );
   });
 
   test('splits media layouts at the 48rem container threshold', () => {

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -20,6 +20,7 @@ const runtimePatchSnippet = createRawSnippet(() => ({
 void runtimePatchSnippet;
 
 const HERO_SECTION_CSS = readFileSync(join(import.meta.dir, 'hero-section.css'), 'utf8');
+const HERO_SECTION_SOURCE = readFileSync(join(import.meta.dir, 'hero-section.svelte'), 'utf8');
 
 describe('HeroSection', () => {
   test('renders title and optional description copy', () => {
@@ -92,6 +93,7 @@ describe('HeroSection', () => {
     expect(HERO_SECTION_CSS).toContain('inline-size: 100%;');
     expect(HERO_SECTION_CSS).toContain('position: absolute;');
     expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio > svg');
+    expect(HERO_SECTION_SOURCE).toContain("import '@lostgradient/cinder/aspect-ratio/styles';");
     expect(HERO_SECTION_CSS).not.toContain('cinder-hero-section__media {\n    border:');
   });
 

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -91,9 +91,11 @@ describe('HeroSection', () => {
     );
     expect(HERO_SECTION_CSS).toContain('inline-size: 100%;');
     expect(HERO_SECTION_CSS).toContain('position: absolute;');
-    expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio > *');
     expect(HERO_SECTION_CSS).toContain(
-      '.cinder-hero-section__media > .cinder-aspect-ratio > picture',
+      '.cinder-hero-section__media > .cinder-aspect-ratio > *:only-child',
+    );
+    expect(HERO_SECTION_CSS).toContain(
+      '.cinder-hero-section__media > .cinder-aspect-ratio > picture:only-child',
     );
     expect(HERO_SECTION_CSS).toContain('.cinder-hero-section__media > .cinder-aspect-ratio');
     expect(HERO_SECTION_CSS).not.toContain('cinder-hero-section__media {\n    border:');
@@ -111,12 +113,19 @@ describe('HeroSection', () => {
       container.querySelector('.cinder-hero-section__media picture img')?.getAttribute('alt'),
     ).toBe('Product preview');
     expect(HERO_SECTION_CSS).toContain(
-      '.cinder-hero-section__media > .cinder-aspect-ratio > picture > img',
+      '.cinder-hero-section__media > .cinder-aspect-ratio > picture:only-child > img',
     );
   });
 
   test('splits media layouts at the 48rem container threshold', () => {
     expect(HERO_SECTION_CSS).toContain('@container cinder-hero-section (min-width: 48rem)');
     expect(HERO_SECTION_CSS).not.toContain('@container cinder-hero-section (min-width: 64rem)');
+  });
+
+  test('preserves multi-root media flow and keeps focused media visible', () => {
+    expect(HERO_SECTION_CSS).toContain('> *:only-child');
+    expect(HERO_SECTION_CSS).toContain(':only-child:focus-visible');
+    expect(HERO_SECTION_CSS).toContain('box-shadow: inset 0 0 0 var(--cinder-ring-width)');
+    expect(HERO_SECTION_CSS).toContain('outline-offset: -2px');
   });
 });

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -125,7 +125,7 @@ describe('HeroSection', () => {
   test('preserves multi-root media flow and keeps focused media visible', () => {
     expect(HERO_SECTION_CSS).toContain('> *:only-child');
     expect(HERO_SECTION_CSS).toContain('> *:only-child > img:only-child');
-    expect(HERO_SECTION_CSS).toContain(':focus-visible::after');
+    expect(HERO_SECTION_CSS).toContain(':has(> *:only-child:focus-visible)::after');
     expect(HERO_SECTION_CSS).toContain('z-index: 2;');
     expect(HERO_SECTION_CSS).toContain('pointer-events: none;');
     expect(HERO_SECTION_CSS).toContain(':only-child:focus-visible');

--- a/packages/components/src/components/hero-section/hero-section.test.ts
+++ b/packages/components/src/components/hero-section/hero-section.test.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -16,6 +18,8 @@ const runtimePatchSnippet = createRawSnippet(() => ({
   setup: () => {},
 }));
 void runtimePatchSnippet;
+
+const HERO_SECTION_CSS = readFileSync(join(import.meta.dir, 'hero-section.css'), 'utf8');
 
 describe('HeroSection', () => {
   test('renders title and optional description copy', () => {
@@ -71,5 +75,27 @@ describe('HeroSection', () => {
     const element = container.querySelector('.cinder-hero-section');
     expect(element?.classList.contains('cinder-hero-section')).toBe(true);
     expect(element?.classList.contains('my-custom-class')).toBe(true);
+  });
+
+  test('gives intrinsic media a full-width aspect-ratio box without a card frame', () => {
+    const media = createRawSnippet(() => ({
+      render: () => '<img src="placeholder.png" alt="Product preview" />',
+    }));
+    const { container } = render(HeroSection, {
+      props: { title: 'Hero', media },
+    });
+
+    expect(container.querySelector('.cinder-hero-section__media-ratio')).not.toBeNull();
+    expect(container.querySelector('.cinder-hero-section__media img')?.getAttribute('alt')).toBe(
+      'Product preview',
+    );
+    expect(HERO_SECTION_CSS).toContain('inline-size: 100%;');
+    expect(HERO_SECTION_CSS).toContain('position: absolute;');
+    expect(HERO_SECTION_CSS).not.toContain('cinder-hero-section__media {\n    border:');
+  });
+
+  test('splits media layouts at the 48rem container threshold', () => {
+    expect(HERO_SECTION_CSS).toContain('@container cinder-hero-section (min-width: 48rem)');
+    expect(HERO_SECTION_CSS).not.toContain('@container cinder-hero-section (min-width: 64rem)');
   });
 });


### PR DESCRIPTION
Closes #960

## Summary
- wrap HeroSection media in the existing AspectRatio primitive so intrinsic media fills a stable 16:9 box
- remove the copied FeatureSection card frame from the default hero media slot
- lower the split-layout container threshold to 48rem
- add focused media and breakpoint regression coverage

## Verification
- `bun test packages/components/src/components/hero-section/hero-section.test.ts`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder typecheck`
