### PR TITLE
docs: clarify near-neighbour component choices

### DIFF
--- a/.changeset/navigation-metadata.md
+++ b/.changeset/navigation-metadata.md
@@ -1,5 +1,6 @@
 ---
 '@lostgradient/cinder': patch
+'@lostgradient/cinder-mcp': patch
 ---
 
 Clarify navigation component alternatives in the generated component manifest.

--- a/.changeset/navigation-metadata.md
+++ b/.changeset/navigation-metadata.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Clarify navigation component alternatives in the generated component manifest.

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -5366,7 +5366,7 @@
           "reason": "The page has too few headings to justify a secondary navigation rail."
         },
         {
-          "reason": "Rendering expandable hierarchical navigation — use tree instead.",
+          "reason": "Rendering expandable hierarchical data with selection state — use tree instead.",
           "alternative": "tree"
         }
       ],

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -4463,9 +4463,22 @@
         },
         {
           "reason": "Rendering a single flat horizontal nav row — use navigation-bar instead."
+        },
+        {
+          "reason": "Showing an in-page heading outline — use table-of-contents instead."
+        },
+        {
+          "reason": "Rendering expandable hierarchical data — use tree instead."
         }
       ],
-      "related": ["side-navigation-item", "side-navigation-group", "navigation-bar", "sidebar"],
+      "related": [
+        "side-navigation-item",
+        "side-navigation-group",
+        "navigation-bar",
+        "table-of-contents",
+        "tree",
+        "sidebar"
+      ],
       "hasConstraints": false,
       "hasExamples": true,
       "artifacts": {
@@ -5349,9 +5362,12 @@
         },
         {
           "reason": "The page has too few headings to justify a secondary navigation rail."
+        },
+        {
+          "reason": "Rendering expandable hierarchical navigation — use tree instead."
         }
       ],
-      "related": ["side-navigation", "breadcrumbs", "section-heading"],
+      "related": ["side-navigation", "tree", "breadcrumbs", "section-heading"],
       "hasConstraints": false,
       "hasExamples": true,
       "artifacts": {
@@ -5769,9 +5785,15 @@
         },
         {
           "reason": "Switching between sibling views of the same region — use tabs instead."
+        },
+        {
+          "reason": "Showing an in-page heading outline — use table-of-contents instead."
+        },
+        {
+          "reason": "Providing route or section navigation — use side-navigation instead."
         }
       ],
-      "related": ["tree-item", "accordion"],
+      "related": ["tree-item", "table-of-contents", "side-navigation", "accordion"],
       "hasConstraints": false,
       "hasExamples": true,
       "artifacts": {

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -4459,17 +4459,19 @@
       ],
       "avoidWhen": [
         {
-          "reason": "Anchoring primary navigation across the top of the page — use navigation-bar instead."
+          "reason": "Anchoring primary navigation across the top of the page.",
+          "alternative": "navigation-bar"
         },
         {
-          "reason": "Rendering a single flat horizontal nav row — use navigation-bar instead."
+          "reason": "Rendering a single flat horizontal nav row.",
+          "alternative": "navigation-bar"
         },
         {
-          "reason": "Showing an in-page heading outline — use table-of-contents instead.",
+          "reason": "Showing an in-page heading outline.",
           "alternative": "table-of-contents"
         },
         {
-          "reason": "Rendering expandable hierarchical non-navigation data — use tree instead.",
+          "reason": "Rendering expandable hierarchical non-navigation data.",
           "alternative": "tree"
         }
       ],
@@ -5366,7 +5368,7 @@
           "reason": "The page has too few headings to justify a secondary navigation rail."
         },
         {
-          "reason": "Rendering expandable hierarchical data with selection state — use tree instead.",
+          "reason": "Rendering expandable hierarchical data with selection state.",
           "alternative": "tree"
         }
       ],
@@ -5790,11 +5792,11 @@
           "reason": "Switching between sibling views of the same region — use tabs instead."
         },
         {
-          "reason": "Showing an in-page heading outline — use table-of-contents instead.",
+          "reason": "Showing an in-page heading outline.",
           "alternative": "table-of-contents"
         },
         {
-          "reason": "Providing route or section navigation — use side-navigation instead.",
+          "reason": "Providing route or section navigation.",
           "alternative": "side-navigation"
         }
       ],

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -4465,10 +4465,12 @@
           "reason": "Rendering a single flat horizontal nav row — use navigation-bar instead."
         },
         {
-          "reason": "Showing an in-page heading outline — use table-of-contents instead."
+          "reason": "Showing an in-page heading outline — use table-of-contents instead.",
+          "alternative": "table-of-contents"
         },
         {
-          "reason": "Rendering expandable hierarchical data — use tree instead."
+          "reason": "Rendering expandable hierarchical data — use tree instead.",
+          "alternative": "tree"
         }
       ],
       "related": [
@@ -5364,7 +5366,8 @@
           "reason": "The page has too few headings to justify a secondary navigation rail."
         },
         {
-          "reason": "Rendering expandable hierarchical navigation — use tree instead."
+          "reason": "Rendering expandable hierarchical navigation — use tree instead.",
+          "alternative": "tree"
         }
       ],
       "related": ["side-navigation", "tree", "breadcrumbs", "section-heading"],
@@ -5787,10 +5790,12 @@
           "reason": "Switching between sibling views of the same region — use tabs instead."
         },
         {
-          "reason": "Showing an in-page heading outline — use table-of-contents instead."
+          "reason": "Showing an in-page heading outline — use table-of-contents instead.",
+          "alternative": "table-of-contents"
         },
         {
-          "reason": "Providing route or section navigation — use side-navigation instead."
+          "reason": "Providing route or section navigation — use side-navigation instead.",
+          "alternative": "side-navigation"
         }
       ],
       "related": ["tree-item", "table-of-contents", "side-navigation", "accordion"],

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -4469,7 +4469,7 @@
           "alternative": "table-of-contents"
         },
         {
-          "reason": "Rendering expandable hierarchical data — use tree instead.",
+          "reason": "Rendering expandable hierarchical non-navigation data — use tree instead.",
           "alternative": "tree"
         }
       ],

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -5796,7 +5796,7 @@
           "alternative": "table-of-contents"
         },
         {
-          "reason": "Providing route or section navigation.",
+          "reason": "Providing vertical sidebar route navigation.",
           "alternative": "side-navigation"
         }
       ],

--- a/packages/components/src/components/side-navigation/side-navigation.svelte
+++ b/packages/components/src/components/side-navigation/side-navigation.svelte
@@ -11,7 +11,7 @@
    * @avoidWhen Anchoring primary navigation across the top of the page — use navigation-bar instead.
    * @avoidWhen Rendering a single flat horizontal nav row — use navigation-bar instead.
    * @avoidWhen Showing an in-page heading outline — use table-of-contents instead. | table-of-contents
-   * @avoidWhen Rendering expandable hierarchical data — use tree instead. | tree
+   * @avoidWhen Rendering expandable hierarchical non-navigation data — use tree instead. | tree
    * @related side-navigation-item, side-navigation-group, navigation-bar, table-of-contents, tree, sidebar
    */
   export type { SideNavigationProps } from './side-navigation.types.ts';

--- a/packages/components/src/components/side-navigation/side-navigation.svelte
+++ b/packages/components/src/components/side-navigation/side-navigation.svelte
@@ -8,10 +8,10 @@
    * @tag sidebar
    * @useWhen Building a tall, dense application sidebar with many sections and nested groups.
    * @useWhen Pairing with sidebar so the column collapses responsively on narrow viewports.
-   * @avoidWhen Anchoring primary navigation across the top of the page — use navigation-bar instead.
-   * @avoidWhen Rendering a single flat horizontal nav row — use navigation-bar instead.
-   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead. | table-of-contents
-   * @avoidWhen Rendering expandable hierarchical non-navigation data — use tree instead. | tree
+   * @avoidWhen Anchoring primary navigation across the top of the page. | navigation-bar
+   * @avoidWhen Rendering a single flat horizontal nav row. | navigation-bar
+   * @avoidWhen Showing an in-page heading outline. | table-of-contents
+   * @avoidWhen Rendering expandable hierarchical non-navigation data. | tree
    * @related side-navigation-item, side-navigation-group, navigation-bar, table-of-contents, tree, sidebar
    */
   export type { SideNavigationProps } from './side-navigation.types.ts';

--- a/packages/components/src/components/side-navigation/side-navigation.svelte
+++ b/packages/components/src/components/side-navigation/side-navigation.svelte
@@ -10,8 +10,8 @@
    * @useWhen Pairing with sidebar so the column collapses responsively on narrow viewports.
    * @avoidWhen Anchoring primary navigation across the top of the page — use navigation-bar instead.
    * @avoidWhen Rendering a single flat horizontal nav row — use navigation-bar instead.
-   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead.
-   * @avoidWhen Rendering expandable hierarchical data — use tree instead.
+   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead. | table-of-contents
+   * @avoidWhen Rendering expandable hierarchical data — use tree instead. | tree
    * @related side-navigation-item, side-navigation-group, navigation-bar, table-of-contents, tree, sidebar
    */
   export type { SideNavigationProps } from './side-navigation.types.ts';

--- a/packages/components/src/components/side-navigation/side-navigation.svelte
+++ b/packages/components/src/components/side-navigation/side-navigation.svelte
@@ -10,7 +10,9 @@
    * @useWhen Pairing with sidebar so the column collapses responsively on narrow viewports.
    * @avoidWhen Anchoring primary navigation across the top of the page — use navigation-bar instead.
    * @avoidWhen Rendering a single flat horizontal nav row — use navigation-bar instead.
-   * @related side-navigation-item, side-navigation-group, navigation-bar, sidebar
+   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead.
+   * @avoidWhen Rendering expandable hierarchical data — use tree instead.
+   * @related side-navigation-item, side-navigation-group, navigation-bar, table-of-contents, tree, sidebar
    */
   export type { SideNavigationProps } from './side-navigation.types.ts';
 </script>

--- a/packages/components/src/components/table-of-contents/table-of-contents.svelte
+++ b/packages/components/src/components/table-of-contents/table-of-contents.svelte
@@ -11,7 +11,7 @@
    * @useWhen Letting users jump between headings while keeping context via active-section highlighting.
    * @avoidWhen Navigating between routes or top-level app areas — use navigation-bar or side-navigation.
    * @avoidWhen The page has too few headings to justify a secondary navigation rail.
-   * @avoidWhen Rendering expandable hierarchical data with selection state — use tree instead. | tree
+   * @avoidWhen Rendering expandable hierarchical data with selection state. | tree
    * @related side-navigation, tree, breadcrumbs, section-heading
    * @a11yPattern WAI-ARIA Navigation Landmark
    */

--- a/packages/components/src/components/table-of-contents/table-of-contents.svelte
+++ b/packages/components/src/components/table-of-contents/table-of-contents.svelte
@@ -11,7 +11,7 @@
    * @useWhen Letting users jump between headings while keeping context via active-section highlighting.
    * @avoidWhen Navigating between routes or top-level app areas — use navigation-bar or side-navigation.
    * @avoidWhen The page has too few headings to justify a secondary navigation rail.
-   * @avoidWhen Rendering expandable hierarchical navigation — use tree instead.
+   * @avoidWhen Rendering expandable hierarchical navigation — use tree instead. | tree
    * @related side-navigation, tree, breadcrumbs, section-heading
    * @a11yPattern WAI-ARIA Navigation Landmark
    */

--- a/packages/components/src/components/table-of-contents/table-of-contents.svelte
+++ b/packages/components/src/components/table-of-contents/table-of-contents.svelte
@@ -11,7 +11,7 @@
    * @useWhen Letting users jump between headings while keeping context via active-section highlighting.
    * @avoidWhen Navigating between routes or top-level app areas — use navigation-bar or side-navigation.
    * @avoidWhen The page has too few headings to justify a secondary navigation rail.
-   * @avoidWhen Rendering expandable hierarchical navigation — use tree instead. | tree
+   * @avoidWhen Rendering expandable hierarchical data with selection state — use tree instead. | tree
    * @related side-navigation, tree, breadcrumbs, section-heading
    * @a11yPattern WAI-ARIA Navigation Landmark
    */

--- a/packages/components/src/components/table-of-contents/table-of-contents.svelte
+++ b/packages/components/src/components/table-of-contents/table-of-contents.svelte
@@ -11,7 +11,8 @@
    * @useWhen Letting users jump between headings while keeping context via active-section highlighting.
    * @avoidWhen Navigating between routes or top-level app areas — use navigation-bar or side-navigation.
    * @avoidWhen The page has too few headings to justify a secondary navigation rail.
-   * @related side-navigation, breadcrumbs, section-heading
+   * @avoidWhen Rendering expandable hierarchical navigation — use tree instead.
+   * @related side-navigation, tree, breadcrumbs, section-heading
    * @a11yPattern WAI-ARIA Navigation Landmark
    */
   export type { TableOfContentsItem, TableOfContentsProps } from './table-of-contents.types.ts';

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -10,8 +10,8 @@
    * @useWhen Coordinating single- or multi-select state across all descendant tree-items via the selectionMode prop.
    * @avoidWhen Disclosing flat sibling sections — use accordion instead.
    * @avoidWhen Switching between sibling views of the same region — use tabs instead.
-   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead. | table-of-contents
-   * @avoidWhen Providing route or section navigation — use side-navigation instead. | side-navigation
+   * @avoidWhen Showing an in-page heading outline. | table-of-contents
+   * @avoidWhen Providing route or section navigation. | side-navigation
    * @related tree-item, table-of-contents, side-navigation, accordion
    */
   export type {

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -11,7 +11,7 @@
    * @avoidWhen Disclosing flat sibling sections — use accordion instead.
    * @avoidWhen Switching between sibling views of the same region — use tabs instead.
    * @avoidWhen Showing an in-page heading outline. | table-of-contents
-   * @avoidWhen Providing route or section navigation. | side-navigation
+   * @avoidWhen Providing vertical sidebar route navigation. | side-navigation
    * @related tree-item, table-of-contents, side-navigation, accordion
    */
   export type {

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -10,7 +10,9 @@
    * @useWhen Coordinating single- or multi-select state across all descendant tree-items via the selectionMode prop.
    * @avoidWhen Disclosing flat sibling sections — use accordion instead.
    * @avoidWhen Switching between sibling views of the same region — use tabs instead.
-   * @related tree-item, accordion
+   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead.
+   * @avoidWhen Providing route or section navigation — use side-navigation instead.
+   * @related tree-item, table-of-contents, side-navigation, accordion
    */
   export type {
     TreeFilterPredicate,

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -10,8 +10,8 @@
    * @useWhen Coordinating single- or multi-select state across all descendant tree-items via the selectionMode prop.
    * @avoidWhen Disclosing flat sibling sections — use accordion instead.
    * @avoidWhen Switching between sibling views of the same region — use tabs instead.
-   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead.
-   * @avoidWhen Providing route or section navigation — use side-navigation instead.
+   * @avoidWhen Showing an in-page heading outline — use table-of-contents instead. | table-of-contents
+   * @avoidWhen Providing route or section navigation — use side-navigation instead. | side-navigation
    * @related tree-item, table-of-contents, side-navigation, accordion
    */
   export type {


### PR DESCRIPTION
Closes #967

Adds explicit @avoidWhen guidance and related metadata for TableOfContents, SideNavigation, and Tree, documenting their distinct semantics. Regenerates components.json.

Validation:
- bun run --filter=@lostgradient/cinder components:generate
- focused metadata diff reviewed
- git diff --check