### PR TITLE
feat(page-header): add named content regions

### DIFF
--- a/.changeset/page-header-named-regions.md
+++ b/.changeset/page-header-named-regions.md
@@ -1,0 +1,8 @@
+---
+'@lostgradient/cinder': minor
+---
+
+Give PageHeader named `title`, `description`, `breadcrumbs`, and `actions`
+regions. Replace `meta` with `description`, move trailing content from
+`children` to `actions`, and pass rich title or description content as snippets
+under those names.

--- a/docs/component-api-conventions.md
+++ b/docs/component-api-conventions.md
@@ -1,7 +1,8 @@
 # Component API Conventions
 
-Cinder component props use one public vocabulary. The rules below are enforced
-by `packages/components/scripts/check-prop-conventions.ts`.
+Cinder component props use one public vocabulary. Mechanically checkable naming
+rules are enforced by `packages/components/scripts/check-prop-conventions.ts`;
+the composition rules also define the review standard for public APIs.
 
 ## Handlers
 
@@ -17,6 +18,21 @@ by `packages/components/scripts/check-prop-conventions.ts`.
 Do not expose `defaultValue`. Use `value = $bindable(fallback)` in the
 component. If native form reset needs a target, capture the mount-time `value`
 internally with `untrack(() => value)` and keep that closure variable private.
+
+## Strings and snippets
+
+- Use strings for plain labels and values whose semantic wrapper is fully owned
+  by the component.
+- Use a named `Snippet` prop for a structural region such as `actions`,
+  `breadcrumbs`, `header`, or `footer`. Region names describe placement and
+  purpose; do not collapse multiple regions into generic `children`.
+- When a text-first region intentionally supports rich phrasing, accept
+  `string | Snippet` under the region's semantic name. The component still owns
+  the heading, paragraph, or label element, and the snippet must respect that
+  element's content model.
+- Reserve `children` for components with exactly one obvious, primary content
+  region. If consumers need to reconstruct the component's layout inside
+  `children`, the API needs named regions instead.
 
 ## Boolean props
 

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -3516,11 +3516,11 @@
       "exportName": "PageHeader",
       "category": "layout",
       "status": "stable",
-      "purpose": "Page-level heading row that pairs a required title with optional metadata and optional trailing actions.",
+      "purpose": "Page-level heading with named title, description, breadcrumb, and action regions.",
       "tags": ["page", "heading", "layout"],
       "useWhen": [
         "Rendering a route-level heading that needs consistent spacing and border treatment across pages.",
-        "Showing high-level page metadata (counts or state summaries) beside a title with optional right-aligned controls."
+        "Pairing page context and supporting copy with optional right-aligned controls."
       ],
       "avoidWhen": [
         {

--- a/packages/components/src/components/page-header/README.md
+++ b/packages/components/src/components/page-header/README.md
@@ -1,6 +1,6 @@
 # PageHeader
 
-Page-level heading row that pairs a required title with optional metadata and optional trailing actions.
+Page-level heading with named title, description, breadcrumb, and action regions.
 
 ## Usage
 
@@ -16,12 +16,13 @@ Page-level heading row that pairs a required title with optional metadata and op
 
 <!-- generated:props:start -->
 
-| Prop       | Type       | Required | Default | Description                                                                                                                      |
-| ---------- | ---------- | -------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `class`    | `string`   | no       | —       | Additional class names merged with `.cinder-page-header`.                                                                        |
-| `meta`     | `string`   | no       | —       | Optional supporting metadata displayed beside the title.                                                                         |
-| `title`    | `string`   | yes      | —       | Page-level heading text. Rendered as `<h1>`.                                                                                     |
-| `children` | `(opaque)` | no       | —       | Optional trailing actions (buttons, menus, controls). Not expressible in JSON Schema; see the component types for the signature. |
+| Prop          | Type       | Required | Default | Description                                                                                                                                                           |
+| ------------- | ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `class`       | `string`   | no       | —       | Additional class names merged with `.cinder-page-header`.                                                                                                             |
+| `actions`     | `(opaque)` | no       | —       | Optional trailing actions (buttons, menus, controls). Not expressible in JSON Schema; see the component types for the signature.                                      |
+| `breadcrumbs` | `(opaque)` | no       | —       | Optional breadcrumb navigation rendered above the heading row. Not expressible in JSON Schema; see the component types for the signature.                             |
+| `description` | `(opaque)` | no       | —       | Optional supporting content rendered below the title; snippets must emit phrasing content. Not expressible in JSON Schema; see the component types for the signature. |
+| `title`       | `(opaque)` | yes      | —       | Page-level heading content. Rendered inside `<h1>`; snippets must emit phrasing content. Not expressible in JSON Schema; see the component types for the signature.   |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/page-header/README.md
+++ b/packages/components/src/components/page-header/README.md
@@ -19,8 +19,8 @@ Page-level heading with named title, description, breadcrumb, and action regions
 | Prop          | Type       | Required | Default | Description                                                                                                                               |
 | ------------- | ---------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `class`       | `string`   | no       | —       | Additional class names merged with `.cinder-page-header`.                                                                                 |
-| `description` | `string`   | no       | —       | Optional supporting text rendered below the title.                                                                                        |
-| `title`       | `string`   | yes      | —       | Page-level heading text rendered inside `<h1>`.                                                                                           |
+| `description` | `string`   | no       | —       | Optional supporting text rendered below the title; the runtime API also accepts a template-only snippet.                                  |
+| `title`       | `string`   | yes      | —       | Page-level heading text rendered inside `<h1>`; the runtime API also accepts a template-only snippet.                                     |
 | `actions`     | `(opaque)` | no       | —       | Optional trailing actions (buttons, menus, controls). Not expressible in JSON Schema; see the component types for the signature.          |
 | `breadcrumbs` | `(opaque)` | no       | —       | Optional breadcrumb navigation rendered above the heading row. Not expressible in JSON Schema; see the component types for the signature. |
 

--- a/packages/components/src/components/page-header/README.md
+++ b/packages/components/src/components/page-header/README.md
@@ -16,13 +16,13 @@ Page-level heading with named title, description, breadcrumb, and action regions
 
 <!-- generated:props:start -->
 
-| Prop          | Type       | Required | Default | Description                                                                                                                                                           |
-| ------------- | ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `class`       | `string`   | no       | —       | Additional class names merged with `.cinder-page-header`.                                                                                                             |
-| `actions`     | `(opaque)` | no       | —       | Optional trailing actions (buttons, menus, controls). Not expressible in JSON Schema; see the component types for the signature.                                      |
-| `breadcrumbs` | `(opaque)` | no       | —       | Optional breadcrumb navigation rendered above the heading row. Not expressible in JSON Schema; see the component types for the signature.                             |
-| `description` | `(opaque)` | no       | —       | Optional supporting content rendered below the title; snippets must emit phrasing content. Not expressible in JSON Schema; see the component types for the signature. |
-| `title`       | `(opaque)` | yes      | —       | Page-level heading content. Rendered inside `<h1>`; snippets must emit phrasing content. Not expressible in JSON Schema; see the component types for the signature.   |
+| Prop          | Type       | Required | Default | Description                                                                                                                               |
+| ------------- | ---------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `class`       | `string`   | no       | —       | Additional class names merged with `.cinder-page-header`.                                                                                 |
+| `description` | `string`   | no       | —       | Optional supporting text rendered below the title.                                                                                        |
+| `title`       | `string`   | yes      | —       | Page-level heading text rendered inside `<h1>`.                                                                                           |
+| `actions`     | `(opaque)` | no       | —       | Optional trailing actions (buttons, menus, controls). Not expressible in JSON Schema; see the component types for the signature.          |
+| `breadcrumbs` | `(opaque)` | no       | —       | Optional breadcrumb navigation rendered above the heading row. Not expressible in JSON Schema; see the component types for the signature. |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/page-header/page-header.a11y.md
+++ b/packages/components/src/components/page-header/page-header.a11y.md
@@ -2,14 +2,14 @@
 
 ## Pattern
 
-PageHeader organizes page-level heading content. Preserve heading semantics, keep metadata supplemental, and ensure action controls remain operable with keyboard and assistive technology.
+PageHeader organizes page-level heading content. Preserve heading semantics, keep supporting descriptions supplemental, and ensure breadcrumb and action controls remain operable with keyboard and assistive technology.
 
-Purpose: Page-level heading row that pairs a required title with optional metadata and optional trailing actions.
+Purpose: Page-level heading with named title, description, breadcrumb, and action regions.
 
 ## Use when
 
 - Rendering a route-level heading that needs consistent spacing and border treatment across pages.
-- Showing high-level page metadata (counts or state summaries) beside a title with optional right-aligned controls.
+- Pairing page context and supporting copy with optional right-aligned controls.
 
 ## Avoid when
 
@@ -26,7 +26,7 @@ Keep focus indicators visible. If you wrap or restyle PageHeader, verify the foc
 
 Use the public props and documented examples to provide accessible names, descriptions, current state, disabled state, selection state, or value text. Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate meaning.
 
-When PageHeader accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
+The caller owns semantics inside PageHeader's named snippets. Keep title and description snippets to phrasing content, render breadcrumb navigation with an accessible name, prefer native action controls, and add ARIA only when it matches the rendered behavior.
 
 ## Verification
 

--- a/packages/components/src/components/page-header/page-header.css
+++ b/packages/components/src/components/page-header/page-header.css
@@ -1,19 +1,30 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
 @layer cinder.components {
   .cinder-page-header {
+    min-width: 0;
+    border-bottom: 1px solid var(--cinder-border);
+  }
+
+  .cinder-page-header__breadcrumbs {
+    padding: var(--cinder-space-3) var(--cinder-space-4) 0;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    line-height: var(--cinder-leading-tight);
+  }
+
+  .cinder-page-header__row {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     gap: var(--cinder-space-3);
     min-width: 0;
     padding: var(--cinder-space-3) var(--cinder-space-4);
-    border-bottom: 1px solid var(--cinder-border);
   }
 
   .cinder-page-header__heading-group {
     display: flex;
     flex: 1 1 auto;
-    align-items: baseline;
-    gap: var(--cinder-space-3);
+    flex-direction: column;
+    gap: var(--cinder-space-1);
     min-width: 0;
   }
 
@@ -30,15 +41,12 @@
     white-space: nowrap;
   }
 
-  .cinder-page-header__meta {
+  .cinder-page-header__description {
     min-width: 0;
     margin: 0;
     color: var(--cinder-text-muted);
     font-size: var(--cinder-text-sm);
-    line-height: var(--cinder-leading-tight);
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    line-height: var(--cinder-leading-normal);
   }
 
   .cinder-page-header__actions {
@@ -47,5 +55,6 @@
     flex-shrink: 0;
     align-items: center;
     gap: var(--cinder-space-2);
+    padding-block: var(--cinder-space-1);
   }
 }

--- a/packages/components/src/components/page-header/page-header.examples.json
+++ b/packages/components/src/components/page-header/page-header.examples.json
@@ -6,8 +6,8 @@
     {
       "id": "basic",
       "title": "Basic page header",
-      "description": "Page-level heading with optional metadata and right-aligned actions using the default snippet.",
-      "code": "<script lang=\"ts\">\n  import { Button } from '@lostgradient/cinder/button';\n  import { PageHeader } from '@lostgradient/cinder/page-header';\n</script>\n\n<div>\n  <PageHeader title=\"Approvals\" meta=\"3 pending · 12 resolved\" />\n</div>\n\n<div style=\"margin-top: var(--cinder-space-4);\">\n  <PageHeader title=\"Schedules\" meta=\"No schedules\">\n    <Button variant=\"primary\" size=\"sm\" label=\"+ New schedule\" />\n  </PageHeader>\n</div>\n"
+      "description": "Page-level heading with named title, description, breadcrumb, and action regions.",
+      "code": "<script lang=\"ts\">\n  import { Button } from '@lostgradient/cinder/button';\n  import { PageHeader } from '@lostgradient/cinder/page-header';\n</script>\n\n<div>\n  <PageHeader title=\"Approvals\" description=\"3 pending · 12 resolved\" />\n</div>\n\n<div style=\"margin-top: var(--cinder-space-4);\">\n  <PageHeader>\n    {#snippet breadcrumbs()}\n      <nav aria-label=\"Breadcrumb\"><a href=\"/\">Home</a> / Schedules</nav>\n    {/snippet}\n    {#snippet title()}Schedules{/snippet}\n    {#snippet description()}Create and manage recurring automation schedules.{/snippet}\n    {#snippet actions()}\n      <Button variant=\"primary\" size=\"sm\" label=\"+ New schedule\" />\n    {/snippet}\n  </PageHeader>\n</div>\n"
     }
   ]
 }

--- a/packages/components/src/components/page-header/page-header.examples.json
+++ b/packages/components/src/components/page-header/page-header.examples.json
@@ -7,7 +7,7 @@
       "id": "basic",
       "title": "Basic page header",
       "description": "Page-level heading with named title, description, breadcrumb, and action regions.",
-      "code": "<script lang=\"ts\">\n  import { Button } from '@lostgradient/cinder/button';\n  import { PageHeader } from '@lostgradient/cinder/page-header';\n</script>\n\n<div>\n  <PageHeader title=\"Approvals\" description=\"3 pending · 12 resolved\" />\n</div>\n\n<div style=\"margin-top: var(--cinder-space-4);\">\n  <PageHeader>\n    {#snippet breadcrumbs()}\n      <nav aria-label=\"Breadcrumb\"><a href=\"/\">Home</a> / Schedules</nav>\n    {/snippet}\n    {#snippet title()}Schedules{/snippet}\n    {#snippet description()}Create and manage recurring automation schedules.{/snippet}\n    {#snippet actions()}\n      <Button variant=\"primary\" size=\"sm\" label=\"+ New schedule\" />\n    {/snippet}\n  </PageHeader>\n</div>\n"
+      "code": "<script lang=\"ts\">\n  import { Button } from '@lostgradient/cinder/button';\n  import { Breadcrumbs } from '@lostgradient/cinder/breadcrumbs';\n  import { PageHeader } from '@lostgradient/cinder/page-header';\n</script>\n\n<div>\n  <PageHeader title=\"Approvals\" description=\"3 pending · 12 resolved\" />\n</div>\n\n<div style=\"margin-top: var(--cinder-space-4);\">\n  <PageHeader>\n    {#snippet breadcrumbs()}\n      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Schedules' }]} />\n    {/snippet}\n    {#snippet title()}Schedules{/snippet}\n    {#snippet description()}Create and manage recurring automation schedules.{/snippet}\n    {#snippet actions()}\n      <Button variant=\"primary\" size=\"sm\" label=\"+ New schedule\" />\n    {/snippet}\n  </PageHeader>\n</div>\n"
     }
   ]
 }

--- a/packages/components/src/components/page-header/page-header.schema.json
+++ b/packages/components/src/components/page-header/page-header.schema.json
@@ -2,27 +2,34 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
-    "title": {
-      "type": "string",
-      "description": "Page-level heading text. Rendered as `<h1>`."
-    },
-    "meta": {
-      "type": "string",
-      "description": "Optional supporting metadata displayed beside the title."
-    },
     "class": {
       "type": "string",
       "description": "Additional class names merged with `.cinder-page-header`."
     }
   },
   "additionalProperties": false,
-  "required": ["title"],
   "metadata": {
     "unsupportedProps": [
       {
-        "name": "children",
+        "name": "actions",
         "reason": "function-or-snippet",
         "description": "Optional trailing actions (buttons, menus, controls)."
+      },
+      {
+        "name": "breadcrumbs",
+        "reason": "function-or-snippet",
+        "description": "Optional breadcrumb navigation rendered above the heading row."
+      },
+      {
+        "name": "description",
+        "reason": "function-or-snippet",
+        "description": "Optional supporting content rendered below the title; snippets must emit phrasing content."
+      },
+      {
+        "name": "title",
+        "reason": "function-or-snippet",
+        "required": true,
+        "description": "Page-level heading content. Rendered inside `<h1>`; snippets must emit phrasing content."
       }
     ]
   }

--- a/packages/components/src/components/page-header/page-header.schema.json
+++ b/packages/components/src/components/page-header/page-header.schema.json
@@ -4,11 +4,11 @@
   "properties": {
     "title": {
       "type": "string",
-      "description": "Page-level heading text rendered inside `<h1>`."
+      "description": "Page-level heading text rendered inside `<h1>`; the runtime API also accepts a template-only snippet."
     },
     "description": {
       "type": "string",
-      "description": "Optional supporting text rendered below the title."
+      "description": "Optional supporting text rendered below the title; the runtime API also accepts a template-only snippet."
     },
     "class": {
       "type": "string",

--- a/packages/components/src/components/page-header/page-header.schema.json
+++ b/packages/components/src/components/page-header/page-header.schema.json
@@ -2,12 +2,21 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
   "properties": {
+    "title": {
+      "type": "string",
+      "description": "Page-level heading text rendered inside `<h1>`."
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional supporting text rendered below the title."
+    },
     "class": {
       "type": "string",
       "description": "Additional class names merged with `.cinder-page-header`."
     }
   },
   "additionalProperties": false,
+  "required": ["title"],
   "metadata": {
     "unsupportedProps": [
       {
@@ -19,17 +28,6 @@
         "name": "breadcrumbs",
         "reason": "function-or-snippet",
         "description": "Optional breadcrumb navigation rendered above the heading row."
-      },
-      {
-        "name": "description",
-        "reason": "function-or-snippet",
-        "description": "Optional supporting content rendered below the title; snippets must emit phrasing content."
-      },
-      {
-        "name": "title",
-        "reason": "function-or-snippet",
-        "required": true,
-        "description": "Page-level heading content. Rendered inside `<h1>`; snippets must emit phrasing content."
       }
     ]
   }

--- a/packages/components/src/components/page-header/page-header.schema.ts
+++ b/packages/components/src/components/page-header/page-header.schema.ts
@@ -4,27 +4,36 @@ const schema = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
   type: 'object',
   properties: {
-    title: {
-      type: 'string',
-      description: 'Page-level heading text. Rendered as `<h1>`.',
-    },
-    meta: {
-      type: 'string',
-      description: 'Optional supporting metadata displayed beside the title.',
-    },
     class: {
       type: 'string',
       description: 'Additional class names merged with `.cinder-page-header`.',
     },
   },
   additionalProperties: false,
-  required: ['title'],
   metadata: {
     unsupportedProps: [
       {
-        name: 'children',
+        name: 'actions',
         reason: 'function-or-snippet',
         description: 'Optional trailing actions (buttons, menus, controls).',
+      },
+      {
+        name: 'breadcrumbs',
+        reason: 'function-or-snippet',
+        description: 'Optional breadcrumb navigation rendered above the heading row.',
+      },
+      {
+        name: 'description',
+        reason: 'function-or-snippet',
+        description:
+          'Optional supporting content rendered below the title; snippets must emit phrasing content.',
+      },
+      {
+        name: 'title',
+        reason: 'function-or-snippet',
+        required: true,
+        description:
+          'Page-level heading content. Rendered inside `<h1>`; snippets must emit phrasing content.',
       },
     ],
   },

--- a/packages/components/src/components/page-header/page-header.schema.ts
+++ b/packages/components/src/components/page-header/page-header.schema.ts
@@ -4,12 +4,21 @@ const schema = {
   $schema: 'https://json-schema.org/draft/2020-12/schema',
   type: 'object',
   properties: {
+    title: {
+      type: 'string',
+      description: 'Page-level heading text rendered inside `<h1>`.',
+    },
+    description: {
+      type: 'string',
+      description: 'Optional supporting text rendered below the title.',
+    },
     class: {
       type: 'string',
       description: 'Additional class names merged with `.cinder-page-header`.',
     },
   },
   additionalProperties: false,
+  required: ['title'],
   metadata: {
     unsupportedProps: [
       {
@@ -21,19 +30,6 @@ const schema = {
         name: 'breadcrumbs',
         reason: 'function-or-snippet',
         description: 'Optional breadcrumb navigation rendered above the heading row.',
-      },
-      {
-        name: 'description',
-        reason: 'function-or-snippet',
-        description:
-          'Optional supporting content rendered below the title; snippets must emit phrasing content.',
-      },
-      {
-        name: 'title',
-        reason: 'function-or-snippet',
-        required: true,
-        description:
-          'Page-level heading content. Rendered inside `<h1>`; snippets must emit phrasing content.',
       },
     ],
   },

--- a/packages/components/src/components/page-header/page-header.schema.ts
+++ b/packages/components/src/components/page-header/page-header.schema.ts
@@ -6,11 +6,13 @@ const schema = {
   properties: {
     title: {
       type: 'string',
-      description: 'Page-level heading text rendered inside `<h1>`.',
+      description:
+        'Page-level heading text rendered inside `<h1>`; the runtime API also accepts a template-only snippet.',
     },
     description: {
       type: 'string',
-      description: 'Optional supporting text rendered below the title.',
+      description:
+        'Optional supporting text rendered below the title; the runtime API also accepts a template-only snippet.',
     },
     class: {
       type: 'string',

--- a/packages/components/src/components/page-header/page-header.svelte
+++ b/packages/components/src/components/page-header/page-header.svelte
@@ -3,12 +3,12 @@
    * @cinder
    * @category layout
    * @status stable
-   * @purpose Page-level heading row that pairs a required title with optional metadata and optional trailing actions.
+   * @purpose Page-level heading with named title, description, breadcrumb, and action regions.
    * @tag page
    * @tag heading
    * @tag layout
    * @useWhen Rendering a route-level heading that needs consistent spacing and border treatment across pages.
-   * @useWhen Showing high-level page metadata (counts or state summaries) beside a title with optional right-aligned controls.
+   * @useWhen Pairing page context and supporting copy with optional right-aligned controls.
    * @avoidWhen Rendering section-scoped headings within page content — use section-heading.
    * @avoidWhen Building complex hero layouts with rich copy and media — use hero-section.
    * @related section-heading, hero-section
@@ -20,20 +20,47 @@
   import { classNames } from '../../utilities/class-names.ts';
   import type { PageHeaderProps } from './page-header.types.ts';
 
-  let { title, meta, class: className, children, ...rest }: PageHeaderProps = $props();
+  let {
+    title,
+    description,
+    breadcrumbs,
+    actions,
+    class: className,
+    ...rest
+  }: PageHeaderProps = $props();
 </script>
 
 <div class={classNames('cinder-page-header', className)} {...rest}>
-  <div class="cinder-page-header__heading-group">
-    <h1 class="cinder-page-header__title">{title}</h1>
-    {#if meta}
-      <p class="cinder-page-header__meta">{meta}</p>
-    {/if}
-  </div>
-
-  {#if children}
-    <div class="cinder-page-header__actions">
-      {@render children()}
+  {#if breadcrumbs}
+    <div class="cinder-page-header__breadcrumbs">
+      {@render breadcrumbs()}
     </div>
   {/if}
+
+  <div class="cinder-page-header__row">
+    <div class="cinder-page-header__heading-group">
+      <h1 class="cinder-page-header__title">
+        {#if typeof title === 'string'}
+          {title}
+        {:else}
+          {@render title()}
+        {/if}
+      </h1>
+      {#if description}
+        <p class="cinder-page-header__description">
+          {#if typeof description === 'string'}
+            {description}
+          {:else}
+            {@render description()}
+          {/if}
+        </p>
+      {/if}
+    </div>
+
+    {#if actions}
+      <div class="cinder-page-header__actions">
+        {@render actions()}
+      </div>
+    {/if}
+  </div>
 </div>

--- a/packages/components/src/components/page-header/page-header.test.ts
+++ b/packages/components/src/components/page-header/page-header.test.ts
@@ -1,6 +1,8 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, test } from 'bun:test';
 
+import Ajv2020 from 'ajv/dist/2020';
+
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
 // setupHappyDom() MUST run before any `@testing-library/svelte` import.
@@ -15,8 +17,25 @@ afterEach(() => {
 
 const { createRawSnippet } = await import('svelte');
 const { default: PageHeader } = await import('./page-header.svelte');
+const { default: pageHeaderSchema } = await import('./page-header.schema.ts');
 
 describe('PageHeader', () => {
+  test('schema requires a string title and supports an optional string description', () => {
+    const validate = new Ajv2020({ strict: false }).compile(pageHeaderSchema);
+
+    expect(pageHeaderSchema.required).toEqual(['title']);
+    expect(pageHeaderSchema.properties).toMatchObject({
+      title: { type: 'string' },
+      description: { type: 'string' },
+    });
+    expect(pageHeaderSchema.metadata?.unsupportedProps?.map((prop) => prop.name)).toEqual([
+      'actions',
+      'breadcrumbs',
+    ]);
+    expect(validate({ title: 'Approvals', description: 'Review pending requests.' })).toBe(true);
+    expect(validate({})).toBe(false);
+  });
+
   test('renders the required title as h1', () => {
     const { container } = render(PageHeader, { props: { title: 'Approvals' } });
     const titleEl = container.querySelector('.cinder-page-header__title');

--- a/packages/components/src/components/page-header/page-header.test.ts
+++ b/packages/components/src/components/page-header/page-header.test.ts
@@ -25,38 +25,44 @@ describe('PageHeader', () => {
     expect(titleEl?.textContent?.trim()).toBe('Approvals');
   });
 
-  test('renders meta text when provided', () => {
-    const { container } = render(PageHeader, {
-      props: { title: 'Approvals', meta: '3 pending · 12 resolved' },
-    });
-
-    const metaEl = container.querySelector('.cinder-page-header__meta');
-    expect(metaEl).not.toBeNull();
-    expect(metaEl?.textContent?.trim()).toBe('3 pending · 12 resolved');
-  });
-
-  test('does not render meta element when meta is omitted', () => {
-    const { container } = render(PageHeader, { props: { title: 'Schedules' } });
-    expect(container.querySelector('.cinder-page-header__meta')).toBeNull();
-  });
-
-  test('renders trailing actions when children snippet is provided', () => {
-    const actionsSnippet = createRawSnippet(() => ({
-      render: () => `<button>+ New schedule</button>`,
+  test('renders named title, description, breadcrumb, and action regions', () => {
+    const title = createRawSnippet(() => ({
+      render: () => `<span>Schedules</span>`,
+      setup: () => {},
+    }));
+    const description = createRawSnippet(() => ({
+      render: () => `<span>Manage automated schedules.</span>`,
+      setup: () => {},
+    }));
+    const breadcrumbs = createRawSnippet(() => ({
+      render: () => `<nav aria-label="Breadcrumb">Home / Schedules</nav>`,
+      setup: () => {},
+    }));
+    const actions = createRawSnippet(() => ({
+      render: () => `<button>New schedule</button>`,
       setup: () => {},
     }));
 
     const { container } = render(PageHeader, {
-      props: { title: 'Schedules', children: actionsSnippet },
+      props: { title, description, breadcrumbs, actions },
     });
 
-    const actionsEl = container.querySelector('.cinder-page-header__actions');
-    expect(actionsEl).not.toBeNull();
-    expect(actionsEl?.querySelector('button')?.textContent).toBe('+ New schedule');
+    expect(container.querySelector('h1')?.textContent).toBe('Schedules');
+    expect(container.querySelector('.cinder-page-header__description')?.textContent).toBe(
+      'Manage automated schedules.',
+    );
+    expect(
+      container.querySelector('.cinder-page-header__breadcrumbs nav')?.getAttribute('aria-label'),
+    ).toBe('Breadcrumb');
+    expect(container.querySelector('.cinder-page-header__actions button')?.textContent).toBe(
+      'New schedule',
+    );
   });
 
-  test('does not render actions container when children snippet is omitted', () => {
-    const { container } = render(PageHeader, { props: { title: 'Settings' } });
+  test('does not render optional named regions when they are omitted', () => {
+    const { container } = render(PageHeader, { props: { title: 'Schedules' } });
+    expect(container.querySelector('.cinder-page-header__description')).toBeNull();
+    expect(container.querySelector('.cinder-page-header__breadcrumbs')).toBeNull();
     expect(container.querySelector('.cinder-page-header__actions')).toBeNull();
   });
 

--- a/packages/components/src/components/page-header/page-header.types.ts
+++ b/packages/components/src/components/page-header/page-header.types.ts
@@ -2,13 +2,18 @@ import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
 
 /** Props for the PageHeader component. */
-export type PageHeaderProps = Omit<HTMLAttributes<HTMLDivElement>, 'class' | 'children'> & {
-  /** Page-level heading text. Rendered as `<h1>`. */
-  title: string;
-  /** Optional supporting metadata displayed beside the title. */
-  meta?: string;
+export type PageHeaderProps = Omit<
+  HTMLAttributes<HTMLDivElement>,
+  'class' | 'children' | 'title'
+> & {
+  /** Page-level heading content. Rendered inside `<h1>`; snippets must emit phrasing content. */
+  title: string | Snippet;
+  /** Optional supporting content rendered below the title; snippets must emit phrasing content. */
+  description?: string | Snippet;
+  /** Optional breadcrumb navigation rendered above the heading row. */
+  breadcrumbs?: Snippet;
+  /** Optional trailing actions (buttons, menus, controls). */
+  actions?: Snippet;
   /** Additional class names merged with `.cinder-page-header`. */
   class?: string;
-  /** Optional trailing actions (buttons, menus, controls). */
-  children?: Snippet;
 };

--- a/packages/components/src/components/page-header/page-header.types.ts
+++ b/packages/components/src/components/page-header/page-header.types.ts
@@ -17,3 +17,16 @@ export type PageHeaderProps = Omit<
   /** Additional class names merged with `.cinder-page-header`. */
   class?: string;
 };
+
+/**
+ * Schema-generator surface. The runtime title and description also accept
+ * snippets, while schema-driven consumers use their string variants.
+ */
+export interface PageHeaderSchemaProps {
+  /** Page-level heading text rendered inside `<h1>`. */
+  title: string;
+  /** Optional supporting text rendered below the title. */
+  description?: string;
+  /** Additional class names merged with `.cinder-page-header`. */
+  class?: string;
+}

--- a/packages/components/src/components/page-header/page-header.types.ts
+++ b/packages/components/src/components/page-header/page-header.types.ts
@@ -23,9 +23,9 @@ export type PageHeaderProps = Omit<
  * snippets, while schema-driven consumers use their string variants.
  */
 export interface PageHeaderSchemaProps {
-  /** Page-level heading text rendered inside `<h1>`. */
+  /** Page-level heading text rendered inside `<h1>`; the runtime API also accepts a template-only snippet. */
   title: string;
-  /** Optional supporting text rendered below the title. */
+  /** Optional supporting text rendered below the title; the runtime API also accepts a template-only snippet. */
   description?: string;
   /** Additional class names merged with `.cinder-page-header`. */
   class?: string;

--- a/packages/playground/src/examples/page-header/basic.example.svelte
+++ b/packages/playground/src/examples/page-header/basic.example.svelte
@@ -6,6 +6,7 @@
 
 <script lang="ts">
   import { Button } from '@lostgradient/cinder/button';
+  import { Breadcrumbs } from '@lostgradient/cinder/breadcrumbs';
   import { PageHeader } from '@lostgradient/cinder/page-header';
 </script>
 
@@ -16,7 +17,7 @@
 <div style="margin-top: var(--cinder-space-4);">
   <PageHeader>
     {#snippet breadcrumbs()}
-      <nav aria-label="Breadcrumb"><a href="/">Home</a> / Schedules</nav>
+      <Breadcrumbs items={[{ label: 'Home', href: '/' }, { label: 'Schedules' }]} />
     {/snippet}
     {#snippet title()}Schedules{/snippet}
     {#snippet description()}Create and manage recurring automation schedules.{/snippet}

--- a/packages/playground/src/examples/page-header/basic.example.svelte
+++ b/packages/playground/src/examples/page-header/basic.example.svelte
@@ -1,7 +1,7 @@
 <script lang="ts" module>
   export const title = 'Basic page header';
   export const description =
-    'Page-level heading with optional metadata and right-aligned actions using the default snippet.';
+    'Page-level heading with named title, description, breadcrumb, and action regions.';
 </script>
 
 <script lang="ts">
@@ -10,11 +10,18 @@
 </script>
 
 <div>
-  <PageHeader title="Approvals" meta="3 pending · 12 resolved" />
+  <PageHeader title="Approvals" description="3 pending · 12 resolved" />
 </div>
 
 <div style="margin-top: var(--cinder-space-4);">
-  <PageHeader title="Schedules" meta="No schedules">
-    <Button variant="primary" size="sm" label="+ New schedule" />
+  <PageHeader>
+    {#snippet breadcrumbs()}
+      <nav aria-label="Breadcrumb"><a href="/">Home</a> / Schedules</nav>
+    {/snippet}
+    {#snippet title()}Schedules{/snippet}
+    {#snippet description()}Create and manage recurring automation schedules.{/snippet}
+    {#snippet actions()}
+      <Button variant="primary" size="sm" label="+ New schedule" />
+    {/snippet}
   </PageHeader>
 </div>


### PR DESCRIPTION
Closes #966

## Summary
- replace PageHeader’s generic child/meta contract with named title, description, breadcrumbs, and actions regions
- allow text-first title and description regions to accept either strings or snippets while retaining component-owned semantics
- document the library-wide strings-versus-snippets policy and regenerate PageHeader metadata/examples
- include a pre-release migration note for `meta` → `description` and `children` → `actions`

## Verification
- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 src/components/page-header/page-header.test.ts` (5 passed)
- `bun run --filter=@lostgradient/cinder typecheck` (0 errors)
- `bun run --filter=@lostgradient/cinder components:check`
- focused Stylelint, type-aware Oxlint, Prettier, and `git diff --check`
- official Svelte autofixer: no issues
- playground visual review at 1280×720 in light and dark themes