### PR TITLE
fix(number-input): use Lucide stepper icons

### DIFF
--- a/.changeset/number-input-lucide-steppers.md
+++ b/.changeset/number-input-lucide-steppers.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Replace NumberInput stepper text glyphs with the canonical Lucide plus and minus icons.

--- a/packages/components/src/components/number-input/number-input.a11y.md
+++ b/packages/components/src/components/number-input/number-input.a11y.md
@@ -45,7 +45,7 @@ collide with stepping.
 
 - Two `<button type="button">`. `type="button"` matters inside a form — without it, clicking either
   button submits the form.
-- Visible glyphs (`+` and U+2212 minus) are `aria-hidden="true"`; the accessible name comes from
+- Lucide `Plus` and `Minus` SVG icons are `aria-hidden="true"`; the accessible name comes from
   `aria-label="Increment"` / `aria-label="Decrement"`.
 - Stepper buttons use the native `disabled` attribute at boundaries — not `aria-disabled`. This
   removes them from the tab order, which matches user expectation when the value is already at the

--- a/packages/components/src/components/number-input/number-input.svelte
+++ b/packages/components/src/components/number-input/number-input.svelte
@@ -16,6 +16,8 @@
 </script>
 
 <script lang="ts">
+  import Minus from 'lucide-svelte/icons/minus';
+  import Plus from 'lucide-svelte/icons/plus';
   import type { NumberInputProps } from './number-input.types.ts';
   import { untrack } from 'svelte';
 
@@ -569,7 +571,7 @@
       tabindex="-1"
       onclick={() => stepBy('increment')}
     >
-      <span aria-hidden="true">+</span>
+      <Plus class="cinder-icon-sm" aria-hidden="true" />
     </button>
     <button
       type="button"
@@ -579,7 +581,7 @@
       tabindex="-1"
       onclick={() => stepBy('decrement')}
     >
-      <span aria-hidden="true">&#x2212;</span>
+      <Minus class="cinder-icon-sm" aria-hidden="true" />
     </button>
   </div>
 

--- a/packages/components/src/components/number-input/number-input.test.ts
+++ b/packages/components/src/components/number-input/number-input.test.ts
@@ -53,7 +53,7 @@ async function focus(input: HTMLInputElement) {
 
 describe('NumberInput basics', () => {
   test('renders Lucide icons for the stepper controls', () => {
-    const { container } = render(NumberInput, { value: 2 });
+    const { container } = render(NumberInput, { props: { id: 'n', value: 2 } });
 
     expect(getIncrement(container).querySelector('svg.lucide-plus')).not.toBeNull();
     expect(getDecrement(container).querySelector('svg.lucide-minus')).not.toBeNull();

--- a/packages/components/src/components/number-input/number-input.test.ts
+++ b/packages/components/src/components/number-input/number-input.test.ts
@@ -52,6 +52,15 @@ async function focus(input: HTMLInputElement) {
 }
 
 describe('NumberInput basics', () => {
+  test('renders Lucide icons for the stepper controls', () => {
+    const { container } = render(NumberInput, { value: 2 });
+
+    expect(getIncrement(container).querySelector('svg.lucide-plus')).not.toBeNull();
+    expect(getDecrement(container).querySelector('svg.lucide-minus')).not.toBeNull();
+    expect(getIncrement(container).textContent?.trim()).toBe('');
+    expect(getDecrement(container).textContent?.trim()).toBe('');
+  });
+
   test('type surface excludes inherited defaultValue', () => {
     const excludesInheritedDefaultValue: 'defaultValue' extends keyof NumberInputProps
       ? false


### PR DESCRIPTION
Closes #1014\n\n## Summary\n- replace NumberInput increment/decrement text glyphs with Lucide Plus and Minus icons\n- preserve existing accessible labels and stepper behavior\n- add a regression asserting icon output and no visible text glyphs\n\n## Verification\n- bun run --filter=@lostgradient/cinder test -- ./src/components/number-input/number-input.test.ts\n- bun run --filter=@lostgradient/cinder typecheck