### PR TITLE
fix(components): replace text glyph affordances

### DIFF
--- a/.changeset/lucide-interactive-affordances.md
+++ b/.changeset/lucide-interactive-affordances.md
@@ -1,0 +1,6 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Replace remaining add and disclosure text glyphs in InvocationRuleBuilder,
+MultiSelect, and JsonSchemaEditor with consistently sized Lucide icons.

--- a/packages/components/src/components/invocation-rule-builder/invocation-rule-builder.svelte
+++ b/packages/components/src/components/invocation-rule-builder/invocation-rule-builder.svelte
@@ -28,6 +28,7 @@
 </script>
 
 <script lang="ts">
+  import Plus from 'lucide-svelte/icons/plus';
   import { tick } from 'svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import Combobox from '../combobox/combobox.svelte';
@@ -771,7 +772,8 @@
             data-irb-add-condition
             onclick={() => handleAddCondition(rule.id)}
           >
-            + {addConditionLabel}
+            <Plus size={14} strokeWidth={2.25} aria-hidden="true" />
+            {addConditionLabel}
           </button>
         {/if}
       </div>
@@ -857,7 +859,8 @@
               data-irb-add-action
               onclick={() => handleAddAction(rule.id)}
             >
-              + {addActionLabel}
+              <Plus size={14} strokeWidth={2.25} aria-hidden="true" />
+              {addActionLabel}
             </button>
           {/if}
         </div>
@@ -872,7 +875,8 @@
       data-irb-add-rule
       onclick={handleAddRule}
     >
-      + {addRuleLabel}
+      <Plus size={14} strokeWidth={2.25} aria-hidden="true" />
+      {addRuleLabel}
     </button>
   {/if}
 

--- a/packages/components/src/components/invocation-rule-builder/invocation-rule-builder.test.ts
+++ b/packages/components/src/components/invocation-rule-builder/invocation-rule-builder.test.ts
@@ -338,6 +338,21 @@ describe('InvocationRuleBuilder', () => {
       expect(container.querySelector('[data-irb-add-rule]')).not.toBeNull();
     });
 
+    test('renders Lucide icons without text glyphs in add controls', () => {
+      const { container } = renderBuilder([makeRule()]);
+      const controls = [
+        ['[data-irb-add-condition]', 'Add condition'],
+        ['[data-irb-add-action]', 'Add action'],
+        ['[data-irb-add-rule]', 'Add rule'],
+      ] as const;
+
+      for (const [selector, label] of controls) {
+        const control = container.querySelector<HTMLButtonElement>(selector);
+        expect(control?.querySelector('svg')).not.toBeNull();
+        expect(control?.textContent?.trim()).toBe(label);
+      }
+    });
+
     test('does not render add-rule button in readonly mode', () => {
       const { container } = renderBuilder([makeRule()], { readonly: true });
       expect(container.querySelector('[data-irb-add-rule]')).toBeNull();

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.css
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.css
@@ -241,16 +241,14 @@
   }
 
   .cinder-jse-property-row__chevron {
-    display: inline-block;
-    font-size: var(--cinder-text-xs);
+    display: block;
+    flex: 0 0 auto;
     color: var(--cinder-text-subtle);
-    transition: transform var(--cinder-duration-fast) ease;
-    width: 0.75rem;
-    text-align: center;
+    transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
   .cinder-jse-property-row__trigger[aria-expanded='true'] > .cinder-jse-property-row__chevron {
-    transform: rotate(90deg);
+    transform: rotate(180deg);
   }
 
   .cinder-jse-property-row__name {

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -14,6 +14,7 @@
 </script>
 
 <script lang="ts">
+  import ChevronDown from 'lucide-svelte/icons/chevron-down';
   import { onDestroy } from 'svelte';
   import Alert from '../alert/alert.svelte';
   import Button from '../button/button.svelte';
@@ -232,7 +233,12 @@
           aria-controls={panelId}
           onclick={() => toggleExpanded(key, isOpen)}
         >
-          <span class="cinder-jse-property-row__chevron" aria-hidden="true">▸</span>
+          <ChevronDown
+            class="cinder-jse-property-row__chevron"
+            size={14}
+            strokeWidth={2}
+            aria-hidden="true"
+          />
           <span class="cinder-jse-property-row__name">{key}</span>
           <span class="cinder-jse-property-row__type">{summariseType(properties[key] ?? {})}</span>
         </button>

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -16,6 +16,29 @@ const { calculatePropertyValidationErrorCount } = await import('./property-list-
 afterEach(() => cleanup());
 
 describe('PropertyList', () => {
+  test('uses a rotating Lucide chevron for property disclosure', async () => {
+    const { container } = render(PropertyList, {
+      idPrefix: 'properties',
+      path: '/properties',
+      properties: { name: { type: 'string' } },
+      required: [],
+      onchange: () => {},
+    });
+
+    const trigger = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Expand name property"]',
+    );
+    const chevron = trigger?.querySelector('.cinder-jse-property-row__chevron');
+    expect(chevron?.tagName.toLowerCase()).toBe('svg');
+    expect(trigger?.textContent).not.toContain('▸');
+    expect(trigger?.getAttribute('aria-expanded')).toBe('false');
+
+    const css = await Bun.file(new URL('./json-schema-editor.css', import.meta.url)).text();
+    expect(css).toMatch(
+      /\.cinder-jse-property-row__trigger\[aria-expanded='true'\]\s*>\s*\.cinder-jse-property-row__chevron\s*\{[^}]*transform:\s*rotate\(180deg\)/,
+    );
+  });
+
   test('can add the first required-only property name', async () => {
     let latestRequired: string[] = [];
     const { container } = render(PropertyList, {

--- a/packages/components/src/components/multi-select/multi-select.svelte
+++ b/packages/components/src/components/multi-select/multi-select.svelte
@@ -22,6 +22,7 @@
 </script>
 
 <script lang="ts" generics="T extends string = string">
+  import ChevronDown from 'lucide-svelte/icons/chevron-down';
   import { tick, untrack } from 'svelte';
 
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
@@ -432,7 +433,9 @@
       {#if selectedCount > 0}
         <span class="cinder-multi-select__count" aria-hidden="true">{selectedCount}</span>
       {/if}
-      <span class="cinder-multi-select__chevron" aria-hidden="true">▾</span>
+      <span class="cinder-multi-select__chevron" aria-hidden="true">
+        <ChevronDown size={16} strokeWidth={2} />
+      </span>
     </button>
 
     {#if selectedCount > 0 && !field.disabled && !readonly}

--- a/packages/components/src/components/multi-select/multi-select.test.ts
+++ b/packages/components/src/components/multi-select/multi-select.test.ts
@@ -38,6 +38,9 @@ describe('MultiSelect', () => {
   test('renders trigger, placeholder, and listbox semantics', async () => {
     const { container } = render(MultiSelect, { id: 'fruits', items });
     expect(container.querySelector('#fruits')?.textContent).toContain('Select options');
+    const chevron = container.querySelector('.cinder-multi-select__chevron');
+    expect(chevron?.querySelector('svg')).not.toBeNull();
+    expect(chevron?.textContent?.trim()).toBe('');
     await openMenu(container);
     const listbox = container.querySelector('[role="listbox"]');
     expect(listbox?.getAttribute('aria-multiselectable')).toBe('true');


### PR DESCRIPTION
Closes #1017

## Summary

- replace InvocationRuleBuilder add-control text glyphs with sized Lucide Plus icons
- replace MultiSelect and JsonSchemaEditor disclosure glyphs with sized Lucide ChevronDown icons
- preserve labels, keyboard behavior, disclosure state, and add focused regression coverage

## Validation

- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 src/components/invocation-rule-builder/invocation-rule-builder.test.ts src/components/multi-select/multi-select.test.ts src/components/json-schema-editor/property-list.test.ts` (171 pass)
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `bunx stylelint packages/components/src/components/json-schema-editor/json-schema-editor.css`
- `bunx oxlint --type-aware --deny-warnings` on the three changed test files
- `bunx prettier --check` on all changed files
- official Svelte autofixer: zero issues in all three changed components