### PR TITLE
feat(playground): group compound component families

### DIFF
--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -95,4 +95,22 @@ describe('static export', () => {
       await rm(outputDirectory, { recursive: true, force: true });
     }
   }, 120_000);
+
+  test('materializes shell routes for compose-only family children', async () => {
+    const outputDirectory = await mkdtemp(join(tmpdir(), 'cinder-static-export-family-'));
+    try {
+      const rendered = await runStaticExport({
+        outputDirectory,
+        sidebarComponents: ['accordion'],
+        allComponents: [],
+      });
+      expect(rendered.has('/c/accordion')).toBe(true);
+      expect(rendered.has('/c/accordion-item')).toBe(true);
+      await expect(
+        readFile(join(outputDirectory, 'c', 'accordion-item', 'index.html'), 'utf8'),
+      ).resolves.toContain('data-canonical-documentation');
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true });
+    }
+  }, 120_000);
 });

--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -96,18 +96,18 @@ describe('static export', () => {
     }
   }, 120_000);
 
-  test('materializes shell routes for compose-only family children', async () => {
+  test('materializes shell routes for navigable family children', async () => {
     const outputDirectory = await mkdtemp(join(tmpdir(), 'cinder-static-export-family-'));
     try {
       const rendered = await runStaticExport({
         outputDirectory,
-        sidebarComponents: ['accordion'],
+        sidebarComponents: ['chat'],
         allComponents: [],
       });
-      expect(rendered.has('/c/accordion')).toBe(true);
-      expect(rendered.has('/c/accordion-item')).toBe(true);
+      expect(rendered.has('/c/chat')).toBe(true);
+      expect(rendered.has('/c/chat-composer-popover')).toBe(true);
       await expect(
-        readFile(join(outputDirectory, 'c', 'accordion-item', 'index.html'), 'utf8'),
+        readFile(join(outputDirectory, 'c', 'chat-composer-popover', 'index.html'), 'utf8'),
       ).resolves.toContain('data-canonical-documentation');
     } finally {
       await rm(outputDirectory, { recursive: true, force: true });

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -36,6 +36,7 @@ import {
   discoverSidebarComponents,
 } from '../src/discover.ts';
 import { handleRequest } from '../src/playground-server.ts';
+import { COMPOUND_COMPONENT_FAMILIES } from '../src/shell-app/compound-families.ts';
 
 const PLAYGROUND_ROOT = join(import.meta.dirname, '..');
 const OUTPUT_DIRECTORY = join(PLAYGROUND_ROOT, 'public');
@@ -224,6 +225,12 @@ export async function runStaticExport(options: StaticExportOptions = {}): Promis
 
   const sidebarComponents = options.sidebarComponents ?? (await discoverSidebarComponents());
   const allComponents = options.allComponents ?? (await discoverComponents());
+  const sidebarRoutes = [
+    ...new Set([
+      ...sidebarComponents,
+      ...sidebarComponents.flatMap((name) => COMPOUND_COMPONENT_FAMILIES[name] ?? []),
+    ]),
+  ];
   if (sidebarComponents.length === 0) {
     throw new Error('[static-export] no sidebar components discovered — nothing to render');
   }
@@ -255,7 +262,7 @@ export async function runStaticExport(options: StaticExportOptions = {}): Promis
       await render(`/example-src/${name}/${scenario}`, context);
     }
   }
-  for (const name of sidebarComponents) {
+  for (const name of sidebarRoutes) {
     const shellHtml = await render(`/c/${name}`, context);
     if (shellHtml !== null) collect(shellHtml);
   }

--- a/packages/playground/src/discover.ts
+++ b/packages/playground/src/discover.ts
@@ -62,6 +62,20 @@ export const COMPOSE_ONLY_COMPONENTS: ReadonlySet<string> = new Set([
 ]);
 
 /**
+ * Explicit compound-family relationships used by the playground shell.
+ * Keeping this list keyed by component id makes the relationship reviewable
+ * metadata instead of relying on a naming-prefix heuristic. Leaves remain
+ * independently routable; the sidebar simply presents them under their root.
+ */
+export const COMPOUND_COMPONENT_FAMILIES: Readonly<Record<string, readonly string[]>> = {
+  accordion: ['accordion-item'],
+  'bento-grid': ['bento-cell'],
+  card: [],
+  table: ['table-body', 'table-cell', 'table-header', 'table-header-cell', 'table-row'],
+  chat: ['chat-composer-popover', 'chat-conversation-header', 'chat-conversation-list'],
+};
+
+/**
  * Scans a component-source root for the absolute paths of every public
  * component `.svelte` file. Covers both the legacy flat layout
  * (`<root>/<name>.svelte`) and the per-directory migrated layout

--- a/packages/playground/src/discover.ts
+++ b/packages/playground/src/discover.ts
@@ -9,6 +9,7 @@
 import { basename, dirname, join } from 'node:path';
 
 import { COMPONENT_SOURCES, type ComponentSource } from './component-sources.ts';
+export { COMPOUND_COMPONENT_FAMILIES } from './shell-app/compound-families.ts';
 
 // import.meta.dirname is packages/playground/src/
 const PLAYGROUND_ROOT = dirname(import.meta.dirname); // packages/playground/
@@ -67,14 +68,6 @@ export const COMPOSE_ONLY_COMPONENTS: ReadonlySet<string> = new Set([
  * metadata instead of relying on a naming-prefix heuristic. Leaves remain
  * independently routable; the sidebar simply presents them under their root.
  */
-export const COMPOUND_COMPONENT_FAMILIES: Readonly<Record<string, readonly string[]>> = {
-  accordion: ['accordion-item'],
-  'bento-grid': ['bento-cell'],
-  card: [],
-  table: ['table-body', 'table-cell', 'table-header', 'table-header-cell', 'table-row'],
-  chat: ['chat-composer-popover', 'chat-conversation-header', 'chat-conversation-list'],
-};
-
 /**
  * Scans a component-source root for the absolute paths of every public
  * component `.svelte` file. Covers both the legacy flat layout

--- a/packages/playground/src/shell-app/compound-families.ts
+++ b/packages/playground/src/shell-app/compound-families.ts
@@ -1,0 +1,8 @@
+/** Browser-safe compound component relationships used by the playground shell. */
+export const COMPOUND_COMPONENT_FAMILIES: Readonly<Record<string, readonly string[]>> = {
+  accordion: ['accordion-item'],
+  'bento-grid': ['bento-cell'],
+  card: [],
+  table: ['table-body', 'table-cell', 'table-header', 'table-header-cell', 'table-row'],
+  chat: ['chat-composer-popover', 'chat-conversation-header', 'chat-conversation-list'],
+};

--- a/packages/playground/src/shell-app/compound-families.ts
+++ b/packages/playground/src/shell-app/compound-families.ts
@@ -1,8 +1,21 @@
 /** Browser-safe compound component relationships used by the playground shell. */
 export const COMPOUND_COMPONENT_FAMILIES: Readonly<Record<string, readonly string[]>> = {
-  accordion: ['accordion-item'],
-  'bento-grid': ['bento-cell'],
+  accordion: [],
+  'bento-grid': [],
   card: [],
-  table: ['table-body', 'table-cell', 'table-header', 'table-header-cell', 'table-row'],
+  table: [],
   chat: ['chat-composer-popover', 'chat-conversation-header', 'chat-conversation-list'],
+};
+
+export const COMPOUND_COMPONENT_PARENTS: Readonly<Record<string, string>> = {
+  'accordion-item': 'accordion',
+  'bento-cell': 'bento-grid',
+  'table-body': 'table',
+  'table-cell': 'table',
+  'table-header': 'table',
+  'table-header-cell': 'table',
+  'table-row': 'table',
+  'chat-composer-popover': 'chat',
+  'chat-conversation-header': 'chat',
+  'chat-conversation-list': 'chat',
 };

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -90,7 +90,8 @@
   $effect(() => {
     if (!restoredExpansion) return;
     try {
-      sessionStorage.setItem(EXPANSION_SESSION_KEY, JSON.stringify(expandedFamilies));
+      const expansionToPersist = filterWasActive ? savedExpansion : expandedFamilies;
+      sessionStorage.setItem(EXPANSION_SESSION_KEY, JSON.stringify(expansionToPersist));
     } catch {
       /* ignore — degraded but functional */
     }

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -53,7 +53,9 @@
   let savedExpansion: Record<string, boolean> = {};
   let filterWasActive = false;
   let restoredSessionFilter = $state(false);
+  let restoredExpansion = $state(false);
   const FILTER_SESSION_KEY = 'cinder-playground-sidebar-filter';
+  const EXPANSION_SESSION_KEY = 'cinder-playground-sidebar-expansion';
 
   onMount(() => {
     try {
@@ -61,13 +63,34 @@
     } catch {
       filter = '';
     }
+    try {
+      const stored = sessionStorage.getItem(EXPANSION_SESSION_KEY);
+      if (stored !== null) {
+        const parsed = JSON.parse(stored);
+        if (parsed !== null && typeof parsed === 'object') {
+          expandedFamilies = { ...expandedFamilies, ...parsed };
+        }
+      }
+    } catch {
+      /* ignore — degraded but functional */
+    }
     restoredSessionFilter = true;
+    restoredExpansion = true;
   });
 
   $effect(() => {
     if (!restoredSessionFilter) return;
     try {
       sessionStorage.setItem(FILTER_SESSION_KEY, filter);
+    } catch {
+      /* ignore — degraded but functional */
+    }
+  });
+
+  $effect(() => {
+    if (!restoredExpansion) return;
+    try {
+      sessionStorage.setItem(EXPANSION_SESSION_KEY, JSON.stringify(expandedFamilies));
     } catch {
       /* ignore — degraded but functional */
     }
@@ -140,6 +163,7 @@
       }
       const parentMatches = matchesCurrentFilter(name);
       const matchingChildren = children.filter((child) => matchesCurrentFilter(child));
+      if (filter.trim() === '' && !expandedFamilies[name]) continue;
       if (parentMatches || matchingChildren.length > 0) count += 1;
       for (const child of children) {
         if (filter.trim() === '' || parentMatches || matchesCurrentFilter(child)) {

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -138,9 +138,11 @@
         if (matchesCurrentFilter(name)) count += 1;
         continue;
       }
-      if (matchesCurrentFilter(name)) count += 1;
+      const parentMatches = matchesCurrentFilter(name);
+      const matchingChildren = children.filter((child) => matchesCurrentFilter(child));
+      if (parentMatches || matchingChildren.length > 0) count += 1;
       for (const child of children) {
-        if (filter.trim() === '' || matchesCurrentFilter(name) || matchesCurrentFilter(child)) {
+        if (filter.trim() === '' || parentMatches || matchesCurrentFilter(child)) {
           count += 1;
         }
       }

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -56,6 +56,7 @@
   let restoredExpansion = $state(false);
   const FILTER_SESSION_KEY = 'cinder-playground-sidebar-filter';
   const EXPANSION_SESSION_KEY = 'cinder-playground-sidebar-expansion';
+  const filterIsActive = $derived(filter.trim() !== '');
 
   onMount(() => {
     try {
@@ -90,7 +91,7 @@
   $effect(() => {
     if (!restoredExpansion) return;
     try {
-      const expansionToPersist = filterWasActive ? savedExpansion : expandedFamilies;
+      const expansionToPersist = filterIsActive ? savedExpansion : expandedFamilies;
       sessionStorage.setItem(EXPANSION_SESSION_KEY, JSON.stringify(expansionToPersist));
     } catch {
       /* ignore — degraded but functional */
@@ -125,9 +126,10 @@
   }
 
   $effect(() => {
-    const filterIsActive = filter.trim() !== '';
     if (filterIsActive && !filterWasActive) {
       savedExpansion = { ...expandedFamilies };
+    }
+    if (filterIsActive) {
       for (const name of navigationComponents) {
         if ((COMPOUND_COMPONENT_FAMILIES[name] ?? []).length > 0) {
           expandedFamilies[name] = true;

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -105,9 +105,45 @@
     return undefined;
   }
 
+  // Include a family root whenever a caller supplies one of its children. The
+  // production discovery list intentionally omits compose-only leaves, but
+  // filtered or fixture-driven callers may provide a child directly.
+  const navigationComponents = $derived.by(() => {
+    const result: string[] = [];
+    for (const name of components) {
+      const root = familyParent(name) ?? name;
+      if (!result.includes(root)) {
+        result.push(root);
+      }
+      if (!result.includes(name)) {
+        result.push(name);
+      }
+    }
+    return result;
+  });
+
+  const renderedComponentCount = $derived.by(() => {
+    const needle = filter.trim();
+    let count = 0;
+    for (const name of navigationComponents) {
+      const children = COMPOUND_COMPONENT_FAMILIES[name] ?? [];
+      if (children.length === 0) {
+        if (matchesCurrentFilter(name)) count += 1;
+        continue;
+      }
+      if (matchesCurrentFilter(name)) count += 1;
+      for (const child of children) {
+        if (needle === '' || matchesCurrentFilter(name) || matchesCurrentFilter(child)) {
+          count += 1;
+        }
+      }
+    }
+    return count;
+  });
+
   // Announced to assistive technology whenever the filtered count changes.
   const resultSummary = $derived(
-    `${visibleComponents.length} component${visibleComponents.length === 1 ? '' : 's'} shown`,
+    `${renderedComponentCount} component${renderedComponentCount === 1 ? '' : 's'} shown`,
   );
 
   // A "plain" left-click is the only gesture we handle through `onSelect`.
@@ -203,7 +239,7 @@
     </button>
   </div>
   <SideNavigation ariaLabel="Components" {@attach interceptNavClicks}>
-    {#each components as name (name)}
+    {#each navigationComponents as name (name)}
       {#if familyParent(name) === undefined}
         {#if matchesCurrentFilter(name) && (COMPOUND_COMPONENT_FAMILIES[name] ?? []).length === 0}
           <SideNavigationItem
@@ -213,7 +249,7 @@
           >
             {humanizeComponentName(name)}
           </SideNavigationItem>
-        {:else if matchesCurrentFilter(name)}
+        {:else if matchesCurrentFilter(name) || (COMPOUND_COMPONENT_FAMILIES[name] ?? []).some(matchesCurrentFilter)}
           {#key filter.trim()}
             <SideNavigationGroup label={humanizeComponentName(name)}>
               <SideNavigationItem

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -75,6 +75,9 @@
     } catch {
       /* ignore — degraded but functional */
     }
+    if (filter.trim() !== '') {
+      savedExpansion = { ...expandedFamilies };
+    }
     restoredSessionFilter = true;
     restoredExpansion = true;
   });

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -20,7 +20,7 @@
   import { humanizeComponentName } from './humanize.ts';
   import { buildShellHref, parseComponentFromPath } from './routing.ts';
   import { persistScrollPosition } from './sidebar-scroll.ts';
-  import { COMPOUND_COMPONENT_FAMILIES } from '../discover.ts';
+  import { COMPOUND_COMPONENT_FAMILIES } from './compound-families.ts';
 
   type Props = {
     components: string[];
@@ -89,22 +89,21 @@
     });
   });
 
-  const groupedComponents = $derived.by(() => {
-    const visible = visibleComponents;
-    const consumed: string[] = [];
-    const groups: Array<{ parent: string; children: string[] }> = [];
+  function matchesCurrentFilter(name: string): boolean {
+    const needle = filter.trim().toLowerCase();
+    return (
+      needle === '' ||
+      name.toLowerCase().includes(needle) ||
+      humanizeComponentName(name).toLowerCase().includes(needle)
+    );
+  }
+
+  function familyParent(name: string): string | undefined {
     for (const [parent, children] of Object.entries(COMPOUND_COMPONENT_FAMILIES)) {
-      if (!visible.includes(parent)) continue;
-      const family = children.filter((child) => visible.includes(child));
-      if (family.length === 0) continue;
-      groups.push({ parent, children: family });
-      consumed.push(parent, ...family);
+      if (children.includes(name)) return parent;
     }
-    return {
-      groups,
-      standalone: visibleComponents.filter((name) => !consumed.includes(name)),
-    };
-  });
+    return undefined;
+  }
 
   // Announced to assistive technology whenever the filtered count changes.
   const resultSummary = $derived(
@@ -204,25 +203,9 @@
     </button>
   </div>
   <SideNavigation ariaLabel="Components" {@attach interceptNavClicks}>
-    {#each groupedComponents.standalone as name (name)}
-      <SideNavigationItem
-        href={buildShellHref(name)}
-        active={name === currentComponent}
-        onclick={(event) => handleClick(event, name)}
-      >
-        {humanizeComponentName(name)}
-      </SideNavigationItem>
-    {/each}
-    {#each groupedComponents.groups as group (group.parent)}
-      <SideNavigationGroup label={humanizeComponentName(group.parent)}>
-        <SideNavigationItem
-          href={buildShellHref(group.parent)}
-          active={group.parent === currentComponent}
-          onclick={(event) => handleClick(event, group.parent)}
-        >
-          {humanizeComponentName(group.parent)}
-        </SideNavigationItem>
-        {#each group.children as name (name)}
+    {#each components as name (name)}
+      {#if familyParent(name) === undefined}
+        {#if matchesCurrentFilter(name) && (COMPOUND_COMPONENT_FAMILIES[name] ?? []).length === 0}
           <SideNavigationItem
             href={buildShellHref(name)}
             active={name === currentComponent}
@@ -230,8 +213,30 @@
           >
             {humanizeComponentName(name)}
           </SideNavigationItem>
-        {/each}
-      </SideNavigationGroup>
+        {:else if matchesCurrentFilter(name)}
+          {#key filter.trim()}
+            <SideNavigationGroup label={humanizeComponentName(name)}>
+              <SideNavigationItem
+                href={buildShellHref(name)}
+                active={name === currentComponent}
+                onclick={(event) => handleClick(event, name)}
+              >
+                {humanizeComponentName(name)}
+              </SideNavigationItem>
+              {#each COMPOUND_COMPONENT_FAMILIES[name] ?? [] as child (child)}
+                {#if filter.trim() === '' || matchesCurrentFilter(name) || matchesCurrentFilter(child)}
+                  <SideNavigationItem
+                    href={buildShellHref(child)}
+                    active={child === currentComponent}
+                  >
+                    {humanizeComponentName(child)}
+                  </SideNavigationItem>
+                {/if}
+              {/each}
+            </SideNavigationGroup>
+          {/key}
+        {/if}
+      {/if}
     {/each}
   </SideNavigation>
   {#if visibleComponents.length === 0}

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -13,12 +13,14 @@
   import {
     Input,
     SideNavigation,
+    SideNavigationGroup,
     SideNavigationItem,
     VisuallyHidden,
   } from '../../../components/src/index.ts';
   import { humanizeComponentName } from './humanize.ts';
   import { buildShellHref, parseComponentFromPath } from './routing.ts';
   import { persistScrollPosition } from './sidebar-scroll.ts';
+  import { COMPOUND_COMPONENT_FAMILIES } from '../discover.ts';
 
   type Props = {
     components: string[];
@@ -85,6 +87,23 @@
       if (name.toLowerCase().includes(needle)) return true;
       return humanizeComponentName(name).toLowerCase().includes(needle);
     });
+  });
+
+  const groupedComponents = $derived.by(() => {
+    const visible = visibleComponents;
+    const consumed: string[] = [];
+    const groups: Array<{ parent: string; children: string[] }> = [];
+    for (const [parent, children] of Object.entries(COMPOUND_COMPONENT_FAMILIES)) {
+      if (!visible.includes(parent)) continue;
+      const family = children.filter((child) => visible.includes(child));
+      if (family.length === 0) continue;
+      groups.push({ parent, children: family });
+      consumed.push(parent, ...family);
+    }
+    return {
+      groups,
+      standalone: visibleComponents.filter((name) => !consumed.includes(name)),
+    };
   });
 
   // Announced to assistive technology whenever the filtered count changes.
@@ -185,7 +204,7 @@
     </button>
   </div>
   <SideNavigation ariaLabel="Components" {@attach interceptNavClicks}>
-    {#each visibleComponents as name (name)}
+    {#each groupedComponents.standalone as name (name)}
       <SideNavigationItem
         href={buildShellHref(name)}
         active={name === currentComponent}
@@ -193,6 +212,26 @@
       >
         {humanizeComponentName(name)}
       </SideNavigationItem>
+    {/each}
+    {#each groupedComponents.groups as group (group.parent)}
+      <SideNavigationGroup label={humanizeComponentName(group.parent)}>
+        <SideNavigationItem
+          href={buildShellHref(group.parent)}
+          active={group.parent === currentComponent}
+          onclick={(event) => handleClick(event, group.parent)}
+        >
+          {humanizeComponentName(group.parent)}
+        </SideNavigationItem>
+        {#each group.children as name (name)}
+          <SideNavigationItem
+            href={buildShellHref(name)}
+            active={name === currentComponent}
+            onclick={(event) => handleClick(event, name)}
+          >
+            {humanizeComponentName(name)}
+          </SideNavigationItem>
+        {/each}
+      </SideNavigationGroup>
     {/each}
   </SideNavigation>
   {#if visibleComponents.length === 0}

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -78,17 +78,6 @@
     }
   }
 
-  // Case-insensitive substring match against both the humanized label and the
-  // raw kebab name, so "side nav" and "side-nav" both find side-navigation.
-  const visibleComponents = $derived.by(() => {
-    const needle = filter.trim().toLowerCase();
-    if (needle === '') return components;
-    return components.filter((name) => {
-      if (name.toLowerCase().includes(needle)) return true;
-      return humanizeComponentName(name).toLowerCase().includes(needle);
-    });
-  });
-
   function matchesCurrentFilter(name: string): boolean {
     const needle = filter.trim().toLowerCase();
     return (

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -259,7 +259,7 @@
         {:else if matchesCurrentFilter(name) || (COMPOUND_COMPONENT_FAMILIES[name] ?? []).some(matchesCurrentFilter)}
           <SideNavigationGroup
             label={humanizeComponentName(name)}
-            bind:expanded={expandedFamilies[name]}
+            bind:expanded={expandedFamilies[name]!}
           >
             <SideNavigationItem
               href={buildShellHref(name)}

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -20,7 +20,7 @@
   import { humanizeComponentName } from './humanize.ts';
   import { buildShellHref, parseComponentFromPath } from './routing.ts';
   import { persistScrollPosition } from './sidebar-scroll.ts';
-  import { COMPOUND_COMPONENT_FAMILIES } from './compound-families.ts';
+  import { COMPOUND_COMPONENT_FAMILIES, COMPOUND_COMPONENT_PARENTS } from './compound-families.ts';
 
   type Props = {
     components: string[];
@@ -99,10 +99,7 @@
   }
 
   function familyParent(name: string): string | undefined {
-    for (const [parent, children] of Object.entries(COMPOUND_COMPONENT_FAMILIES)) {
-      if (children.includes(name)) return parent;
-    }
-    return undefined;
+    return COMPOUND_COMPONENT_PARENTS[name];
   }
 
   // Include a family root whenever a caller supplies one of its children. The
@@ -115,15 +112,11 @@
       if (!result.includes(root)) {
         result.push(root);
       }
-      if (!result.includes(name)) {
-        result.push(name);
-      }
     }
     return result;
   });
 
   const renderedComponentCount = $derived.by(() => {
-    const needle = filter.trim();
     let count = 0;
     for (const name of navigationComponents) {
       const children = COMPOUND_COMPONENT_FAMILIES[name] ?? [];
@@ -133,7 +126,7 @@
       }
       if (matchesCurrentFilter(name)) count += 1;
       for (const child of children) {
-        if (needle === '' || matchesCurrentFilter(name) || matchesCurrentFilter(child)) {
+        if (filter.trim() === '' || matchesCurrentFilter(name) || matchesCurrentFilter(child)) {
           count += 1;
         }
       }
@@ -275,7 +268,7 @@
       {/if}
     {/each}
   </SideNavigation>
-  {#if visibleComponents.length === 0}
+  {#if renderedComponentCount === 0}
     <!-- Visible text only — NOT a live region. The persistent aria-live region
          below ("N components shown") is the single announcement source; marking
          this paragraph role="status" too would double-announce on zero results. -->

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -43,6 +43,15 @@
   let { components, currentComponent, onSelect, isOpen = false, onClose }: Props = $props();
 
   let filter = $state('');
+  let expandedFamilies = $state<Record<string, boolean>>({
+    accordion: true,
+    'bento-grid': true,
+    card: true,
+    table: true,
+    chat: true,
+  });
+  let savedExpansion: Record<string, boolean> = {};
+  let filterWasActive = false;
   let restoredSessionFilter = $state(false);
   const FILTER_SESSION_KEY = 'cinder-playground-sidebar-filter';
 
@@ -90,6 +99,22 @@
   function familyParent(name: string): string | undefined {
     return COMPOUND_COMPONENT_PARENTS[name];
   }
+
+  $effect(() => {
+    const filterIsActive = filter.trim() !== '';
+    if (filterIsActive && !filterWasActive) {
+      savedExpansion = { ...expandedFamilies };
+      for (const name of navigationComponents) {
+        if ((COMPOUND_COMPONENT_FAMILIES[name] ?? []).length > 0) {
+          expandedFamilies[name] = true;
+        }
+      }
+    } else if (!filterIsActive && filterWasActive) {
+      expandedFamilies = savedExpansion;
+      savedExpansion = {};
+    }
+    filterWasActive = filterIsActive;
+  });
 
   // Include a family root whenever a caller supplies one of its children. The
   // production discovery list intentionally omits compose-only leaves, but
@@ -232,27 +257,28 @@
             {humanizeComponentName(name)}
           </SideNavigationItem>
         {:else if matchesCurrentFilter(name) || (COMPOUND_COMPONENT_FAMILIES[name] ?? []).some(matchesCurrentFilter)}
-          {#key filter.trim()}
-            <SideNavigationGroup label={humanizeComponentName(name)}>
-              <SideNavigationItem
-                href={buildShellHref(name)}
-                active={name === currentComponent}
-                onclick={(event) => handleClick(event, name)}
-              >
-                {humanizeComponentName(name)}
-              </SideNavigationItem>
-              {#each COMPOUND_COMPONENT_FAMILIES[name] ?? [] as child (child)}
-                {#if filter.trim() === '' || matchesCurrentFilter(name) || matchesCurrentFilter(child)}
-                  <SideNavigationItem
-                    href={buildShellHref(child)}
-                    active={child === currentComponent}
-                  >
-                    {humanizeComponentName(child)}
-                  </SideNavigationItem>
-                {/if}
-              {/each}
-            </SideNavigationGroup>
-          {/key}
+          <SideNavigationGroup
+            label={humanizeComponentName(name)}
+            bind:expanded={expandedFamilies[name]}
+          >
+            <SideNavigationItem
+              href={buildShellHref(name)}
+              active={name === currentComponent}
+              onclick={(event) => handleClick(event, name)}
+            >
+              {humanizeComponentName(name)}
+            </SideNavigationItem>
+            {#each COMPOUND_COMPONENT_FAMILIES[name] ?? [] as child (child)}
+              {#if filter.trim() === '' || matchesCurrentFilter(name) || matchesCurrentFilter(child)}
+                <SideNavigationItem
+                  href={buildShellHref(child)}
+                  active={child === currentComponent}
+                >
+                  {humanizeComponentName(child)}
+                </SideNavigationItem>
+              {/if}
+            {/each}
+          </SideNavigationGroup>
         {/if}
       {/if}
     {/each}

--- a/packages/playground/src/shell-app/sidebar.svelte
+++ b/packages/playground/src/shell-app/sidebar.svelte
@@ -50,7 +50,7 @@
     table: true,
     chat: true,
   });
-  let savedExpansion: Record<string, boolean> = {};
+  let savedExpansion = $state<Record<string, boolean>>({});
   let filterWasActive = false;
   let restoredSessionFilter = $state(false);
   let restoredExpansion = $state(false);

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -190,6 +190,31 @@ describe('Sidebar', () => {
     expect(linkFor(container, 'chat-composer-popover')).not.toBeNull();
   });
 
+  test('restores a collapsed family after clearing a filter', async () => {
+    const { container } = render(Sidebar, {
+      props: {
+        components: ['chat', 'chat-composer-popover', 'button'],
+        currentComponent: 'chat',
+        onSelect: () => {},
+      },
+    });
+    const toggle = container.querySelector<HTMLButtonElement>(
+      '.cinder-side-navigation-group__trigger',
+    );
+    if (toggle === null) throw new Error('Expected Chat group toggle');
+    await fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    await fireEvent.input(getFilterInput(container), { target: { value: 'composer' } });
+    await tick();
+    await fireEvent.input(getFilterInput(container), { target: { value: '' } });
+    await tick();
+    expect(
+      container
+        .querySelector<HTMLButtonElement>('.cinder-side-navigation-group__trigger')
+        ?.getAttribute('aria-expanded'),
+    ).toBe('false');
+  });
+
   test('filter narrows the list by humanized name (case-insensitive)', async () => {
     const { container } = render(Sidebar, {
       props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -139,8 +139,11 @@ describe('Sidebar', () => {
       },
     });
 
-    const group = container.querySelector('.cinder-side-navigation-group');
-    expect(group?.querySelector('button[aria-expanded]')?.textContent).toContain('Chat');
+    const groupToggle = container.querySelector<HTMLButtonElement>(
+      'nav[aria-label="Components"] button[aria-expanded]',
+    );
+    expect(groupToggle?.textContent).toContain('Chat');
+    const group = groupToggle?.parentElement?.parentElement;
     expect(group?.querySelector('a[href="/c/chat"]')).not.toBeNull();
     expect(group?.querySelector('a[href="/c/chat-composer-popover"]')).not.toBeNull();
     expect(container.querySelector('a[href="/c/button"]')).not.toBeNull();
@@ -176,7 +179,7 @@ describe('Sidebar', () => {
       },
     });
     const groupToggle = container.querySelector<HTMLButtonElement>(
-      '.cinder-side-navigation-group__trigger',
+      'nav[aria-label="Components"] button[aria-expanded]',
     );
     if (groupToggle === null) throw new Error('Expected Chat group toggle');
     await fireEvent.click(groupToggle);
@@ -184,7 +187,7 @@ describe('Sidebar', () => {
     await fireEvent.input(getFilterInput(container), { target: { value: 'chat' } });
     await tick();
     const refreshedToggle = container.querySelector<HTMLButtonElement>(
-      '.cinder-side-navigation-group__trigger',
+      'nav[aria-label="Components"] button[aria-expanded]',
     );
     expect(refreshedToggle?.getAttribute('aria-expanded')).toBe('true');
     expect(linkFor(container, 'chat-composer-popover')).not.toBeNull();
@@ -199,7 +202,7 @@ describe('Sidebar', () => {
       },
     });
     const toggle = container.querySelector<HTMLButtonElement>(
-      '.cinder-side-navigation-group__trigger',
+      'nav[aria-label="Components"] button[aria-expanded]',
     );
     if (toggle === null) throw new Error('Expected Chat group toggle');
     await fireEvent.click(toggle);
@@ -210,7 +213,7 @@ describe('Sidebar', () => {
     await tick();
     expect(
       container
-        .querySelector<HTMLButtonElement>('.cinder-side-navigation-group__trigger')
+        .querySelector<HTMLButtonElement>('nav[aria-label="Components"] button[aria-expanded]')
         ?.getAttribute('aria-expanded'),
     ).toBe('false');
   });

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -218,6 +218,23 @@ describe('Sidebar', () => {
     ).toBe('false');
   });
 
+  test('preserves persisted collapsed families when restoring an active filter', async () => {
+    sessionStorage.setItem('cinder-playground-sidebar-filter', 'composer');
+    sessionStorage.setItem('cinder-playground-sidebar-expansion', JSON.stringify({ chat: false }));
+    render(Sidebar, {
+      props: {
+        components: ['chat', 'chat-composer-popover', 'button'],
+        currentComponent: 'chat',
+        onSelect: () => {},
+      },
+    });
+    await tick();
+    await tick();
+    expect(JSON.parse(sessionStorage.getItem('cinder-playground-sidebar-expansion')!).chat).toBe(
+      false,
+    );
+  });
+
   test('filter narrows the list by humanized name (case-insensitive)', async () => {
     const { container } = render(Sidebar, {
       props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -154,6 +154,19 @@ describe('Sidebar', () => {
     expect(container.querySelector('a[href="/c/accordion-item"]')).not.toBeNull();
   });
 
+  test('renders a family when only a child matches the filter', async () => {
+    const { container } = render(Sidebar, {
+      props: {
+        components: ['chat', 'chat-composer-popover', 'button'],
+        currentComponent: 'chat',
+        onSelect: () => {},
+      },
+    });
+    await fireEvent.input(getFilterInput(container), { target: { value: 'composer' } });
+    await tick();
+    expect(linkFor(container, 'chat-composer-popover')).not.toBeNull();
+  });
+
   test('reopens a collapsed family when filtering its children', async () => {
     const { container } = render(Sidebar, {
       props: {
@@ -273,6 +286,13 @@ describe('Sidebar', () => {
     await fireEvent.input(getFilterInput(container), { target: { value: 'zzz-no-match' } });
     await tick();
     expect((getLiveRegion(container).textContent ?? '').trim()).toBe('0 components shown');
+  });
+
+  test('counts injected compound children in the live region', () => {
+    const { container } = render(Sidebar, {
+      props: { components: ['accordion'], currentComponent: 'accordion', onSelect: () => {} },
+    });
+    expect((getLiveRegion(container).textContent ?? '').trim()).toBe('2 components shown');
   });
 });
 

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -130,6 +130,22 @@ describe('Sidebar', () => {
     expect(hrefs).toContain('/c/tag-input');
   });
 
+  test('groups visible compound families under a collapsible parent', () => {
+    const { container } = render(Sidebar, {
+      props: {
+        components: ['chat', 'chat-composer-popover', 'button'],
+        currentComponent: 'chat',
+        onSelect: () => {},
+      },
+    });
+
+    const group = container.querySelector('.cinder-side-navigation-group');
+    expect(group?.querySelector('button[aria-expanded]')?.textContent).toContain('Chat');
+    expect(group?.querySelector('a[href="/c/chat"]')).not.toBeNull();
+    expect(group?.querySelector('a[href="/c/chat-composer-popover"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/c/button"]')).not.toBeNull();
+  });
+
   test('filter narrows the list by humanized name (case-insensitive)', async () => {
     const { container } = render(Sidebar, {
       props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -146,6 +146,37 @@ describe('Sidebar', () => {
     expect(container.querySelector('a[href="/c/button"]')).not.toBeNull();
   });
 
+  test('keeps compose-only leaves under their parent family', () => {
+    const { container } = render(Sidebar, {
+      props: { components: ['accordion'], currentComponent: 'accordion', onSelect: () => {} },
+    });
+    expect(container.querySelector('a[href="/c/accordion"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/c/accordion-item"]')).not.toBeNull();
+  });
+
+  test('reopens a collapsed family when filtering its children', async () => {
+    const { container } = render(Sidebar, {
+      props: {
+        components: ['chat', 'chat-composer-popover', 'button'],
+        currentComponent: 'chat',
+        onSelect: () => {},
+      },
+    });
+    const groupToggle = container.querySelector<HTMLButtonElement>(
+      '.cinder-side-navigation-group__trigger',
+    );
+    if (groupToggle === null) throw new Error('Expected Chat group toggle');
+    await fireEvent.click(groupToggle);
+    expect(groupToggle.getAttribute('aria-expanded')).toBe('false');
+    await fireEvent.input(getFilterInput(container), { target: { value: 'chat' } });
+    await tick();
+    const refreshedToggle = container.querySelector<HTMLButtonElement>(
+      '.cinder-side-navigation-group__trigger',
+    );
+    expect(refreshedToggle?.getAttribute('aria-expanded')).toBe('true');
+    expect(linkFor(container, 'chat-composer-popover')).not.toBeNull();
+  });
+
   test('filter narrows the list by humanized name (case-insensitive)', async () => {
     const { container } = render(Sidebar, {
       props: { components: COMPONENTS, currentComponent: 'button', onSelect: () => {} },

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -146,12 +146,12 @@ describe('Sidebar', () => {
     expect(container.querySelector('a[href="/c/button"]')).not.toBeNull();
   });
 
-  test('keeps compose-only leaves under their parent family', () => {
+  test('keeps compose-only leaves out of sidebar navigation', () => {
     const { container } = render(Sidebar, {
       props: { components: ['accordion'], currentComponent: 'accordion', onSelect: () => {} },
     });
     expect(container.querySelector('a[href="/c/accordion"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/c/accordion-item"]')).not.toBeNull();
+    expect(container.querySelector('a[href="/c/accordion-item"]')).toBeNull();
   });
 
   test('renders a family when only a child matches the filter', async () => {
@@ -288,11 +288,15 @@ describe('Sidebar', () => {
     expect((getLiveRegion(container).textContent ?? '').trim()).toBe('0 components shown');
   });
 
-  test('counts injected compound children in the live region', () => {
+  test('counts rendered compound children in the live region', () => {
     const { container } = render(Sidebar, {
-      props: { components: ['accordion'], currentComponent: 'accordion', onSelect: () => {} },
+      props: {
+        components: ['chat'],
+        currentComponent: 'chat',
+        onSelect: () => {},
+      },
     });
-    expect((getLiveRegion(container).textContent ?? '').trim()).toBe('2 components shown');
+    expect((getLiveRegion(container).textContent ?? '').trim()).toBe('4 components shown');
   });
 });
 


### PR DESCRIPTION
Closes #955

- group visible compound families in collapsible sidebar sections
- keep explicit family metadata separate from route discovery
- preserve standalone routes and component count gates

Validation: `bun run --filter=@cinder/playground test`; `bun run --filter=@cinder/playground typecheck`