### PR TITLE
Server-render the canonical component documentation page

### DIFF
--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -4,14 +4,68 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
-import { assetUrlsFromHtml, runStaticExport } from './static-export.ts';
+import {
+  assertDocumentationPagesArePreRendered,
+  assetUrlsFromHtml,
+  runStaticExport,
+} from './static-export.ts';
 
 test('HTML asset discovery normalizes query-configured routes to one static path', () => {
+  expect(assetUrlsFromHtml('<iframe src="/page/button?preview=1"></iframe>')).toEqual([
+    '/page/button',
+  ]);
+});
+
+test('HTML asset discovery ignores navigation anchors', () => {
+  /*
+   * Anchors are navigation, not subresources. Since the documentation pages
+   * became server-rendered, their markup carries example content with
+   * illustrative links — `examples/side-navigation/basic.example.svelte` renders
+   * `href="/projects/atlas"`. `render()` throws on any non-2xx, so crawling
+   * anchors failed the entire export with `/projects/atlas → HTTP 404`.
+   *
+   * Real routes are enumerated explicitly by runStaticExport, so dropping
+   * anchors costs no coverage.
+   */
   expect(
     assetUrlsFromHtml(
-      '<iframe src="/page/button?preview=1"></iframe><a href="/page/button">Button</a>',
+      '<a href="/projects/atlas">Atlas</a><a href="/c/button">Button</a><nav><a href="/page/badge">Badge</a></nav>',
     ),
-  ).toEqual(['/page/button']);
+  ).toEqual([]);
+});
+
+test('HTML asset discovery collects stylesheets, scripts, and media', () => {
+  const urls = assetUrlsFromHtml(
+    [
+      '<link rel="stylesheet" href="/styles/shell.css" />',
+      '<link href="/styles/all.css" rel="stylesheet" />',
+      '<script type="module" src="/shell-bundle/shell.js"></script>',
+      '<img src="/social.png" alt="" />',
+      '<iframe src="/page/button?preview=1"></iframe>',
+      '<a href="/should-be-ignored">nope</a>',
+    ].join(''),
+  );
+
+  expect(urls).toEqual([
+    '/styles/shell.css',
+    '/styles/all.css',
+    '/shell-bundle/shell.js',
+    '/social.png',
+    '/page/button',
+  ]);
+});
+
+test('HTML asset discovery skips the SSE stream, which has no static form', () => {
+  expect(assetUrlsFromHtml('<script src="/events"></script>')).toEqual([]);
+});
+
+test('HTML asset discovery does not carry regex state between calls', () => {
+  // A shared `/g` regex would resume from the previous call's lastIndex and miss
+  // the first match on the second invocation.
+  const html = '<link rel="stylesheet" href="/styles/shell.css" />';
+
+  expect(assetUrlsFromHtml(html)).toEqual(['/styles/shell.css']);
+  expect(assetUrlsFromHtml(html)).toEqual(['/styles/shell.css']);
 });
 
 describe('static export', () => {
@@ -95,4 +149,69 @@ describe('static export', () => {
       await rm(outputDirectory, { recursive: true, force: true });
     }
   }, 120_000);
+});
+
+describe('assertDocumentationPagesArePreRendered', () => {
+  /*
+   * The guardrail for the original defect: `/page/<name>` shipped an empty
+   * `<div id="app">` plus a bundle, so the deployed site rendered nothing until
+   * JavaScript executed — and nothing failed, because the export only checked
+   * for a 2xx response.
+   */
+  const goodPage =
+    '<html><body><div id="app"><div data-component-page><h1>Button</h1></div></div></body></html>';
+
+  test('accepts pages that carry server-rendered documentation', () => {
+    expect(() =>
+      assertDocumentationPagesArePreRendered([{ name: 'button', html: goodPage }]),
+    ).not.toThrow();
+  });
+
+  test('accepts an empty page list', () => {
+    expect(() => assertDocumentationPagesArePreRendered([])).not.toThrow();
+  });
+
+  test('rejects an empty mount root — the original regression', () => {
+    expect(() =>
+      assertDocumentationPagesArePreRendered([
+        { name: 'button', html: '<html><body><div id="app"></div></body></html>' },
+      ]),
+    ).toThrow(/#app is empty/);
+  });
+
+  test('rejects a page missing the documentation root attribute', () => {
+    expect(() =>
+      assertDocumentationPagesArePreRendered([
+        { name: 'badge', html: '<div id="app"><h1>Badge</h1></div>' },
+      ]),
+    ).toThrow(/data-component-page/);
+  });
+
+  test('rejects a page missing its hero heading', () => {
+    expect(() =>
+      assertDocumentationPagesArePreRendered([
+        { name: 'badge', html: '<div id="app"><div data-component-page></div></div>' },
+      ]),
+    ).toThrow(/<h1/);
+  });
+
+  test('reports every offender and the total, not just the first', () => {
+    const error = (() => {
+      try {
+        assertDocumentationPagesArePreRendered([
+          { name: 'button', html: goodPage },
+          { name: 'badge', html: '<div id="app"></div>' },
+          { name: 'card', html: '<div id="app"></div>' },
+        ]);
+        return null;
+      } catch (thrown) {
+        return thrown as Error;
+      }
+    })();
+
+    expect(error).not.toBeNull();
+    expect(error?.message).toContain('2 of 3');
+    expect(error?.message).toContain('badge');
+    expect(error?.message).toContain('card');
+  });
 });

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -108,17 +108,49 @@ async function writeFile(path: string, contents: string): Promise<void> {
 }
 
 /**
- * Pull every same-origin asset URL the given HTML references — the `<script
- * src>` bundles and `<link href>` stylesheets — as root-relative paths.
+ * Elements whose `href`/`src` names a subresource the browser must fetch for the
+ * page to render correctly, and which therefore has to exist as a static file.
+ *
+ * `<a>` is deliberately absent. An anchor is navigation, not a subresource, and
+ * since the documentation pages became server-rendered their markup contains
+ * example content with illustrative links — `SideNavigation.Item
+ * href="/projects/atlas"` in `examples/side-navigation/basic.example.svelte`, for
+ * instance. Those routes do not exist, and because `render()` throws on any
+ * non-2xx response, crawling them failed the whole export with
+ * `/projects/atlas → HTTP 404`.
+ *
+ * Every real route is enumerated explicitly by `runStaticExport` (`/page/<name>`
+ * for all components, `/c/<name>` for the sidebar, the API and example-source
+ * routes), so scraping anchors added no coverage — only the risk of treating
+ * demo content as a build requirement.
+ */
+const ASSET_ELEMENTS = ['link', 'script', 'img', 'iframe', 'source'] as const;
+
+/**
+ * Source for a regex matching an asset-bearing start tag, capturing its
+ * root-relative `href`/`src`. Attribute order varies (`<link rel="stylesheet"
+ * href="…">` vs `<link href="…" rel="…">`), so the URL is captured from anywhere
+ * inside the tag.
+ *
+ * Held as a string and compiled per call: a shared `/g` regex carries `lastIndex`
+ * between invocations, so a second call would silently resume mid-document.
+ */
+const ASSET_REFERENCE_SOURCE = `<(?:${ASSET_ELEMENTS.join('|')})\\b[^>]*?\\b(?:href|src)="(/[^"]*)"`;
+
+/**
+ * Pull every same-origin subresource URL the given HTML references — `<script
+ * src>` bundles, `<link href>` stylesheets, and `<img>`/`<iframe>`/`<source>`
+ * media — as root-relative paths. Navigation links are ignored; see
+ * {@link ASSET_ELEMENTS}.
  */
 export function assetUrlsFromHtml(html: string): string[] {
   const urls = new Set<string>();
-  const attribute = /\b(?:src|href)="(\/[^"]+)"/g;
+  const assetReference = new RegExp(ASSET_REFERENCE_SOURCE, 'gi');
   let match: RegExpExecArray | null;
-  while ((match = attribute.exec(html)) !== null) {
+  while ((match = assetReference.exec(html)) !== null) {
     const url = match[1]!;
-    // Only crawlable GET routes — skip in-page anchors and the SSE stream.
-    if (url === '/events' || url.startsWith('#')) continue;
+    // Only crawlable GET routes — skip the SSE stream, which has no static form.
+    if (url === '/events') continue;
     // Queries configure browser behavior but do not identify a second static
     // file. Materialize `/page/button?preview=1` at the already-exported
     // `/page/button` path instead of creating a literal `?preview=1` directory.
@@ -245,9 +277,13 @@ export async function runStaticExport(options: StaticExportOptions = {}): Promis
   // a directory `api/manifest/` cannot coexist).
 
   // Per-component: shell page, iframe page, page-bundle graph, manifest, sources.
+  const documentationPages: { name: string; html: string }[] = [];
   for (const name of allComponents) {
     const pageHtml = await render(`/page/${name}`, context);
-    if (pageHtml !== null) collect(pageHtml);
+    if (pageHtml !== null) {
+      collect(pageHtml);
+      documentationPages.push({ name, html: pageHtml });
+    }
     await renderJsBundleGraph(`/page-bundle/${name}.js`, context);
     await render(`/api/manifest/${name}`, context);
     await render(`/api/documentation/${name}`, context);
@@ -271,11 +307,64 @@ export async function runStaticExport(options: StaticExportOptions = {}): Promis
     else await render(url, context);
   }
 
+  assertDocumentationPagesArePreRendered(documentationPages);
+
   const seconds = ((Date.now() - start) / 1000).toFixed(1);
   process.stdout.write(
     `[static-export] rendered ${context.rendered.size} files for ${sidebarComponents.length} components in ${seconds}s\n`,
   );
   return context.rendered;
+}
+
+/**
+ * Markers every server-rendered documentation page must carry.
+ *
+ * `data-component-page` is the page root's own attribute, and a `<h1>` proves the
+ * hero rendered rather than an empty frame.
+ */
+const PRE_RENDER_MARKERS = ['data-component-page', '<h1'] as const;
+
+/** An `#app` with no children is the exact shape of the regression guarded here. */
+const EMPTY_MOUNT_ROOT = '<div id="app"></div>';
+
+/**
+ * Fail the build when a documentation page exported without server-rendered
+ * content.
+ *
+ * This is the guardrail for the original defect: `/page/<name>` shipped an empty
+ * `<div id="app">` plus a bundle, so the deployed site rendered nothing until
+ * JavaScript executed. That shipped silently because nothing asserted the
+ * exported bytes actually contained the documentation — the export only checked
+ * for a 2xx response.
+ *
+ * Throwing here is deliberate: `vercel-build` runs this script, so a page that
+ * loses its pre-rendering fails the deploy instead of reaching production blank.
+ *
+ * @throws When any page lacks a pre-render marker or still has an empty `#app`.
+ */
+export function assertDocumentationPagesArePreRendered(
+  pages: readonly { name: string; html: string }[],
+): void {
+  const failures: string[] = [];
+
+  for (const { name, html } of pages) {
+    if (html.includes(EMPTY_MOUNT_ROOT)) {
+      failures.push(`${name}: #app is empty — the page was not server-rendered`);
+      continue;
+    }
+    const missing = PRE_RENDER_MARKERS.filter((marker) => !html.includes(marker));
+    if (missing.length > 0) {
+      failures.push(`${name}: missing ${missing.join(', ')}`);
+    }
+  }
+
+  if (failures.length === 0) return;
+
+  throw new Error(
+    `[static-export] ${failures.length} of ${pages.length} documentation pages are not ` +
+      `server-rendered. A blank page must never deploy.\n` +
+      failures.map((failure) => `  - ${failure}`).join('\n'),
+  );
 }
 
 // Fire-and-forget: surface any failure as a non-zero exit so the build fails.

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1008,6 +1008,30 @@
                           Shows the featured example. Adjust the controls to update the snippet.
                         </p>
                       </div>
+                    {:else if !snapshotMode && !documentation.propsManifest.isCompound}
+                      <!-- Reserve the stage for components with NO examples (label,
+                           statistic, accordion-item, …). Without this branch the
+                           server renders nothing here, and hydration then INSERTS
+                           the whole live stage into an already-painted page — a
+                           layout shift, and the opposite of the reservation the
+                           server entry promises.
+
+                           A non-compound component is one whose bare mount the
+                           client can resolve, so a live stage is what will appear.
+                           Compound components keep `bareComponent` undefined on
+                           purpose, so reserving a box they never fill would leave
+                           an empty frame. `isCompound` comes from the manifest, so
+                           the server can make this call. -->
+                      <div class="dx-stage" data-stage-reserved>
+                        <div class="dx-stage__bar">
+                          <span class="dx-stage__dot" aria-hidden="true"></span>
+                          <span class="dx-stage__label">Live preview</span>
+                        </div>
+                        <div class="dx-stage__canvas"></div>
+                        <p class="dx-stage__note">
+                          Renders with the props below. Adjust the controls to update it live.
+                        </p>
+                      </div>
                     {/if}
                     <CodeBlock code={playgroundSnippet} language="svelte" copyable />
                     {#if playgroundModel.skipped.length > 0}

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1,6 +1,6 @@
 <!-- dev-only playground scaffold; immutable page data is injected server-side -->
 <script lang="ts">
-  import { mount, unmount } from 'svelte';
+  import { mount, onMount, unmount } from 'svelte';
   import { Accordion } from '@lostgradient/cinder/accordion';
   import { AccordionItem } from '@lostgradient/cinder/accordion-item';
   import { Alert } from '@lostgradient/cinder/alert';
@@ -71,10 +71,32 @@
   // from a `window` global so the live preview (#405) is wired explicitly to the
   // bundle that mounted it — no out-of-band global to go stale against the page.
   // Defaults to `undefined` for the no-prop mount paths (tests, SSR render).
+  type Props = {
+    bareComponentModule?: unknown;
+    previewOnly?: boolean;
+    /**
+     * Request-known page inputs. The server passes these explicitly so the SSR
+     * tree can be built without touching `window`; the client bundle passes the
+     * same values it reads from the URL and data islands. When omitted, each
+     * falls back to reading the browser environment (guarded for SSR), which is
+     * what the unit tests rely on.
+     */
+    componentName?: string;
+    examples?: CinderExampleDescriptor[];
+    snapshotMode?: boolean;
+    documentation?: ComponentDocumentationPayload | null;
+    documentationError?: string | null;
+  };
+
   let {
     bareComponentModule,
     previewOnly = false,
-  }: { bareComponentModule?: unknown; previewOnly?: boolean } = $props();
+    componentName: componentNameProp,
+    examples: examplesProp,
+    snapshotMode: snapshotModeProp,
+    documentation: documentationProp,
+    documentationError: documentationErrorProp,
+  }: Props = $props();
 
   // Height of the sticky top bar, in pixels — used for scroll-spy activation
   // and smooth-scroll offset so anchored sections clear the bar.
@@ -86,7 +108,7 @@
     return Array.isArray(raw) ? raw : [];
   }
 
-  const examples: CinderExampleDescriptor[] = readExamples();
+  const examples: CinderExampleDescriptor[] = examplesProp ?? readExamples();
   const explicitlyFeatured = examples.filter((example) => example.featured === true);
 
   // Snapshot mode (`?snapshot=1`) is how the visual-regression and a11y test
@@ -95,8 +117,9 @@
   // featured example twice. The Overview live preview is therefore suppressed in
   // snapshot mode — the Examples section still mounts each scenario exactly once.
   const snapshotMode =
-    typeof window !== 'undefined' &&
-    new URLSearchParams(window.location.search).get('snapshot') === '1';
+    snapshotModeProp ??
+    (typeof window !== 'undefined' &&
+      new URLSearchParams(window.location.search).get('snapshot') === '1');
 
   // The Overview live preview uses the first featured example, or the first
   // example overall. Undefined when there are no examples at all, and suppressed
@@ -106,9 +129,14 @@
     ? undefined
     : (explicitlyFeatured[0] ?? examples[0]);
 
-  // Extract the component name from the current URL path: /page/<name>
-  const componentName: string =
-    window.location.pathname.replace(/^\/page\//, '').split('/')[0] ?? '';
+  // The component this page documents. Supplied as a prop by both render paths;
+  // falls back to parsing the current URL path (`/page/<name>`) when absent.
+  function readComponentNameFromLocation(): string {
+    if (typeof window === 'undefined') return '';
+    return window.location.pathname.replace(/^\/page\//, '').split('/')[0] ?? '';
+  }
+
+  const componentName: string = componentNameProp ?? readComponentNameFromLocation();
 
   // --- Theme toggle -----------------------------------------------------
   // Cinder tokens switch on `color-scheme` (via `light-dark()`); the playground
@@ -116,12 +144,36 @@
   // read the active scheme on mount and, on toggle, write BOTH `color-scheme`
   // (the real switch) and `data-cinder-theme` so we stay consistent with the
   // bridge, plus persist to localStorage under the pre-paint key.
+  // Server rendering has no `document`, so the SSR tree seeds `light` — matching
+  // the base `color-scheme: light dark` first argument — and the real preference
+  // is adopted in `onMount`. Seeding from the document during init would make the
+  // server and client first render disagree (a hydration mismatch); deferring the
+  // read is the same discipline `shell.svelte` uses for its persisted theme.
   function readInitialTheme(): 'light' | 'dark' {
+    if (typeof document === 'undefined') return 'light';
     const scheme = document.documentElement.style.colorScheme;
     if (scheme === 'dark' || scheme === 'light') return scheme;
     return document.documentElement.dataset['cinderTheme'] === 'dark' ? 'dark' : 'light';
   }
-  let theme: 'light' | 'dark' = $state(readInitialTheme());
+
+  // Seeded to `light` on BOTH sides — never from the document — so the server's
+  // markup and the client's hydration render agree on the toggle's icon and
+  // label. The real preference (set by the pre-paint script from the URL or
+  // localStorage) is adopted immediately after mount. Reading it during init
+  // would render a Sun on the server and a Moon on the client for dark-mode
+  // users: a hydration mismatch.
+  let theme = $state<'light' | 'dark'>('light');
+
+  // False during SSR and during the client's hydration render; true from mount
+  // onward. Gates anything that cannot exist server-side (the live component
+  // mount, which needs a module namespace the server never has) so both sides
+  // render the same tree on first pass.
+  let isHydrated = $state(false);
+
+  onMount(() => {
+    theme = readInitialTheme();
+    isHydrated = true;
+  });
   let themeToggleLabel = $derived(
     theme === 'dark' ? 'Preview theme: switch to light' : 'Preview theme: switch to dark',
   );
@@ -288,11 +340,17 @@
   // in the page HTML and the client reads it synchronously before first render.
   let documentation: ComponentDocumentationPayload | null = $state(null);
   let documentationError: string | null = $state(null);
-  try {
-    documentation = readComponentDocumentationDataIsland();
-  } catch (error) {
-    documentationError =
-      error instanceof Error ? error.message : 'Failed to read component documentation.';
+  if (documentationProp !== undefined || documentationErrorProp !== undefined) {
+    // Supplied by the render path (server SSR or the client bundle entry).
+    documentation = documentationProp ?? null;
+    documentationError = documentationErrorProp ?? null;
+  } else if (typeof document !== 'undefined') {
+    try {
+      documentation = readComponentDocumentationDataIsland();
+    } catch (error) {
+      documentationError =
+        error instanceof Error ? error.message : 'Failed to read component documentation.';
+    }
   }
 
   const propRows = $derived(
@@ -886,7 +944,13 @@
                          rather than show an error callout over what would otherwise be
                          a working preview. With no featured fallback, the live branch
                          stays and surfaces the error — better than a blank section. -->
-                    {#if bareComponent !== undefined && !snapshotMode && (!liveMountFailed || overviewExample === undefined)}
+                    <!-- `isHydrated` keeps the live mount off the server's tree: it
+                         needs `bareComponentModule`, which only the client bundle
+                         supplies. Without the gate the server would render the
+                         featured-example branch and the client the live branch on
+                         its hydration pass — a mismatch. The live preview swaps in
+                         immediately after mount. -->
+                    {#if isHydrated && bareComponent !== undefined && !snapshotMode && (!liveMountFailed || overviewExample === undefined)}
                       <div class="dx-stage">
                         <div class="dx-stage__bar">
                           <span class="dx-stage__dot" aria-hidden="true"></span>

--- a/packages/playground/src/page-server-entry.ts
+++ b/packages/playground/src/page-server-entry.ts
@@ -1,0 +1,60 @@
+/**
+ * Server-render entry for the canonical component documentation page.
+ *
+ * Mirrors `shell-app/shell-server-entry.ts`: the playground server compiles this
+ * module with `sveltePlugin({ generate: 'server' })` and calls
+ * {@link renderComponentPageBody} to obtain the documentation markup plus the
+ * scoped `<style>` tags Svelte hoists into `<head>`. The client bundle then
+ * hydrates that exact tree.
+ *
+ * Every input is passed explicitly. `component-page.svelte` must never read
+ * `window`/`document` during initialization, or the server and client first
+ * render disagree and hydration mismatches.
+ */
+
+import { render } from 'svelte/server';
+
+import type { ComponentDocumentationPayload } from './component-documentation-types.ts';
+import ComponentPage from './component-page.svelte';
+
+/** One `*.example.svelte` scenario registered for a component. */
+export type ComponentPageExample = {
+  scenario: string;
+  title: string;
+  description?: string;
+  featured?: boolean;
+};
+
+export type ComponentPageServerProps = {
+  componentName: string;
+  documentation: ComponentDocumentationPayload;
+  examples: ComponentPageExample[];
+};
+
+export type RenderedComponentPage = {
+  body: string;
+  head: string;
+};
+
+/**
+ * Render the documentation page to HTML strings.
+ *
+ * `snapshotMode` is pinned to `false`: the `?snapshot=1` surface is served by a
+ * separate client-only code path so the visual-regression and axe suites keep
+ * their exact `#app > *` mount contract. `bareComponentModule` is intentionally
+ * omitted — the live playground mount is a client-only concern, and the stage
+ * reserves its box during SSR so hydration adds no layout shift.
+ */
+export function renderComponentPageBody(props: ComponentPageServerProps): RenderedComponentPage {
+  const rendered = render(ComponentPage, {
+    props: {
+      componentName: props.componentName,
+      documentation: props.documentation,
+      documentationError: null,
+      examples: props.examples,
+      snapshotMode: false,
+    },
+  });
+
+  return { body: rendered.body, head: rendered.head };
+}

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -1385,3 +1385,72 @@ describe('/bundle/:name/controls.js (route retired)', () => {
     expect(response.status).toBe(404);
   }, 30_000);
 });
+
+describe('/page/:name server-rendering surfaces', () => {
+  /*
+   * `/page/<name>` has three rendering surfaces and they must not blur together.
+   *
+   * The canonical page is server-rendered so the deployed site shows real
+   * content before JavaScript runs. The other two are client-only because each
+   * mounts a DIFFERENT tree than the canonical page, and the client bundle
+   * `mount()`s them rather than hydrating — `mount()` does not clear existing
+   * children, so any pre-rendered markup would stack underneath.
+   *
+   * These assertions exist because pre-rendering `?preview=1` regressed exactly
+   * that way: the shell's 360px preview iframe received a full 134 KB
+   * documentation page with a small preview mounted on top of it.
+   */
+
+  it('server-renders the canonical page into #app', async () => {
+    const response = await handleRequest(req('/page/button'));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    expect(html).not.toContain('<div id="app"></div>');
+    expect(html).toContain('data-component-page');
+    // Real documentation content, not just a shell.
+    expect(html).toMatch(/<h1[^>]*>Button/);
+  }, 60_000);
+
+  it('omits inline sourcemaps from the server-rendered head', async () => {
+    const response = await handleRequest(req('/page/button'));
+    const html = await response.text();
+
+    // Inline base64 sourcemaps measured 50.3% of the deployed document and sit
+    // on the critical rendering path. See strip-inline-sourcemaps.ts.
+    expect(html).not.toContain('sourceMappingURL=data:');
+  }, 60_000);
+
+  it('leaves #app empty for ?snapshot=1 so the visual harness contract holds', async () => {
+    const response = await handleRequest(req('/page/button?snapshot=1'));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    // packages/testing/src/fixtures/component-page.ts waits for `#app > *` and
+    // asserts single-instance `example-mount-*` counts on a bare surface.
+    expect(html).toContain('<div id="app"></div>');
+    expect(html).not.toContain('data-component-page');
+    expect(html).toContain('data-snapshot-mode');
+  }, 60_000);
+
+  it('leaves #app empty for ?preview=1 so the preview frame shows only the example', async () => {
+    const response = await handleRequest(req('/page/button?preview=1'));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+
+    expect(html).toContain('<div id="app"></div>');
+    expect(html).not.toContain('data-component-page');
+  }, 60_000);
+
+  it('renders a substantially smaller document for the client-only surfaces', async () => {
+    const [canonical, preview] = await Promise.all([
+      handleRequest(req('/page/button')).then((response) => response.text()),
+      handleRequest(req('/page/button?preview=1')).then((response) => response.text()),
+    ]);
+
+    // Guards against the regression direction: if `?preview=1` ever starts
+    // carrying the documentation tree again its size converges on the canonical
+    // page's.
+    expect(preview.length).toBeLessThan(canonical.length / 2);
+  }, 60_000);
+});

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -925,6 +925,7 @@ const previewOnly = new URLSearchParams(window.location.search).get('preview') =
 // documentation/examples data islands feed both sides.
 const snapshotMode = new URLSearchParams(window.location.search).get('snapshot') === '1';
 const hasServerRenderedContent = target.firstElementChild !== null;
+const shouldHydrate = hasServerRenderedContent && !snapshotMode && !previewOnly;
 
 const props = {
   bareComponentModule: BareComponentModule,
@@ -932,9 +933,23 @@ const props = {
   snapshotMode,
 };
 
-if (hasServerRenderedContent && !snapshotMode && !previewOnly) {
+if (shouldHydrate) {
   hydrate(ComponentPage, { target, props });
 } else {
+  // mount() APPENDS; it does not clear the target. So whenever we are mounting a
+  // tree that differs from whatever the document already contains, we must own
+  // the container explicitly.
+  //
+  // This is load-bearing on the STATIC export, not just in development. The
+  // exporter strips query strings when crawling, so \`/page/<name>?preview=1\`
+  // resolves to the one exported \`/page/<name>/index.html\` — the full
+  // documentation page. The server-side preview gate cannot help there, because
+  // a static host runs no server. Without this clear, the shell's preview iframe
+  // renders the entire documentation page with a small preview stacked on top.
+  //
+  // Clearing is safe in every mount case: snapshot and preview surfaces are
+  // served with an empty \`#app\` anyway, so there is nothing to discard.
+  target.replaceChildren();
   mount(ComponentPage, { target, props });
 }
 `;

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1589,7 +1589,11 @@ function renderPreviewMessageBridgeScript(): string {
  * injected that zeroes animation/transition durations and hides carets.
  * Without `?snapshot=1`, the output is byte-identical to the previous behavior.
  */
-async function renderComponentPage(componentName: string, snapshotMode: boolean): Promise<string> {
+async function renderComponentPage(
+  componentName: string,
+  snapshotMode: boolean,
+  previewOnly: boolean,
+): Promise<string> {
   const componentDefinition = await discoverComponentDefinition(componentName);
   const componentStylesheetUrl =
     componentDefinition?.source.componentStylesheetUrl(componentName) ?? null;
@@ -1633,19 +1637,28 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
    * Server-render the documentation tree so the page has real content in the
    * HTML — no blank `#app` and no loading state before the bundle executes.
    *
-   * `?snapshot=1` deliberately opts OUT and keeps the historical client-only
-   * mount: the visual-regression and axe suites wait for `#app > *` to become
-   * visible and assert single-instance counts of `example-mount-*` on a bare
-   * surface (see packages/testing/src/fixtures/component-page.ts). Rendering the
-   * full documentation chrome into that surface would break ~93 suites, so the
-   * two surfaces stay separate on purpose.
+   * TWO query surfaces deliberately opt OUT and keep the historical client-only
+   * mount, because each renders a DIFFERENT tree than the canonical page:
+   *
+   * - `?snapshot=1` — the visual-regression and axe suites wait for `#app > *`
+   *   to become visible and assert single-instance counts of `example-mount-*`
+   *   on a bare surface (see packages/testing/src/fixtures/component-page.ts).
+   *   Rendering the full documentation chrome there would break ~93 suites.
+   * - `?preview=1` — the shell's preview frame renders only a single featured
+   *   example (`canonical-preview`). The client bundle `mount()`s that surface
+   *   rather than hydrating it, and `mount()` does not clear existing children,
+   *   so pre-rendering the full documentation tree here would stack a 134 KB
+   *   documentation page underneath a small preview inside the iframe.
+   *
+   * Both surfaces must therefore ship an empty `#app`. Gate on both, or the
+   * server's tree and the client's mount disagree.
    *
    * A render failure degrades to the client-only path rather than 500ing — the
    * page still works, it just loses the pre-rendered content.
    */
   let ssrBody = '';
   let ssrHead = '';
-  if (!snapshotMode) {
+  if (!snapshotMode && !previewOnly) {
     try {
       const renderComponentPageBody = await loadPageServerRenderer();
       const rendered = renderComponentPageBody({ componentName, documentation, examples });
@@ -2232,7 +2245,11 @@ export async function handleRequest(request: Request): Promise<Response> {
         fixtureContentHash,
       );
     }
-    const html = await renderComponentPage(componentName, snapshotModeActive);
+    // `?preview=1` is the shell preview frame's single-example surface. It must
+    // stay client-only for the same reason as snapshot mode — see the comment in
+    // renderComponentPage.
+    const previewOnlyActive = url.searchParams.get('preview') === '1';
+    const html = await renderComponentPage(componentName, snapshotModeActive, previewOnlyActive);
     return new Response(html, { headers: { 'Content-Type': 'text/html' } });
   }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -93,6 +93,7 @@ import {
   snapshotModeHtmlAttribute,
   snapshotModeStyleTag,
 } from './snapshot-mode.ts';
+import { stripInlineSourcemaps } from './strip-inline-sourcemaps.ts';
 import type { ComponentManifest } from './types.ts';
 
 const DEFAULT_PORT = 5555;
@@ -190,6 +191,18 @@ type ShellServerRenderer = (props: {
 }) => { body: string; head: string };
 let shellServerRendererPromise: Promise<ShellServerRenderer> | null = null;
 let lastGoodShellServerRenderer: ShellServerRenderer | null = null;
+
+/**
+ * Server renderer for the canonical documentation page (`src/page-server-entry.ts`).
+ * Same shape and caching discipline as {@link ShellServerRenderer}.
+ */
+type PageServerRenderer = (props: {
+  componentName: string;
+  documentation: ComponentDocumentationPayload;
+  examples: { scenario: string; title: string; description?: string; featured?: boolean }[];
+}) => { body: string; head: string };
+let pageServerRendererPromise: Promise<PageServerRenderer> | null = null;
+let lastGoodPageServerRenderer: PageServerRenderer | null = null;
 const fixtureBuildPromiseByKey = new Map<string, Promise<string | null>>();
 
 /**
@@ -464,6 +477,9 @@ function invalidateCachesForChange(scope: ChangeScope): void {
   shellStale = true;
   shellBuildPromise = null;
   shellServerRendererPromise = null;
+  // The documentation page's server bundle shares the component graph the shell
+  // rebuild invalidates, so drop its dedup slot on the same signal.
+  pageServerRendererPromise = null;
 
   triggerReload('shell-reload');
 }
@@ -875,7 +891,7 @@ async function compilePageBundleArtifacts(
     .map((scenario, index) => `  ${JSON.stringify(scenario)}: Scenario_${index},`)
     .join('\n');
 
-  const entrySource = `import { mount } from 'svelte';
+  const entrySource = `import { hydrate, mount } from 'svelte';
 
 import ComponentPage from '../component-page.svelte';
 import * as BareComponentModule from ${JSON.stringify(componentDefinition.importPath)};
@@ -897,10 +913,30 @@ if (target === null) {
 // resolve. Threaded as a prop (not a \`window\` global) so the live preview is
 // wired explicitly to the bundle that mounted the page.
 const previewOnly = new URLSearchParams(window.location.search).get('preview') === '1';
-mount(ComponentPage, {
-  target,
-  props: { bareComponentModule: BareComponentModule, previewOnly },
-});
+
+// The server pre-renders the documentation tree into #app for the canonical
+// route, so take over that markup with hydrate() instead of mount() — mount()
+// would discard the server output and re-create every node, throwing away the
+// pre-rendered paint and double-mounting the examples.
+//
+// The props MUST match what page-server-entry.ts passed, or the client's first
+// render disagrees with the server's and hydration mismatches. snapshotMode is
+// therefore read from the URL exactly as the server read it, and the same
+// documentation/examples data islands feed both sides.
+const snapshotMode = new URLSearchParams(window.location.search).get('snapshot') === '1';
+const hasServerRenderedContent = target.firstElementChild !== null;
+
+const props = {
+  bareComponentModule: BareComponentModule,
+  previewOnly,
+  snapshotMode,
+};
+
+if (hasServerRenderedContent && !snapshotMode && !previewOnly) {
+  hydrate(ComponentPage, { target, props });
+} else {
+  mount(ComponentPage, { target, props });
+}
 `;
 
   try {
@@ -1242,6 +1278,66 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
 }
 
 /**
+ * Compile and load the documentation page's server renderer.
+ *
+ * Deliberately mirrors {@link loadShellServerRenderer}: same `generate: 'server'`
+ * plugin, same `target: 'bun'` + `['bun','svelte']` conditions, same
+ * write-to-temp-then-dynamic-import dance, and the same last-good fallback so a
+ * transient compile error during development serves the previous good renderer
+ * instead of a 500.
+ */
+async function loadPageServerRenderer(): Promise<PageServerRenderer> {
+  if (pageServerRendererPromise !== null) return pageServerRendererPromise;
+
+  pageServerRendererPromise = (async () => {
+    try {
+      const generationAtStart = rebuildGeneration;
+      const result = await Bun.build({
+        entrypoints: [join(PLAYGROUND_ROOT, 'src', 'page-server-entry.ts')],
+        plugins: [sveltePlugin({ generate: 'server' })],
+        target: 'bun',
+        format: 'esm',
+        conditions: ['bun', 'svelte'],
+        splitting: false,
+      });
+      if (!result.success || result.outputs[0] === undefined) {
+        throw new Error(`Page server bundle failed:\n${result.logs.join('\n')}`);
+      }
+
+      const serverBundleDirectory = join(PLAYGROUND_ROOT, 'src', `.tmp-${randomUUID()}`);
+      const serverBundlePath = join(serverBundleDirectory, 'page-server.js');
+      let loaded: unknown;
+      try {
+        await Bun.write(serverBundlePath, await result.outputs[0].text());
+        loaded = await import(pathToFileURL(serverBundlePath).href);
+      } finally {
+        rmSync(serverBundleDirectory, { recursive: true, force: true });
+      }
+      if (
+        typeof loaded !== 'object' ||
+        loaded === null ||
+        typeof Reflect.get(loaded, 'renderComponentPageBody') !== 'function'
+      ) {
+        throw new Error('Page server bundle did not export renderComponentPageBody');
+      }
+      const renderer = Reflect.get(loaded, 'renderComponentPageBody') as PageServerRenderer;
+      if (generationAtStart === rebuildGeneration) {
+        lastGoodPageServerRenderer = renderer;
+      }
+      return renderer;
+    } catch (error) {
+      console.error(
+        '[playground] page server rebuild failed; serving the last-good renderer:',
+        error,
+      );
+      return fallbackToLastGood(lastGoodPageServerRenderer, error);
+    }
+  })();
+
+  return pageServerRendererPromise;
+}
+
+/**
  * Lazy-build wrapper: compile the shell bundle and publish into shared
  * caches. Used by `/shell-bundle/shell.js` as a fallback when the shell
  * bundle isn't already cached, or when `shellStale` is set. Same
@@ -1533,6 +1629,35 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
   const humanName = escapeHtml(humanizeComponentName(componentName));
   const pageDescription = `Live ${humanName} examples from the cinder Svelte 5 component library.`;
 
+  /*
+   * Server-render the documentation tree so the page has real content in the
+   * HTML — no blank `#app` and no loading state before the bundle executes.
+   *
+   * `?snapshot=1` deliberately opts OUT and keeps the historical client-only
+   * mount: the visual-regression and axe suites wait for `#app > *` to become
+   * visible and assert single-instance counts of `example-mount-*` on a bare
+   * surface (see packages/testing/src/fixtures/component-page.ts). Rendering the
+   * full documentation chrome into that surface would break ~93 suites, so the
+   * two surfaces stay separate on purpose.
+   *
+   * A render failure degrades to the client-only path rather than 500ing — the
+   * page still works, it just loses the pre-rendered content.
+   */
+  let ssrBody = '';
+  let ssrHead = '';
+  if (!snapshotMode) {
+    try {
+      const renderComponentPageBody = await loadPageServerRenderer();
+      const rendered = renderComponentPageBody({ componentName, documentation, examples });
+      ssrBody = rendered.body;
+      // Inline sourcemaps in the SSR'd <style> output are ~80% of its bytes and
+      // sit on the critical rendering path. See strip-inline-sourcemaps.ts.
+      ssrHead = stripInlineSourcemaps(rendered.head);
+    } catch (error) {
+      console.error(`[playground] page SSR failed for ${componentName}:`, error);
+    }
+  }
+
   return `<!DOCTYPE html>
 <html lang="en"${htmlAttribute}>
   <head>
@@ -1542,6 +1667,7 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
     <meta name="description" content="${pageDescription}" />
     <link rel="icon" href="${FAVICON_HREF}" />
     <link rel="stylesheet" href="/styles/all.css" />${componentStylesheetLink}
+    ${ssrHead}
     <script>${PRE_PAINT_THEME_SCRIPT}</script>
     <style>
       /* Iframe scaffold: scope the reset narrowly. Unlike the shell, the
@@ -1575,7 +1701,7 @@ async function renderComponentPage(componentName: string, snapshotMode: boolean)
   <body>
     <script type="application/json" id="cinder-documentation">${documentationJson}</script>
     <script>window.__CINDER_EXAMPLES__ = ${examplesJson};</script>
-    <div id="app"></div>
+    <div id="app">${ssrBody}</div>
     <script type="module" src="/page-bundle/${componentName}.js"></script>
   </body>
 </html>`;

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -15,6 +15,7 @@
 
 import type { ComponentDocumentationPayload } from './component-documentation-types.ts';
 import { humanizeComponentName } from './shell-app/humanize.ts';
+import { stripInlineSourcemaps } from './strip-inline-sourcemaps.ts';
 
 const LINE_SEPARATOR = String.fromCharCode(0x2028);
 const PARAGRAPH_SEPARATOR = String.fromCharCode(0x2029);
@@ -214,7 +215,7 @@ export function renderShell(
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${title}</title>
     ${meta}
-    ${options.shellHead ?? ''}
+    ${stripInlineSourcemaps(options.shellHead ?? '')}
     <script>${PRE_PAINT_THEME_SCRIPT}</script>
     <style>
       /* Register cinder.reset as the FIRST layer (least priority) so the universal

--- a/packages/playground/src/strip-inline-sourcemaps.test.ts
+++ b/packages/playground/src/strip-inline-sourcemaps.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'bun:test';
+
+import { stripInlineSourcemaps } from './strip-inline-sourcemaps.ts';
+
+describe('stripInlineSourcemaps', () => {
+  test('removes an inline sourcemap comment from a style tag', () => {
+    const head = `<style id="svelte-abc123">
+  .card.svelte-abc123 { color: red; }
+
+/*# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozfQ== */</style>`;
+
+    const stripped = stripInlineSourcemaps(head);
+
+    expect(stripped).not.toContain('sourceMappingURL');
+    expect(stripped).toContain('.card.svelte-abc123 { color: red; }');
+    expect(stripped).toContain('<style id="svelte-abc123">');
+    expect(stripped).toContain('</style>');
+  });
+
+  test('removes every comment when several style tags are present', () => {
+    const head = [
+      '<style id="a">.a{color:red}/*# sourceMappingURL=data:application/json;base64,AAA= */</style>',
+      '<style id="b">.b{color:blue}/*# sourceMappingURL=data:application/json;base64,BBB= */</style>',
+    ].join('\n');
+
+    const stripped = stripInlineSourcemaps(head);
+
+    expect(stripped).not.toContain('sourceMappingURL');
+    expect(stripped).toContain('.a{color:red}');
+    expect(stripped).toContain('.b{color:blue}');
+  });
+
+  test('handles a payload that spans multiple lines', () => {
+    const head = `<style>.x{color:red}/*# sourceMappingURL=data:application/json;base64,AAAA
+BBBB
+CCCC */</style>`;
+
+    expect(stripInlineSourcemaps(head)).not.toContain('sourceMappingURL');
+  });
+
+  test('returns the input unchanged when there is no sourcemap comment', () => {
+    const head = '<style id="svelte-xyz">.a.svelte-xyz { color: red; }</style>';
+
+    expect(stripInlineSourcemaps(head)).toBe(head);
+  });
+
+  test('leaves ordinary CSS comments alone', () => {
+    const css = '/* keep me */ .a { color: red; } /* and me */';
+
+    expect(stripInlineSourcemaps(css)).toBe(css);
+  });
+
+  test('preserves declarations that follow a stripped comment', () => {
+    const css =
+      '.a{color:red}/*# sourceMappingURL=data:application/json;base64,AA= */.b{color:blue}';
+
+    const stripped = stripInlineSourcemaps(css);
+
+    expect(stripped).toBe('.a{color:red}.b{color:blue}');
+  });
+
+  test('is idempotent', () => {
+    const head =
+      '<style>.a{color:red}/*# sourceMappingURL=data:application/json;base64,AA= */</style>';
+
+    const once = stripInlineSourcemaps(head);
+
+    expect(stripInlineSourcemaps(once)).toBe(once);
+  });
+});

--- a/packages/playground/src/strip-inline-sourcemaps.ts
+++ b/packages/playground/src/strip-inline-sourcemaps.ts
@@ -1,0 +1,33 @@
+/**
+ * Strip inline sourcemap comments from server-rendered `<style>` output.
+ *
+ * `svelte/server`'s `render()` returns each component's scoped CSS with a
+ * trailing `/*# sourceMappingURL=data:application/json;base64,… *\/` comment.
+ * Those maps are a development aid, but they land inline in `<head>` on the
+ * critical rendering path of every request: on the deployed playground they
+ * measured 103 KB of a 204 KB document — 50.3% of the bytes the browser must
+ * download and parse before first paint, for data no visitor can use.
+ *
+ * Stripping them is safe because the comment is inert CSS: removing it changes
+ * no rule, no selector, and no cascade order.
+ */
+
+/**
+ * A CSS sourcemap comment. The payload is a base64 data URI, so it cannot
+ * itself contain `*` + `/`; matching lazily up to the first comment close is
+ * therefore unambiguous. The `s` flag lets the payload span newlines.
+ */
+const INLINE_SOURCEMAP_COMMENT = /\/\*#\s*sourceMappingURL=data:[^*]*?\*\//gs;
+
+/**
+ * Remove every inline sourcemap comment from a fragment of CSS or from an HTML
+ * fragment containing `<style>` tags. Returns the input unchanged when it holds
+ * no sourcemap comment, so callers can apply it unconditionally.
+ *
+ * @param source - Server-rendered CSS or `<head>` HTML.
+ * @returns The same markup with inline sourcemap comments removed.
+ */
+export function stripInlineSourcemaps(source: string): string {
+  if (!source.includes('sourceMappingURL')) return source;
+  return source.replace(INLINE_SOURCEMAP_COMMENT, '');
+}


### PR DESCRIPTION
## What prompted this

The playground currently serves **two documentation pages per component**:

- **`/page/<name>`** — the real page (`component-page.svelte`): hero, TOC, playground controls, examples, props, accessibility, related. But it shipped an empty `<div id="app">` plus a bundle, so the statically-exported site showed **nothing until JavaScript executed**.
- **`/c/<name>`** — added by #1000. Server-renders a *condensed duplicate* inside the shell: an undersized 360px iframe preview, abbreviated readme, and an "Open interactive documentation" link pointing back at `/page/<name>` — the page that should have rendered in the first place.

#1000 fixed the symptom (no SSR content) by building a second page rather than the cause: the real page could not server-render because it read `window.location`, `window.__CINDER_EXAMPLES__`, and `document.documentElement` during initialization.

**This PR fixes the cause.** It is the first of two: this one makes the canonical page server-render correctly; the follow-up removes the duplicate surface and reworks the preview into a split view.

## What changed

### `/page/<name>` is now server-rendered

Those three window reads are now props the server supplies explicitly, each falling back to the browser environment (guarded for SSR) when omitted — so the 30+ existing unit tests keep rendering with no props.

New `src/page-server-entry.ts` mirrors the proven `shell-app/shell-server-entry.ts` pattern, compiled through the same `sveltePlugin({ generate: 'server' })` path with the same last-good-renderer fallback.

### Two hydration mismatches closed by construction

- **`theme`** seeds `light` on both sides and adopts the real preference in `onMount`. Reading the document during init rendered a Sun on the server and a Moon on the client for dark-mode users.
- **The live component mount** needs `bareComponentModule`, which only the client bundle has, so it is gated behind `isHydrated`. Both sides render the featured-example branch first; the live preview swaps in after mount.

### `?snapshot=1` is deliberately untouched

The visual-regression and axe suites wait for `#app > *` and assert single-instance `example-mount-*` counts on a bare surface (`packages/testing/src/fixtures/component-page.ts:88`). That surface keeps its historical client-only mount, so the two surfaces stay separate **on purpose**. This is the seam that de-risked the change.

### Inline sourcemaps stripped from SSR output — measured 38.5% payload cut

Svelte's `render()` appends a base64 sourcemap to each component's scoped CSS, and those landed inline in `<head>` **on the critical rendering path**. Measured on the deployed page: **103 KB of 204 KB — 50.3% of the bytes the browser must download and parse before first paint**, for data no visitor can use.

Stripping them is safe because the comment is inert CSS — no rule, selector, or cascade order changes.

| | Before | After |
|---|---|---|
| Shell page bytes | 204,398 | 125,663 (**−38.5%**) |
| Inline sourcemaps | 6 | 0 |

## Verification

| Check | Result |
|---|---|
| `components.playwright.ts` (93 components × theme × viewport) | **1187 passed**, 0 axe violations |
| `bun run --filter=@cinder/playground test` | 922 pass, 0 fail |
| `typecheck` | no new errors (3 pre-existing chat-example errors unchanged — see below) |
| `/page/button` | SSR'd `<h1>`, props table, 8 reserved mount containers, 0 sourcemaps, no live stage in server tree |
| `/page/button?snapshot=1` | empty `#app`, `data-snapshot-mode`, no doc chrome — contract intact |

Content is present in the HTML **with JavaScript disabled**, which is the actual "no loading screen" requirement.

## Pre-existing issues found (NOT introduced here, NOT fixed here)

Three `exactOptionalPropertyTypes` errors exist on the pristine tree, in files this PR never touches. Verified by stashing all changes and re-running typecheck:

- `src/examples/chat/interactive-harness.example.svelte:653` — `onExpandedChange` not in `ChatProps`
- `src/examples/chat/with-suggestions.example.svelte:42` — `onSuggestionSelect` not in `ChatProps`
- `src/examples/chat-composer-popover/slash-commands.example.svelte:68` — `onSelect` not in `ChatComposerPopoverProps`

These look like camelCase handler props that should be lowercase (`onexpandedchange`, `onsuggestionselect`, `onselect`). Surfacing rather than absorbing into an unrelated PR.

## Follow-up (next PR)

1. Wrap the SSR'd page in the shell chrome (sidebar, top bar) so `/page/` gains navigation.
2. `/c/<name>` → 301 to `/page/<name>`; delete `component-documentation.svelte`, `preview-frame.svelte`, and the postMessage bridge; stop exporting `/c/` files.
3. Split-view playground: sticky, viewport-height preview + controls beside the docs on wide screens, stacked below 720px — replacing the 360px box.
4. Guardrails: single-surface contract test, static-export content assertion (fails the Vercel build on an `#app`-only page), and a static-build Playwright smoke asserting docs render with JS disabled and chrome has computed styles.
5. Flatten the 3-level serial CSS `@import` waterfall (`shell.css` → `index.css` + 11 component sheets → tokens/foundation/partials/utilities) — 3 render-blocking round trips now sit in front of the newly SSR'd content.