### PR TITLE
build: declare cross-package turbo inputs and enable remote caching

### DIFF
--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -27,13 +27,20 @@ env:
   # TURBO_FORCE is load-bearing in a way it was not before remote caching: it is
   # the only thing stopping this workflow from reading the shared remote cache
   # and degrading into a no-op verifier that replays entries instead of proving
-  # the code still executes. Never remove it. Writes still happen under force,
-  # which is the point — main-green is the from-scratch cache PRODUCER.
+  # the code still executes. Never remove it.
+  #
+  # There is deliberately no `actions/cache` step for `.turbo` in this workflow.
+  # A restore could never be read under force, and a save would collide with
+  # unit-tests.yaml's unsuffixed primary key: `actions/cache` selects an exact
+  # key match before consulting `restore-keys`, so once unit-tests has saved
+  # `turbo-<os>-<lock>-<config>`, entries saved here under any other key are
+  # never consumed. Remote caching is the cross-run sharing mechanism now, and
+  # this workflow always has secrets (push to main + schedule, never a fork).
   TURBO_FORCE: 'true'
-  # main-green only ever runs on `push` to main and on `schedule`, never from a
-  # fork, so these are always populated.
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  # OS discriminator for the remote cache — see the `test` task in turbo.json.
+  TURBO_PLATFORM: ${{ runner.os }}
 
 jobs:
   workspace-gates:
@@ -195,25 +202,6 @@ jobs:
               process.exit(0);
             });
           "
-
-      # Save-only, and deliberately the LAST step. `TURBO_FORCE` (see the `env`
-      # block) makes every task above re-execute, so restoring a .turbo cache
-      # here would download an archive whose entries can never be read — pure
-      # dead time. The entries turbo *writes* during those forced executions are
-      # still worth keeping: they were produced by a from-scratch run of the
-      # full suite, which makes main-green the trusted cache producer that
-      # unit-tests.yaml's `turbo-${{ runner.os }}-` restore-key prefix then
-      # consumes. Hence `cache/save` rather than `cache` (restore + save).
-      #
-      # The key carries `github.sha` so each merge uploads a fresh entry —
-      # bun.lock and turbo.json alone are too coarse and would let the first
-      # run for a given lockfile pin the cache forever.
-      - name: Save Turbo cache
-        if: always()
-        uses: actions/cache/save@v6
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}-${{ github.sha }}
 
   component-tests:
     name: component-tests (${{ matrix.chunk }}/4)

--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -23,7 +23,17 @@ env:
   # hits instead of re-executing — exactly the case this workflow exists to
   # catch — so force real execution here. unit-tests.yaml deliberately keeps
   # cache hits; do not add this there.
+  #
+  # TURBO_FORCE is load-bearing in a way it was not before remote caching: it is
+  # the only thing stopping this workflow from reading the shared remote cache
+  # and degrading into a no-op verifier that replays entries instead of proving
+  # the code still executes. Never remove it. Writes still happen under force,
+  # which is the point — main-green is the from-scratch cache PRODUCER.
   TURBO_FORCE: 'true'
+  # main-green only ever runs on `push` to main and on `schedule`, never from a
+  # fork, so these are always populated.
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
   workspace-gates:
@@ -38,14 +48,6 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-
-      - name: Restore Turbo cache
-        uses: actions/cache@v6
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}
-          restore-keys: |
-            turbo-${{ runner.os }}-
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -193,6 +195,25 @@ jobs:
               process.exit(0);
             });
           "
+
+      # Save-only, and deliberately the LAST step. `TURBO_FORCE` (see the `env`
+      # block) makes every task above re-execute, so restoring a .turbo cache
+      # here would download an archive whose entries can never be read — pure
+      # dead time. The entries turbo *writes* during those forced executions are
+      # still worth keeping: they were produced by a from-scratch run of the
+      # full suite, which makes main-green the trusted cache producer that
+      # unit-tests.yaml's `turbo-${{ runner.os }}-` restore-key prefix then
+      # consumes. Hence `cache/save` rather than `cache` (restore + save).
+      #
+      # The key carries `github.sha` so each merge uploads a fresh entry —
+      # bun.lock and turbo.json alone are too coarse and would let the first
+      # run for a given lockfile pin the cache forever.
+      - name: Save Turbo cache
+        if: always()
+        uses: actions/cache/save@v6
+        with:
+          path: .turbo
+          key: turbo-${{ runner.os }}-${{ hashFiles('bun.lock') }}-${{ hashFiles('turbo.json') }}-${{ github.sha }}
 
   component-tests:
     name: component-tests (${{ matrix.chunk }}/4)

--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -39,8 +39,6 @@ env:
   TURBO_FORCE: 'true'
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-  # OS discriminator for the remote cache — see the `test` task in turbo.json.
-  TURBO_PLATFORM: ${{ runner.os }}
 
 jobs:
   workspace-gates:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -91,11 +91,11 @@ env:
   # can reach. Do not "clean it up".
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
-  # OS discriminator for the remote cache — see the `test` task in turbo.json.
-  # Turbo's hash has no platform component, so without this a macOS laptop and
-  # this Linux runner would share `test` entries despite platform-conditioned
-  # assertions in the suite.
-  TURBO_PLATFORM: ${{ runner.os }}
+  # No OS discriminator is set here on purpose. The `test` tasks in turbo.json
+  # declare `RUNNER_OS`, which GitHub already defines in every job — nothing to
+  # wire up. (`${{ runner.os }}` cannot be used in a workflow-level `env:` block
+  # at all: the `runner` context only exists at step level, and referencing it
+  # here makes GitHub reject the whole workflow file.)
 
 jobs:
   scope:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -83,6 +83,14 @@ env:
   # Read by `turbo run --affected`; harmless on push/workflow_dispatch runs
   # since those invocations omit --affected entirely.
   TURBO_SCM_BASE: origin/${{ github.base_ref }}
+  # Remote cache. This trigger is `pull_request`, NOT `pull_request_target`, so
+  # runs from forks get an empty string for both of these — turbo then silently
+  # skips the remote cache and falls back to the `actions/cache` .turbo restore
+  # below. That fallback is why this workflow keeps its local cache step even
+  # though main-green.yaml drops its restore: it is the only cache a fork PR
+  # can reach. Do not "clean it up".
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ vars.TURBO_TEAM }}
 
 jobs:
   scope:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -91,6 +91,11 @@ env:
   # can reach. Do not "clean it up".
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}
+  # OS discriminator for the remote cache — see the `test` task in turbo.json.
+  # Turbo's hash has no platform component, so without this a macOS laptop and
+  # this Linux runner would share `test` entries despite platform-conditioned
+  # assertions in the suite.
+  TURBO_PLATFORM: ${{ runner.os }}
 
 jobs:
   scope:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,15 +61,14 @@ those broad checks.
 
 `build`, `test`, `test:coverage`, `typecheck`, and `lint` run through Turborepo
 and are content-hashed, so an unchanged package replays its previous result
-instead of re-executing. Locally that cache lives in `.turbo/cache/` at the main
-checkout. Worktrees under `.claude/worktrees/` symlink their `node_modules` back
-to that checkout and turbo follows it, so worktrees already share one local cache
-even though each reads its own `turbo.json` — verified by watching entry counts
-while running a task from a worktree.
+instead of re-executing. Locally that cache lives in `.turbo/cache/` at the root
+turbo resolves for the run. Each worktree has its own real `node_modules` (see
+the worktree rule in [AGENTS.md](./AGENTS.md) — never symlink one to another
+checkout), so treat every worktree and every clone as starting with a cold local
+cache.
 
-What the local cache can't do is span machines. The remote cache is what makes a
-CI-produced build a hit on your laptop, and what gives a fresh clone or a
-brand-new worktree a warm start instead of a cold one. Export the credentials
+That is precisely the gap the remote cache closes: a fresh worktree, a fresh
+clone, or a second machine starts warm instead of cold. Export the credentials
 from your shell profile rather than running `turbo link`, which writes
 `.turbo/config.json` into whichever root it was run from:
 
@@ -77,17 +76,31 @@ from your shell profile rather than running `turbo link`, which writes
 # ~/.zshrc
 export TURBO_TOKEN='<your Vercel access token>'
 export TURBO_TEAM='<vercel team slug>'
+export TURBO_PLATFORM="$(uname -s)"
 ```
 
-Mint the token at Vercel → Account Settings → Tokens. Nothing here is required —
-without it turbo silently falls back to the local `.turbo/` cache.
+Mint the token at Vercel → Account Settings → Tokens, scoped to the team rather
+than Full Account. None of this is required — without it turbo silently falls
+back to the local `.turbo/` cache.
 
-In CI the same pair is read from `secrets.TURBO_TOKEN` and `vars.TURBO_TEAM` by
+`TURBO_PLATFORM` is an OS discriminator, not a credential. Turbo's task hash
+covers declared files, environment variables, and engines, but has **no platform
+component**. Since parts of the suite branch on `process.platform`, sharing one
+remote namespace between macOS laptops and Linux CI would let a success be
+replayed on the OS that never ran that branch. `turbo.json` declares it on
+`test`/`test:coverage` only, so `build`, `typecheck`, and `lint` keep full
+CI-to-laptop sharing. It fails safe when unset: an unset value hashes differently
+from `Linux`, so a laptop cannot read a CI test entry by accident.
+
+In CI the same variables come from `secrets.TURBO_TOKEN` and `vars.TURBO_TEAM` in
 `unit-tests.yaml` and `main-green.yaml`. Two deliberate asymmetries:
 
-- `main-green.yaml` sets `TURBO_FORCE=true` so it never _reads_ the cache. It is
-  the full-execution safety net; replaying cache entries would defeat its entire
-  purpose. It still writes, which makes it the trusted from-scratch producer.
+- `main-green.yaml` sets `TURBO_FORCE=true` so it never _reads_ any cache. It is
+  the full-execution safety net; replaying entries would defeat its purpose. It
+  also has no `actions/cache` step at all — a restore could never be read under
+  force, and a save would be dead weight, because `actions/cache` matches an
+  exact key before consulting `restore-keys` and `unit-tests.yaml` already owns
+  the unsuffixed primary key.
 - `unit-tests.yaml` keeps its `actions/cache` step for `.turbo`. It triggers on
   `pull_request` (not `pull_request_target`), so fork PRs get empty secrets and
   no remote cache — the local archive is the only cache they can reach.
@@ -101,6 +114,15 @@ In CI the same pair is read from `secrets.TURBO_TOKEN` and `vars.TURBO_TEAM` by
 > not cover them. `turbo.json` declares that directory as an explicit input on
 > the affected tasks. If you add a new cross-package import from a cached task,
 > add its directory to that task's `inputs` too.
+
+> [!IMPORTANT] A package-task override replaces the base task — it does not merge
+> Writing `"@scope/pkg#build": { "dependsOn": ["@scope/other#build"] }` discards
+> the base task's `^build` rather than adding to it, which silently drops every
+> workspace-dependency edge. That is how the editor tasks came to omit Cinder's
+> build hash despite importing Cinder components. Always keep `^build` in the
+> list and append: `["^build", "@scope/other#build"]`. After any change, run
+> `bunx turbo run build lint typecheck test --dry=json` and confirm each task's
+> resolved `dependencies` is a superset of what it was before.
 
 ## Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,8 +115,12 @@ In CI the same variables come from `secrets.TURBO_TOKEN` and `vars.TURBO_TEAM` i
 > (`svelte-plugin.ts`, `check-coverage-ratchet.ts`, the artifact generators),
 > and those files never land in cinder's `dist/**`, so the `^build` edge does
 > not cover them. `turbo.json` declares that directory as an explicit input on
-> the affected tasks. If you add a new cross-package import from a cached task,
-> add its directory to that task's `inputs` too.
+> the affected tasks, and does the same for `packages/testing/scripts/**` (which
+> the playground imports) and `packages/playground/src/**` (which the testing
+> package imports back). If you add a new cross-package import from a cached
+> task, add its directory to that task's `inputs` too — a relative `../../`
+> import into a package you do not declare a dependency on is invisible to the
+> task graph.
 
 > [!IMPORTANT] A package-task override replaces the base task — it does not merge
 > Writing `"@scope/pkg#build": { "dependsOn": ["@scope/other#build"] }` discards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,10 @@ remote namespace between macOS laptops and Linux CI would let a success be
 replayed on the OS that never ran that branch. `turbo.json` declares it on
 `test`/`test:coverage` only, so `build`, `typecheck`, and `lint` keep full
 CI-to-laptop sharing. It fails safe when unset: an unset value hashes differently
-from `Linux`, so a laptop cannot read a CI test entry by accident.
+from any set value, so a laptop cannot read a CI test entry by accident.
+
+CI needs no equivalent setting — the same task declaration also lists
+`RUNNER_OS`, which GitHub defines in every job automatically.
 
 In CI the same variables come from `secrets.TURBO_TOKEN` and `vars.TURBO_TEAM` in
 `unit-tests.yaml` and `main-green.yaml`. Two deliberate asymmetries:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,51 @@ root `bun run validate`, full test/coverage/browser suites, or consumer
 validation as an ordinary local pull request gate; required CI and release own
 those broad checks.
 
+## Turborepo remote cache
+
+`build`, `test`, `test:coverage`, `typecheck`, and `lint` run through Turborepo
+and are content-hashed, so an unchanged package replays its previous result
+instead of re-executing. Locally that cache lives in `.turbo/cache/` at the main
+checkout. Worktrees under `.claude/worktrees/` symlink their `node_modules` back
+to that checkout and turbo follows it, so worktrees already share one local cache
+even though each reads its own `turbo.json` — verified by watching entry counts
+while running a task from a worktree.
+
+What the local cache can't do is span machines. The remote cache is what makes a
+CI-produced build a hit on your laptop, and what gives a fresh clone or a
+brand-new worktree a warm start instead of a cold one. Export the credentials
+from your shell profile rather than running `turbo link`, which writes
+`.turbo/config.json` into whichever root it was run from:
+
+```bash
+# ~/.zshrc
+export TURBO_TOKEN='<your Vercel access token>'
+export TURBO_TEAM='<vercel team slug>'
+```
+
+Mint the token at Vercel → Account Settings → Tokens. Nothing here is required —
+without it turbo silently falls back to the local `.turbo/` cache.
+
+In CI the same pair is read from `secrets.TURBO_TOKEN` and `vars.TURBO_TEAM` by
+`unit-tests.yaml` and `main-green.yaml`. Two deliberate asymmetries:
+
+- `main-green.yaml` sets `TURBO_FORCE=true` so it never _reads_ the cache. It is
+  the full-execution safety net; replaying cache entries would defeat its entire
+  purpose. It still writes, which makes it the trusted from-scratch producer.
+- `unit-tests.yaml` keeps its `actions/cache` step for `.turbo`. It triggers on
+  `pull_request` (not `pull_request_target`), so fork PRs get empty secrets and
+  no remote cache — the local archive is the only cache they can reach.
+
+> [!WARNING] Cache correctness is a shared concern now
+> Because entries are shared across machines, an under-declared task input
+> becomes a wrong result everywhere rather than one stale local hit. Several
+> packages import across the boundary from `packages/components/scripts/**`
+> (`svelte-plugin.ts`, `check-coverage-ratchet.ts`, the artifact generators),
+> and those files never land in cinder's `dist/**`, so the `^build` edge does
+> not cover them. `turbo.json` declares that directory as an explicit input on
+> the affected tasks. If you add a new cross-package import from a cached task,
+> add its directory to that task's `inputs` too.
+
 ## Tests
 
 - Unit tests use `bun:test` and live alongside the source as `*.test.ts`.

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -19,8 +19,69 @@ import {
   rootValidationSeparatesSourceAndConsumerGates,
   workflowDeclaresPermission,
   workflowDispatchInputHasDefault,
+  workflowExpressionContextRoots,
   workflowRunScriptsContainActiveLine,
 } from './validate-release-workflow.ts';
+
+/**
+ * The four contexts GitHub makes available to a workflow-level `env:` block.
+ * Mirrors the allowlist the validator applies.
+ */
+const CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL = new Set(['github', 'secrets', 'inputs', 'vars']);
+
+function workflowLevelEnvironmentLineIsRejected(line: string): boolean {
+  return workflowExpressionContextRoots(line).some(
+    (root) => !CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL.has(root),
+  );
+}
+
+describe('workflow-level env context guard', () => {
+  // Regression: `TURBO_PLATFORM: ${{ runner.os }}` in a workflow-level `env:`
+  // made GitHub reject unit-tests.yaml and main-green.yaml outright — every job
+  // failed before starting, and the YAML parsed fine so nothing caught it.
+  test.each([
+    ['runner, the context that caused the outage', '  TURBO_PLATFORM: ${{ runner.os }}'],
+    ['runner via bracket access', "  TURBO_PLATFORM: ${{ runner['os'] }}"],
+    ['env, which is not available to itself', '  A: ${{ env.FOO }}'],
+    ['jobs', '  A: ${{ jobs.some_job.outputs.value }}'],
+    ['needs', '  A: ${{ needs.build.outputs.artifact }}'],
+    ['matrix', '  A: ${{ matrix.chunk }}'],
+    ['steps', '  A: ${{ steps.compute.outputs.value }}'],
+    ['strategy', '  A: ${{ strategy.job-index }}'],
+  ])('rejects %s', (_label, line) => {
+    expect(workflowLevelEnvironmentLineIsRejected(line)).toBe(true);
+  });
+
+  test.each([
+    ['secrets', '  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}'],
+    ['vars', '  TURBO_TEAM: ${{ vars.TURBO_TEAM }}'],
+    ['a deep github path', '  A: ${{ github.event.pull_request.number }}'],
+    ['github with bracket access mid-chain', "  A: ${{ github['event'].pull_request.number }}"],
+    ['github inside an interpolated string', '  TURBO_SCM_BASE: origin/${{ github.base_ref }}'],
+    ['a bare function call', "  A: ${{ hashFiles('bun.lock') }}"],
+    ['a dotted string literal argument', "  A: ${{ format('{0}.{1}', github.a, github.b) }}"],
+    [
+      'a boolean expression over github',
+      '  A: ${{ github.event_name && github.sha || github.ref }}',
+    ],
+    ['a plain value with no expression', '  BUN_VERSION: 1.3.13'],
+  ])('allows %s', (_label, line) => {
+    expect(workflowLevelEnvironmentLineIsRejected(line)).toBe(false);
+  });
+
+  test('reports only the root of a chain, not every segment', () => {
+    expect(workflowExpressionContextRoots('  A: ${{ github.event.pull_request.number }}')).toEqual([
+      'github',
+    ]);
+  });
+
+  test('collects a root from each expression on one line', () => {
+    expect(workflowExpressionContextRoots('  A: ${{ github.sha }}-${{ runner.os }}')).toEqual([
+      'github',
+      'runner',
+    ]);
+  });
+});
 
 describe('validate-release-workflow changeset guards', () => {
   test('requires artifact and publish commands for every public package', () => {

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -21,6 +21,7 @@ import {
   workflowDispatchInputHasDefault,
   workflowExpressionContextRoots,
   workflowExpressionFunctionNames,
+  workflowLevelEnvironmentLines,
   workflowRunScriptsContainActiveLine,
 } from './validate-release-workflow.ts';
 
@@ -110,6 +111,63 @@ describe('workflow-level env context guard', () => {
       'github',
       'runner',
     ]);
+  });
+});
+
+describe('workflow-level env block scanning', () => {
+  test('collects entries in the top-level env block only', () => {
+    const workflow = [
+      'name: example',
+      'env:',
+      '  TOP: ${{ vars.A }}',
+      'jobs:',
+      '  build:',
+      '    env:',
+      '      JOB_LEVEL: ${{ runner.os }}',
+      '    steps:',
+      '      - run: echo hi',
+    ].join('\n');
+
+    // The job-level `runner.os` is legal and must NOT be collected — collecting
+    // it would make the guard reject valid workflows.
+    expect(workflowLevelEnvironmentLines(workflow)).toEqual(['  TOP: ${{ vars.A }}']);
+  });
+
+  // Regression: a column-0 comment used to be read as the next top-level key,
+  // ending the scan and letting everything after it bypass the guard entirely.
+  test('keeps scanning past a comment at column zero', () => {
+    const workflow = [
+      'env:',
+      '  FIRST: ${{ vars.A }}',
+      '# an unindented comment is legal YAML inside the block',
+      '  SECOND: ${{ runner.os }}',
+    ].join('\n');
+
+    expect(workflowLevelEnvironmentLines(workflow)).toEqual([
+      '  FIRST: ${{ vars.A }}',
+      '  SECOND: ${{ runner.os }}',
+    ]);
+  });
+
+  test('keeps scanning past a blank line inside the block', () => {
+    const workflow = ['env:', '  FIRST: ${{ vars.A }}', '', '  SECOND: ${{ runner.os }}'].join(
+      '\n',
+    );
+
+    expect(workflowLevelEnvironmentLines(workflow)).toEqual([
+      '  FIRST: ${{ vars.A }}',
+      '  SECOND: ${{ runner.os }}',
+    ]);
+  });
+
+  test('stops at the next real top-level key', () => {
+    const workflow = ['env:', '  FIRST: ${{ vars.A }}', 'on:', '  push: {}'].join('\n');
+
+    expect(workflowLevelEnvironmentLines(workflow)).toEqual(['  FIRST: ${{ vars.A }}']);
+  });
+
+  test('returns nothing when there is no workflow-level env block', () => {
+    expect(workflowLevelEnvironmentLines('name: example\non:\n  push: {}')).toEqual([]);
   });
 });
 

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -169,6 +169,31 @@ describe('workflow-level env block scanning', () => {
   test('returns nothing when there is no workflow-level env block', () => {
     expect(workflowLevelEnvironmentLines('name: example\non:\n  push: {}')).toEqual([]);
   });
+
+  // A flow mapping lives entirely on the key's own line. A scanner that only
+  // looked at indented lines would open the block, skip this line as the key,
+  // then close at the next top-level key having inspected nothing.
+  test('inspects an inline flow mapping', () => {
+    const workflow = ['env: { TURBO_PLATFORM: "${{ runner.os }}" }', 'on:', '  push: {}'].join(
+      '\n',
+    );
+
+    expect(workflowLevelEnvironmentLines(workflow)).toEqual([
+      'env: { TURBO_PLATFORM: "${{ runner.os }}" }',
+    ]);
+  });
+
+  test('does not treat a flow mapping as an open block', () => {
+    const workflow = [
+      'env: { A: ${{ vars.A }} }',
+      'jobs:',
+      '  build:',
+      '    x: ${{ runner.os }}',
+    ].join('\n');
+
+    // The job-level line must not leak in just because a flow mapping preceded it.
+    expect(workflowLevelEnvironmentLines(workflow)).toEqual(['env: { A: ${{ vars.A }} }']);
+  });
 });
 
 describe('validate-release-workflow changeset guards', () => {

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -69,6 +69,11 @@ describe('workflow-level env context guard', () => {
     ['hashFiles regardless of casing', "  A: ${{ HASHFILES('bun.lock') }}"],
     ['the always status function', '  A: ${{ always() }}'],
     ['the success status function', '  A: ${{ success() }}'],
+    // A whole context is as invalid as one of its properties, and neither the
+    // dotted-root scan nor the function scan sees these on its own.
+    ['a bare context with no property access', '  A: ${{ runner }}'],
+    ['a bare context passed to an allowed function', '  A: ${{ toJSON(runner) }}'],
+    ['a bare context inside a comparison', "  A: ${{ matrix == 'x' }}"],
   ])('rejects %s', (_label, line) => {
     expect(workflowLevelEnvironmentLineIsRejected(line)).toBe(true);
   });
@@ -81,6 +86,9 @@ describe('workflow-level env context guard', () => {
     ['github inside an interpolated string', '  TURBO_SCM_BASE: origin/${{ github.base_ref }}'],
     ['an always-available function', "  A: ${{ format('{0}', github.sha) }}"],
     ['toJSON over an allowed context', '  A: ${{ toJSON(github.event) }}'],
+    ['a bare allowed context', '  A: ${{ github }}'],
+    ['a boolean literal', '  A: ${{ true }}'],
+    ['a comparison against an allowed context', "  A: ${{ inputs.mode == 'full' }}"],
     ['a dotted string literal argument', "  A: ${{ format('{0}.{1}', github.a, github.b) }}"],
     [
       'a boolean expression over github',

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -20,6 +20,7 @@ import {
   workflowDeclaresPermission,
   workflowDispatchInputHasDefault,
   workflowExpressionContextRoots,
+  workflowExpressionFunctionNames,
   workflowRunScriptsContainActiveLine,
 } from './validate-release-workflow.ts';
 
@@ -29,10 +30,24 @@ import {
  */
 const CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL = new Set(['github', 'secrets', 'inputs', 'vars']);
 
+/** Mirrors the validator's set of functions unavailable before a runner exists. */
+const FUNCTIONS_UNAVAILABLE_AT_WORKFLOW_LEVEL = new Set([
+  'hashfiles',
+  'success',
+  'failure',
+  'cancelled',
+  'always',
+]);
+
 function workflowLevelEnvironmentLineIsRejected(line: string): boolean {
-  return workflowExpressionContextRoots(line).some(
+  const hasUnavailableContext = workflowExpressionContextRoots(line).some(
     (root) => !CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL.has(root),
   );
+  const hasUnavailableFunction = workflowExpressionFunctionNames(line).some((name) =>
+    FUNCTIONS_UNAVAILABLE_AT_WORKFLOW_LEVEL.has(name),
+  );
+
+  return hasUnavailableContext || hasUnavailableFunction;
 }
 
 describe('workflow-level env context guard', () => {
@@ -48,6 +63,12 @@ describe('workflow-level env context guard', () => {
     ['matrix', '  A: ${{ matrix.chunk }}'],
     ['steps', '  A: ${{ steps.compute.outputs.value }}'],
     ['strategy', '  A: ${{ strategy.job-index }}'],
+    // hashFiles needs a checked-out workspace; the status functions describe a
+    // job that has not started. Neither exists before a runner is assigned.
+    ['hashFiles, which needs a workspace', "  A: ${{ hashFiles('bun.lock') }}"],
+    ['hashFiles regardless of casing', "  A: ${{ HASHFILES('bun.lock') }}"],
+    ['the always status function', '  A: ${{ always() }}'],
+    ['the success status function', '  A: ${{ success() }}'],
   ])('rejects %s', (_label, line) => {
     expect(workflowLevelEnvironmentLineIsRejected(line)).toBe(true);
   });
@@ -58,7 +79,8 @@ describe('workflow-level env context guard', () => {
     ['a deep github path', '  A: ${{ github.event.pull_request.number }}'],
     ['github with bracket access mid-chain', "  A: ${{ github['event'].pull_request.number }}"],
     ['github inside an interpolated string', '  TURBO_SCM_BASE: origin/${{ github.base_ref }}'],
-    ['a bare function call', "  A: ${{ hashFiles('bun.lock') }}"],
+    ['an always-available function', "  A: ${{ format('{0}', github.sha) }}"],
+    ['toJSON over an allowed context', '  A: ${{ toJSON(github.event) }}'],
     ['a dotted string literal argument', "  A: ${{ format('{0}.{1}', github.a, github.b) }}"],
     [
       'a boolean expression over github',

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -26,8 +26,10 @@
  *     inherited by the publish step without appearing in the step's own lines,
  *     so the whole-file check closes that evasion path. Comment lines are
  *     allowed (they document the OIDC rationale).
- *   - release-manual.yaml is NOT checked — that file intentionally uses a token
- *     as a documented break-glass fallback.
+ *   - release-manual.yaml is exempt from the TOKEN guards above only — that file
+ *     intentionally uses a token as a documented break-glass fallback. It is
+ *     still covered by the workflow-level `env:` context check below, which
+ *     scans every workflow in the directory.
  *   - No workflow (not just release.yaml) references a job- or step-scoped
  *     context (`runner`, `steps`, `job`, `matrix`, `needs`, `strategy`) inside a
  *     workflow-level `env:` block. GitHub rejects the entire file in that case,
@@ -810,6 +812,41 @@ function runValidation(): void {
 const CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL = new Set(['github', 'secrets', 'inputs', 'vars']);
 
 /**
+ * Expression functions that are NOT available to a workflow-level `env:`.
+ *
+ * `hashFiles` needs a workspace that only exists once a job has checked out on a
+ * runner, and the status functions describe a job that has not started. The
+ * always-available functions (`contains`, `startsWith`, `endsWith`, `format`,
+ * `join`, `toJSON`, `fromJSON`) are deliberately absent from this set.
+ */
+const FUNCTIONS_UNAVAILABLE_AT_WORKFLOW_LEVEL = new Set([
+  'hashfiles',
+  'success',
+  'failure',
+  'cancelled',
+  'always',
+]);
+
+/**
+ * Names of functions invoked inside every `${{ … }}` expression on a line,
+ * lowercased because GitHub's expression functions are case-insensitive.
+ */
+export function workflowExpressionFunctionNames(line: string): string[] {
+  const names: string[] = [];
+
+  for (const expression of line.matchAll(/\$\{\{(?<body>.*?)\}\}/g)) {
+    const body = (expression.groups?.['body'] ?? '').replace(/'(?:[^']|'')*'/g, "''");
+
+    for (const call of body.matchAll(/(?<![.\w-])(?<name>[A-Za-z_][A-Za-z0-9_-]*)\s*\(/g)) {
+      const name = call.groups?.['name'];
+      if (name !== undefined) names.push(name.toLowerCase());
+    }
+  }
+
+  return names;
+}
+
+/**
  * Extract the root identifier of every context reference inside a `${{ … }}`
  * expression — the part before the first `.` or `[`, so both `runner.os` and
  * `runner['os']` yield `runner`.
@@ -872,6 +909,20 @@ function validateWorkflowLevelEnvironmentContexts(): void {
       }
 
       if (!insideWorkflowEnvironmentBlock || isComment(line)) continue;
+
+      for (const functionName of workflowExpressionFunctionNames(line)) {
+        if (!FUNCTIONS_UNAVAILABLE_AT_WORKFLOW_LEVEL.has(functionName)) continue;
+
+        fail(
+          `${fileName} calls \`${functionName}()\` in its workflow-level \`env:\` block:\n` +
+            `  ${line.trim()}\n\n` +
+            '`hashFiles` needs a checked-out workspace, and the status functions\n' +
+            '(`success`, `failure`, `cancelled`, `always`) describe a job that has not\n' +
+            'started — none are available before a job is assigned to a runner. GitHub\n' +
+            'rejects the ENTIRE workflow file, so every job fails before it starts.\n' +
+            'Move the value to the job or step that needs it.',
+        );
+      }
 
       for (const root of workflowExpressionContextRoots(line)) {
         if (CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL.has(root)) continue;

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -839,7 +839,7 @@ function validateWorkflowLevelEnvironmentContexts(): void {
       const startsAtColumnZero = /^\S/.test(line);
 
       if (startsAtColumnZero) {
-        insideWorkflowEnvironmentBlock = /^env:/.test(line);
+        insideWorkflowEnvironmentBlock = line.startsWith('env:');
         continue;
       }
 

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -917,7 +917,21 @@ export function workflowLevelEnvironmentLines(content: string): string[] {
     if (isComment(line) || line.trim().length === 0) continue;
 
     if (/^\S/.test(line)) {
-      insideWorkflowEnvironmentBlock = line.startsWith('env:');
+      insideWorkflowEnvironmentBlock = false;
+
+      if (!line.startsWith('env:')) continue;
+
+      // `env: { A: "${{ runner.os }}" }` is a valid flow mapping that lives
+      // entirely on the key's own line. Inspect that remainder here — a
+      // line-based scanner that only looked at INDENTED lines would mark the
+      // block open, skip this line as the key, and then close the block at the
+      // next top-level key without ever examining the mapping.
+      if (line.slice('env:'.length).trim().length > 0) {
+        environmentLines.push(line);
+        continue;
+      }
+
+      insideWorkflowEnvironmentBlock = true;
       continue;
     }
 

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -827,6 +827,9 @@ const FUNCTIONS_UNAVAILABLE_AT_WORKFLOW_LEVEL = new Set([
   'always',
 ]);
 
+/** Bare words in a GitHub expression that are values, not context references. */
+const EXPRESSION_LITERALS = new Set(['true', 'false', 'null']);
+
 /**
  * Names of functions invoked inside every `${{ … }}` expression on a line,
  * lowercased because GitHub's expression functions are case-insensitive.
@@ -858,6 +861,12 @@ export function workflowExpressionFunctionNames(line: string): string[] {
  * The leading `(?<![.\w-])` is what keeps this to the ROOT: without it,
  * `github.event.pull_request.number` reports `event` and `pull_request` as
  * roots too and the allowlist rejects a perfectly valid expression.
+ *
+ * A bare context counts. `${{ runner }}` and `${{ toJSON(runner) }}` are just as
+ * invalid as `${{ runner.os }}`, and an earlier version of this function missed
+ * both by requiring a trailing `.` or `[`. So any identifier NOT followed by `(`
+ * is treated as a context reference; one followed by `(` is a function name and
+ * belongs to `workflowExpressionFunctionNames` instead.
  */
 export function workflowExpressionContextRoots(line: string): string[] {
   const roots: string[] = [];
@@ -866,10 +875,15 @@ export function workflowExpressionContextRoots(line: string): string[] {
     const body = (expression.groups?.['body'] ?? '').replace(/'(?:[^']|'')*'/g, "''");
 
     for (const reference of body.matchAll(
-      /(?<![.\w-])(?<root>[A-Za-z_][A-Za-z0-9_-]*)\s*(?:\.|\[)/g,
+      /(?<![.\w-])(?<root>[A-Za-z_][A-Za-z0-9_-]*)\s*(?<suffix>\()?/g,
     )) {
       const root = reference.groups?.['root'];
-      if (root !== undefined) roots.push(root);
+
+      if (root === undefined) continue;
+      if (reference.groups?.['suffix'] === '(') continue;
+      if (EXPRESSION_LITERALS.has(root.toLowerCase())) continue;
+
+      roots.push(root);
     }
   }
 

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -807,17 +807,45 @@ function runValidation(): void {
  * in a workflow-level `env:`); the rest share the same failure mode because
  * they are all scoped to a job or a step.
  */
-const contextsUnavailableAtWorkflowLevel = [
-  'runner',
-  'steps',
-  'job',
-  'matrix',
-  'needs',
-  'strategy',
-];
+const CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL = new Set(['github', 'secrets', 'inputs', 'vars']);
 
 /**
- * Reject job/step-scoped contexts inside a top-level `env:` block.
+ * Extract the root identifier of every context reference inside a `${{ … }}`
+ * expression — the part before the first `.` or `[`, so both `runner.os` and
+ * `runner['os']` yield `runner`.
+ *
+ * Single-quoted strings are stripped first so a literal like `format('a.b', …)`
+ * cannot be mistaken for a context reference. Function calls are naturally
+ * excluded: `fromJSON(…)` is followed by `(`, never `.` or `[`.
+ *
+ * The leading `(?<![.\w-])` is what keeps this to the ROOT: without it,
+ * `github.event.pull_request.number` reports `event` and `pull_request` as
+ * roots too and the allowlist rejects a perfectly valid expression.
+ */
+export function workflowExpressionContextRoots(line: string): string[] {
+  const roots: string[] = [];
+
+  for (const expression of line.matchAll(/\$\{\{(?<body>.*?)\}\}/g)) {
+    const body = (expression.groups?.['body'] ?? '').replace(/'(?:[^']|'')*'/g, "''");
+
+    for (const reference of body.matchAll(
+      /(?<![.\w-])(?<root>[A-Za-z_][A-Za-z0-9_-]*)\s*(?:\.|\[)/g,
+    )) {
+      const root = reference.groups?.['root'];
+      if (root !== undefined) roots.push(root);
+    }
+  }
+
+  return roots;
+}
+
+/**
+ * Reject contexts that do not exist in a top-level `env:` block.
+ *
+ * Uses GitHub's allowlist rather than a denylist of known-bad roots: the set of
+ * *available* contexts is short, closed, and documented, whereas a denylist
+ * silently passes anything it forgot (`env`, `jobs`, and bracket access all
+ * slipped through the first version of this check).
  *
  * Scans raw lines rather than the parsed tree: we need the workflow-level block
  * specifically, and a parsed mapping loses the column information that
@@ -845,24 +873,26 @@ function validateWorkflowLevelEnvironmentContexts(): void {
 
       if (!insideWorkflowEnvironmentBlock || isComment(line)) continue;
 
-      for (const context of contextsUnavailableAtWorkflowLevel) {
-        if (!new RegExp(String.raw`\$\{\{\s*${context}\.`).test(line)) continue;
+      for (const root of workflowExpressionContextRoots(line)) {
+        if (CONTEXTS_AVAILABLE_AT_WORKFLOW_LEVEL.has(root)) continue;
 
         fail(
-          `${fileName} uses the \`${context}\` context in its workflow-level \`env:\` block:\n` +
+          `${fileName} uses the \`${root}\` context in its workflow-level \`env:\` block:\n` +
             `  ${line.trim()}\n\n` +
-            `\`${context}\` is scoped to a job or a step and does not exist when a\n` +
-            'workflow-level `env:` is evaluated. GitHub rejects the whole workflow file,\n' +
-            'so every job fails before it starts with no useful annotation. Move the value\n' +
-            'to the step that needs it, or use a context available at workflow level\n' +
-            '(`github`, `vars`, `secrets`, `inputs`). For the runner OS specifically,\n' +
-            'GitHub already exports `RUNNER_OS` as a plain variable inside every job.',
+            'A workflow-level `env:` is evaluated before any job is assigned to a runner,\n' +
+            'so only `github`, `secrets`, `inputs`, and `vars` exist there. Anything else\n' +
+            '(`runner`, `steps`, `job`, `matrix`, `needs`, `strategy`, `env`, `jobs`, …)\n' +
+            'makes GitHub reject the ENTIRE workflow file: every job fails before it starts,\n' +
+            'reporting only a generic "workflow file issue" with no annotation.\n\n' +
+            'Move the value to the job or step that needs it. For the runner OS\n' +
+            'specifically, GitHub already exports `RUNNER_OS` as a plain variable inside\n' +
+            'every job — no expression required.',
         );
       }
     }
   }
 
-  pass('No job/step-scoped contexts in any workflow-level `env:` block');
+  pass('Workflow-level `env:` blocks only use contexts available at workflow level');
 }
 
 if (import.meta.main) {

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -28,6 +28,11 @@
  *     allowed (they document the OIDC rationale).
  *   - release-manual.yaml is NOT checked — that file intentionally uses a token
  *     as a documented break-glass fallback.
+ *   - No workflow (not just release.yaml) references a job- or step-scoped
+ *     context (`runner`, `steps`, `job`, `matrix`, `needs`, `strategy`) inside a
+ *     workflow-level `env:` block. GitHub rejects the entire file in that case,
+ *     failing every job before it starts with only a generic "workflow file
+ *     issue" message. The YAML itself parses fine, so nothing else catches it.
  *   - Pending changeset files do NOT target packages listed in
  *     `.changeset/config.json` `ignore`. Ignored-package changesets are never
  *     consumed by `changeset version`, but `changesets/action` still treats them
@@ -787,6 +792,77 @@ function runValidation(): void {
 
   pass('No pending changesets target ignored packages');
   pass('release.yaml is correctly configured for npm Trusted Publishing');
+
+  validateWorkflowLevelEnvironmentContexts();
+}
+
+/**
+ * Contexts that do not exist when a workflow-level `env:` block is evaluated.
+ * GitHub rejects the ENTIRE workflow file if one appears there — the run fails
+ * before any job starts, reporting only "This run likely failed because of a
+ * workflow file issue" with no annotation pointing at the line. A YAML parse
+ * check cannot catch it: the file is perfectly valid YAML.
+ *
+ * `runner` is the one that actually bit us (`TURBO_PLATFORM: ${{ runner.os }}`
+ * in a workflow-level `env:`); the rest share the same failure mode because
+ * they are all scoped to a job or a step.
+ */
+const contextsUnavailableAtWorkflowLevel = [
+  'runner',
+  'steps',
+  'job',
+  'matrix',
+  'needs',
+  'strategy',
+];
+
+/**
+ * Reject job/step-scoped contexts inside a top-level `env:` block.
+ *
+ * Scans raw lines rather than the parsed tree: we need the workflow-level block
+ * specifically, and a parsed mapping loses the column information that
+ * distinguishes it from `jobs.<id>.env`. A top-level key sits at column 0, so
+ * the block runs from a line matching `env:` at column 0 until the next
+ * column-0 key.
+ */
+function validateWorkflowLevelEnvironmentContexts(): void {
+  const workflowFileNames = readdirSync(workflowsDirectoryPath).filter(
+    (fileName) => fileName.endsWith('.yaml') || fileName.endsWith('.yml'),
+  );
+
+  for (const fileName of workflowFileNames) {
+    const lines = readFileSync(join(workflowsDirectoryPath, fileName), 'utf8').split('\n');
+
+    let insideWorkflowEnvironmentBlock = false;
+
+    for (const line of lines) {
+      const startsAtColumnZero = /^\S/.test(line);
+
+      if (startsAtColumnZero) {
+        insideWorkflowEnvironmentBlock = /^env:/.test(line);
+        continue;
+      }
+
+      if (!insideWorkflowEnvironmentBlock || isComment(line)) continue;
+
+      for (const context of contextsUnavailableAtWorkflowLevel) {
+        if (!new RegExp(String.raw`\$\{\{\s*${context}\.`).test(line)) continue;
+
+        fail(
+          `${fileName} uses the \`${context}\` context in its workflow-level \`env:\` block:\n` +
+            `  ${line.trim()}\n\n` +
+            `\`${context}\` is scoped to a job or a step and does not exist when a\n` +
+            'workflow-level `env:` is evaluated. GitHub rejects the whole workflow file,\n' +
+            'so every job fails before it starts with no useful annotation. Move the value\n' +
+            'to the step that needs it, or use a context available at workflow level\n' +
+            '(`github`, `vars`, `secrets`, `inputs`). For the runner OS specifically,\n' +
+            'GitHub already exports `RUNNER_OS` as a plain variable inside every job.',
+        );
+      }
+    }
+  }
+
+  pass('No job/step-scoped contexts in any workflow-level `env:` block');
 }
 
 if (import.meta.main) {

--- a/packages/components/scripts/validate-release-workflow.ts
+++ b/packages/components/scripts/validate-release-workflow.ts
@@ -904,26 +904,38 @@ export function workflowExpressionContextRoots(line: string): string[] {
  * the block runs from a line matching `env:` at column 0 until the next
  * column-0 key.
  */
+export function workflowLevelEnvironmentLines(content: string): string[] {
+  const environmentLines: string[] = [];
+
+  let insideWorkflowEnvironmentBlock = false;
+
+  for (const line of content.split('\n')) {
+    // Comments first: YAML ignores comment indentation, so a `# note` at column
+    // 0 is legal INSIDE the block. Testing for a column-zero key before this
+    // would treat that comment as the next top-level key, end the scan early,
+    // and let everything after it through unchecked.
+    if (isComment(line) || line.trim().length === 0) continue;
+
+    if (/^\S/.test(line)) {
+      insideWorkflowEnvironmentBlock = line.startsWith('env:');
+      continue;
+    }
+
+    if (insideWorkflowEnvironmentBlock) environmentLines.push(line);
+  }
+
+  return environmentLines;
+}
+
 function validateWorkflowLevelEnvironmentContexts(): void {
   const workflowFileNames = readdirSync(workflowsDirectoryPath).filter(
     (fileName) => fileName.endsWith('.yaml') || fileName.endsWith('.yml'),
   );
 
   for (const fileName of workflowFileNames) {
-    const lines = readFileSync(join(workflowsDirectoryPath, fileName), 'utf8').split('\n');
+    const content = readFileSync(join(workflowsDirectoryPath, fileName), 'utf8');
 
-    let insideWorkflowEnvironmentBlock = false;
-
-    for (const line of lines) {
-      const startsAtColumnZero = /^\S/.test(line);
-
-      if (startsAtColumnZero) {
-        insideWorkflowEnvironmentBlock = line.startsWith('env:');
-        continue;
-      }
-
-      if (!insideWorkflowEnvironmentBlock || isComment(line)) continue;
-
+    for (const line of workflowLevelEnvironmentLines(content)) {
       for (const functionName of workflowExpressionFunctionNames(line)) {
         if (!FUNCTIONS_UNAVAILABLE_AT_WORKFLOW_LEVEL.has(functionName)) continue;
 

--- a/turbo.json
+++ b/turbo.json
@@ -6,11 +6,12 @@
     ".oxlintrc.json",
     "tsconfig.build.json"
   ],
-  // `NODE_ENV` is a real hash input, not boilerplate: `packages/components/scripts/svelte-plugin.ts`
-  // branches on it to pick Svelte's `dev` compilation mode, and the editor's runtime guards read it
-  // too. The `build` scripts pin it to `production` internally, but `test` inherits whatever the
-  // caller had, so a local run and a CI run must not be allowed to share a cache entry.
-  "globalEnv": ["NODE_ENV"],
+  // No `globalEnv`. `NODE_ENV` was here first, on the grounds that
+  // `packages/components/scripts/svelte-plugin.ts` branches on it to pick Svelte's `dev`
+  // compilation mode — but as `globalEnv` it partitioned EVERY task on the caller's ambient value,
+  // including `build`, which normalizes `NODE_ENV` to `production` internally before compiling and
+  // so cannot vary because of it. That is pure cache-hit-rate loss for no correctness gain. It is
+  // declared on `test`/`test:coverage` instead, the only tasks that inherit the caller's value.
   "tasks": {
     // A package-task override REPLACES the base definition — turbo does not merge them field by
     // field. That makes a hand-written `dependsOn` a silent way to LOSE edges that `^build` would
@@ -29,9 +30,15 @@
     // Package `src/**` directories are deliberately NOT listed as inputs: a change there rehashes
     // that package's `build`, and turbo folds a dependency task's hash into its dependents, so
     // `^build` already covers it.
+    // `CINDER_FORCE_BUILD` is the escape hatch in `scripts/lib/build-cache.ts` for recovering from
+    // suspect `dist` output — `shouldSkipBuild()` returns `skip: false` when it is `1`. Declaring
+    // it here is what makes that work through `bun run build`: without it, turbo restores a cached
+    // entry and the package script never runs, so the documented "never skips" behavior would
+    // silently not apply to the root build command.
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
+      "env": ["CINDER_FORCE_BUILD"],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/components/scripts/**",
@@ -75,9 +82,10 @@
         "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/testing/scripts/**",
         "$TURBO_ROOT$/.github/workflows/**",
-        "$TURBO_ROOT$/docs/**"
+        "$TURBO_ROOT$/docs/**",
+        "$TURBO_ROOT$/.changeset/**"
       ],
-      "env": ["TURBO_PLATFORM", "RUNNER_OS"]
+      "env": ["TURBO_PLATFORM", "RUNNER_OS", "NODE_ENV"]
     },
     "test:coverage": {
       "dependsOn": ["^build"],
@@ -87,9 +95,10 @@
         "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/testing/scripts/**",
         "$TURBO_ROOT$/.github/workflows/**",
-        "$TURBO_ROOT$/docs/**"
+        "$TURBO_ROOT$/docs/**",
+        "$TURBO_ROOT$/.changeset/**"
       ],
-      "env": ["TURBO_PLATFORM", "RUNNER_OS"]
+      "env": ["TURBO_PLATFORM", "RUNNER_OS", "NODE_ENV"]
     },
     "typecheck": {
       "dependsOn": ["^build"],
@@ -126,9 +135,10 @@
         "$TURBO_ROOT$/packages/testing/scripts/**",
         "$TURBO_ROOT$/packages/playground/src/**",
         "$TURBO_ROOT$/.github/workflows/**",
-        "$TURBO_ROOT$/docs/**"
+        "$TURBO_ROOT$/docs/**",
+        "$TURBO_ROOT$/.changeset/**"
       ],
-      "env": ["TURBO_PLATFORM", "RUNNER_OS"]
+      "env": ["TURBO_PLATFORM", "RUNNER_OS", "NODE_ENV"]
     },
     "@cinder/testing#typecheck": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -12,110 +12,71 @@
   // caller had, so a local run and a CI run must not be allowed to share a cache entry.
   "globalEnv": ["NODE_ENV"],
   "tasks": {
+    // A package-task override REPLACES the base definition — turbo does not merge them field by
+    // field. That makes a hand-written `dependsOn` a silent way to LOSE edges that `^build` would
+    // have supplied: the editor overrides used to declare only `@lostgradient/markdown#build`, which
+    // dropped the `@lostgradient/cinder#build` edge even though editor imports Cinder components
+    // directly. So: always keep `^build` in the list and append extra edges to it, never restate the
+    // expansion by hand. Most overrides then turn out to be identical to the base task and are gone.
+    //
     // `packages/components/scripts/**` is an input to tasks in EVERY package, not just cinder's:
     // chat, editor, and playground import `svelte-plugin.ts`, `check-coverage-ratchet.ts`, the
     // component-artifact generators, and `lib/visual-fixtures/**` across the package boundary. Those
     // files never land in cinder's `dist/**`, so the `^build` edge does not cover them. They used to
     // be listed one-by-one in `globalDependencies`, which was both incomplete (only two of them were
-    // listed) and too blunt (a global dependency invalidates every cached task in the repo). Scoping
-    // the whole directory to the four tasks that actually execute it is stricter AND cheaper.
+    // listed) and too blunt (a global dependency invalidates every cached task in the repo).
     //
-    // `packages/components/src/**` deliberately is NOT listed: a change there rehashes cinder's
-    // `build`, and turbo folds a dependency task's hash into its dependents, so `^build` already
-    // covers it.
+    // Package `src/**` directories are deliberately NOT listed as inputs: a change there rehashes
+    // that package's `build`, and turbo folds a dependency task's hash into its dependents, so
+    // `^build` already covers it.
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
+    // `TURBO_PLATFORM` is an OS discriminator for the REMOTE cache. Turbo's hash covers declared
+    // files, env vars, and engines — there is no platform component (confirmed in `--dry=json`'s
+    // `globalCacheInputs`). Once macOS laptops and Linux CI share one remote namespace, a
+    // platform-conditioned test can have its success replayed on the OS that never executed that
+    // branch; `packages/testing/scripts/start-server.test.ts` and
+    // `packages/components/scripts/husky/utilities.test.ts` both derive assertions from
+    // `process.platform`. CI sets this to `runner.os`; developers export `$(uname -s)` (see
+    // CONTRIBUTING.md). It fails SAFE when unset — an unset value simply hashes differently from
+    // `Linux`, so a laptop can never read a CI test entry by accident.
+    //
+    // Only `test`/`test:coverage` carry it. `build`, `typecheck`, and `lint` are deterministic
+    // across platforms, so they keep full CI-to-laptop cache sharing.
     "test": {
       "dependsOn": ["^build"],
       "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"],
+      "env": ["TURBO_PLATFORM"]
     },
     "test:coverage": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"],
+      "env": ["TURBO_PLATFORM"]
     },
     "typecheck": {
       "dependsOn": ["^build"],
       "outputs": [],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
-    "@cinder/playground#typecheck": {
-      "dependsOn": [
-        "@lostgradient/markdown#build",
-        "@lostgradient/cinder#build",
-        "@lostgradient/editor#build",
-        "@lostgradient/chat#build"
-      ],
-      "outputs": [],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/packages/components/scripts/**",
-        "$TURBO_ROOT$/packages/components/src/**",
-        "$TURBO_ROOT$/packages/chat/src/**",
-        "$TURBO_ROOT$/packages/editor/src/**",
-        "$TURBO_ROOT$/packages/markdown/src/**"
-      ]
-    },
-    // Exists only to widen `inputs`; `^build` already expands to exactly the
-    // four builds this needs, so keep the wildcard rather than freezing today's
-    // expansion — a future workspace dependency must not silently go unbuilt.
-    "@cinder/playground#test": {
+    // `^build`, not `[]`: oxlint runs with `--type-aware`, which reads dependency `.d.ts` files, so
+    // a package's lint genuinely needs its dependencies built. Builds hash-skip, so the added edge
+    // is close to free on a warm tree.
+    "lint": {
       "dependsOn": ["^build"],
       "outputs": [],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
-    "@lostgradient/chat#typecheck": {
-      "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": [],
-      "inputs": [
-        "$TURBO_DEFAULT$",
-        "$TURBO_ROOT$/packages/components/scripts/**",
-        "$TURBO_ROOT$/packages/components/src/**",
-        "$TURBO_ROOT$/packages/markdown/src/**"
-      ]
-    },
-    // `lint` needs the same cross-package inputs as the rest: oxlint runs with
-    // `--type-aware`, and chat/editor lint scripts that import `svelte-plugin.ts`
-    // from the components package. Type-aware linting reads that file for type
-    // information, so a type change there can shift diagnostics — without this
-    // input the cached `lint` would not notice.
-    "lint": {
-      "dependsOn": [],
-      "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
-    },
-    "@lostgradient/editor#lint": {
-      "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
-    },
+    // The one surviving override. Cinder's lint reaches editor types, which is an edge `^build`
+    // cannot supply (editor depends on cinder, not the reverse). Appended to `^build` rather than
+    // replacing it, so the `@cinder/testing#build` and markdown edges survive.
     "@lostgradient/cinder#lint": {
-      "dependsOn": ["@lostgradient/markdown#build", "@lostgradient/editor#build"],
+      "dependsOn": ["^build", "@lostgradient/editor#build"],
       "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
-    },
-    "@lostgradient/editor#build": {
-      "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": ["dist/**"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
-    },
-    "@lostgradient/editor#typecheck": {
-      "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
-    },
-    "@lostgradient/editor#test": {
-      "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
-    },
-    "@lostgradient/editor#test:coverage": {
-      "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": ["coverage/**"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "validate": {

--- a/turbo.json
+++ b/turbo.json
@@ -56,13 +56,19 @@
     //
     // Only `test`/`test:coverage` carry these. `build`, `typecheck`, and `lint` are deterministic
     // across platforms, so they keep full CI-to-laptop cache sharing.
+    // `.github/workflows/**` is a test input, not just CI configuration:
+    // `validate-release-workflow.test.ts` reads unit-tests.yaml and main-green.yaml off disk and
+    // asserts their build ordering and filters, so a workflow regression would otherwise collect a
+    // false cached pass. Declared on the base task rather than scoped to cinder — workflow files
+    // change rarely, so the extra invalidation for other packages costs almost nothing.
     "test": {
       "dependsOn": ["^build"],
       "outputs": [],
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/components/scripts/**",
-        "$TURBO_ROOT$/packages/testing/scripts/**"
+        "$TURBO_ROOT$/packages/testing/scripts/**",
+        "$TURBO_ROOT$/.github/workflows/**"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
@@ -72,7 +78,8 @@
       "inputs": [
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/components/scripts/**",
-        "$TURBO_ROOT$/packages/testing/scripts/**"
+        "$TURBO_ROOT$/packages/testing/scripts/**",
+        "$TURBO_ROOT$/.github/workflows/**"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
@@ -109,7 +116,8 @@
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/testing/scripts/**",
-        "$TURBO_ROOT$/packages/playground/src/**"
+        "$TURBO_ROOT$/packages/playground/src/**",
+        "$TURBO_ROOT$/.github/workflows/**"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -34,29 +34,35 @@
       "outputs": ["dist/**"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
-    // `TURBO_PLATFORM` is an OS discriminator for the REMOTE cache. Turbo's hash covers declared
-    // files, env vars, and engines — there is no platform component (confirmed in `--dry=json`'s
-    // `globalCacheInputs`). Once macOS laptops and Linux CI share one remote namespace, a
-    // platform-conditioned test can have its success replayed on the OS that never executed that
-    // branch; `packages/testing/scripts/start-server.test.ts` and
+    // `RUNNER_OS` + `TURBO_PLATFORM` are OS discriminators for the REMOTE cache. Turbo's hash covers
+    // declared files, env vars, and engines — there is no platform component (confirmed absent from
+    // `--dry=json`'s `globalCacheInputs`). Once macOS laptops and Linux CI share one remote
+    // namespace, a platform-conditioned test can have its success replayed on the OS that never
+    // executed that branch; `packages/testing/scripts/start-server.test.ts` and
     // `packages/components/scripts/husky/utilities.test.ts` both derive assertions from
-    // `process.platform`. CI sets this to `runner.os`; developers export `$(uname -s)` (see
-    // CONTRIBUTING.md). It fails SAFE when unset — an unset value simply hashes differently from
-    // `Linux`, so a laptop can never read a CI test entry by accident.
+    // `process.platform`.
     //
-    // Only `test`/`test:coverage` carry it. `build`, `typecheck`, and `lint` are deterministic
+    // Two variables because no single one covers both environments. GitHub defines `RUNNER_OS` in
+    // every job automatically, so CI needs no workflow wiring (and `${{ runner.os }}` could not be
+    // used in a workflow-level `env:` block anyway — the `runner` context only exists at step
+    // level). Developers export `TURBO_PLATFORM="$(uname -s)"` per CONTRIBUTING.md. Every
+    // combination hashes distinctly: Linux CI sets only RUNNER_OS, a macOS laptop sets only
+    // TURBO_PLATFORM=Darwin, a Linux laptop sets only TURBO_PLATFORM=Linux. Unset fails SAFE — it
+    // hashes differently from any set value, so a laptop cannot read a CI test entry by accident.
+    //
+    // Only `test`/`test:coverage` carry these. `build`, `typecheck`, and `lint` are deterministic
     // across platforms, so they keep full CI-to-laptop cache sharing.
     "test": {
       "dependsOn": ["^build"],
       "outputs": [],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"],
-      "env": ["TURBO_PLATFORM"]
+      "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
     "test:coverage": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
       "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"],
-      "env": ["TURBO_PLATFORM"]
+      "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
     "typecheck": {
       "dependsOn": ["^build"],

--- a/turbo.json
+++ b/turbo.json
@@ -30,11 +30,17 @@
     // Package `src/**` directories are deliberately NOT listed as inputs: a change there rehashes
     // that package's `build`, and turbo folds a dependency task's hash into its dependents, so
     // `^build` already covers it.
+    //
     // `CINDER_FORCE_BUILD` is the escape hatch in `scripts/lib/build-cache.ts` for recovering from
-    // suspect `dist` output — `shouldSkipBuild()` returns `skip: false` when it is `1`. Declaring
-    // it here is what makes that work through `bun run build`: without it, turbo restores a cached
-    // entry and the package script never runs, so the documented "never skips" behavior would
-    // silently not apply to the root build command.
+    // suspect `dist` output — `shouldSkipBuild()` returns `skip: false` when it is `1`. Declaring it
+    // here puts forced builds on a separate cache lineage from unforced ones, so the FIRST forced
+    // run after any change re-executes instead of replaying an unforced entry.
+    //
+    // It is deliberately NOT a claim that the variable bypasses turbo. It cannot: once a forced run
+    // stores its entry, repeating the same command hits that entry and the package script never
+    // runs again. Turbo's cache sits above the script, so no env var read INSIDE the script can
+    // defeat it. To genuinely re-execute through the root build, force turbo itself:
+    // `TURBO_FORCE=1 bun run build` (or `bunx turbo run build --force`).
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
@@ -83,7 +89,8 @@
         "$TURBO_ROOT$/packages/testing/scripts/**",
         "$TURBO_ROOT$/.github/workflows/**",
         "$TURBO_ROOT$/docs/**",
-        "$TURBO_ROOT$/.changeset/**"
+        "$TURBO_ROOT$/.changeset/**",
+        "$TURBO_ROOT$/packages/*/package.json"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS", "NODE_ENV"]
     },
@@ -96,7 +103,8 @@
         "$TURBO_ROOT$/packages/testing/scripts/**",
         "$TURBO_ROOT$/.github/workflows/**",
         "$TURBO_ROOT$/docs/**",
-        "$TURBO_ROOT$/.changeset/**"
+        "$TURBO_ROOT$/.changeset/**",
+        "$TURBO_ROOT$/packages/*/package.json"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS", "NODE_ENV"]
     },
@@ -136,7 +144,8 @@
         "$TURBO_ROOT$/packages/playground/src/**",
         "$TURBO_ROOT$/.github/workflows/**",
         "$TURBO_ROOT$/docs/**",
-        "$TURBO_ROOT$/.changeset/**"
+        "$TURBO_ROOT$/.changeset/**",
+        "$TURBO_ROOT$/packages/*/package.json"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS", "NODE_ENV"]
     },

--- a/turbo.json
+++ b/turbo.json
@@ -32,7 +32,11 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**"
+      ]
     },
     // `RUNNER_OS` + `TURBO_PLATFORM` are OS discriminators for the REMOTE cache. Turbo's hash covers
     // declared files, env vars, and engines — there is no platform component (confirmed absent from
@@ -55,19 +59,31 @@
     "test": {
       "dependsOn": ["^build"],
       "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**"
+      ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
     "test:coverage": {
       "dependsOn": ["^build"],
       "outputs": ["coverage/**"],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**"
+      ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
     "typecheck": {
       "dependsOn": ["^build"],
       "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**"
+      ]
     },
     // `^build`, not `[]`: oxlint runs with `--type-aware`, which reads dependency `.d.ts` files, so
     // a package's lint genuinely needs its dependencies built. Builds hash-skip, so the added edge
@@ -75,15 +91,49 @@
     "lint": {
       "dependsOn": ["^build"],
       "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**"
+      ]
     },
-    // The one surviving override. Cinder's lint reaches editor types, which is an edge `^build`
+    // `@cinder/testing` reaches the other way across the boundary: `scripts/changed-components.ts`
+    // imports `packages/playground/src/component-sources.ts`, and testing does not depend on
+    // playground, so `^build` cannot fold that hash in. Scoped to testing's own tasks rather than
+    // added to the base inputs — playground/src is the most-edited tree in the repo, and hashing it
+    // into every package's tasks would gut the cache for changes that cannot possibly affect them.
+    "@cinder/testing#test": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**",
+        "$TURBO_ROOT$/packages/playground/src/**"
+      ],
+      "env": ["TURBO_PLATFORM", "RUNNER_OS"]
+    },
+    "@cinder/testing#typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**",
+        "$TURBO_ROOT$/packages/playground/src/**"
+      ]
+    },
+    // Cinder's lint reaches editor types, which is an edge `^build`
     // cannot supply (editor depends on cinder, not the reverse). Appended to `^build` rather than
     // replacing it, so the `@cinder/testing#build` and markdown edges survive.
     "@lostgradient/cinder#lint": {
       "dependsOn": ["^build", "@lostgradient/editor#build"],
       "outputs": [],
-      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
+      "inputs": [
+        "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
+        "$TURBO_ROOT$/packages/testing/scripts/**"
+      ]
     },
     "validate": {
       "dependsOn": ["^build", "build"],

--- a/turbo.json
+++ b/turbo.json
@@ -4,26 +4,44 @@
     "tsconfig.json",
     "tsconfig.base.json",
     ".oxlintrc.json",
-    "packages/components/scripts/check-coverage-ratchet.ts",
-    "tsconfig.build.json",
-    "packages/components/scripts/svelte-plugin.ts"
+    "tsconfig.build.json"
   ],
+  // `NODE_ENV` is a real hash input, not boilerplate: `packages/components/scripts/svelte-plugin.ts`
+  // branches on it to pick Svelte's `dev` compilation mode, and the editor's runtime guards read it
+  // too. The `build` scripts pin it to `production` internally, but `test` inherits whatever the
+  // caller had, so a local run and a CI run must not be allowed to share a cache entry.
+  "globalEnv": ["NODE_ENV"],
   "tasks": {
+    // `packages/components/scripts/**` is an input to tasks in EVERY package, not just cinder's:
+    // chat, editor, and playground import `svelte-plugin.ts`, `check-coverage-ratchet.ts`, the
+    // component-artifact generators, and `lib/visual-fixtures/**` across the package boundary. Those
+    // files never land in cinder's `dist/**`, so the `^build` edge does not cover them. They used to
+    // be listed one-by-one in `globalDependencies`, which was both incomplete (only two of them were
+    // listed) and too blunt (a global dependency invalidates every cached task in the repo). Scoping
+    // the whole directory to the four tasks that actually execute it is stricter AND cheaper.
+    //
+    // `packages/components/src/**` deliberately is NOT listed: a change there rehashes cinder's
+    // `build`, and turbo folds a dependency task's hash into its dependents, so `^build` already
+    // covers it.
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "test": {
       "dependsOn": ["^build"],
-      "outputs": []
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "test:coverage": {
       "dependsOn": ["^build"],
-      "outputs": ["coverage/**"]
+      "outputs": ["coverage/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "typecheck": {
       "dependsOn": ["^build"],
-      "outputs": []
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "@cinder/playground#typecheck": {
       "dependsOn": [
@@ -35,48 +53,70 @@
       "outputs": [],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/components/src/**",
         "$TURBO_ROOT$/packages/chat/src/**",
         "$TURBO_ROOT$/packages/editor/src/**",
         "$TURBO_ROOT$/packages/markdown/src/**"
       ]
     },
+    // Exists only to widen `inputs`; `^build` already expands to exactly the
+    // four builds this needs, so keep the wildcard rather than freezing today's
+    // expansion — a future workspace dependency must not silently go unbuilt.
+    "@cinder/playground#test": {
+      "dependsOn": ["^build"],
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
+    },
     "@lostgradient/chat#typecheck": {
       "dependsOn": ["@lostgradient/markdown#build"],
       "outputs": [],
       "inputs": [
         "$TURBO_DEFAULT$",
+        "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/components/src/**",
         "$TURBO_ROOT$/packages/markdown/src/**"
       ]
     },
+    // `lint` needs the same cross-package inputs as the rest: oxlint runs with
+    // `--type-aware`, and chat/editor lint scripts that import `svelte-plugin.ts`
+    // from the components package. Type-aware linting reads that file for type
+    // information, so a type change there can shift diagnostics — without this
+    // input the cached `lint` would not notice.
     "lint": {
       "dependsOn": [],
-      "outputs": []
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "@lostgradient/editor#lint": {
       "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": []
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "@lostgradient/cinder#lint": {
       "dependsOn": ["@lostgradient/markdown#build", "@lostgradient/editor#build"],
-      "outputs": []
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "@lostgradient/editor#build": {
       "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "@lostgradient/editor#typecheck": {
       "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": []
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "@lostgradient/editor#test": {
       "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": []
+      "outputs": [],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "@lostgradient/editor#test:coverage": {
       "dependsOn": ["@lostgradient/markdown#build"],
-      "outputs": ["coverage/**"]
+      "outputs": ["coverage/**"],
+      "inputs": ["$TURBO_DEFAULT$", "$TURBO_ROOT$/packages/components/scripts/**"]
     },
     "validate": {
       "dependsOn": ["^build", "build"],

--- a/turbo.json
+++ b/turbo.json
@@ -56,11 +56,17 @@
     //
     // Only `test`/`test:coverage` carry these. `build`, `typecheck`, and `lint` are deterministic
     // across platforms, so they keep full CI-to-laptop cache sharing.
-    // `.github/workflows/**` is a test input, not just CI configuration:
-    // `validate-release-workflow.test.ts` reads unit-tests.yaml and main-green.yaml off disk and
-    // asserts their build ordering and filters, so a workflow regression would otherwise collect a
-    // false cached pass. Declared on the base task rather than scoped to cinder — workflow files
-    // change rarely, so the extra invalidation for other packages costs almost nothing.
+    //
+    // `.github/workflows/**` and `docs/**` are test inputs, not just repo furniture. Drift tests
+    // read them off disk: `validate-release-workflow.test.ts` asserts unit-tests.yaml's and
+    // main-green.yaml's build ordering and filters, and `tokens-doc-drift.test.ts` fails when
+    // `docs/tokens.md`'s token table diverges from `tokens-base.css`. Without these declared, a
+    // regression in either collects a false cached pass.
+    //
+    // Whole directories rather than the two named files, deliberately: a hand-maintained list of
+    // individual paths is exactly the fragile pattern this PR removed from `globalDependencies`,
+    // and it would silently fail to cover the next drift test someone adds. Both trees change
+    // rarely enough that the extra invalidation is cheap.
     "test": {
       "dependsOn": ["^build"],
       "outputs": [],
@@ -68,7 +74,8 @@
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/testing/scripts/**",
-        "$TURBO_ROOT$/.github/workflows/**"
+        "$TURBO_ROOT$/.github/workflows/**",
+        "$TURBO_ROOT$/docs/**"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
@@ -79,7 +86,8 @@
         "$TURBO_DEFAULT$",
         "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/testing/scripts/**",
-        "$TURBO_ROOT$/.github/workflows/**"
+        "$TURBO_ROOT$/.github/workflows/**",
+        "$TURBO_ROOT$/docs/**"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },
@@ -117,7 +125,8 @@
         "$TURBO_ROOT$/packages/components/scripts/**",
         "$TURBO_ROOT$/packages/testing/scripts/**",
         "$TURBO_ROOT$/packages/playground/src/**",
-        "$TURBO_ROOT$/.github/workflows/**"
+        "$TURBO_ROOT$/.github/workflows/**",
+        "$TURBO_ROOT$/docs/**"
       ],
       "env": ["TURBO_PLATFORM", "RUNNER_OS"]
     },


### PR DESCRIPTION
## Why

Turborepo's task graph was already sound, but its **hash inputs were under-declared**. That matters far more once cache entries are shared between machines: an under-declared input used to mean one stale local hit that a `clean` fixed, and now means the same wrong result on CI and every laptop. This PR closes those gaps, then turns on remote caching.

> Reviewers: this description was rewritten after three review rounds. It describes the branch as it stands, not the original approach — several early decisions were reversed and the notes at the bottom say which.

## Under-declared hash inputs

Packages reach across the boundary with relative `../../` imports into packages they do not declare a dependency on. Those paths are invisible to the task graph, and none of the targets land in a `dist/**` that `^build` would cover:

| Imported tree | Imported by | Declared on |
| --- | --- | --- |
| `packages/components/scripts/**` | chat, editor, playground, testing | base `build`/`test`/`test:coverage`/`typecheck`/`lint` |
| `packages/testing/scripts/**` | playground | same base tasks |
| `packages/playground/src/**` | testing | `@cinder/testing` tasks only |
| `.github/workflows/**` | cinder's own tests, which read them off disk | base `test`/`test:coverage` |

`playground/src` is scoped rather than global because it is the most-edited tree in the repo; hashing it everywhere would gut the cache for changes that cannot affect those packages. Workflow files are global because they change rarely.

Package `src/**` directories are deliberately **not** declared: a change there rehashes that package's `build`, and turbo folds a dependency task's hash into its dependents.

## Lost dependency edges (the bigger bug)

A package-task override **replaces** the base task — turbo does not merge field by field. Every hand-written `dependsOn` was therefore silently dropping `^build`:

- all five `@lostgradient/editor` overrides declared only `markdown#build`, dropping `cinder#build` — while editor imports Cinder components directly
- `@lostgradient/chat#typecheck` had the same hole
- `@lostgradient/cinder#lint` had lost `@cinder/testing#build`

Now every override keeps `^build` and appends. Most then turned out to be identical to the base task, so **ten overrides collapse to two**. Base `lint` also gained `^build`, since oxlint runs `--type-aware` and reads dependency `.d.ts` files.

Verified after every edit with a superset diff of `--dry=json` dependencies against the pre-change graph: **0 edges lost, 0 tasks dropped.**

## Platform partitioning

Turbo's hash covers files, env vars, and engines — there is **no platform component** (confirmed absent from `globalCacheInputs`). Since parts of the suite branch on `process.platform`, one shared remote namespace would let a success be replayed on the OS that never ran that branch.

`test`/`test:coverage` declare `TURBO_PLATFORM` and `RUNNER_OS`. GitHub defines `RUNNER_OS` in every job automatically, so CI needs no wiring; developers export `$(uname -s)`. All four states hash distinctly, and unset fails safe. `build`, `typecheck`, and `lint` are deterministic across platforms and keep full CI-to-laptop sharing.

## CI

- `main-green` has **no** `.turbo` cache step. A restore could never be read under `TURBO_FORCE=true`, and a save would collide with `unit-tests.yaml`'s unsuffixed primary key — `actions/cache` matches an exact key before consulting `restore-keys`. Remote caching is the sharing mechanism now.
- `unit-tests` **keeps** its `actions/cache` step. It triggers on `pull_request`, not `pull_request_target`, so fork PRs get empty secrets and no remote cache; that archive is the only cache they can reach.
- Missing or invalid credentials degrade to a warning and a local fallback (verified: exit 0), never a failure.

## New guard

`${{ runner.os }}` in a workflow-level `env:` block made GitHub reject both workflow files outright — every job failed before starting with only "This run likely failed because of a workflow file issue," and the YAML parses fine so nothing local caught it. I shipped that bug in this branch and CI caught it.

`validate-release-workflow.ts` now scans every workflow's top-level `env:` against GitHub's allowlist (`github`, `secrets`, `inputs`, `vars`), handling bracket access and stripping string literals, and rejects functions unavailable before a runner exists (`hashFiles`, `success`, `failure`, `cancelled`, `always`). 22 test cases cover every rejected context, both access syntaxes, and the false-positive shapes.

## Reversed along the way

- **A save-only `.turbo` step in main-green** — removed entirely once review pointed out the key collision made it unconsumable.
- **"Worktrees share one local cache"** — I observed this and wrote it into the docs, but it was an artifact of a worktree with a symlinked `node_modules`, which `AGENTS.md` L121 explicitly forbids. Every worktree gets a real `bun install` and a cold local cache; that is what remote caching is for.
- **A denylist of six bad context roots** — replaced with GitHub's allowlist after review showed `env`, `jobs`, and bracket access all slipped through.

No changeset: build tooling, CI, and docs only. No published package source is touched.
