### PR TITLE
Make downstream snapshot tests reliable on macOS

### DIFF
--- a/scripts/cinder-downstream-snapshot.test.ts
+++ b/scripts/cinder-downstream-snapshot.test.ts
@@ -2,8 +2,52 @@ import { expect, test } from 'bun:test';
 import { mkdir, mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { selectMostRecentlyPublishedVersion } from './cinder-downstream-snapshot.ts';
+
+/**
+ * Absolute path to the CLI under test. Resolving from `import.meta.url` rather than
+ * the runner's working directory keeps every invocation identical no matter where
+ * `bun test` was started from.
+ */
+const snapshotCliPath = fileURLToPath(new URL('./cinder-downstream-snapshot.ts', import.meta.url));
+
+const STDERR_EXCERPT_LIMIT = 2000;
+
+type SnapshotCliResult = { exitCode: number; stdout: string; stderr: string };
+
+/**
+ * Runs the snapshot CLI with the installed Bun executable and returns its exit code
+ * and captured streams. stdout and stderr are drained concurrently with the exit
+ * code so neither pipe can fill and stall the child.
+ *
+ * Pass `expectSuccess: false` to inspect a failing invocation instead of throwing.
+ */
+async function runSnapshotCli(
+  args: string[],
+  { expectSuccess = true }: { expectSuccess?: boolean } = {},
+): Promise<SnapshotCliResult> {
+  const child = Bun.spawn([process.execPath, snapshotCliPath, ...args], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+    child.exited,
+  ]);
+
+  if (expectSuccess && exitCode !== 0) {
+    throw new Error(
+      `snapshot CLI exited ${exitCode} for arguments [${args.join(' ')}]\n` +
+        `stderr: ${stderr.slice(0, STDERR_EXCERPT_LIMIT)}`,
+    );
+  }
+
+  return { exitCode, stdout, stderr };
+}
 
 test('snapshot input is deterministic and sorted', async () => {
   const root = await mkdtemp(join(tmpdir(), 'cinder-snapshot-'));
@@ -14,29 +58,30 @@ test('snapshot input is deterministic and sorted', async () => {
     request,
     JSON.stringify({ schemaVersion: 1, repositories: [{ name: 'repo', path: root }] }),
   );
-  const first = Bun.spawnSync([
-    'bun',
-    'run',
-    'scripts/cinder-downstream-snapshot.ts',
-    '--request',
-    request,
-  ]).stdout.toString();
-  const second = Bun.spawnSync([
-    'bun',
-    'run',
-    'scripts/cinder-downstream-snapshot.ts',
-    '--request',
-    request,
-  ]).stdout.toString();
+  const first = await runSnapshotCli(['--request', request]);
+  const second = await runSnapshotCli(['--request', request]);
   const normalize = (value: string) =>
     JSON.stringify({ ...JSON.parse(value), collectedAt: 'stable' });
-  expect(normalize(first)).toBe(normalize(second));
+  expect(normalize(first.stdout)).toBe(normalize(second.stdout));
 });
 
-test('help prints usage without requiring a request', () => {
-  const result = Bun.spawnSync(['bun', 'run', 'scripts/cinder-downstream-snapshot.ts', '--help']);
+test('help prints usage without requiring a request', async () => {
+  const result = await runSnapshotCli(['--help']);
   expect(result.exitCode).toBe(0);
-  expect(result.stdout.toString()).toContain('Usage:');
+  expect(result.stdout).toContain('Usage:');
+});
+
+test('invalid options report exit code and stderr instead of a JSON parse error', async () => {
+  const result = await runSnapshotCli(['--wat'], { expectSuccess: false });
+  expect(result.exitCode).not.toBe(0);
+  expect(result.stdout).toBe('');
+  expect(result.stderr).toContain('Unknown option: --wat');
+
+  const failure = await runSnapshotCli(['--wat']).catch((error: unknown) => error as Error);
+  expect(failure).toBeInstanceOf(Error);
+  expect((failure as Error).message).toContain(`exited ${result.exitCode}`);
+  expect((failure as Error).message).toContain('Unknown option: --wat');
+  expect((failure as Error).message).not.toContain('JSON Parse error');
 });
 
 test('partial repository failures stay in the snapshot', async () => {
@@ -49,15 +94,9 @@ test('partial repository failures stay in the snapshot', async () => {
       repositories: [{ name: 'missing', path: join(root, 'missing') }],
     }),
   );
-  const result = Bun.spawnSync([
-    'bun',
-    'run',
-    'scripts/cinder-downstream-snapshot.ts',
-    '--request',
-    request,
-  ]);
+  const result = await runSnapshotCli(['--request', request]);
   expect(result.exitCode).toBe(0);
-  expect(JSON.parse(result.stdout.toString()).errors[0].scope).toBe('repository:missing');
+  expect(JSON.parse(result.stdout).errors[0].scope).toBe('repository:missing');
 });
 
 test('hashes binary bytes and rejects malformed options', async () => {
@@ -68,20 +107,13 @@ test('hashes binary bytes and rejects malformed options', async () => {
     request,
     JSON.stringify({ schemaVersion: 1, repositories: [{ name: 'repo', path: root }] }),
   );
-  const result = Bun.spawnSync([
-    'bun',
-    'run',
-    'scripts/cinder-downstream-snapshot.ts',
-    '--request',
-    request,
-  ]);
-  const file = JSON.parse(result.stdout.toString()).repositories[0].files.find(
+  const result = await runSnapshotCli(['--request', request]);
+  const file = JSON.parse(result.stdout).repositories[0].files.find(
     (entry: { path: string }) => entry.path === 'binary.bin',
   );
   expect(file.bytes).toBe(3);
-  expect(
-    Bun.spawnSync(['bun', 'run', 'scripts/cinder-downstream-snapshot.ts', '--wat']).exitCode,
-  ).not.toBe(0);
+  const malformed = await runSnapshotCli(['--wat'], { expectSuccess: false });
+  expect(malformed.exitCode).not.toBe(0);
 });
 
 test('keeps scans inside the repository and excludes Git internals', async () => {
@@ -100,15 +132,8 @@ test('keeps scans inside the repository and excludes Git internals', async () =>
     defaultRequest,
     JSON.stringify({ schemaVersion: 1, repositories: [{ name: 'repo', path: root }] }),
   );
-  const defaultSnapshot = JSON.parse(
-    Bun.spawnSync([
-      'bun',
-      'run',
-      'scripts/cinder-downstream-snapshot.ts',
-      '--request',
-      defaultRequest,
-    ]).stdout.toString(),
-  );
+  const defaultResult = await runSnapshotCli(['--request', defaultRequest]);
+  const defaultSnapshot = JSON.parse(defaultResult.stdout);
   expect(defaultSnapshot.repositories[0].files.map((file: { path: string }) => file.path)).toEqual([
     'inside.txt',
   ]);
@@ -121,15 +146,8 @@ test('keeps scans inside the repository and excludes Git internals', async () =>
       repositories: [{ name: 'repo', path: root, globs: ['nested/**/*.txt'] }],
     }),
   );
-  const narrowedSnapshot = JSON.parse(
-    Bun.spawnSync([
-      'bun',
-      'run',
-      'scripts/cinder-downstream-snapshot.ts',
-      '--request',
-      narrowedRequest,
-    ]).stdout.toString(),
-  );
+  const narrowedResult = await runSnapshotCli(['--request', narrowedRequest]);
+  const narrowedSnapshot = JSON.parse(narrowedResult.stdout);
   expect(narrowedSnapshot.repositories[0].files).toEqual([]);
 
   const escapingRequest = join(parent, 'escaping-request.json');
@@ -140,15 +158,8 @@ test('keeps scans inside the repository and excludes Git internals', async () =>
       repositories: [{ name: 'repo', path: root, globs: ['../outside.txt'] }],
     }),
   );
-  const escapingSnapshot = JSON.parse(
-    Bun.spawnSync([
-      'bun',
-      'run',
-      'scripts/cinder-downstream-snapshot.ts',
-      '--request',
-      escapingRequest,
-    ]).stdout.toString(),
-  );
+  const escapingResult = await runSnapshotCli(['--request', escapingRequest]);
+  const escapingSnapshot = JSON.parse(escapingResult.stdout);
   expect(escapingSnapshot.repositories).toEqual([]);
   expect(escapingSnapshot.errors[0].message).toContain('escapes repository root');
 });
@@ -176,15 +187,8 @@ test('requires the requested branch and commit to match checkout HEAD', async ()
       repositories: [{ name: 'repo', path: root, branch: 'main', commit: mainCommit }],
     }),
   );
-  const snapshot = JSON.parse(
-    Bun.spawnSync([
-      'bun',
-      'run',
-      'scripts/cinder-downstream-snapshot.ts',
-      '--request',
-      request,
-    ]).stdout.toString(),
-  );
+  const result = await runSnapshotCli(['--request', request]);
+  const snapshot = JSON.parse(result.stdout);
   expect(snapshot.repositories).toEqual([]);
   expect(snapshot.errors[0].message).toContain('does not match checkout HEAD');
 });
@@ -210,15 +214,8 @@ test('matches evidence case-insensitively without decoding unrelated binary file
       ],
     }),
   );
-  const snapshot = JSON.parse(
-    Bun.spawnSync([
-      'bun',
-      'run',
-      'scripts/cinder-downstream-snapshot.ts',
-      '--request',
-      request,
-    ]).stdout.toString(),
-  );
+  const result = await runSnapshotCli(['--request', request]);
+  const snapshot = JSON.parse(result.stdout);
   expect(snapshot.repositories[0].evidence.source).toEqual([
     { path: 'source.ts', line: 1, text: 'const CINDER_API_URL = "example";' },
     { path: 'source.ts', line: 2, text: 'CINDER_API_TOKEN=[REDACTED]' },
@@ -259,15 +256,8 @@ test('records Git links without scanning nested checkout contents', async () => 
     request,
     JSON.stringify({ schemaVersion: 1, repositories: [{ name: 'repo', path: root }] }),
   );
-  const snapshot = JSON.parse(
-    Bun.spawnSync([
-      'bun',
-      'run',
-      'scripts/cinder-downstream-snapshot.ts',
-      '--request',
-      request,
-    ]).stdout.toString(),
-  );
+  const result = await runSnapshotCli(['--request', request]);
+  const snapshot = JSON.parse(result.stdout);
   expect(
     snapshot.repositories[0].files.find((file: { path: string }) => file.path === 'vendor/nested'),
   ).toEqual({ path: 'vendor/nested', gitlink: gitlinkCommit });
@@ -285,15 +275,8 @@ test('records Git links without scanning nested checkout contents', async () => 
       repositories: [{ name: 'repo', path: root, globs: ['tracked.txt'] }],
     }),
   );
-  const scopedSnapshot = JSON.parse(
-    Bun.spawnSync([
-      'bun',
-      'run',
-      'scripts/cinder-downstream-snapshot.ts',
-      '--request',
-      scopedRequest,
-    ]).stdout.toString(),
-  );
+  const scopedResult = await runSnapshotCli(['--request', scopedRequest]);
+  const scopedSnapshot = JSON.parse(scopedResult.stdout);
   expect(
     scopedSnapshot.repositories[0].files.some(
       (file: { path: string }) => file.path === 'vendor/nested',


### PR DESCRIPTION
Closes #1032

## Summary

The eight failing tests in `scripts/cinder-downstream-snapshot.test.ts` each launched the CLI with `Bun.spawnSync(['bun', 'run', 'scripts/cinder-downstream-snapshot.ts', ...])` and parsed `stdout` **without checking the exit status**. Any child failure therefore surfaced as `JSON Parse error: Unexpected EOF` pointing at the assertion line rather than at the process that actually failed — which is why the original report could only infer its cause.

This replaces every snapshot-CLI invocation with a single `runSnapshotCli` helper. In honest order of evidence:

1. **Exit-status check before parsing (the fix that matters most).** The helper throws with the exit code, the arguments, and bounded stderr (2000 chars) when an expected-success invocation fails. Whatever the underlying trigger, a future occurrence is now diagnosable instead of inferred.
2. **cwd-relative argv (reproduced).** The script path is resolved absolutely from `import.meta.url`, so the child's arguments no longer depend on where `bun test` was started.
3. **PATH-resolved `bun` plus a nested `bun run` (removed as hardening).** The helper invokes `process.execPath` against the script directly, so it always uses the same Bun running the suite and drops the intermediate process.

The helper uses async `Bun.spawn` with `stdout`/`stderr` explicitly piped and drains both concurrently with `proc.exited` in one `Promise.all`, per the issue's implementation scope. To be clear about what that is and isn't: it is correct async practice and required to capture stderr at all, but I have **no evidence that synchronous pipe capture was ever the problem** — this CLI emits a few KB of JSON, which `spawnSync` handles fine.

## On the root cause

I want to be precise about what is and isn't proven here.

I ran the reporter's exact command from the repository root on the same platform (macOS 26.5.2, Bun 1.3.13) **five times and got 11/11 passing** — their scenario did not reproduce. I did reproduce an identical failure signature by running the suite from a different working directory:

```
cd scripts && bun test ./cinder-downstream-snapshot.test.ts
# → 3 pass, 8 fail, all "JSON Parse error: Unexpected EOF"
```

That 8/3 split matches the report exactly, but it is **not** evidence that cwd was the reporter's trigger: any failure that breaks the child spawn produces 8/3, because exactly 8 tests parse spawn stdout and exactly 3 do not. This is a different trigger with the same signature.

That is precisely why the fix leads with the exit-status check rather than resting on the one trigger I could reproduce.

## Verification

| Command | Before | After |
| --- | --- | --- |
| `bun test scripts/cinder-downstream-snapshot.test.ts` (repo root) | 11 pass, 0 fail | **12 pass, 0 fail** |
| `cd scripts && bun test ./cinder-downstream-snapshot.test.ts` | **3 pass, 8 fail** | **12 pass, 0 fail** |
| `bun run test:workspace-scripts` | 11 pass, 0 fail | **12 pass, 0 fail** |
| `bun run scripts/cinder-downstream-snapshot.ts --help` | prints `Usage:`, exit 0 | prints `Usage:`, exit 0 |

The subdirectory run is the regression proof: 8 failures → 0.

**Linux CI** (`unit-tests` job, ubuntu-latest, Bun 1.3.13) ran all 12 tests individually — the job log confirms `(pass)` for each, including the new regression test.

Also run: `bunx oxlint scripts/cinder-downstream-snapshot.test.ts` (0 warnings, 0 errors), `prettier --check` on the touched file (clean), `git diff --check` (clean).

## New regression test

`invalid options report exit code and stderr instead of a JSON parse error` asserts that `--wat` (which exits 1 with empty stdout and `Unknown option: --wat` on stderr) surfaces through the helper's thrown message with both the exit code and the stderr text, and explicitly that the message does **not** contain `JSON Parse error`. That is the issue's third acceptance criterion stated directly as an assertion.

**Mutation-checked:** with the helper's `throw` removed, the suite goes to `11 pass, 1 fail` and the failing test is exactly this one. The test detects the defect it claims to.

## Scope

- Production `scripts/cinder-downstream-snapshot.ts` is **unchanged** — no independent production defect was reproduced. The defect is entirely in the test harness's argv construction and missing exit-status check.
- The `Bun.spawnSync(['git', ...])` fixture commands are left synchronous; they are unrelated to the CLI invocation.
- No retries added, no timeouts raised, no platform-specific skips, no CI resource limits changed.

## Note on an unrelated pre-existing issue

`bunx tsc --noEmit -p tsconfig.json` reports 185 errors on this branch — and **the identical 185 on the unmodified `origin/main` baseline**, none of them in the touched file. That raw invocation is not the repository's actual typecheck gate (`bun run typecheck` is), so this PR neither adds to nor fixes it. Flagging it rather than silently passing over it.
