### PR TITLE
fix: support remote downstream audit snapshots

### DIFF
--- a/scripts/cinder-downstream-audit-request.json
+++ b/scripts/cinder-downstream-audit-request.json
@@ -8,24 +8,44 @@
     {
       "name": "agent-bureau",
       "remote": "https://github.com/stevekinney/agent-bureau.git",
-      "ref": "main"
+      "ref": "main",
+      "globs": ["package.json", "README.md", "src/**/*.{ts,tsx,svelte,css}"],
+      "evidence": { "imports": ["src/**/*.{ts,tsx,svelte}"], "styles": ["src/**/*.{svelte,css}"] }
     },
     {
       "name": "narrate-studio",
       "remote": "https://github.com/stevekinney/narrate-studio.git",
-      "ref": "main"
+      "ref": "main",
+      "globs": ["package.json", "README.md", "src/**/*.{ts,tsx,svelte,css}"],
+      "evidence": { "imports": ["src/**/*.{ts,tsx,svelte}"], "styles": ["src/**/*.{svelte,css}"] }
     },
     {
       "name": "stevekinney.net",
       "remote": "https://github.com/stevekinney/stevekinney.net.git",
-      "ref": "main"
+      "ref": "main",
+      "globs": ["package.json", "README.md", "src/**/*.{ts,tsx,svelte,css}"],
+      "evidence": { "imports": ["src/**/*.{ts,tsx,svelte}"], "styles": ["src/**/*.{svelte,css}"] }
     },
-    { "name": "tribunal", "remote": "https://github.com/stevekinney/tribunal.git", "ref": "main" },
-    { "name": "weft", "remote": "https://github.com/stevekinney/weft.git", "ref": "main" },
+    {
+      "name": "tribunal",
+      "remote": "https://github.com/stevekinney/tribunal.git",
+      "ref": "main",
+      "globs": ["package.json", "README.md", "src/**/*.{ts,tsx,svelte,css}"],
+      "evidence": { "imports": ["src/**/*.{ts,tsx,svelte}"], "styles": ["src/**/*.{svelte,css}"] }
+    },
+    {
+      "name": "weft",
+      "remote": "https://github.com/stevekinney/weft.git",
+      "ref": "main",
+      "globs": ["package.json", "README.md", "src/**/*.{ts,tsx,svelte,css}"],
+      "evidence": { "imports": ["src/**/*.{ts,tsx,svelte}"], "styles": ["src/**/*.{svelte,css}"] }
+    },
     {
       "name": "weft-console",
       "remote": "https://github.com/stevekinney/weft-console.git",
-      "ref": "main"
+      "ref": "main",
+      "globs": ["package.json", "README.md", "src/**/*.{ts,tsx,svelte,css}"],
+      "evidence": { "imports": ["src/**/*.{ts,tsx,svelte}"], "styles": ["src/**/*.{svelte,css}"] }
     }
   ],
   "issueWindow": { "open": 100, "recentlyClosed": 100, "since": "2026-07-17" }

--- a/scripts/cinder-downstream-audit-request.json
+++ b/scripts/cinder-downstream-audit-request.json
@@ -1,0 +1,32 @@
+{
+  "schemaVersion": 1,
+  "packages": [
+    { "name": "@lostgradient/cinder", "resolution": "published" },
+    { "name": "@lostgradient/chat", "resolution": "published" }
+  ],
+  "repositories": [
+    {
+      "name": "agent-bureau",
+      "remote": "https://github.com/stevekinney/agent-bureau.git",
+      "ref": "main"
+    },
+    {
+      "name": "narrate-studio",
+      "remote": "https://github.com/stevekinney/narrate-studio.git",
+      "ref": "main"
+    },
+    {
+      "name": "stevekinney.net",
+      "remote": "https://github.com/stevekinney/stevekinney.net.git",
+      "ref": "main"
+    },
+    { "name": "tribunal", "remote": "https://github.com/stevekinney/tribunal.git", "ref": "main" },
+    { "name": "weft", "remote": "https://github.com/stevekinney/weft.git", "ref": "main" },
+    {
+      "name": "weft-console",
+      "remote": "https://github.com/stevekinney/weft-console.git",
+      "ref": "main"
+    }
+  ],
+  "issueWindow": { "open": 100, "recentlyClosed": 100, "since": "2026-07-17" }
+}

--- a/scripts/cinder-downstream-snapshot.test.ts
+++ b/scripts/cinder-downstream-snapshot.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { selectMostRecentlyPublishedVersion } from './cinder-downstream-snapshot.ts';
+import { redactRemote, selectMostRecentlyPublishedVersion } from './cinder-downstream-snapshot.ts';
 
 /**
  * Absolute path to the CLI under test. Resolving from `import.meta.url` rather than
@@ -84,7 +84,7 @@ test('invalid options report exit code and stderr instead of a JSON parse error'
   expect((failure as Error).message).not.toContain('JSON Parse error');
 });
 
-test('clones a file remote ref, records its commit, and redacts remote credentials', async () => {
+test('clones a file remote ref and records its commit', async () => {
   const source = await mkdtemp(join(tmpdir(), 'cinder-snapshot-remote-'));
   Bun.spawnSync(['git', '-C', source, 'init', '-q', '-b', 'main']);
   Bun.spawnSync(['git', '-C', source, 'config', 'user.email', 'snapshot@example.test']);
@@ -112,6 +112,12 @@ test('clones a file remote ref, records its commit, and redacts remote credentia
   ]);
   const snapshot = JSON.parse(result.stdout.toString());
   expect(snapshot.repositories[0].commit).toBe(expected);
+});
+
+test('redacts credentials from remote output', () => {
+  expect(redactRemote('https://user:secret@example.test/repository.git')).toBe(
+    'https://%5BREDACTED%5D@example.test/repository.git',
+  );
 });
 
 test('partial repository failures stay in the snapshot', async () => {

--- a/scripts/cinder-downstream-snapshot.test.ts
+++ b/scripts/cinder-downstream-snapshot.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { redactRemote, selectMostRecentlyPublishedVersion } from './cinder-downstream-snapshot.ts';
+import {
+  redactRemote,
+  redactSecrets,
+  selectMostRecentlyPublishedVersion,
+} from './cinder-downstream-snapshot.ts';
 
 /**
  * Absolute path to the CLI under test. Resolving from `import.meta.url` rather than
@@ -103,14 +107,8 @@ test('clones a file remote ref and records its commit', async () => {
       repositories: [{ name: 'remote', remote: `file://${source}`, ref: 'main' }],
     }),
   );
-  const result = Bun.spawnSync([
-    'bun',
-    'run',
-    'scripts/cinder-downstream-snapshot.ts',
-    '--request',
-    request,
-  ]);
-  const snapshot = JSON.parse(result.stdout.toString());
+  const result = await runSnapshotCli(['--request', request]);
+  const snapshot = JSON.parse(result.stdout);
   expect(snapshot.repositories[0].commit).toBe(expected);
 });
 
@@ -120,6 +118,9 @@ test('redacts credentials from remote output', () => {
   );
   expect(redactRemote('git@github.com:owner/repository.git')).toBe(
     'git@github.com:owner/repository.git',
+  );
+  expect(redactSecrets('ssh://user:secret@example.test/repository.git')).toBe(
+    'ssh://[REDACTED]@example.test/repository.git',
   );
 });
 

--- a/scripts/cinder-downstream-snapshot.test.ts
+++ b/scripts/cinder-downstream-snapshot.test.ts
@@ -118,6 +118,9 @@ test('redacts credentials from remote output', () => {
   expect(redactRemote('https://user:secret@example.test/repository.git')).toBe(
     'https://%5BREDACTED%5D@example.test/repository.git',
   );
+  expect(redactRemote('git@github.com:owner/repository.git')).toBe(
+    'git@github.com:owner/repository.git',
+  );
 });
 
 test('partial repository failures stay in the snapshot', async () => {

--- a/scripts/cinder-downstream-snapshot.test.ts
+++ b/scripts/cinder-downstream-snapshot.test.ts
@@ -84,6 +84,36 @@ test('invalid options report exit code and stderr instead of a JSON parse error'
   expect((failure as Error).message).not.toContain('JSON Parse error');
 });
 
+test('clones a file remote ref, records its commit, and redacts remote credentials', async () => {
+  const source = await mkdtemp(join(tmpdir(), 'cinder-snapshot-remote-'));
+  Bun.spawnSync(['git', '-C', source, 'init', '-q', '-b', 'main']);
+  Bun.spawnSync(['git', '-C', source, 'config', 'user.email', 'snapshot@example.test']);
+  Bun.spawnSync(['git', '-C', source, 'config', 'user.name', 'Snapshot']);
+  await Bun.write(join(source, 'remote.txt'), 'remote');
+  Bun.spawnSync(['git', '-C', source, 'add', 'remote.txt']);
+  Bun.spawnSync(['git', '-C', source, 'commit', '-qm', 'remote']);
+  const expected = Bun.spawnSync(['git', '-C', source, 'rev-parse', 'HEAD'])
+    .stdout.toString()
+    .trim();
+  const request = join(await mkdtemp(join(tmpdir(), 'cinder-snapshot-request-')), 'request.json');
+  await Bun.write(
+    request,
+    JSON.stringify({
+      schemaVersion: 1,
+      repositories: [{ name: 'remote', remote: `file://${source}`, ref: 'main' }],
+    }),
+  );
+  const result = Bun.spawnSync([
+    'bun',
+    'run',
+    'scripts/cinder-downstream-snapshot.ts',
+    '--request',
+    request,
+  ]);
+  const snapshot = JSON.parse(result.stdout.toString());
+  expect(snapshot.repositories[0].commit).toBe(expected);
+});
+
 test('partial repository failures stay in the snapshot', async () => {
   const root = await mkdtemp(join(tmpdir(), 'cinder-snapshot-error-'));
   const request = join(root, 'request.json');

--- a/scripts/cinder-downstream-snapshot.test.ts
+++ b/scripts/cinder-downstream-snapshot.test.ts
@@ -110,6 +110,8 @@ test('clones a file remote ref and records its commit', async () => {
   const result = await runSnapshotCli(['--request', request]);
   const snapshot = JSON.parse(result.stdout);
   expect(snapshot.repositories[0].commit).toBe(expected);
+  expect(snapshot.repositories[0].remote).toBe(`file://${source}`);
+  expect(snapshot.repositories[0].ref).toBe('main');
 });
 
 test('redacts credentials from remote output', () => {

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -39,7 +39,7 @@ function redactEvidenceLine(line: string): string {
   return line.replace(SENSITIVE_EVIDENCE_ASSIGNMENT, '$1[REDACTED]');
 }
 
-function redactRemote(remote: string): string {
+export function redactRemote(remote: string): string {
   try {
     const url = new URL(remote);
     if (url.username || url.password) {
@@ -50,6 +50,10 @@ function redactRemote(remote: string): string {
   } catch {
     return '[REDACTED]';
   }
+}
+
+function redactSecrets(value: string): string {
+  return value.replace(/(https?:\/\/)[^\s/@]+(?::[^\s/@]*)?@/giu, '$1[REDACTED]@');
 }
 
 export function selectMostRecentlyPublishedVersion(packument: PackagePackument): string {
@@ -142,8 +146,6 @@ async function main(): Promise<void> {
         exports: metadata.exports ?? null,
       });
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith('repository source must be exactly'))
-        throw new Error(`repository:${repository.name}: ${error.message}`);
       errors.push({
         scope: `package:${packageRequest.name}`,
         message: error instanceof Error ? error.message : String(error),
@@ -187,7 +189,12 @@ async function main(): Promise<void> {
             : clone;
         if (fetch.exitCode !== 0)
           throw new Error(`clone failed: ${fetch.stderr.toString().trim()}`);
-        Bun.spawnSync(['git', '-C', temporaryRoot, 'checkout', '--detach', 'FETCH_HEAD']);
+        const checkout = Bun.spawnSync(
+          ['git', '-C', temporaryRoot, 'checkout', '--detach', 'FETCH_HEAD'],
+          { timeout: REMOTE_CLONE_TIMEOUT_MS },
+        );
+        if (checkout.exitCode !== 0)
+          throw new Error(`checkout failed: ${checkout.stderr.toString().trim()}`);
         root = temporaryRoot;
       } else {
         root = resolve(repository.path!);
@@ -337,9 +344,6 @@ async function main(): Promise<void> {
         ...(repository.remote === undefined
           ? {}
           : { remote: redactRemote(repository.remote), ref: repository.ref! }),
-        ...(repository.remote === undefined
-          ? {}
-          : { remote: repository.remote, ref: repository.ref! }),
         branch: repository.branch ?? null,
         commit: resolvedCommit,
         files: files.toSorted((a, b) => a.path.localeCompare(b.path)),
@@ -348,7 +352,7 @@ async function main(): Promise<void> {
     } catch (error) {
       errors.push({
         scope: `repository:${repository.name}`,
-        message: redactEvidenceLine(error instanceof Error ? error.message : String(error)),
+        message: redactSecrets(error instanceof Error ? error.message : String(error)),
       });
     } finally {
       if (temporaryRoot !== null) await rm(temporaryRoot, { recursive: true, force: true });

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -48,7 +48,7 @@ export function redactRemote(remote: string): string {
     }
     return url.toString();
   } catch {
-    return '[REDACTED]';
+    return remote.replace(/([^\s/@]+):[^\s/@]+@/u, '[REDACTED]@');
   }
 }
 
@@ -160,6 +160,12 @@ async function main(): Promise<void> {
     try {
       const hasPath = repository.path !== undefined;
       const hasRemote = repository.remote !== undefined;
+      if (hasPath && (typeof repository.path !== 'string' || repository.path.length === 0))
+        throw new Error('repository path must be a non-empty string');
+      if (hasRemote && (typeof repository.remote !== 'string' || repository.remote.length === 0))
+        throw new Error('repository remote must be a non-empty string');
+      if (hasRemote && (typeof repository.ref !== 'string' || repository.ref.length === 0))
+        throw new Error('repository ref must be a non-empty string');
       if (
         hasPath === hasRemote ||
         (hasRemote && repository.ref === undefined) ||

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -1,4 +1,4 @@
-import { lstat, readFile, readlink } from 'node:fs/promises';
+import { lstat, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
 import { isAbsolute, relative, resolve } from 'node:path';
 
 type Request = {
@@ -6,7 +6,9 @@ type Request = {
   packages?: Array<{ name: string; version?: string; resolution?: 'latest' | 'published' }>;
   repositories?: Array<{
     name: string;
-    path: string;
+    path?: string;
+    remote?: string;
+    ref?: string;
     commit?: string;
     branch?: string;
     globs?: string[];
@@ -135,8 +137,37 @@ async function main(): Promise<void> {
   for (const repository of (request.repositories ?? []).toSorted((a, b) =>
     a.name.localeCompare(b.name),
   )) {
+    let temporaryRoot: string | null = null;
     try {
-      const root = resolve(repository.path);
+      const hasPath = repository.path !== undefined;
+      const hasRemote = repository.remote !== undefined;
+      if (
+        hasPath === hasRemote ||
+        (hasRemote && repository.ref === undefined) ||
+        (!hasRemote && repository.ref !== undefined)
+      ) {
+        throw new Error('repository source must be exactly path(+optional branch) XOR remote+ref');
+      }
+      let root: string;
+      if (hasRemote) {
+        temporaryRoot = await mkdtemp('/tmp/cinder-downstream-');
+        const clone = Bun.spawnSync([
+          'git',
+          'clone',
+          '--depth',
+          '1',
+          '--single-branch',
+          '--branch',
+          repository.ref!,
+          repository.remote!,
+          temporaryRoot,
+        ]);
+        if (clone.exitCode !== 0)
+          throw new Error(`clone failed: ${clone.stderr.toString().trim()}`);
+        root = temporaryRoot;
+      } else {
+        root = resolve(repository.path!);
+      }
       const files = [];
       const evidence: Record<
         string,
@@ -218,7 +249,7 @@ async function main(): Promise<void> {
         }
       }
       let resolvedCommit = repository.commit ?? null;
-      if (repository.commit || repository.branch) {
+      if (repository.commit || repository.branch || repository.remote) {
         const headRevision = Bun.spawnSync([
           'git',
           '-C',
@@ -279,6 +310,9 @@ async function main(): Promise<void> {
       }
       repositories.push({
         name: repository.name,
+        ...(repository.remote === undefined
+          ? {}
+          : { remote: repository.remote, ref: repository.ref! }),
         branch: repository.branch ?? null,
         commit: resolvedCommit,
         files: files.toSorted((a, b) => a.path.localeCompare(b.path)),
@@ -289,6 +323,8 @@ async function main(): Promise<void> {
         scope: `repository:${repository.name}`,
         message: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      if (temporaryRoot !== null) await rm(temporaryRoot, { recursive: true, force: true });
     }
   }
   const output = {

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -39,6 +39,19 @@ function redactEvidenceLine(line: string): string {
   return line.replace(SENSITIVE_EVIDENCE_ASSIGNMENT, '$1[REDACTED]');
 }
 
+function redactRemote(remote: string): string {
+  try {
+    const url = new URL(remote);
+    if (url.username || url.password) {
+      url.username = '[REDACTED]';
+      url.password = '';
+    }
+    return url.toString();
+  } catch {
+    return '[REDACTED]';
+  }
+}
+
 export function selectMostRecentlyPublishedVersion(packument: PackagePackument): string {
   const versions = packument.versions ?? {};
   const candidates = Object.entries(packument.time ?? {})
@@ -323,6 +336,9 @@ async function main(): Promise<void> {
         name: repository.name,
         ...(repository.remote === undefined
           ? {}
+          : { remote: redactRemote(repository.remote), ref: repository.ref! }),
+        ...(repository.remote === undefined
+          ? {}
           : { remote: repository.remote, ref: repository.ref! }),
         branch: repository.branch ?? null,
         commit: resolvedCommit,
@@ -332,7 +348,7 @@ async function main(): Promise<void> {
     } catch (error) {
       errors.push({
         scope: `repository:${repository.name}`,
-        message: error instanceof Error ? error.message : String(error),
+        message: redactEvidenceLine(error instanceof Error ? error.message : String(error)),
       });
     } finally {
       if (temporaryRoot !== null) await rm(temporaryRoot, { recursive: true, force: true });

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -193,8 +193,14 @@ async function main(): Promise<void> {
                 { timeout: REMOTE_CLONE_TIMEOUT_MS },
               )
             : clone;
+        if (clone.exitCode !== 0)
+          throw new Error(
+            `git init failed (exit ${clone.exitCode}): ${(clone.stderr.toString() || clone.stdout.toString()).trim()}`,
+          );
         if (fetch.exitCode !== 0)
-          throw new Error(`clone failed: ${fetch.stderr.toString().trim()}`);
+          throw new Error(
+            `git fetch failed (exit ${fetch.exitCode}): ${(fetch.stderr.toString() || fetch.stdout.toString()).trim()}`,
+          );
         const checkout = Bun.spawnSync(
           ['git', '-C', temporaryRoot, 'checkout', '--detach', 'FETCH_HEAD'],
           { timeout: REMOTE_CLONE_TIMEOUT_MS },
@@ -361,7 +367,16 @@ async function main(): Promise<void> {
         message: redactSecrets(error instanceof Error ? error.message : String(error)),
       });
     } finally {
-      if (temporaryRoot !== null) await rm(temporaryRoot, { recursive: true, force: true });
+      if (temporaryRoot !== null) {
+        try {
+          await rm(temporaryRoot, { recursive: true, force: true });
+        } catch (error) {
+          errors.push({
+            scope: `repository:${repository.name}:cleanup`,
+            message: redactSecrets(error instanceof Error ? error.message : String(error)),
+          });
+        }
+      }
     }
   }
   const output = {

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -52,8 +52,8 @@ export function redactRemote(remote: string): string {
   }
 }
 
-function redactSecrets(value: string): string {
-  return value.replace(/(https?:\/\/)[^\s/@]+(?::[^\s/@]*)?@/giu, '$1[REDACTED]@');
+export function redactSecrets(value: string): string {
+  return value.replace(/([a-z][a-z\d+.-]*:\/\/)[^\s/@]+(?::[^\s/@]*)?@/giu, '$1[REDACTED]@');
 }
 
 export function selectMostRecentlyPublishedVersion(packument: PackagePackument): string {

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -1,5 +1,6 @@
 import { lstat, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, relative, resolve } from 'node:path';
 
 type Request = {
   schemaVersion: 1;
@@ -30,6 +31,7 @@ type PackagePackument = {
 
 const usage = 'Usage: bun run scripts/cinder-downstream-snapshot.ts --request FILE [--output FILE]';
 const NPM_METADATA_TIMEOUT_MS = 10_000;
+const REMOTE_CLONE_TIMEOUT_MS = 60_000;
 const SENSITIVE_EVIDENCE_ASSIGNMENT =
   /^(.*?(?:["']?[\w.-]*(?:authorization|credential|password|secret|token|api[_-]?key)[\w.-]*["']?)\s*[:=]\s*).*$/iu;
 
@@ -127,6 +129,8 @@ async function main(): Promise<void> {
         exports: metadata.exports ?? null,
       });
     } catch (error) {
+      if (error instanceof Error && error.message.startsWith('repository source must be exactly'))
+        throw new Error(`repository:${repository.name}: ${error.message}`);
       errors.push({
         scope: `package:${packageRequest.name}`,
         message: error instanceof Error ? error.message : String(error),
@@ -150,20 +154,27 @@ async function main(): Promise<void> {
       }
       let root: string;
       if (hasRemote) {
-        temporaryRoot = await mkdtemp('/tmp/cinder-downstream-');
-        const clone = Bun.spawnSync([
-          'git',
-          'clone',
-          '--depth',
-          '1',
-          '--single-branch',
-          '--branch',
-          repository.ref!,
-          repository.remote!,
-          temporaryRoot,
-        ]);
-        if (clone.exitCode !== 0)
-          throw new Error(`clone failed: ${clone.stderr.toString().trim()}`);
+        temporaryRoot = await mkdtemp(join(tmpdir(), 'cinder-downstream-'));
+        const clone = Bun.spawnSync(['git', 'init', '-q', temporaryRoot]);
+        const fetch =
+          clone.exitCode === 0
+            ? Bun.spawnSync(
+                [
+                  'git',
+                  '-C',
+                  temporaryRoot,
+                  'fetch',
+                  '--depth',
+                  '1',
+                  repository.remote!,
+                  repository.ref!,
+                ],
+                { timeout: REMOTE_CLONE_TIMEOUT_MS },
+              )
+            : clone;
+        if (fetch.exitCode !== 0)
+          throw new Error(`clone failed: ${fetch.stderr.toString().trim()}`);
+        Bun.spawnSync(['git', '-C', temporaryRoot, 'checkout', '--detach', 'FETCH_HEAD']);
         root = temporaryRoot;
       } else {
         root = resolve(repository.path!);


### PR DESCRIPTION
Closes #901

## Summary
- accept exactly one local path or remote/ref repository source
- clone requested refs into unique temporary directories with cleanup
- add canonical six-repository/two-package production request

## Validation
- bun test scripts/cinder-downstream-snapshot.test.ts
- bun run scripts/cinder-downstream-snapshot.ts --help