### PR TITLE
fix(consumer): make hydration teardown deterministic

### DIFF
--- a/.changeset/deterministic-hydration-teardown.md
+++ b/.changeset/deterministic-hydration-teardown.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Make hydration smoke teardown ordered, bounded, and diagnostic across browser resources.

--- a/.changeset/deterministic-hydration-teardown.md
+++ b/.changeset/deterministic-hydration-teardown.md
@@ -1,5 +1,0 @@
----
-'@lostgradient/cinder': patch
----
-
-Make hydration smoke teardown ordered, bounded, and diagnostic across browser resources.

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -8,7 +8,46 @@ import {
   chatPeerValidationTarballPath,
   EXAMPLES_CONSUMER_READINESS_PATH,
   resolveChatFixtureCinderVersion,
+  runBoundedHydrationTeardown,
 } from './validate-consumers.ts';
+
+describe('hydration teardown', () => {
+  test('forces later resources closed when page close never settles', async () => {
+    const calls: string[] = [];
+    const failures = await runBoundedHydrationTeardown(
+      [
+        {
+          phase: 'page.close',
+          close: () => new Promise<void>(() => {}),
+          forceClose: () => {
+            calls.push('page.forceClose');
+          },
+          state: () => 'pageClosed=false',
+        },
+        {
+          phase: 'browser.close',
+          close: async () => {
+            calls.push('browser.close');
+          },
+          state: () => 'browserConnected=false',
+        },
+        {
+          phase: 'fixture-server.exited',
+          close: async () => {
+            calls.push('fixture-server.exited');
+          },
+          state: () => 'fixtureServerExitCode=0',
+        },
+      ],
+      1,
+    );
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]?.phase).toBe('page.close');
+    expect(failures[0]?.state).toBe('pageClosed=false');
+    expect(calls).toEqual(['page.forceClose', 'browser.close', 'fixture-server.exited']);
+  });
+});
 
 describe('examples consumer readiness', () => {
   test('polls a static build asset instead of repeatedly rendering every example', () => {

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -7,6 +7,7 @@ import {
   bumpPackageVersion,
   chatPeerValidationTarballPath,
   EXAMPLES_CONSUMER_READINESS_PATH,
+  parseHydrationBrowserProcessIds,
   resolveChatFixtureCinderVersion,
   runBoundedHydrationTeardown,
   unreclaimedTeardownFailures,
@@ -188,6 +189,40 @@ describe('hydration teardown reclamation verdict', () => {
     // No `reclaimed` signal: the fixture server sits outside the browser
     // containment chain, so its failure always counts.
     expect(unreclaimedTeardownFailures(failures)).toHaveLength(1);
+  });
+
+  test('refuses to read an unreadable process table as a reclaimed browser', () => {
+    // `[]` means "provably gone" and subsumes earlier teardown failures, so a
+    // failed `ps` must never produce it — that would turn the gate permanently
+    // green, which is strictly worse than the flake this fixes.
+    expect(() =>
+      parseHydrationBrowserProcessIds(
+        { exitCode: 1, stdout: '', stderr: 'ps: permission denied' },
+        'cinder-hydration-abc',
+        10,
+      ),
+    ).toThrow('ps failed');
+
+    expect(
+      parseHydrationBrowserProcessIds(
+        { exitCode: 0, stdout: '', stderr: '' },
+        'cinder-hydration-abc',
+        10,
+      ),
+    ).toEqual([]);
+  });
+
+  test('matches only this run’s launch token and never its own pid', () => {
+    const token = 'cinder-hydration-abc';
+    const stdout = [
+      `  4242 /path/chrome-headless-shell --cinder-hydration-token=${token} --headless`,
+      `    10 bun validate-consumers.ts --cinder-hydration-token=${token}`,
+      '  5150 /path/chrome-headless-shell --cinder-hydration-token=cinder-hydration-other',
+    ].join('\n');
+
+    expect(parseHydrationBrowserProcessIds({ exitCode: 0, stdout, stderr: '' }, token, 10)).toEqual(
+      [4242],
+    );
   });
 });
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -230,7 +230,8 @@ describe('hydration teardown reclamation verdict', () => {
       ),
     ).toEqual([4242]);
 
-    // The same line truncated to a default-width terminal must NOT look clean.
+    // A default-width truncated line incorrectly looks clean because it hides
+    // the token; the wide process listing is what prevents that false verdict.
     expect(
       parseHydrationBrowserProcessIds(
         { exitCode: 0, stdout: `  4242 ${argv.slice(0, 80)}`, stderr: '' },

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -19,9 +19,9 @@ describe('hydration teardown', () => {
       [
         {
           phase: 'page.close',
-          close: () => new Promise<void>(() => {}),
-          forceClose: () => {
-            calls.push('page.forceClose');
+          close: () => {
+            calls.push('page.close');
+            return new Promise<void>(() => {});
           },
           state: () => 'pageClosed=false',
         },
@@ -46,7 +46,7 @@ describe('hydration teardown', () => {
     expect(failures).toHaveLength(1);
     expect(failures[0]?.phase).toBe('page.close');
     expect(failures[0]?.state).toBe('pageClosed=false');
-    expect(calls).toEqual(['page.forceClose', 'browser.close', 'fixture-server.exited']);
+    expect(calls).toEqual(['page.close', 'browser.close', 'fixture-server.exited']);
   });
 
   test('continues after a force-close path also times out', async () => {

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -9,6 +9,7 @@ import {
   EXAMPLES_CONSUMER_READINESS_PATH,
   resolveChatFixtureCinderVersion,
   runBoundedHydrationTeardown,
+  unreclaimedTeardownFailures,
 } from './validate-consumers.ts';
 
 describe('hydration teardown', () => {
@@ -73,6 +74,120 @@ describe('hydration teardown', () => {
     expect(failures[0]?.phase).toBe('browser.close');
     expect(failures[1]?.phase).toBe('browser.close.force');
     expect(calls).toEqual(['fixture-server.exited']);
+  });
+});
+
+/**
+ * Reproduces the #900 recurrence: `/subpath`'s `page.close()` is issued and
+ * never settles, and the sequence must decide the run on whether Chromium was
+ * ultimately reclaimed — not on whether that one call came back.
+ *
+ * `closeCount` proves each cleanup method is invoked exactly once and never
+ * retried; the "never settles" case is a promise that is simply never resolved,
+ * so no timer or sleep is involved.
+ */
+async function runAbandonedPageTeardown(browserIsGone: () => boolean) {
+  const closeCount = { browser: 0, context: 0, page: 0 };
+  const order: string[] = [];
+
+  const failures = await runBoundedHydrationTeardown(
+    [
+      {
+        phase: 'page.close route=/subpath',
+        close: () => {
+          closeCount.page += 1;
+          order.push('page.close');
+          return new Promise<void>(() => {});
+        },
+        state: () => 'pageClosed=false browserConnected=true',
+        reclaimed: browserIsGone,
+      },
+      {
+        phase: 'context.close',
+        close: async () => {
+          closeCount.context += 1;
+          order.push('context.close');
+        },
+        state: () => 'contextPages=0',
+        reclaimed: browserIsGone,
+      },
+      {
+        phase: 'browser.close',
+        close: async () => {
+          closeCount.browser += 1;
+          order.push('browser.close');
+        },
+        state: () => 'browserConnected=false processRunning=false',
+        reclaimed: browserIsGone,
+      },
+    ],
+    1,
+  );
+
+  return { closeCount, failures, order };
+}
+
+describe('hydration teardown reclamation verdict', () => {
+  test('still closes context and browser after a page close that never settles', async () => {
+    const { closeCount, order } = await runAbandonedPageTeardown(() => true);
+
+    expect(order).toEqual(['page.close', 'context.close', 'browser.close']);
+    expect(closeCount).toEqual({ browser: 1, context: 1, page: 1 });
+  });
+
+  test('treats an abandoned page close as clean once Chromium is gone', async () => {
+    const { closeCount, failures } = await runAbandonedPageTeardown(() => true);
+
+    // The close call failed, but the resource it owned was reclaimed by the
+    // wider close — so the gate stays green and the same commit stops
+    // alternating red/green on runner contention.
+    expect(failures).toHaveLength(1);
+    expect(unreclaimedTeardownFailures(failures)).toEqual([]);
+
+    // Taking the verdict must not re-drive any cleanup.
+    expect(closeCount).toEqual({ browser: 1, context: 1, page: 1 });
+  });
+
+  test('reports the exact failing phase when Chromium really survives', async () => {
+    const { failures } = await runAbandonedPageTeardown(() => false);
+    const unreclaimed = unreclaimedTeardownFailures(failures);
+
+    expect(unreclaimed).toHaveLength(1);
+    expect(unreclaimed[0]?.phase).toBe('page.close route=/subpath');
+    expect(unreclaimed[0]?.state).toBe('pageClosed=false browserConnected=true');
+  });
+
+  test('treats an unobservable reclamation signal as unproven rather than clean', async () => {
+    const failures = await runBoundedHydrationTeardown(
+      [
+        {
+          phase: 'browser.close',
+          close: () => Promise.reject(new Error('closing Chromium failed')),
+          state: () => 'browserConnected=true processRunning=unknown',
+          reclaimed: () => 'unavailable',
+        },
+      ],
+      1,
+    );
+
+    expect(unreclaimedTeardownFailures(failures)).toHaveLength(1);
+  });
+
+  test('never subsumes a resource nothing wider can reclaim', async () => {
+    const failures = await runBoundedHydrationTeardown(
+      [
+        {
+          phase: 'fixture-server.exited',
+          close: () => Promise.reject(new Error('fixture server did not exit')),
+          state: () => 'fixtureServerExitCode=running',
+        },
+      ],
+      1,
+    );
+
+    // No `reclaimed` signal: the fixture server sits outside the browser
+    // containment chain, so its failure always counts.
+    expect(unreclaimedTeardownFailures(failures)).toHaveLength(1);
   });
 });
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -212,6 +212,34 @@ describe('hydration teardown reclamation verdict', () => {
     ).toEqual([]);
   });
 
+  test('finds the launch token deep inside a full-length Chromium argv', () => {
+    const token = 'cinder-hydration-abc';
+    // Playwright appends our flag ~1.7 KB into Chromium's ~1.9 KB argv, so the
+    // listing must be read untruncated (`ps -ww`). A truncated line drops the
+    // token, reports "no process", and lets the reclamation verdict read a
+    // leaked browser as reclaimed — the gate would fail open.
+    const argv = `/path/chrome-headless-shell ${'--disable-some-feature '.repeat(75)}--cinder-hydration-token=${token} --headless`;
+
+    expect(argv.length).toBeGreaterThan(1_500);
+    expect(argv.indexOf(token)).toBeGreaterThan(80);
+    expect(
+      parseHydrationBrowserProcessIds(
+        { exitCode: 0, stdout: `  4242 ${argv}`, stderr: '' },
+        token,
+        10,
+      ),
+    ).toEqual([4242]);
+
+    // The same line truncated to a default-width terminal must NOT look clean.
+    expect(
+      parseHydrationBrowserProcessIds(
+        { exitCode: 0, stdout: `  4242 ${argv.slice(0, 80)}`, stderr: '' },
+        token,
+        10,
+      ),
+    ).toEqual([]);
+  });
+
   test('matches only this run’s launch token and never its own pid', () => {
     const token = 'cinder-hydration-abc';
     const stdout = [

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -47,6 +47,33 @@ describe('hydration teardown', () => {
     expect(failures[0]?.state).toBe('pageClosed=false');
     expect(calls).toEqual(['page.forceClose', 'browser.close', 'fixture-server.exited']);
   });
+
+  test('continues after a force-close path also times out', async () => {
+    const calls: string[] = [];
+    const failures = await runBoundedHydrationTeardown(
+      [
+        {
+          phase: 'browser.close',
+          close: () => new Promise<void>(() => {}),
+          forceClose: () => new Promise<void>(() => {}),
+          state: () => 'browserConnected=true',
+        },
+        {
+          phase: 'fixture-server.exited',
+          close: async () => {
+            calls.push('fixture-server.exited');
+          },
+          state: () => 'fixtureServerExitCode=0',
+        },
+      ],
+      1,
+    );
+
+    expect(failures).toHaveLength(2);
+    expect(failures[0]?.phase).toBe('browser.close');
+    expect(failures[1]?.phase).toBe('browser.close.force');
+    expect(calls).toEqual(['fixture-server.exited']);
+  });
 });
 
 describe('examples consumer readiness', () => {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1643,8 +1643,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
         'explicit `@lostgradient/cinder/button/styles` import',
       );
     } finally {
-      fixtureServer.kill();
-      await fixtureServer.exited;
+      await stopHydrationFixtureServer(fixtureServer);
     }
   } finally {
     restoreManifest();
@@ -1662,7 +1661,7 @@ type SvelteKitHydrationRoute = '/subpath' | '/chat-layout' | '/dev-ssr';
  * `/dev/shm` is not constrained), so the crash first surfaced as a blocked
  * release rather than in PR CI. Writing shared memory under `/tmp` avoids it.
  */
-async function launchHydrationChromium() {
+async function launchHydrationChromium(): Promise<Browser> {
   const { chromium } = await import('@playwright/test');
   return promiseWithTimeout(
     chromium.launch({ args: ['--disable-dev-shm-usage'] }),
@@ -1698,6 +1697,66 @@ class HydrationTeardownError extends Error {
   }
 }
 
+const HYDRATION_TEARDOWN_TIMEOUT_MS = 5_000;
+
+type TeardownStep = {
+  phase: string;
+  close: () => Promise<void>;
+  forceClose?: () => Promise<void> | void;
+  state: () => string;
+};
+
+type TeardownStepFailure = { phase: string; error: unknown; state: string };
+
+export async function runBoundedHydrationTeardown(
+  steps: readonly TeardownStep[],
+  timeoutMs = HYDRATION_TEARDOWN_TIMEOUT_MS,
+): Promise<TeardownStepFailure[]> {
+  const failures: TeardownStepFailure[] = [];
+  for (const step of steps) {
+    try {
+      await promiseWithTimeout(step.close(), timeoutMs, `teardown phase=${step.phase}`);
+    } catch (error) {
+      let state: string;
+      try {
+        state = step.state();
+      } catch (stateError) {
+        state = `state-error=${stateError instanceof Error ? stateError.message : String(stateError)}`;
+      }
+      failures.push({ phase: step.phase, error, state });
+      try {
+        await step.forceClose?.();
+      } catch (forceError) {
+        failures.push({ phase: `${step.phase}.force`, error: forceError, state });
+      }
+    }
+  }
+  return failures;
+}
+
+async function stopHydrationFixtureServer(server: Bun.Subprocess): Promise<void> {
+  const failures = await runBoundedHydrationTeardown([
+    {
+      phase: 'fixture-server.exited',
+      close: async () => {
+        server.kill();
+        await server.exited;
+      },
+      forceClose: () => server.kill(),
+      state: () => `fixtureServerExitCode=${server.exitCode ?? 'running'}`,
+    },
+  ]);
+  if (failures.length > 0) {
+    const failure = failures[0]!;
+    throw new HydrationTeardownError(
+      new Error(
+        `teardown phase=${failure.phase} ${failure.state}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
+        { cause: failure.error },
+      ),
+    );
+  }
+}
+
 async function runSvelteKitHydrationRoutesOnce(
   httpPort: number,
   label: string,
@@ -1707,11 +1766,20 @@ async function runSvelteKitHydrationRoutesOnce(
   let context: BrowserContext | undefined;
   let bodyError: unknown;
   let bodyFailed = false;
+  const browserEvents: string[] = [];
+  browser.on('disconnected', () => browserEvents.push('browser:disconnected'));
 
   try {
     context = await browser.newContext();
     for (const routePath of routePaths) {
-      await assertSvelteKitHydrationRoute(browser, context, httpPort, label, routePath);
+      await assertSvelteKitHydrationRoute(
+        browser,
+        context,
+        httpPort,
+        label,
+        routePath,
+        browserEvents,
+      );
     }
   } catch (error) {
     bodyError = error;
@@ -1723,40 +1791,38 @@ async function runSvelteKitHydrationRoutesOnce(
   // passing run never leaks a Chromium process/handle that would hang a later
   // validate:consumer run; collect rather than throw inline so `browser.close()`
   // still runs if `context.close()` fails.
-  const closeErrors: unknown[] = [];
-  if (context !== undefined) {
-    await promiseWithTimeout(
-      context.close(),
-      5_000,
-      `closing SvelteKit hydration context after ${routePaths.join(', ')}`,
-    ).catch((error: unknown) =>
-      closeErrors.push(
-        new Error(
-          `teardown phase=context.close routes=${routePaths.join(',')} browserConnected=${browser.isConnected()}: ${error instanceof Error ? error.message : String(error)}`,
-          { cause: error },
-        ),
-      ),
-    );
-  }
-  await promiseWithTimeout(
-    browser.close(),
-    5_000,
-    `closing Chromium after SvelteKit hydration routes ${routePaths.join(', ')}`,
-  ).catch((error: unknown) =>
-    closeErrors.push(
-      new Error(
-        `teardown phase=browser.close routes=${routePaths.join(',')} browserConnected=${browser.isConnected()}: ${error instanceof Error ? error.message : String(error)}`,
-        { cause: error },
-      ),
-    ),
-  );
+  const closeErrors = await runBoundedHydrationTeardown([
+    ...(context === undefined
+      ? []
+      : [
+          {
+            phase: 'context.close',
+            close: () => context!.close(),
+            state: () => `contextPages=${context!.pages().length}`,
+          },
+        ]),
+    {
+      phase: 'browser.close',
+      close: () => browser.close(),
+      forceClose: () => browser.close(),
+      state: () => `browserConnected=${browser.isConnected()}`,
+    },
+  ]);
 
   // A body failure wins: its error is what the retry decision needs (a crashed
   // browser makes both closes throw too — those are swallowed). But when every
   // route assertion PASSED and teardown still failed, surface it: a browser
   // dying during close is a real problem, not noise to hide behind a green run.
   if (bodyFailed) throw bodyError;
-  if (closeErrors.length > 0) throw new HydrationTeardownError(closeErrors[0]);
+  if (closeErrors.length > 0) {
+    const first = closeErrors[0]!;
+    throw new HydrationTeardownError(
+      new Error(
+        `teardown phase=${first.phase} routes=${routePaths.join(',')} ${first.state} events=${browserEvents.join('|') || 'none'}: ${first.error instanceof Error ? first.error.message : String(first.error)}`,
+        { cause: first.error },
+      ),
+    );
+  }
 }
 
 async function assertSvelteKitClientRoutesHydrate(
@@ -1787,9 +1853,12 @@ async function assertSvelteKitHydrationRoute(
   httpPort: number,
   label: string,
   routePath: SvelteKitHydrationRoute,
+  browserEvents: string[],
 ): Promise<void> {
   const page = await context.newPage();
   const errors: string[] = [];
+  page.on('crash', () => browserEvents.push(`page:crash route=${routePath}`));
+  page.on('requestfailed', (request) => browserEvents.push(`requestfailed:${request.url()}`));
   page.on('pageerror', (error) => errors.push(error.message));
   page.on('console', (message) => {
     const text = message.text();
@@ -1801,6 +1870,7 @@ async function assertSvelteKitHydrationRoute(
     }
   });
 
+  let bodyError: unknown;
   try {
     await page.goto(`http://127.0.0.1:${httpPort}${routePath}`, {
       waitUntil: 'domcontentloaded',
@@ -1813,19 +1883,25 @@ async function assertSvelteKitHydrationRoute(
         `sveltekit-consumer ${label} ${routePath} emitted client hydration/runtime errors:\n${errors.map((error) => `  ${error}`).join('\n')}`,
       );
     }
-  } finally {
-    await promiseWithTimeout(
-      page.close(),
-      5_000,
-      `closing SvelteKit hydration page for ${routePath}`,
-    ).catch((error: unknown) => {
-      throw new HydrationTeardownError(
-        new Error(
-          `teardown phase=page.close route=${routePath} browserConnected=${browser.isConnected()}: ${error instanceof Error ? error.message : String(error)}`,
-          { cause: error },
-        ),
-      );
-    });
+  } catch (error) {
+    bodyError = error;
+  }
+  const pageFailures = await runBoundedHydrationTeardown([
+    {
+      phase: 'page.close',
+      close: () => page.close(),
+      state: () => `pageClosed=${page.isClosed()} browserConnected=${browser.isConnected()}`,
+    },
+  ]);
+  if (bodyError !== undefined) throw bodyError;
+  if (pageFailures.length > 0) {
+    const failure = pageFailures[0]!;
+    throw new HydrationTeardownError(
+      new Error(
+        `teardown phase=${failure.phase} route=${routePath} ${failure.state} events=${browserEvents.join('|') || 'none'}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
+        { cause: failure.error },
+      ),
+    );
   }
 }
 
@@ -2394,8 +2470,7 @@ async function runExamplesConsumerFixture(): Promise<void> {
         `[validate-consumers] examples-consumer OK — ${expected.entryCount} example entries each rendered exactly once.\n`,
       );
     } finally {
-      fixtureServer.kill();
-      await fixtureServer.exited;
+      await stopHydrationFixtureServer(fixtureServer);
     }
   } finally {
     restoreManifest();

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1797,8 +1797,8 @@ async function runSvelteKitHydrationRoutesOnce(
       : [
           {
             phase: 'context.close',
-            close: () => context!.close(),
-            state: () => `contextPages=${context!.pages().length}`,
+            close: () => context.close(),
+            state: () => `contextPages=${context.pages().length}`,
           },
         ]),
     {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1647,7 +1647,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
     } catch (error) {
       bodyError = error;
     }
-    const teardownError = await stopHydrationFixtureServer(fixtureServer).catch((error) => error);
+    const teardownError = await stopConsumerFixtureServer(fixtureServer).catch((error) => error);
     if (bodyError !== undefined) {
       if (teardownError !== undefined) {
         process.stderr.write(
@@ -1701,6 +1701,17 @@ function forceKillHydrationBrowser(processToken: string): void {
   }
 }
 
+async function waitForHydrationBrowserExit(processToken: string): Promise<void> {
+  const deadline = Date.now() + 500;
+  while (hydrationBrowserProcessIds(processToken).length > 0 && Date.now() < deadline) {
+    await Bun.sleep(10);
+  }
+  const remaining = hydrationBrowserProcessIds(processToken);
+  if (remaining.length > 0) {
+    throw new Error(`Chromium process still running after SIGKILL: ${remaining.join(', ')}`);
+  }
+}
+
 async function launchHydrationChromium(): Promise<HydrationBrowser> {
   const { chromium } = await import('@playwright/test');
   const processToken = `cinder-hydration-${randomUUID()}`;
@@ -1733,10 +1744,10 @@ function isBrowserCrashError(error: unknown): boolean {
  * distinct type: the retry wrapper surfaces it immediately rather than
  * re-running routes that already succeeded.
  */
-class HydrationTeardownError extends Error {
+class ConsumerTeardownError extends Error {
   constructor(cause: unknown) {
     super(cause instanceof Error ? cause.message : String(cause));
-    this.name = 'HydrationTeardownError';
+    this.name = 'ConsumerTeardownError';
     this.cause = cause;
   }
 }
@@ -1784,7 +1795,7 @@ export async function runBoundedHydrationTeardown(
   return failures;
 }
 
-async function stopHydrationFixtureServer(server: Bun.Subprocess): Promise<void> {
+async function stopConsumerFixtureServer(server: Bun.Subprocess): Promise<void> {
   const failures = await runBoundedHydrationTeardown([
     {
       phase: 'fixture-server.exited',
@@ -1792,13 +1803,16 @@ async function stopHydrationFixtureServer(server: Bun.Subprocess): Promise<void>
         server.kill();
         await server.exited;
       },
-      forceClose: () => server.kill('SIGKILL'),
+      forceClose: async () => {
+        server.kill('SIGKILL');
+        await server.exited;
+      },
       state: () => `fixtureServerExitCode=${server.exitCode ?? 'running'}`,
     },
   ]);
   if (failures.length > 0) {
     const failure = failures[0]!;
-    throw new HydrationTeardownError(
+    throw new ConsumerTeardownError(
       new Error(
         `teardown phase=${failure.phase} ${failure.state}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
         { cause: failure.error },
@@ -1855,7 +1869,10 @@ async function runSvelteKitHydrationRoutesOnce(
     {
       phase: 'browser.close',
       close: () => browser.close(),
-      forceClose: () => forceKillHydrationBrowser(processToken),
+      forceClose: async () => {
+        forceKillHydrationBrowser(processToken);
+        await waitForHydrationBrowserExit(processToken);
+      },
       state: () =>
         `browserConnected=${browser.isConnected()} processRunning=${hydrationBrowserProcessIds(processToken).length > 0}`,
     },
@@ -1868,7 +1885,7 @@ async function runSvelteKitHydrationRoutesOnce(
   if (bodyFailed) throw bodyError;
   if (closeErrors.length > 0) {
     const first = closeErrors[0]!;
-    throw new HydrationTeardownError(
+    throw new ConsumerTeardownError(
       new Error(
         `teardown phase=${first.phase} routes=${routePaths.join(',')} ${first.state} events=${browserEvents.join('|') || 'none'}: ${first.error instanceof Error ? first.error.message : String(first.error)}`,
         { cause: first.error },
@@ -1886,10 +1903,10 @@ async function assertSvelteKitClientRoutesHydrate(
     await runSvelteKitHydrationRoutesOnce(httpPort, label, routePaths);
   } catch (error) {
     // Only a crash DURING route assertions is retried. A teardown failure
-    // after passing assertions (HydrationTeardownError) is surfaced as-is —
+    // after passing assertions (ConsumerTeardownError) is surfaced as-is —
     // re-running routes that already succeeded would be wasted work — and any
     // non-crash failure (a real hydration/content assertion) is rethrown too.
-    if (error instanceof HydrationTeardownError || !isBrowserCrashError(error)) throw error;
+    if (error instanceof ConsumerTeardownError || !isBrowserCrashError(error)) throw error;
     process.stderr.write(
       `[validate-consumers] Chromium crashed during ${label} hydration ` +
         `(${routePaths.join(', ')}); relaunching once: ` +
@@ -1910,7 +1927,9 @@ async function assertSvelteKitHydrationRoute(
   const page = await context.newPage();
   const errors: string[] = [];
   page.on('crash', () => browserEvents.push(`page:crash route=${routePath}`));
-  page.on('requestfailed', (request) => browserEvents.push(`requestfailed:${request.url()}`));
+  page.on('requestfailed', (request) =>
+    browserEvents.push(`requestfailed route=${routePath} url=${request.url()}`),
+  );
   page.on('pageerror', (error) => errors.push(error.message));
   page.on('console', (message) => {
     const text = message.text();
@@ -1948,7 +1967,7 @@ async function assertSvelteKitHydrationRoute(
   if (bodyError !== undefined) throw bodyError;
   if (pageFailures.length > 0) {
     const failure = pageFailures[0]!;
-    throw new HydrationTeardownError(
+    throw new ConsumerTeardownError(
       new Error(
         `teardown phase=${failure.phase} route=${routePath} ${failure.state} events=${browserEvents.join('|') || 'none'}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
         { cause: failure.error },
@@ -2525,7 +2544,7 @@ async function runExamplesConsumerFixture(): Promise<void> {
     } catch (error) {
       bodyError = error;
     }
-    const teardownError = await stopHydrationFixtureServer(fixtureServer).catch((error) => error);
+    const teardownError = await stopConsumerFixtureServer(fixtureServer).catch((error) => error);
     if (bodyError !== undefined) {
       if (teardownError !== undefined) {
         process.stderr.write(

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1898,9 +1898,11 @@ async function stopConsumerFixtureServer(server: Bun.Subprocess): Promise<void> 
       reclaimed: () => server.exitCode !== null,
     },
   ]);
-  const unreclaimed = unreclaimedTeardownFailures(failures);
-  if (unreclaimed.length > 0) {
-    const failure = unreclaimed[unreclaimed.length - 1]!;
+  // The fixture server has no wider cleanup step that can subsume its failure.
+  // Preserve the terminal force-close diagnostic even if the subprocess later
+  // reports an exit code while its `exited` promise rejects.
+  const failure = failures.at(-1);
+  if (failure !== undefined) {
     throw new ConsumerTeardownError(
       new Error(
         `teardown phase=${failure.phase} ${failure.state}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1704,7 +1704,19 @@ export function parseHydrationBrowserProcessIds(
 }
 
 function hydrationBrowserProcessIds(processToken: string): number[] {
-  const listing = Bun.spawnSync(['ps', '-axo', 'pid=,command='], { stdout: 'pipe' });
+  // `-ww` disables ps's column truncation, and stderr is piped so a failed
+  // listing can report why.
+  //
+  // The width flag is load-bearing, not defensive tidying: Chromium's argv is
+  // ~1.9 KB and Playwright appends our token ~1.7 KB into it. procps falls back
+  // to 80 columns when stdout is not a TTY — which is exactly the case on a CI
+  // runner — so a default-width listing would drop the token, report "no
+  // process", and let the reclamation verdict read a leaked browser as
+  // reclaimed. That fails open: a permanently green gate hiding an orphan.
+  const listing = Bun.spawnSync(['ps', '-axww', '-o', 'pid=,command='], {
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
   return parseHydrationBrowserProcessIds(
     {
       exitCode: listing.exitCode,

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1704,15 +1704,9 @@ export function parseHydrationBrowserProcessIds(
 }
 
 function hydrationBrowserProcessIds(processToken: string): number[] {
-  // `-ww` disables ps's column truncation, and stderr is piped so a failed
-  // listing can report why.
-  //
-  // The width flag is load-bearing, not defensive tidying: Chromium's argv is
-  // ~1.9 KB and Playwright appends our token ~1.7 KB into it. procps falls back
-  // to 80 columns when stdout is not a TTY — which is exactly the case on a CI
-  // runner — so a default-width listing would drop the token, report "no
-  // process", and let the reclamation verdict read a leaked browser as
-  // reclaimed. That fails open: a permanently green gate hiding an orphan.
+  // `-axww` disables ps's column truncation, and stderr is piped so a failed
+  // listing can report why. Chromium's long argv includes our unique token;
+  // without the width flag, CI's non-TTY ps output can silently drop it.
   const listing = Bun.spawnSync(['ps', '-axww', '-o', 'pid=,command='], {
     stdout: 'pipe',
     stderr: 'pipe',
@@ -1986,7 +1980,8 @@ async function runSvelteKitHydrationRoutesOnce(
   // an abandoned `page.close()` that a later `browser.close()` (or its SIGKILL
   // escalation) reclaimed leaked nothing and must not fail the gate.
   if (bodyFailed) {
-    const secondaryTeardown = unreclaimedTeardownFailures(teardownFailures)[0];
+    const unreclaimed = unreclaimedTeardownFailures(teardownFailures);
+    const secondaryTeardown = unreclaimed[unreclaimed.length - 1];
     if (secondaryTeardown !== undefined) {
       process.stderr.write(
         `[validate-consumers] hydration teardown failed after assertion failure: phase=${secondaryTeardown.phase} ${secondaryTeardown.state}: ${secondaryTeardown.error instanceof Error ? secondaryTeardown.error.message : String(secondaryTeardown.error)}\n`,
@@ -1996,12 +1991,12 @@ async function runSvelteKitHydrationRoutesOnce(
   }
 
   const unreclaimed = unreclaimedTeardownFailures(teardownFailures);
-  const first = unreclaimed[0];
-  if (first !== undefined) {
+  const widest = unreclaimed[unreclaimed.length - 1];
+  if (widest !== undefined) {
     throw new ConsumerTeardownError(
       new Error(
-        `teardown phase=${first.phase} routes=${routePaths.join(',')} ${first.state} events=${browserEvents.join('|') || 'none'}: ${first.error instanceof Error ? first.error.message : String(first.error)}`,
-        { cause: first.error },
+        `teardown phase=${widest.phase} routes=${routePaths.join(',')} ${widest.state} events=${browserEvents.join('|') || 'none'}: ${widest.error instanceof Error ? widest.error.message : String(widest.error)}`,
+        { cause: widest.error },
       ),
     );
   }

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1898,10 +1898,10 @@ async function stopConsumerFixtureServer(server: Bun.Subprocess): Promise<void> 
       reclaimed: () => server.exitCode !== null,
     },
   ]);
-  // The fixture server has no wider cleanup step that can subsume its failure.
-  // Preserve the terminal force-close diagnostic even if the subprocess later
-  // reports an exit code while its `exited` promise rejects.
-  const failure = failures.at(-1);
+  // A successful force-close reclaims the fixture even when the initial
+  // graceful stop missed its deadline. Report only a terminal failure whose
+  // subprocess is still alive after the escalation.
+  const failure = unreclaimedTeardownFailures(failures).at(-1);
   if (failure !== undefined) {
     throw new ConsumerTeardownError(
       new Error(

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1710,7 +1710,7 @@ function forceKillHydrationBrowser(processToken: string): void {
 async function waitForHydrationBrowserExit(processToken: string): Promise<void> {
   const deadline = Date.now() + HYDRATION_TEARDOWN_TIMEOUT_MS;
   while (hydrationBrowserProcessIds(processToken).length > 0 && Date.now() < deadline) {
-    await Bun.sleep(10);
+    await Bun.sleep(50);
   }
   const remaining = hydrationBrowserProcessIds(processToken);
   if (remaining.length > 0) {
@@ -1791,7 +1791,6 @@ const NEVER_RECLAIMED = (): boolean => false;
  * would only describe the client's view of the pipe.
  */
 function isHydrationBrowserGone(browser: Browser, processToken: string): boolean {
-  if (!browser.isConnected()) return true;
   try {
     return hydrationBrowserProcessIds(processToken).length === 0;
   } catch {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1895,10 +1895,12 @@ async function stopConsumerFixtureServer(server: Bun.Subprocess): Promise<void> 
         await server.exited;
       },
       state: () => `fixtureServerExitCode=${server.exitCode ?? 'running'}`,
+      reclaimed: () => server.exitCode !== null,
     },
   ]);
-  if (failures.length > 0) {
-    const failure = failures[0]!;
+  const unreclaimed = unreclaimedTeardownFailures(failures);
+  if (unreclaimed.length > 0) {
+    const failure = unreclaimed[unreclaimed.length - 1]!;
     throw new ConsumerTeardownError(
       new Error(
         `teardown phase=${failure.phase} ${failure.state}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1504,6 +1504,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
       },
     });
 
+    let bodyError: unknown;
     try {
       await waitForUrl(`http://127.0.0.1:${httpPort}/`, 10_000, fixtureServer);
 
@@ -1642,9 +1643,19 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
         '/a-la-carte',
         'explicit `@lostgradient/cinder/button/styles` import',
       );
-    } finally {
-      await stopHydrationFixtureServer(fixtureServer);
+    } catch (error) {
+      bodyError = error;
     }
+    const teardownError = await stopHydrationFixtureServer(fixtureServer).catch((error) => error);
+    if (bodyError !== undefined) {
+      if (teardownError !== undefined) {
+        process.stderr.write(
+          `[validate-consumers] sveltekit-consumer fixture teardown failed after assertion failure: ${teardownError instanceof Error ? teardownError.message : String(teardownError)}\n`,
+        );
+      }
+      throw bodyError;
+    }
+    if (teardownError !== undefined) throw teardownError;
   } finally {
     restoreManifest();
   }
@@ -1725,7 +1736,13 @@ export async function runBoundedHydrationTeardown(
       }
       failures.push({ phase: step.phase, error, state });
       try {
-        await step.forceClose?.();
+        if (step.forceClose) {
+          await promiseWithTimeout(
+            Promise.resolve(step.forceClose()),
+            timeoutMs,
+            `teardown phase=${step.phase}.force`,
+          );
+        }
       } catch (forceError) {
         failures.push({ phase: `${step.phase}.force`, error: forceError, state });
       }
@@ -2416,6 +2433,7 @@ async function runExamplesConsumerFixture(): Promise<void> {
       },
     });
 
+    let bodyError: unknown;
     try {
       // Poll a static build asset so readiness checks do not repeatedly start
       // the intentionally expensive all-examples SSR render and abort it after
@@ -2469,9 +2487,19 @@ async function runExamplesConsumerFixture(): Promise<void> {
       process.stdout.write(
         `[validate-consumers] examples-consumer OK — ${expected.entryCount} example entries each rendered exactly once.\n`,
       );
-    } finally {
-      await stopHydrationFixtureServer(fixtureServer);
+    } catch (error) {
+      bodyError = error;
     }
+    const teardownError = await stopHydrationFixtureServer(fixtureServer).catch((error) => error);
+    if (bodyError !== undefined) {
+      if (teardownError !== undefined) {
+        process.stderr.write(
+          `[validate-consumers] examples-consumer fixture teardown failed after assertion failure: ${teardownError instanceof Error ? teardownError.message : String(teardownError)}\n`,
+        );
+      }
+      throw bodyError;
+    }
+    if (teardownError !== undefined) throw teardownError;
   } finally {
     restoreManifest();
   }

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1677,23 +1677,43 @@ type SvelteKitHydrationRoute = '/subpath' | '/chat-layout' | '/dev-ssr';
  */
 type HydrationBrowser = { browser: Browser; processToken: string };
 
-function hydrationBrowserProcessIds(processToken: string): number[] {
-  const listing = Bun.spawnSync(['ps', '-axo', 'pid=,command='], { stdout: 'pipe' });
+/**
+ * Extracted from the `ps` call so the "unreadable process table" branch can be
+ * pinned by a test without shelling out. Throws rather than returning `[]` on a
+ * failed listing: an empty list means "provably gone" and drives the
+ * reclamation verdict, so collapsing the two would report every resource as
+ * reclaimed and turn the gate permanently green.
+ */
+export function parseHydrationBrowserProcessIds(
+  listing: { exitCode: number; stdout: string; stderr: string },
+  processToken: string,
+  selfPid: number,
+): number[] {
   if (listing.exitCode !== 0) {
     throw new Error(
-      `ps failed while inspecting Chromium process state (exit ${listing.exitCode}): ${listing.stderr.toString()}`,
+      `ps failed while inspecting Chromium process state (exit ${listing.exitCode}): ${listing.stderr}`,
     );
   }
-  return listing.stdout
-    .toString()
-    .split('\n')
-    .flatMap((line) => {
-      if (!line.includes(processToken)) return [];
-      const match = /^\s*(\d+)\s+/.exec(line);
-      if (!match) return [];
-      const pid = Number(match[1]);
-      return pid === process.pid ? [] : [pid];
-    });
+  return listing.stdout.split('\n').flatMap((line) => {
+    if (!line.includes(processToken)) return [];
+    const match = /^\s*(\d+)\s+/.exec(line);
+    if (!match) return [];
+    const pid = Number(match[1]);
+    return pid === selfPid ? [] : [pid];
+  });
+}
+
+function hydrationBrowserProcessIds(processToken: string): number[] {
+  const listing = Bun.spawnSync(['ps', '-axo', 'pid=,command='], { stdout: 'pipe' });
+  return parseHydrationBrowserProcessIds(
+    {
+      exitCode: listing.exitCode,
+      stdout: listing.stdout.toString(),
+      stderr: listing.stderr.toString(),
+    },
+    processToken,
+    process.pid,
+  );
 }
 
 function forceKillHydrationBrowser(processToken: string): void {
@@ -1790,10 +1810,15 @@ const NEVER_RECLAIMED = (): boolean => false;
  * process hosting every context and page is gone with it. `isConnected()` alone
  * would only describe the client's view of the pipe.
  */
-function isHydrationBrowserGone(browser: Browser, processToken: string): boolean {
+function isHydrationBrowserGone(processToken: string): boolean {
   try {
+    // The process table is consulted FIRST and on its own. A closed client pipe
+    // (`isConnected() === false`) says Playwright lost its connection, which is
+    // not proof the process died — a Chromium wedged badly enough to drop the
+    // pipe while still running is exactly the orphan this gate must catch.
     return hydrationBrowserProcessIds(processToken).length === 0;
   } catch {
+    // Unreadable process table: nothing here is proof, so nothing is reclaimed.
     return false;
   }
 }
@@ -1926,7 +1951,7 @@ async function runSvelteKitHydrationRoutesOnce(
               phase: 'context.close',
               close: () => context.close(),
               state: () => `contextPages=${context.pages().length}`,
-              reclaimed: () => isHydrationBrowserGone(browser, processToken),
+              reclaimed: () => isHydrationBrowserGone(processToken),
             },
           ]),
       {
@@ -1938,7 +1963,7 @@ async function runSvelteKitHydrationRoutesOnce(
         },
         state: () =>
           `browserConnected=${browser.isConnected()} processRunning=${hydrationBrowserProcessIds(processToken).length > 0}`,
-        reclaimed: () => isHydrationBrowserGone(browser, processToken),
+        reclaimed: () => isHydrationBrowserGone(processToken),
       },
     ])),
   );
@@ -2047,7 +2072,7 @@ async function assertSvelteKitHydrationRoute(
         phase: `page.close route=${routePath}`,
         close: () => page.close(),
         state: () => `pageClosed=${page.isClosed()} browserConnected=${browser.isConnected()}`,
-        reclaimed: () => page.isClosed() || isHydrationBrowserGone(browser, processToken),
+        reclaimed: () => page.isClosed() || isHydrationBrowserGone(processToken),
       },
     ])),
   );

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1,4 +1,5 @@
 import { Glob } from 'bun';
+import { randomUUID } from 'node:crypto';
 import {
   existsSync,
   readFileSync,
@@ -1672,13 +1673,45 @@ type SvelteKitHydrationRoute = '/subpath' | '/chat-layout' | '/dev-ssr';
  * `/dev/shm` is not constrained), so the crash first surfaced as a blocked
  * release rather than in PR CI. Writing shared memory under `/tmp` avoids it.
  */
-async function launchHydrationChromium(): Promise<Browser> {
+type HydrationBrowser = { browser: Browser; processToken: string };
+
+function hydrationBrowserProcessIds(processToken: string): number[] {
+  const listing = Bun.spawnSync(['ps', '-axo', 'pid=,command='], { stdout: 'pipe' });
+  if (listing.exitCode !== 0) return [];
+  return listing.stdout
+    .toString()
+    .split('\n')
+    .flatMap((line) => {
+      if (!line.includes(processToken)) return [];
+      const match = /^\s*(\d+)\s+/.exec(line);
+      if (!match) return [];
+      const pid = Number(match[1]);
+      return pid === process.pid ? [] : [pid];
+    });
+}
+
+function forceKillHydrationBrowser(processToken: string): void {
+  for (const pid of hydrationBrowserProcessIds(processToken)) {
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      // The process may have exited between `ps` and `kill`; the next state
+      // snapshot records whether any matching process remains.
+    }
+  }
+}
+
+async function launchHydrationChromium(): Promise<HydrationBrowser> {
   const { chromium } = await import('@playwright/test');
-  return promiseWithTimeout(
-    chromium.launch({ args: ['--disable-dev-shm-usage'] }),
+  const processToken = `cinder-hydration-${randomUUID()}`;
+  const browser = await promiseWithTimeout(
+    chromium.launch({
+      args: ['--disable-dev-shm-usage', `--cinder-hydration-token=${processToken}`],
+    }),
     15_000,
     'launching Chromium for SvelteKit hydration validation',
   );
+  return { browser, processToken };
 }
 
 /**
@@ -1779,7 +1812,8 @@ async function runSvelteKitHydrationRoutesOnce(
   label: string,
   routePaths: SvelteKitHydrationRoute[],
 ): Promise<void> {
-  const browser = await launchHydrationChromium();
+  const browserHandle = await launchHydrationChromium();
+  const { browser, processToken } = browserHandle;
   let context: BrowserContext | undefined;
   let bodyError: unknown;
   let bodyFailed = false;
@@ -1821,8 +1855,9 @@ async function runSvelteKitHydrationRoutesOnce(
     {
       phase: 'browser.close',
       close: () => browser.close(),
-      forceClose: () => browser.close(),
-      state: () => `browserConnected=${browser.isConnected()}`,
+      forceClose: () => forceKillHydrationBrowser(processToken),
+      state: () =>
+        `browserConnected=${browser.isConnected()} processRunning=${hydrationBrowserProcessIds(processToken).length > 0}`,
     },
   ]);
 

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1792,7 +1792,7 @@ async function stopHydrationFixtureServer(server: Bun.Subprocess): Promise<void>
         server.kill();
         await server.exited;
       },
-      forceClose: () => server.kill(),
+      forceClose: () => server.kill('SIGKILL'),
       state: () => `fixtureServerExitCode=${server.exitCode ?? 'running'}`,
     },
   ]);

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1506,6 +1506,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
     });
 
     let bodyError: unknown;
+    let bodyFailed = false;
     try {
       await waitForUrl(`http://127.0.0.1:${httpPort}/`, 10_000, fixtureServer);
 
@@ -1646,9 +1647,10 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
       );
     } catch (error) {
       bodyError = error;
+      bodyFailed = true;
     }
     const teardownError = await stopConsumerFixtureServer(fixtureServer).catch((error) => error);
-    if (bodyError !== undefined) {
+    if (bodyFailed) {
       if (teardownError !== undefined) {
         process.stderr.write(
           `[validate-consumers] sveltekit-consumer fixture teardown failed after assertion failure: ${teardownError instanceof Error ? teardownError.message : String(teardownError)}\n`,
@@ -1702,7 +1704,7 @@ function forceKillHydrationBrowser(processToken: string): void {
 }
 
 async function waitForHydrationBrowserExit(processToken: string): Promise<void> {
-  const deadline = Date.now() + 500;
+  const deadline = Date.now() + HYDRATION_TEARDOWN_TIMEOUT_MS;
   while (hydrationBrowserProcessIds(processToken).length > 0 && Date.now() < deadline) {
     await Bun.sleep(10);
   }
@@ -1942,6 +1944,7 @@ async function assertSvelteKitHydrationRoute(
   });
 
   let bodyError: unknown;
+  let bodyFailed = false;
   try {
     await page.goto(`http://127.0.0.1:${httpPort}${routePath}`, {
       waitUntil: 'domcontentloaded',
@@ -1956,6 +1959,7 @@ async function assertSvelteKitHydrationRoute(
     }
   } catch (error) {
     bodyError = error;
+    bodyFailed = true;
   }
   const pageFailures = await runBoundedHydrationTeardown([
     {
@@ -1964,7 +1968,7 @@ async function assertSvelteKitHydrationRoute(
       state: () => `pageClosed=${page.isClosed()} browserConnected=${browser.isConnected()}`,
     },
   ]);
-  if (bodyError !== undefined) throw bodyError;
+  if (bodyFailed) throw bodyError;
   if (pageFailures.length > 0) {
     const failure = pageFailures[0]!;
     throw new ConsumerTeardownError(
@@ -2488,6 +2492,7 @@ async function runExamplesConsumerFixture(): Promise<void> {
     });
 
     let bodyError: unknown;
+    let bodyFailed = false;
     try {
       // Poll a static build asset so readiness checks do not repeatedly start
       // the intentionally expensive all-examples SSR render and abort it after
@@ -2543,9 +2548,10 @@ async function runExamplesConsumerFixture(): Promise<void> {
       );
     } catch (error) {
       bodyError = error;
+      bodyFailed = true;
     }
     const teardownError = await stopConsumerFixtureServer(fixtureServer).catch((error) => error);
-    if (bodyError !== undefined) {
+    if (bodyFailed) {
       if (teardownError !== undefined) {
         process.stderr.write(
           `[validate-consumers] examples-consumer fixture teardown failed after assertion failure: ${teardownError instanceof Error ? teardownError.message : String(teardownError)}\n`,

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1679,7 +1679,11 @@ type HydrationBrowser = { browser: Browser; processToken: string };
 
 function hydrationBrowserProcessIds(processToken: string): number[] {
   const listing = Bun.spawnSync(['ps', '-axo', 'pid=,command='], { stdout: 'pipe' });
-  if (listing.exitCode !== 0) return [];
+  if (listing.exitCode !== 0) {
+    throw new Error(
+      `ps failed while inspecting Chromium process state (exit ${listing.exitCode}): ${listing.stderr.toString()}`,
+    );
+  }
   return listing.stdout
     .toString()
     .split('\n')
@@ -1787,7 +1791,12 @@ const NEVER_RECLAIMED = (): boolean => false;
  * would only describe the client's view of the pipe.
  */
 function isHydrationBrowserGone(browser: Browser, processToken: string): boolean {
-  return !browser.isConnected() || hydrationBrowserProcessIds(processToken).length === 0;
+  if (!browser.isConnected()) return true;
+  try {
+    return hydrationBrowserProcessIds(processToken).length === 0;
+  } catch {
+    return false;
+  }
 }
 
 export async function runBoundedHydrationTeardown(
@@ -1940,7 +1949,15 @@ async function runSvelteKitHydrationRoutesOnce(
   // verdict is taken ONCE, here, against the state after every step has run:
   // an abandoned `page.close()` that a later `browser.close()` (or its SIGKILL
   // escalation) reclaimed leaked nothing and must not fail the gate.
-  if (bodyFailed) throw bodyError;
+  if (bodyFailed) {
+    const secondaryTeardown = unreclaimedTeardownFailures(teardownFailures)[0];
+    if (secondaryTeardown !== undefined) {
+      process.stderr.write(
+        `[validate-consumers] hydration teardown failed after assertion failure: phase=${secondaryTeardown.phase} ${secondaryTeardown.state}: ${secondaryTeardown.error instanceof Error ? secondaryTeardown.error.message : String(secondaryTeardown.error)}\n`,
+      );
+    }
+    throw bodyError;
+  }
 
   const unreclaimed = unreclaimedTeardownFailures(teardownFailures);
   const first = unreclaimed[0];

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1761,9 +1761,34 @@ type TeardownStep = {
   close: () => Promise<void>;
   forceClose?: () => Promise<void> | void;
   state: () => string;
+  /**
+   * Whether the resource this step owns is provably gone. Evaluated only once
+   * the WHOLE teardown sequence has finished, so a wider later step can reclaim
+   * what a narrower earlier one failed to close. Omit for a resource nothing
+   * else can subsume (the fixture server) — an omitted signal is never clean.
+   */
+  reclaimed?: () => boolean | 'unavailable';
 };
 
-type TeardownStepFailure = { phase: string; error: unknown; state: string };
+type TeardownStepFailure = {
+  phase: string;
+  error: unknown;
+  state: string;
+  reclaimed: () => boolean | 'unavailable';
+};
+
+/** Nothing wider will reclaim this resource, so its failure always counts. */
+const NEVER_RECLAIMED = (): boolean => false;
+
+/**
+ * The authoritative reclamation signal for the whole browser chain: the token
+ * stamped into Chromium's argv at launch is gone from the process table, so the
+ * process hosting every context and page is gone with it. `isConnected()` alone
+ * would only describe the client's view of the pipe.
+ */
+function isHydrationBrowserGone(browser: Browser, processToken: string): boolean {
+  return !browser.isConnected() || hydrationBrowserProcessIds(processToken).length === 0;
+}
 
 export async function runBoundedHydrationTeardown(
   steps: readonly TeardownStep[],
@@ -1771,6 +1796,7 @@ export async function runBoundedHydrationTeardown(
 ): Promise<TeardownStepFailure[]> {
   const failures: TeardownStepFailure[] = [];
   for (const step of steps) {
+    const reclaimed = step.reclaimed ?? NEVER_RECLAIMED;
     try {
       await promiseWithTimeout(step.close(), timeoutMs, `teardown phase=${step.phase}`);
     } catch (error) {
@@ -1780,7 +1806,7 @@ export async function runBoundedHydrationTeardown(
       } catch (stateError) {
         state = `state-error=${stateError instanceof Error ? stateError.message : String(stateError)}`;
       }
-      failures.push({ phase: step.phase, error, state });
+      failures.push({ phase: step.phase, error, state, reclaimed });
       try {
         if (step.forceClose) {
           await promiseWithTimeout(
@@ -1790,11 +1816,31 @@ export async function runBoundedHydrationTeardown(
           );
         }
       } catch (forceError) {
-        failures.push({ phase: `${step.phase}.force`, error: forceError, state });
+        failures.push({ phase: `${step.phase}.force`, error: forceError, state, reclaimed });
       }
     }
   }
   return failures;
+}
+
+/**
+ * The teardown contract is **resource reclamation, not per-call success**.
+ *
+ * A `page.close()` that never settles inside its deadline is not by itself a
+ * failure: if the following `browser.close()` (or its SIGKILL escalation) leaves
+ * no Chromium process behind, that page and its renderer are provably gone, so
+ * nothing leaked. Only a step whose resource is STILL unreclaimed once every
+ * step has run should fail the gate.
+ *
+ * This is what makes the smoke deterministic. Throwing the moment `page.close()`
+ * blew its deadline is why an identical commit went red or green purely on how
+ * contended the runner was when Chromium acknowledged `Target.closeTarget` —
+ * run 30174454297 failed and run 30198964154 passed on the same SHA (#900).
+ */
+export function unreclaimedTeardownFailures(
+  failures: readonly TeardownStepFailure[],
+): TeardownStepFailure[] {
+  return failures.filter((failure) => failure.reclaimed() !== true);
 }
 
 async function stopConsumerFixtureServer(server: Bun.Subprocess): Promise<void> {
@@ -1834,6 +1880,9 @@ async function runSvelteKitHydrationRoutesOnce(
   let bodyError: unknown;
   let bodyFailed = false;
   const browserEvents: string[] = [];
+  // Every phase — per-route page closes included — reports into one ledger so
+  // the reclamation verdict can be taken once, after the widest close has run.
+  const teardownFailures: TeardownStepFailure[] = [];
   browser.on('disconnected', () => browserEvents.push('browser:disconnected'));
 
   try {
@@ -1846,6 +1895,8 @@ async function runSvelteKitHydrationRoutesOnce(
         label,
         routePath,
         browserEvents,
+        processToken,
+        teardownFailures,
       );
     }
   } catch (error) {
@@ -1858,35 +1909,42 @@ async function runSvelteKitHydrationRoutesOnce(
   // passing run never leaks a Chromium process/handle that would hang a later
   // validate:consumer run; collect rather than throw inline so `browser.close()`
   // still runs if `context.close()` fails.
-  const closeErrors = await runBoundedHydrationTeardown([
-    ...(context === undefined
-      ? []
-      : [
-          {
-            phase: 'context.close',
-            close: () => context.close(),
-            state: () => `contextPages=${context.pages().length}`,
-          },
-        ]),
-    {
-      phase: 'browser.close',
-      close: () => browser.close(),
-      forceClose: async () => {
-        forceKillHydrationBrowser(processToken);
-        await waitForHydrationBrowserExit(processToken);
+  teardownFailures.push(
+    ...(await runBoundedHydrationTeardown([
+      ...(context === undefined
+        ? []
+        : [
+            {
+              phase: 'context.close',
+              close: () => context.close(),
+              state: () => `contextPages=${context.pages().length}`,
+              reclaimed: () => isHydrationBrowserGone(browser, processToken),
+            },
+          ]),
+      {
+        phase: 'browser.close',
+        close: () => browser.close(),
+        forceClose: async () => {
+          forceKillHydrationBrowser(processToken);
+          await waitForHydrationBrowserExit(processToken);
+        },
+        state: () =>
+          `browserConnected=${browser.isConnected()} processRunning=${hydrationBrowserProcessIds(processToken).length > 0}`,
+        reclaimed: () => isHydrationBrowserGone(browser, processToken),
       },
-      state: () =>
-        `browserConnected=${browser.isConnected()} processRunning=${hydrationBrowserProcessIds(processToken).length > 0}`,
-    },
-  ]);
+    ])),
+  );
 
   // A body failure wins: its error is what the retry decision needs (a crashed
-  // browser makes both closes throw too — those are swallowed). But when every
-  // route assertion PASSED and teardown still failed, surface it: a browser
-  // dying during close is a real problem, not noise to hide behind a green run.
+  // browser makes every close throw too — those are swallowed). Otherwise the
+  // verdict is taken ONCE, here, against the state after every step has run:
+  // an abandoned `page.close()` that a later `browser.close()` (or its SIGKILL
+  // escalation) reclaimed leaked nothing and must not fail the gate.
   if (bodyFailed) throw bodyError;
-  if (closeErrors.length > 0) {
-    const first = closeErrors[0]!;
+
+  const unreclaimed = unreclaimedTeardownFailures(teardownFailures);
+  const first = unreclaimed[0];
+  if (first !== undefined) {
     throw new ConsumerTeardownError(
       new Error(
         `teardown phase=${first.phase} routes=${routePaths.join(',')} ${first.state} events=${browserEvents.join('|') || 'none'}: ${first.error instanceof Error ? first.error.message : String(first.error)}`,
@@ -1925,6 +1983,8 @@ async function assertSvelteKitHydrationRoute(
   label: string,
   routePath: SvelteKitHydrationRoute,
   browserEvents: string[],
+  processToken: string,
+  teardownFailures: TeardownStepFailure[],
 ): Promise<void> {
   const page = await context.newPage();
   const errors: string[] = [];
@@ -1961,23 +2021,22 @@ async function assertSvelteKitHydrationRoute(
     bodyError = error;
     bodyFailed = true;
   }
-  const pageFailures = await runBoundedHydrationTeardown([
-    {
-      phase: 'page.close',
-      close: () => page.close(),
-      state: () => `pageClosed=${page.isClosed()} browserConnected=${browser.isConnected()}`,
-    },
-  ]);
+  // Record, never throw. Throwing here would abandon the context and browser
+  // closes that are the only things able to reclaim this page once its own
+  // close has stopped responding — and would replace a real hydration or
+  // content assertion with a teardown message.
+  teardownFailures.push(
+    ...(await runBoundedHydrationTeardown([
+      {
+        phase: `page.close route=${routePath}`,
+        close: () => page.close(),
+        state: () => `pageClosed=${page.isClosed()} browserConnected=${browser.isConnected()}`,
+        reclaimed: () => page.isClosed() || isHydrationBrowserGone(browser, processToken),
+      },
+    ])),
+  );
+
   if (bodyFailed) throw bodyError;
-  if (pageFailures.length > 0) {
-    const failure = pageFailures[0]!;
-    throw new ConsumerTeardownError(
-      new Error(
-        `teardown phase=${failure.phase} route=${routePath} ${failure.state} events=${browserEvents.join('|') || 'none'}: ${failure.error instanceof Error ? failure.error.message : String(failure.error)}`,
-        { cause: failure.error },
-      ),
-    );
-  }
 }
 
 async function assertSvelteKitHydrationRouteContent(

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2133,6 +2133,10 @@ async function promiseWithTimeout<T>(
   timeoutMs: number,
   description: string,
 ): Promise<T> {
+  // A timeout intentionally abandons the underlying close operation. Mark its
+  // eventual rejection handled so a late browser/fixture error cannot become
+  // an unhandled rejection after teardown has moved on.
+  void promise.catch(() => undefined);
   return await Promise.race([
     promise,
     Bun.sleep(timeoutMs).then(() => fail(`${description} timed out after ${timeoutMs}ms`)),


### PR DESCRIPTION
Closes #900

## Summary

- Make hydration route teardown ordered and bounded across page, context, browser, and fixture server resources.
- Force later cleanup steps after a non-settling close and retain the first failure with phase, route, state, and browser event diagnostics.
- Preserve hydration/content assertion failures while surfacing genuine cleanup failures.
- Add a deterministic regression test for a page close that never settles.

## Verification

- `bun test --conditions browser --conditions svelte --parallel=1 packages/components/scripts/validate-consumers.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder validate:consumer:hydration-smoke`
- `bunx oxlint packages/components/scripts/validate-consumers.ts packages/components/scripts/validate-consumers.test.ts`
