### PR TITLE
Make the downstream snapshot safe for unattended audits

### DIFF
--- a/scripts/cinder-downstream-audit-request.json
+++ b/scripts/cinder-downstream-audit-request.json
@@ -1,0 +1,165 @@
+{
+  "schemaVersion": 1,
+  "packages": [
+    {
+      "name": "@lostgradient/chat",
+      "resolution": "published"
+    },
+    {
+      "name": "@lostgradient/cinder",
+      "resolution": "published"
+    }
+  ],
+  "repositories": [
+    {
+      "name": "agent-bureau",
+      "remote": "https://github.com/stevekinney/agent-bureau.git",
+      "ref": "main",
+      "globs": [
+        "**/package.json",
+        "**/bun.lock",
+        "**/pnpm-lock.yaml",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/*.{ts,tsx,js,jsx,svelte,css,scss,md,mdx}"
+      ],
+      "evidence": {
+        "manifests": [
+          "**/package.json",
+          "**/bun.lock",
+          "**/pnpm-lock.yaml",
+          "**/package-lock.json",
+          "**/yarn.lock"
+        ],
+        "source": ["**/*.{ts,tsx,js,jsx,svelte}"],
+        "styles": ["**/*.{css,scss}"],
+        "documentation": ["**/*.{md,mdx}"]
+      }
+    },
+    {
+      "name": "sandman",
+      "remote": "https://github.com/stevekinney/sandman.git",
+      "ref": "main",
+      "globs": [
+        "**/package.json",
+        "**/bun.lock",
+        "**/pnpm-lock.yaml",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/*.{ts,tsx,js,jsx,svelte,css,scss,md,mdx}"
+      ],
+      "evidence": {
+        "manifests": [
+          "**/package.json",
+          "**/bun.lock",
+          "**/pnpm-lock.yaml",
+          "**/package-lock.json",
+          "**/yarn.lock"
+        ],
+        "source": ["**/*.{ts,tsx,js,jsx,svelte}"],
+        "styles": ["**/*.{css,scss}"],
+        "documentation": ["**/*.{md,mdx}"]
+      }
+    },
+    {
+      "name": "stardust",
+      "remote": "https://github.com/stevekinney/stardust.git",
+      "ref": "main",
+      "globs": [
+        "**/package.json",
+        "**/bun.lock",
+        "**/pnpm-lock.yaml",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/*.{ts,tsx,js,jsx,svelte,css,scss,md,mdx}"
+      ],
+      "evidence": {
+        "manifests": [
+          "**/package.json",
+          "**/bun.lock",
+          "**/pnpm-lock.yaml",
+          "**/package-lock.json",
+          "**/yarn.lock"
+        ],
+        "source": ["**/*.{ts,tsx,js,jsx,svelte}"],
+        "styles": ["**/*.{css,scss}"],
+        "documentation": ["**/*.{md,mdx}"]
+      }
+    },
+    {
+      "name": "temporal-explorer",
+      "remote": "https://github.com/stevekinney/temporal-explorer.git",
+      "ref": "main",
+      "globs": [
+        "**/package.json",
+        "**/bun.lock",
+        "**/pnpm-lock.yaml",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/*.{ts,tsx,js,jsx,svelte,css,scss,md,mdx}"
+      ],
+      "evidence": {
+        "manifests": [
+          "**/package.json",
+          "**/bun.lock",
+          "**/pnpm-lock.yaml",
+          "**/package-lock.json",
+          "**/yarn.lock"
+        ],
+        "source": ["**/*.{ts,tsx,js,jsx,svelte}"],
+        "styles": ["**/*.{css,scss}"],
+        "documentation": ["**/*.{md,mdx}"]
+      }
+    },
+    {
+      "name": "tribunal",
+      "remote": "https://github.com/stevekinney/tribunal.git",
+      "ref": "main",
+      "globs": [
+        "**/package.json",
+        "**/bun.lock",
+        "**/pnpm-lock.yaml",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/*.{ts,tsx,js,jsx,svelte,css,scss,md,mdx}"
+      ],
+      "evidence": {
+        "manifests": [
+          "**/package.json",
+          "**/bun.lock",
+          "**/pnpm-lock.yaml",
+          "**/package-lock.json",
+          "**/yarn.lock"
+        ],
+        "source": ["**/*.{ts,tsx,js,jsx,svelte}"],
+        "styles": ["**/*.{css,scss}"],
+        "documentation": ["**/*.{md,mdx}"]
+      }
+    },
+    {
+      "name": "weft-console",
+      "remote": "https://github.com/stevekinney/weft-console.git",
+      "ref": "main",
+      "globs": [
+        "**/package.json",
+        "**/bun.lock",
+        "**/pnpm-lock.yaml",
+        "**/package-lock.json",
+        "**/yarn.lock",
+        "**/*.{ts,tsx,js,jsx,svelte,css,scss,md,mdx}"
+      ],
+      "evidence": {
+        "manifests": [
+          "**/package.json",
+          "**/bun.lock",
+          "**/pnpm-lock.yaml",
+          "**/package-lock.json",
+          "**/yarn.lock"
+        ],
+        "source": ["**/*.{ts,tsx,js,jsx,svelte}"],
+        "styles": ["**/*.{css,scss}"],
+        "documentation": ["**/*.{md,mdx}"]
+      }
+    }
+  ]
+}

--- a/scripts/cinder-downstream-snapshot.test.ts
+++ b/scripts/cinder-downstream-snapshot.test.ts
@@ -1,10 +1,15 @@
 import { expect, test } from 'bun:test';
-import { mkdir, mkdtemp } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readdir } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { selectMostRecentlyPublishedVersion } from './cinder-downstream-snapshot.ts';
+import {
+  CLONE_DIRECTORY_PREFIX,
+  describeInvalidRepositorySource,
+  removeTemporaryCheckout,
+  selectMostRecentlyPublishedVersion,
+} from './cinder-downstream-snapshot.ts';
 
 /**
  * Absolute path to the CLI under test. Resolving from `import.meta.url` rather than
@@ -47,6 +52,41 @@ async function runSnapshotCli(
   }
 
   return { exitCode, stdout, stderr };
+}
+
+/** Creates a committed local Git repository usable as a `file://` remote in tests. */
+async function createSourceRepository(
+  prefix: string,
+  files: Record<string, string>,
+): Promise<{ root: string; remote: string; commit: string }> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  Bun.spawnSync(['git', '-C', root, 'init', '-b', 'main']);
+  Bun.spawnSync(['git', '-C', root, 'config', 'user.email', 'test@example.com']);
+  Bun.spawnSync(['git', '-C', root, 'config', 'user.name', 'Snapshot Test']);
+  for (const [path, contents] of Object.entries(files)) {
+    await Bun.write(join(root, path), contents);
+  }
+  Bun.spawnSync(['git', '-C', root, 'add', '-A']);
+  Bun.spawnSync(['git', '-C', root, 'commit', '-m', 'initial']);
+  const commit = Bun.spawnSync(['git', '-C', root, 'rev-parse', 'HEAD']).stdout.toString().trim();
+  return { root, remote: `file://${root}`, commit };
+}
+
+/** Lists the snapshot tool's temporary clone directories currently in `tmpdir()`. */
+async function listCloneDirectories(): Promise<string[]> {
+  const entries = await readdir(tmpdir());
+  return entries.filter((entry) => entry.startsWith(CLONE_DIRECTORY_PREFIX)).toSorted();
+}
+
+/**
+ * Asserts a run left no temporary clone directory behind. Only directories absent
+ * beforehand are treated as leaks, so a concurrent worktree running its own snapshot
+ * cannot make this flake in either direction.
+ */
+async function expectNoNewCloneDirectories(before: string[]): Promise<void> {
+  for (const directory of await listCloneDirectories()) {
+    expect(before).toContain(directory);
+  }
 }
 
 test('snapshot input is deterministic and sorted', async () => {
@@ -302,6 +342,318 @@ test('published package resolution selects the most recently published version',
       },
     }),
   ).toBe('1.1.0-beta.1');
+});
+
+test('a repository request declares exactly one of a local path or a remote ref', () => {
+  expect(describeInvalidRepositorySource({ name: 'local', path: '/tmp/checkout' })).toBeNull();
+  expect(
+    describeInvalidRepositorySource({ name: 'local', path: '/tmp/checkout', branch: 'main' }),
+  ).toBeNull();
+  expect(
+    describeInvalidRepositorySource({ name: 'remote', remote: 'file:///tmp/origin', ref: 'main' }),
+  ).toBeNull();
+
+  expect(
+    describeInvalidRepositorySource({
+      name: 'both',
+      path: '/tmp/checkout',
+      remote: 'file:///tmp/origin',
+      ref: 'main',
+    }),
+  ).toBe('declares both path and remote; declare exactly one');
+  expect(describeInvalidRepositorySource({ name: 'neither' })).toBe(
+    'declares neither path nor remote; declare exactly one',
+  );
+  expect(
+    describeInvalidRepositorySource({ name: 'bare-remote', remote: 'file:///tmp/origin' }),
+  ).toBe('declares remote without ref');
+  expect(describeInvalidRepositorySource({ name: 'bare-ref', ref: 'main' })).toBe(
+    'declares ref without remote',
+  );
+});
+
+test('a remote request rejects local-only pins and credential-bearing remotes', () => {
+  const remote = 'https://github.com/stevekinney/tribunal.git';
+  expect(describeInvalidRepositorySource({ name: 'remote', remote, ref: 'main' })).toBeNull();
+
+  expect(
+    describeInvalidRepositorySource({ name: 'remote', remote, ref: 'main', branch: 'main' }),
+  ).toBe('declares remote with branch; a remote source is pinned by ref');
+  expect(
+    describeInvalidRepositorySource({ name: 'remote', remote, ref: 'main', commit: 'abc1234' }),
+  ).toBe('declares remote with commit; a remote source is pinned by ref');
+
+  for (const credentialed of [
+    'https://user:token@github.com/stevekinney/tribunal.git',
+    'https://token@github.com/stevekinney/tribunal.git',
+    'http://user:token@example.com/repository.git',
+  ]) {
+    expect(
+      describeInvalidRepositorySource({ name: 'remote', remote: credentialed, ref: 'main' }),
+    ).toBe('declares a remote with embedded credentials; use a credential helper instead');
+  }
+
+  // An SSH remote's user name is not a secret, and `file://` remotes carry no userinfo.
+  expect(
+    describeInvalidRepositorySource({
+      name: 'ssh',
+      remote: 'git@github.com:stevekinney/tribunal.git',
+      ref: 'main',
+    }),
+  ).toBeNull();
+  expect(
+    describeInvalidRepositorySource({ name: 'file', remote: 'file:///tmp/origin', ref: 'main' }),
+  ).toBeNull();
+});
+
+test('every invalid repository source combination is rejected before any collection', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'cinder-snapshot-invalid-'));
+  const invalidRepositories = [
+    { name: 'both', path: workspace, remote: 'file:///tmp/origin', ref: 'main' },
+    { name: 'neither' },
+    { name: 'bare-remote', remote: 'file:///tmp/origin' },
+    { name: 'bare-ref', ref: 'main' },
+  ];
+
+  for (const repository of invalidRepositories) {
+    const request = join(workspace, `${repository.name}-request.json`);
+    await Bun.write(request, JSON.stringify({ schemaVersion: 1, repositories: [repository] }));
+    const result = await runSnapshotCli(['--request', request], { expectSuccess: false });
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain('invalid repository sources');
+    expect(result.stderr).toContain(repository.name);
+    expect(result.stdout).toBe('');
+  }
+});
+
+test('a remote request clones the requested ref and records its exact commit', async () => {
+  const source = await createSourceRepository('cinder-snapshot-remote-source-', {
+    'package.json': '{ "dependencies": { "@lostgradient/cinder": "^0.1.0" } }',
+    'app.ts': "import { Button } from '@lostgradient/cinder';\n",
+  });
+  const workspace = await mkdtemp(join(tmpdir(), 'cinder-snapshot-remote-'));
+  const request = join(workspace, 'request.json');
+  await Bun.write(
+    request,
+    JSON.stringify({
+      schemaVersion: 1,
+      repositories: [
+        {
+          name: 'downstream',
+          remote: source.remote,
+          ref: 'main',
+          evidence: { manifests: ['**/package.json'], source: ['**/*.ts'] },
+        },
+      ],
+    }),
+  );
+  const cloneDirectoriesBefore = await listCloneDirectories();
+
+  const result = await runSnapshotCli(['--request', request]);
+  const snapshot = JSON.parse(result.stdout);
+  expect(snapshot.errors).toEqual([]);
+
+  const repository = snapshot.repositories[0];
+  expect(repository.name).toBe('downstream');
+  expect(repository.remote).toBe(source.remote);
+  expect(repository.ref).toBe('main');
+  expect(repository.commit).toBe(source.commit);
+  expect(repository.commit).toMatch(/^[0-9a-f]{40}$/u);
+
+  expect(repository.files.map((file: { path: string }) => file.path)).toEqual([
+    'app.ts',
+    'package.json',
+  ]);
+  expect(repository.evidence.source).toEqual([
+    { path: 'app.ts', line: 1, text: "import { Button } from '@lostgradient/cinder';" },
+  ]);
+  expect(repository.evidence.manifests[0].path).toBe('package.json');
+  expect(repository.files.some((file: { path: string }) => file.path.startsWith('.git'))).toBe(
+    false,
+  );
+
+  await expectNoNewCloneDirectories(cloneDirectoriesBefore);
+});
+
+test('replaying a remote request against the same commit is byte-identical', async () => {
+  const source = await createSourceRepository('cinder-snapshot-replay-', {
+    'package.json': '{ "dependencies": { "@lostgradient/cinder": "^0.1.0" } }',
+    'app.svelte': "<script>import { Button } from '@lostgradient/cinder';</script>\n",
+    'notes.md': 'We depend on Cinder tokens.\n',
+  });
+  const workspace = await mkdtemp(join(tmpdir(), 'cinder-snapshot-replay-request-'));
+  const request = join(workspace, 'request.json');
+  await Bun.write(
+    request,
+    JSON.stringify({
+      schemaVersion: 1,
+      repositories: [
+        {
+          name: 'downstream',
+          remote: source.remote,
+          ref: 'main',
+          evidence: {
+            manifests: ['**/package.json'],
+            source: ['**/*.svelte'],
+            documentation: ['**/*.md'],
+          },
+        },
+      ],
+    }),
+  );
+
+  const first = await runSnapshotCli(['--request', request]);
+  const second = await runSnapshotCli(['--request', request]);
+  const normalize = (value: string) =>
+    JSON.stringify({ ...JSON.parse(value), collectedAt: 'stable' });
+
+  expect(normalize(first.stdout)).toBe(normalize(second.stdout));
+  expect(JSON.parse(first.stdout).repositories[0].commit).toBe(source.commit);
+});
+
+test('remote repositories stay sorted by name regardless of request order', async () => {
+  const zulu = await createSourceRepository('cinder-snapshot-zulu-', {
+    'readme.md': 'cinder zulu',
+  });
+  const alpha = await createSourceRepository('cinder-snapshot-alpha-', {
+    'readme.md': 'cinder alpha',
+  });
+  const workspace = await mkdtemp(join(tmpdir(), 'cinder-snapshot-order-'));
+  const request = join(workspace, 'request.json');
+  await Bun.write(
+    request,
+    JSON.stringify({
+      schemaVersion: 1,
+      repositories: [
+        { name: 'zulu', remote: zulu.remote, ref: 'main' },
+        { name: 'alpha', remote: alpha.remote, ref: 'main' },
+      ],
+    }),
+  );
+
+  const result = await runSnapshotCli(['--request', request]);
+  const snapshot = JSON.parse(result.stdout);
+  expect(snapshot.errors).toEqual([]);
+  expect(snapshot.repositories.map((entry: { name: string }) => entry.name)).toEqual([
+    'alpha',
+    'zulu',
+  ]);
+  expect(snapshot.repositories[0].commit).toBe(alpha.commit);
+  expect(snapshot.repositories[1].commit).toBe(zulu.commit);
+});
+
+test('clone failures land in errors and still remove the temporary checkout', async () => {
+  const source = await createSourceRepository('cinder-snapshot-badref-source-', {
+    'readme.md': 'cinder',
+  });
+  const workspace = await mkdtemp(join(tmpdir(), 'cinder-snapshot-badref-'));
+  const request = join(workspace, 'request.json');
+  await Bun.write(
+    request,
+    JSON.stringify({
+      schemaVersion: 1,
+      repositories: [{ name: 'downstream', remote: source.remote, ref: 'refs/heads/absent' }],
+    }),
+  );
+  const cloneDirectoriesBefore = await listCloneDirectories();
+
+  const result = await runSnapshotCli(['--request', request]);
+  expect(result.exitCode).toBe(0);
+  const snapshot = JSON.parse(result.stdout);
+  expect(snapshot.repositories).toEqual([]);
+  expect(snapshot.errors).toHaveLength(1);
+  expect(snapshot.errors[0].scope).toBe('repository:downstream');
+  expect(snapshot.errors[0].message).toContain('cloning refs/heads/absent');
+
+  await expectNoNewCloneDirectories(cloneDirectoriesBefore);
+});
+
+test('collecting a remote repository never mutates the source repository', async () => {
+  const source = await createSourceRepository('cinder-snapshot-immutable-', {
+    'package.json': '{ "name": "downstream" }',
+    'app.ts': "import '@lostgradient/cinder/styles';\n",
+  });
+  const describeSource = () => ({
+    head: Bun.spawnSync(['git', '-C', source.root, 'rev-parse', 'HEAD']).stdout.toString().trim(),
+    status: Bun.spawnSync(['git', '-C', source.root, 'status', '--porcelain'])
+      .stdout.toString()
+      .trim(),
+    index: Bun.spawnSync(['git', '-C', source.root, 'ls-files', '--stage']).stdout.toString(),
+    reflog: Bun.spawnSync(['git', '-C', source.root, 'reflog', '--format=%H %gs'])
+      .stdout.toString()
+      .trim(),
+  });
+  const before = describeSource();
+
+  const workspace = await mkdtemp(join(tmpdir(), 'cinder-snapshot-immutable-request-'));
+  const request = join(workspace, 'request.json');
+  await Bun.write(
+    request,
+    JSON.stringify({
+      schemaVersion: 1,
+      repositories: [{ name: 'downstream', remote: source.remote, ref: 'main' }],
+    }),
+  );
+
+  const result = await runSnapshotCli(['--request', request]);
+  const snapshot = JSON.parse(result.stdout);
+  expect(snapshot.errors).toEqual([]);
+  expect(snapshot.repositories[0].commit).toBe(source.commit);
+  expect(describeSource()).toEqual(before);
+});
+
+test('an unremovable temporary checkout is reported instead of aborting the run', async () => {
+  const parent = await mkdtemp(join(tmpdir(), 'cinder-snapshot-cleanup-'));
+  const checkout = join(parent, 'checkout');
+  await mkdir(checkout, { recursive: true });
+  await Bun.write(join(checkout, 'tracked.txt'), 'cinder');
+
+  expect(await removeTemporaryCheckout(checkout, 'downstream')).toBeNull();
+
+  const blocked = join(parent, 'blocked');
+  await mkdir(blocked, { recursive: true });
+  await Bun.write(join(blocked, 'tracked.txt'), 'cinder');
+  // Without write permission on the parent, the child entry cannot be unlinked.
+  await chmod(parent, 0o500);
+  try {
+    const cleanupError = await removeTemporaryCheckout(blocked, 'downstream');
+    expect(cleanupError?.scope).toBe('repository:downstream');
+    expect(cleanupError?.message).toContain('removing the temporary checkout');
+    expect(cleanupError?.message).toContain(blocked);
+  } finally {
+    await chmod(parent, 0o700);
+  }
+});
+
+test('the canonical audit request only uses remote sources on live default branches', async () => {
+  const auditRequest = await Bun.file(
+    new URL('./cinder-downstream-audit-request.json', import.meta.url),
+  ).json();
+  expect(auditRequest.schemaVersion).toBe(1);
+  expect(auditRequest.repositories).toHaveLength(6);
+  expect(auditRequest.repositories.map((entry: { name: string }) => entry.name)).toEqual(
+    auditRequest.repositories.map((entry: { name: string }) => entry.name).toSorted(),
+  );
+
+  for (const repository of auditRequest.repositories) {
+    expect(describeInvalidRepositorySource(repository)).toBeNull();
+    expect(repository.path).toBeUndefined();
+    expect(repository.remote).toMatch(/^https:\/\/github\.com\/[\w.-]+\/[\w.-]+\.git$/u);
+    expect(repository.branch).toBeUndefined();
+    expect(repository.commit).toBeUndefined();
+    expect(repository.globs.length).toBeGreaterThan(0);
+    expect(Object.keys(repository.evidence).toSorted()).toEqual([
+      'documentation',
+      'manifests',
+      'source',
+      'styles',
+    ]);
+  }
+
+  expect(auditRequest.packages.map((entry: { name: string }) => entry.name)).toEqual([
+    '@lostgradient/chat',
+    '@lostgradient/cinder',
+  ]);
 });
 
 test('workspace script tests are wired into documented and required CI gates', async () => {

--- a/scripts/cinder-downstream-snapshot.ts
+++ b/scripts/cinder-downstream-snapshot.ts
@@ -1,17 +1,22 @@
-import { lstat, readFile, readlink } from 'node:fs/promises';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { lstat, mkdtemp, readFile, readlink, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+
+type RepositoryRequest = {
+  name: string;
+  path?: string;
+  remote?: string;
+  ref?: string;
+  commit?: string;
+  branch?: string;
+  globs?: string[];
+  evidence?: Record<string, string[]>;
+};
 
 type Request = {
   schemaVersion: 1;
   packages?: Array<{ name: string; version?: string; resolution?: 'latest' | 'published' }>;
-  repositories?: Array<{
-    name: string;
-    path: string;
-    commit?: string;
-    branch?: string;
-    globs?: string[];
-    evidence?: Record<string, string[]>;
-  }>;
+  repositories?: RepositoryRequest[];
   issueWindow?: { open?: number; recentlyClosed?: number; since?: string };
 };
 
@@ -26,8 +31,44 @@ type PackagePackument = {
   time?: Record<string, string>;
 };
 
+type RepositoryFile = {
+  path: string;
+  gitlink?: string;
+  symlink?: string;
+  sha256?: string;
+  bytes?: number;
+};
+
+type EvidenceMatch = { path: string; line: number; text: string };
+
+type PackageSnapshot = {
+  name: string;
+  version: string | undefined;
+  tarballIntegrity: string | null;
+  tarball: string | null;
+  exports: unknown;
+};
+
+type RepositorySnapshot = {
+  name: string;
+  remote: string | null;
+  ref: string | null;
+  branch: string | null;
+  commit: string | null;
+  files: RepositoryFile[];
+  evidence: Record<string, EvidenceMatch[]>;
+};
+
+type CollectionError = { scope: string; message: string };
+
 const usage = 'Usage: bun run scripts/cinder-downstream-snapshot.ts --request FILE [--output FILE]';
 const NPM_METADATA_TIMEOUT_MS = 10_000;
+const CLONE_TIMEOUT_MS = 120_000;
+/**
+ * Prefix for every temporary clone directory. Exported so leak-detection tests
+ * cannot drift from the name the tool actually uses.
+ */
+export const CLONE_DIRECTORY_PREFIX = 'cinder-downstream-clone-';
 const SENSITIVE_EVIDENCE_ASSIGNMENT =
   /^(.*?(?:["']?[\w.-]*(?:authorization|credential|password|secret|token|api[_-]?key)[\w.-]*["']?)\s*[:=]\s*).*$/iu;
 
@@ -46,6 +87,54 @@ export function selectMostRecentlyPublishedVersion(packument: PackagePackument):
   const selected = candidates[0]?.version;
   if (!selected) throw new Error('npm registry returned no published versions');
   return selected;
+}
+
+/**
+ * Reports whether an HTTP(S) remote embeds userinfo credentials. Such a remote would
+ * be echoed verbatim into `repositories[].remote` and into any clone-failure message,
+ * writing a token into a snapshot that audits are expected to keep and share. SSH
+ * remotes such as `git@github.com:owner/repository.git` carry a user name rather than
+ * a secret and are left alone.
+ */
+function embedsCredentials(remote: string): boolean {
+  try {
+    const url = new URL(remote);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return false;
+
+    return url.username !== '' || url.password !== '';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Explains why a repository request's source fields are unusable, or returns `null`
+ * when the entry names exactly one source: a local checkout (`path`, optionally
+ * pinned with `branch`/`commit`) or a remote ref (`remote` together with `ref`).
+ *
+ * A remote request is rejected rather than silently narrowed when it also carries
+ * `branch` or `commit` — those only constrain a local checkout, so accepting them
+ * would let a misconfigured audit believe it pinned a revision it did not.
+ */
+export function describeInvalidRepositorySource(repository: RepositoryRequest): string | null {
+  const hasPath = Boolean(repository.path);
+  const hasRemote = Boolean(repository.remote);
+  const hasRef = Boolean(repository.ref);
+
+  if (hasPath && hasRemote) return 'declares both path and remote; declare exactly one';
+  if (hasRemote && !hasRef) return 'declares remote without ref';
+  if (hasRef && !hasRemote) return 'declares ref without remote';
+  if (!hasPath && !hasRemote) return 'declares neither path nor remote; declare exactly one';
+
+  if (hasRemote) {
+    if (repository.branch) return 'declares remote with branch; a remote source is pinned by ref';
+    if (repository.commit) return 'declares remote with commit; a remote source is pinned by ref';
+    if (embedsCredentials(repository.remote ?? '')) {
+      return 'declares a remote with embedded credentials; use a credential helper instead';
+    }
+  }
+
+  return null;
 }
 
 async function findNestedRepositoryRoot(root: string, path: string): Promise<string | null> {
@@ -67,6 +156,202 @@ function matchesRequestedGlobs(path: string, globs: string[] | undefined): boole
   return !globs?.length || globs.some((glob) => new Bun.Glob(glob).match(path));
 }
 
+/** Resolves the exact commit SHA that a checkout's `HEAD` points at. */
+function resolveHeadCommit(root: string): string {
+  const revision = Bun.spawnSync(['git', '-C', root, 'rev-parse', '--verify', 'HEAD^{commit}']);
+  const commit = revision.exitCode === 0 ? revision.stdout.toString().trim() : null;
+  if (!commit) throw new Error('checkout HEAD is unavailable');
+  return commit;
+}
+
+/**
+ * Confirms a local checkout already sits on the requested branch and commit, then
+ * returns the resolved commit. A request naming neither resolves to `null`, so a
+ * plain path scan stays a pure read of whatever is currently on disk.
+ */
+function resolveLocalCommit(root: string, repository: RepositoryRequest): string | null {
+  if (!repository.commit && !repository.branch) return null;
+
+  const headCommit = resolveHeadCommit(root);
+  if (repository.branch) {
+    const currentBranch = Bun.spawnSync([
+      'git',
+      '-C',
+      root,
+      'symbolic-ref',
+      '--quiet',
+      '--short',
+      'HEAD',
+    ]);
+    const branchName = currentBranch.exitCode === 0 ? currentBranch.stdout.toString().trim() : null;
+    const branchRevision = Bun.spawnSync([
+      'git',
+      '-C',
+      root,
+      'rev-parse',
+      '--verify',
+      `refs/heads/${repository.branch}^{commit}`,
+    ]);
+    const branchCommit =
+      branchRevision.exitCode === 0 ? branchRevision.stdout.toString().trim() : null;
+    if (branchName !== repository.branch || branchCommit !== headCommit) {
+      throw new Error(
+        `requested branch ${repository.branch} does not match checkout HEAD (${branchName ?? 'detached'} at ${headCommit})`,
+      );
+    }
+  }
+
+  if (repository.commit) {
+    const commitRevision = Bun.spawnSync([
+      'git',
+      '-C',
+      root,
+      'rev-parse',
+      '--verify',
+      `${repository.commit}^{commit}`,
+    ]);
+    const requestedCommit =
+      commitRevision.exitCode === 0 ? commitRevision.stdout.toString().trim() : null;
+    if (!requestedCommit || requestedCommit !== headCommit) {
+      throw new Error(
+        `requested commit ${repository.commit} does not match checkout HEAD (${headCommit})`,
+      );
+    }
+  }
+
+  return headCommit;
+}
+
+/**
+ * Clones only `ref` from `remote` into `checkout`, shallow and single-branch so a
+ * scheduled audit transfers one commit instead of a repository's whole history. The
+ * clone always targets a fresh directory, so no existing source repository is written
+ * to and no locally checked-out branch can influence the result.
+ */
+function cloneRemoteRef(remote: string, ref: string, checkout: string): void {
+  const clone = Bun.spawnSync(
+    ['git', 'clone', '--depth', '1', '--single-branch', '--branch', ref, '--', remote, checkout],
+    { stdout: 'pipe', stderr: 'pipe', timeout: CLONE_TIMEOUT_MS },
+  );
+
+  if (clone.exitCode === 0) return;
+
+  const detail = clone.stderr.toString().trim() || `git clone exited ${clone.exitCode}`;
+  throw new Error(`cloning ${ref} from ${remote} failed: ${detail}`);
+}
+
+/**
+ * Removes a temporary checkout, returning a collection error instead of throwing.
+ * This runs from a `finally` block, where a thrown error would escape the
+ * per-repository `catch` that already handled the real failure and abort the whole
+ * run without emitting a snapshot. A checkout the tool could not clean up is worth
+ * reporting, but it is not worth losing every other repository's evidence over.
+ */
+export async function removeTemporaryCheckout(
+  directory: string,
+  repositoryName: string,
+): Promise<CollectionError | null> {
+  try {
+    await rm(directory, { recursive: true, force: true });
+    return null;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return {
+      scope: `repository:${repositoryName}`,
+      message: `removing the temporary checkout ${directory} failed: ${detail}`,
+    };
+  }
+}
+
+/**
+ * Hashes every file matching the request's globs and records the Cinder-mentioning
+ * lines for each evidence category. Git internals, nested checkouts, and paths that
+ * escape `root` are excluded; secret-shaped assignments are redacted.
+ */
+async function collectRepositoryEvidence(
+  root: string,
+  repository: RepositoryRequest,
+  outputPath: string | undefined,
+): Promise<{ files: RepositoryFile[]; evidence: Record<string, EvidenceMatch[]> }> {
+  const files: RepositoryFile[] = [];
+  const evidence: Record<string, EvidenceMatch[]> = Object.fromEntries(
+    Object.keys(repository.evidence ?? {}).map((kind) => [kind, []]),
+  );
+  const patterns = repository.globs?.length ? repository.globs : ['**/*'];
+  const paths = new Set<string>();
+  for (const pattern of patterns)
+    for await (const path of new Bun.Glob(pattern).scan({
+      cwd: root,
+      onlyFiles: false,
+      dot: true,
+    }))
+      paths.add(path);
+  const nestedRepositoryRoots = new Set<string>();
+  for (const path of paths) {
+    const segments = path.split('/');
+    const gitMetadataIndex = segments.indexOf('.git');
+    if (gitMetadataIndex > 0) {
+      nestedRepositoryRoots.add(segments.slice(0, gitMetadataIndex).join('/'));
+    }
+    const nestedRoot = await findNestedRepositoryRoot(root, path);
+    if (nestedRoot) nestedRepositoryRoots.add(nestedRoot);
+  }
+  const gitIndex = Bun.spawnSync(['git', '-C', root, 'ls-files', '--stage', '-z']);
+  if (gitIndex.exitCode === 0) {
+    for (const entry of gitIndex.stdout.toString().split('\0')) {
+      const match = /^160000 ([0-9a-f]+) \d+\t(.+)$/u.exec(entry);
+      if (!match?.[1] || !match[2]) continue;
+      nestedRepositoryRoots.add(match[2]);
+      if (matchesRequestedGlobs(match[2], repository.globs)) {
+        files.push({ path: match[2], gitlink: match[1] });
+      }
+    }
+  }
+  for (const path of [...paths].toSorted()) {
+    if (path === '.git' || path.startsWith('.git/')) continue;
+    if (
+      [...nestedRepositoryRoots].some(
+        (nestedRoot) => path === nestedRoot || path.startsWith(`${nestedRoot}/`),
+      )
+    )
+      continue;
+    const absolutePath = resolve(root, path);
+    const relativePath = relative(root, absolutePath);
+    if (relativePath === '..' || relativePath.startsWith('../') || isAbsolute(relativePath)) {
+      throw new Error(`matched path escapes repository root: ${path}`);
+    }
+    const information = await lstat(absolutePath);
+    if (!information.isFile() && !information.isSymbolicLink()) continue;
+    if (outputPath && resolve(outputPath) === absolutePath) continue;
+    if (information.isSymbolicLink()) {
+      const target = await readlink(absolutePath);
+      files.push({ path, symlink: target });
+      continue;
+    }
+    if (!matchesRequestedGlobs(path, repository.globs)) continue;
+    const bytes = await readFile(absolutePath);
+    files.push({
+      path,
+      sha256: new Bun.CryptoHasher('sha256').update(bytes).digest('hex'),
+      bytes: bytes.byteLength,
+    });
+    const matchingEvidence = Object.entries(repository.evidence ?? {}).filter(([, globs]) =>
+      globs.some((glob) => new Bun.Glob(glob).match(path)),
+    );
+    if (matchingEvidence.length === 0) continue;
+    const text = new TextDecoder().decode(bytes);
+    for (const [kind] of matchingEvidence) {
+      text.split('\n').forEach((line, index) => {
+        if (line.toLowerCase().includes('cinder')) {
+          evidence[kind]?.push({ path, line: index + 1, text: redactEvidenceLine(line.trim()) });
+        }
+      });
+    }
+  }
+
+  return { files: files.toSorted((a, b) => a.path.localeCompare(b.path)), evidence };
+}
+
 function parseArgs(args: string[]): { request?: string; output?: string; help?: boolean } {
   const result: { request?: string; output?: string; help?: boolean } = {};
   for (let index = 0; index < args.length; index += 1) {
@@ -81,17 +366,12 @@ function parseArgs(args: string[]): { request?: string; output?: string; help?: 
   return result;
 }
 
-async function main(): Promise<void> {
-  const args = parseArgs(process.argv.slice(2));
-  if (args.help) {
-    console.log(usage);
-    return;
-  }
-  if (!args.request) throw new Error(usage);
-  const request = JSON.parse(await readFile(resolve(args.request), 'utf8')) as Request;
-  if (request.schemaVersion !== 1) throw new Error('request.schemaVersion must be 1');
-  const packages = [];
-  const errors: Array<{ scope: string; message: string }> = [];
+/** Resolves each requested npm package's published version, tarball, and exports. */
+async function collectPackages(
+  request: Request,
+  errors: CollectionError[],
+): Promise<PackageSnapshot[]> {
+  const packages: PackageSnapshot[] = [];
   for (const packageRequest of (request.packages ?? []).toSorted((a, b) =>
     a.name.localeCompare(b.name),
   )) {
@@ -131,157 +411,62 @@ async function main(): Promise<void> {
       });
     }
   }
-  const repositories = [];
-  for (const repository of (request.repositories ?? []).toSorted((a, b) =>
+  return packages;
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(usage);
+    return;
+  }
+  if (!args.request) throw new Error(usage);
+  const request = JSON.parse(await readFile(resolve(args.request), 'utf8')) as Request;
+  if (request.schemaVersion !== 1) throw new Error('request.schemaVersion must be 1');
+  const repositoryRequests = (request.repositories ?? []).toSorted((a, b) =>
     a.name.localeCompare(b.name),
-  )) {
+  );
+  const invalidSources = repositoryRequests
+    .map((repository) => ({
+      name: repository.name,
+      reason: describeInvalidRepositorySource(repository),
+    }))
+    .filter((entry): entry is { name: string; reason: string } => entry.reason !== null);
+  if (invalidSources.length > 0) {
+    throw new Error(
+      `invalid repository sources: ${invalidSources
+        .map(({ name, reason }) => `${name} ${reason}`)
+        .join('; ')}`,
+    );
+  }
+
+  const errors: CollectionError[] = [];
+  const packages = await collectPackages(request, errors);
+  const repositories: RepositorySnapshot[] = [];
+  for (const repository of repositoryRequests) {
+    let cloneDirectory: string | null = null;
     try {
-      const root = resolve(repository.path);
-      const files = [];
-      const evidence: Record<
-        string,
-        Array<{ path: string; line: number; text: string }>
-      > = Object.fromEntries(Object.keys(repository.evidence ?? {}).map((kind) => [kind, []]));
-      const patterns = repository.globs?.length ? repository.globs : ['**/*'];
-      const paths = new Set<string>();
-      for (const pattern of patterns)
-        for await (const path of new Bun.Glob(pattern).scan({
-          cwd: root,
-          onlyFiles: false,
-          dot: true,
-        }))
-          paths.add(path);
-      const nestedRepositoryRoots = new Set<string>();
-      for (const path of paths) {
-        const segments = path.split('/');
-        const gitMetadataIndex = segments.indexOf('.git');
-        if (gitMetadataIndex > 0) {
-          nestedRepositoryRoots.add(segments.slice(0, gitMetadataIndex).join('/'));
-        }
-        const nestedRoot = await findNestedRepositoryRoot(root, path);
-        if (nestedRoot) nestedRepositoryRoots.add(nestedRoot);
+      let root: string;
+      let resolvedCommit: string | null;
+
+      if (repository.remote && repository.ref) {
+        cloneDirectory = await mkdtemp(join(tmpdir(), CLONE_DIRECTORY_PREFIX));
+        root = join(cloneDirectory, 'checkout');
+        cloneRemoteRef(repository.remote, repository.ref, root);
+        resolvedCommit = resolveHeadCommit(root);
+      } else {
+        root = resolve(repository.path ?? '.');
+        resolvedCommit = resolveLocalCommit(root, repository);
       }
-      const gitIndex = Bun.spawnSync(['git', '-C', root, 'ls-files', '--stage', '-z']);
-      if (gitIndex.exitCode === 0) {
-        for (const entry of gitIndex.stdout.toString().split('\0')) {
-          const match = /^160000 ([0-9a-f]+) \d+\t(.+)$/u.exec(entry);
-          if (!match?.[1] || !match[2]) continue;
-          nestedRepositoryRoots.add(match[2]);
-          if (matchesRequestedGlobs(match[2], repository.globs)) {
-            files.push({ path: match[2], gitlink: match[1] });
-          }
-        }
-      }
-      for (const path of [...paths].toSorted()) {
-        if (path === '.git' || path.startsWith('.git/')) continue;
-        if (
-          [...nestedRepositoryRoots].some(
-            (nestedRoot) => path === nestedRoot || path.startsWith(`${nestedRoot}/`),
-          )
-        )
-          continue;
-        const absolutePath = resolve(root, path);
-        const relativePath = relative(root, absolutePath);
-        if (relativePath === '..' || relativePath.startsWith('../') || isAbsolute(relativePath)) {
-          throw new Error(`matched path escapes repository root: ${path}`);
-        }
-        const information = await lstat(absolutePath);
-        if (!information.isFile() && !information.isSymbolicLink()) continue;
-        if (args.output && resolve(args.output) === absolutePath) continue;
-        if (information.isSymbolicLink()) {
-          const target = await readlink(absolutePath);
-          files.push({ path, symlink: target });
-          continue;
-        }
-        if (!matchesRequestedGlobs(path, repository.globs)) continue;
-        const bytes = await readFile(absolutePath);
-        files.push({
-          path,
-          sha256: new Bun.CryptoHasher('sha256').update(bytes).digest('hex'),
-          bytes: bytes.byteLength,
-        });
-        const matchingEvidence = Object.entries(repository.evidence ?? {}).filter(([, globs]) =>
-          globs.some((glob) => new Bun.Glob(glob).match(path)),
-        );
-        if (matchingEvidence.length === 0) continue;
-        const text = new TextDecoder().decode(bytes);
-        for (const [kind] of matchingEvidence) {
-          text.split('\n').forEach((line, index) => {
-            if (line.toLowerCase().includes('cinder')) {
-              evidence[kind]?.push({
-                path,
-                line: index + 1,
-                text: redactEvidenceLine(line.trim()),
-              });
-            }
-          });
-        }
-      }
-      let resolvedCommit = repository.commit ?? null;
-      if (repository.commit || repository.branch) {
-        const headRevision = Bun.spawnSync([
-          'git',
-          '-C',
-          root,
-          'rev-parse',
-          '--verify',
-          'HEAD^{commit}',
-        ]);
-        const headCommit =
-          headRevision.exitCode === 0 ? headRevision.stdout.toString().trim() : null;
-        if (!headCommit) throw new Error('checkout HEAD is unavailable');
-        if (repository.branch) {
-          const currentBranch = Bun.spawnSync([
-            'git',
-            '-C',
-            root,
-            'symbolic-ref',
-            '--quiet',
-            '--short',
-            'HEAD',
-          ]);
-          const branchName =
-            currentBranch.exitCode === 0 ? currentBranch.stdout.toString().trim() : null;
-          const branchRevision = Bun.spawnSync([
-            'git',
-            '-C',
-            root,
-            'rev-parse',
-            '--verify',
-            `refs/heads/${repository.branch}^{commit}`,
-          ]);
-          const branchCommit =
-            branchRevision.exitCode === 0 ? branchRevision.stdout.toString().trim() : null;
-          if (branchName !== repository.branch || branchCommit !== headCommit) {
-            throw new Error(
-              `requested branch ${repository.branch} does not match checkout HEAD (${branchName ?? 'detached'} at ${headCommit})`,
-            );
-          }
-        }
-        if (repository.commit) {
-          const commitRevision = Bun.spawnSync([
-            'git',
-            '-C',
-            root,
-            'rev-parse',
-            '--verify',
-            `${repository.commit}^{commit}`,
-          ]);
-          const requestedCommit =
-            commitRevision.exitCode === 0 ? commitRevision.stdout.toString().trim() : null;
-          if (!requestedCommit || requestedCommit !== headCommit) {
-            throw new Error(
-              `requested commit ${repository.commit} does not match checkout HEAD (${headCommit})`,
-            );
-          }
-        }
-        resolvedCommit = headCommit;
-      }
+
+      const { files, evidence } = await collectRepositoryEvidence(root, repository, args.output);
       repositories.push({
         name: repository.name,
+        remote: repository.remote ?? null,
+        ref: repository.ref ?? null,
         branch: repository.branch ?? null,
         commit: resolvedCommit,
-        files: files.toSorted((a, b) => a.path.localeCompare(b.path)),
+        files,
         evidence,
       });
     } catch (error) {
@@ -289,6 +474,11 @@ async function main(): Promise<void> {
         scope: `repository:${repository.name}`,
         message: error instanceof Error ? error.message : String(error),
       });
+    } finally {
+      if (cloneDirectory) {
+        const cleanupError = await removeTemporaryCheckout(cloneDirectory, repository.name);
+        if (cleanupError) errors.push(cleanupError);
+      }
     }
   }
   const output = {


### PR DESCRIPTION
## Summary

`scripts/cinder-downstream-snapshot.ts` only accepted local repository paths, so a
scheduled audit analyzed whichever branch happened to be checked out locally rather
than each downstream repository's current default branch. When this was discovered,
`~/Developer/tribunal` sat on a topic branch — scanning it would have produced
stale, branch-specific evidence while claiming to audit current downstream usage.
The existing `branch` field could not help: it only *asserts* that a checkout
already sits on the requested branch and errors out otherwise.

There was also no canonical production request. The only committed request is
`scripts/fixtures/cinder-downstream-snapshot/request.json`, a test fixture pointed
at this repository.

## What changed

A repository request now declares exactly **one** source:

```json
{ "name": "repository", "path": "/absolute/path", "branch": "main" }
{ "name": "repository", "remote": "https://github.com/owner/repository.git", "ref": "main" }
```

Malformed entries are rejected at the boundary — before any collection work — with a
nonzero exit that names every offender: both `path` and `remote`, neither, `remote`
without `ref`, and `ref` without `remote`.

For a remote request the collector shallow-clones only the requested ref
(`--depth 1 --single-branch --branch <ref>`) into a uniquely named temporary
directory, resolves the exact commit SHA, runs the existing evidence collector
against that clone, and removes the checkout in a `finally` block. No existing
source repository is ever written to, and no locally checked-out branch can
influence the result. Output gains `remote`, `ref`, and the resolved `commit`;
`.git` exclusion, stable sorting, hashing, partial-error reporting, and secret
redaction are unchanged.

Clone failures are not hidden — they land in `errors` with scope
`repository:<name>` and the run still exits zero, so one unreachable repository
cannot void an otherwise complete snapshot.

A remote request is also rejected — not silently narrowed — when it carries
`branch` or `commit`, since those pin a local checkout only and accepting them
would let a misconfigured audit believe it pinned a revision it did not. HTTP(S)
remotes with embedded userinfo (`https://user:token@…`) are rejected too: the
remote string is written verbatim into `repositories[].remote` and into any
clone-failure message, so accepting one would put a token in the artifact these
audits are meant to keep and diff. SSH remotes carry a user name rather than a
secret and stay valid, as do `file://` remotes.

Clone cleanup is best-effort. A throw from `rm()` inside `finally` would escape
the per-repository `catch` that already handled the real failure, aborting the
whole run and emitting no snapshot at all — so an unremovable checkout is
reported as a `repository:<name>` error instead, and every other repository
still collects.

`scripts/cinder-downstream-audit-request.json` is the new canonical production
request: the two published packages plus the six downstream repositories, each
`ref` verified against the repository's live GitHub default branch.

Refactoring to support this extracted `collectRepositoryEvidence`,
`resolveLocalCommit`, `resolveHeadCommit`, `cloneRemoteRef`, and `collectPackages`
out of the previously monolithic `main`, and typed the snapshot accumulators that
TypeScript had been inferring as `never[]`. Local `path`/`branch`/`commit`
semantics are unchanged.

## Tests

Twenty-two tests, all built on the `runSnapshotCli` helper from #1033. New coverage:
valid local input, valid remote/ref input, all four invalid source combinations,
exact commit recording, temporary-clone cleanup after success and after failure,
`.git` exclusion, stable ordering across remotes, clone failure landing in `errors`,
no mutation of the source repository (HEAD, status, index, and reflog compared
before and after), byte-identical replay of a remote request against the same
commit, rejection of remote `branch`/`commit` pins and credential-bearing
remotes, best-effort cleanup reporting an unremovable checkout instead of
throwing, and the canonical request's shape. Tests use temporary local Git
repositories and `file://` remotes — no GitHub or npm calls. Cleanup assertions
compare the temporary-directory listing before and after a run rather than an
absolute count, so concurrent worktrees cannot flake them.

## Validation

```
bun run test:workspace-scripts        22 pass, 0 fail
bunx oxlint --config .oxlintrc.json   0 warnings, 0 errors
prettier --check                      clean
tsc --noEmit --strict                 clean
git diff --check origin/main..HEAD    clean
```

The canonical request ran end to end against all six live repositories: zero
errors, six repositories, every commit resolved, and no temporary clone directories
left behind.

| repository | ref | resolved commit |
| --- | --- | --- |
| agent-bureau | main | `d9da85eb37fe6854a272841949210e2ded2b70a6` |
| sandman | main | `a2b105e354f50ebaa29f36437b9a62558f507ae9` |
| stardust | main | `9a1402f9e2bc0098d533d45557f9af2b97e5ce33` |
| temporal-explorer | main | `ad1200e1f42bdfa86a14bc977799d7223c6cb606` |
| tribunal | main | `1db649e6bcc27ad92ac689e6e41128b4f4064bda` |
| weft-console | main | `dd94ae88f50bd310ce04b411932769cf172f406d` |

Resolved packages: `@lostgradient/chat@0.4.1`, `@lostgradient/cinder@0.19.1`.
The tribunal commit is `main`, not the topic branch its local checkout is on —
which is the whole point of the change.

Closes #901
