### PR TITLE
Fix hooks to use the active worktree

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 # Wrapper to call Bun-based post-checkout hook
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-bun "$SCRIPT_DIR/../packages/components/scripts/husky/post-checkout.ts" "$@"
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+bun "$WORKTREE_ROOT/packages/components/scripts/husky/post-checkout.ts" "$@"

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 # Wrapper to call Bun-based post-merge hook
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-bun "$SCRIPT_DIR/../packages/components/scripts/husky/post-merge.ts"
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+bun "$WORKTREE_ROOT/packages/components/scripts/husky/post-merge.ts"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 # Lightweight wrapper to call Bun-based hook
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-bun "$SCRIPT_DIR/../packages/components/scripts/husky/pre-commit.ts"
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+bun "$WORKTREE_ROOT/packages/components/scripts/husky/pre-commit.ts"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env sh
 
 # Lightweight wrapper to call Bun-based hook
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-bun "$SCRIPT_DIR/../packages/components/scripts/husky/pre-push.ts"
+WORKTREE_ROOT="$(git rev-parse --show-toplevel)"
+bun "$WORKTREE_ROOT/packages/components/scripts/husky/pre-push.ts"

--- a/packages/components/scripts/husky/pipeline-contract.test.ts
+++ b/packages/components/scripts/husky/pipeline-contract.test.ts
@@ -24,6 +24,7 @@ import { REPO_ROOT } from './utilities.ts';
  */
 
 const huskyDirectory = join(REPO_ROOT, 'packages/components/scripts/husky');
+const hookDirectory = join(REPO_ROOT, '.husky');
 const componentsPackageRoot = join(REPO_ROOT, 'packages/components');
 
 /** Strip line comments and block comments so source-text assertions aren't fooled by comment text. */
@@ -63,6 +64,15 @@ function chainIncludesScript(script: string, name: string): boolean {
 }
 
 describe('pipeline contract: commit stays cheap', () => {
+  it('hook wrappers execute the script from the current worktree', async () => {
+    for (const hookName of ['post-checkout', 'post-merge', 'pre-commit', 'pre-push']) {
+      const source = await Bun.file(join(hookDirectory, hookName)).text();
+      expect(source).toContain('git rev-parse --show-toplevel');
+      expect(source).toContain('$WORKTREE_ROOT/packages/components/scripts/husky/');
+      expect(source).not.toContain('SCRIPT_DIR');
+    }
+  });
+
   it('pre-commit.ts dispatches no install, lint, typecheck, or test job', async () => {
     const source = stripComments(await Bun.file(join(huskyDirectory, 'pre-commit.ts')).text());
     // Required PR CI and main-green own source lint, typecheck, and tests. A


### PR DESCRIPTION
## Summary

Git's shared hooks path can resolve Husky wrappers from the primary checkout even when a commit or push originates in another worktree. The wrappers previously derived their script path from their own invocation path, so the hook ran the active worktree's Git operation against the primary checkout's hook script and repository root. In pre-commit, that allowed lint-staged to stash and restore changes in the wrong worktree.

Each Husky wrapper now resolves the active repository root with `git rev-parse --show-toplevel` and runs the hook script from that worktree.

The contract test locks down both parts of the fix:

- all four wrappers resolve scripts from the active worktree;
- pre-commit dispatches no install, broad lint, typecheck, or test job;
- lint-staged remains formatter and package-sorting only;
- pre-push remains thin and fail-open while pull request CI owns broad validation.

## Validation

```text
bun test packages/components/scripts/husky/pipeline-contract.test.ts
19 pass, 0 fail
```

This is the isolated root-cause fix also present in #976; separating it prevents unrelated overlay and browser-suite work from delaying the Git hook correction.