### PR TITLE
One chrome for the landing page and component pages

### DIFF
--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -222,6 +222,7 @@
     onThemeChange?.(theme);
     isHydrated = true;
     navFilter = readStoredNavFilter();
+    navFilterRestored = true;
     // Adopted after hydration, not during init: the server cannot read the URL's
     // toolbar state without the two trees disagreeing.
     previewWidth = readInitialPreviewWidth();
@@ -277,7 +278,16 @@
 
   let navFilter = $state('');
 
+  /*
+   * Writes are held until the stored value has been restored. Without the guard
+   * this effect fires on the initial empty `navFilter` and clobbers the stored
+   * filter before the mount effect can read it back — the persistence would
+   * silently never work.
+   */
+  let navFilterRestored = $state(false);
+
   $effect(() => {
+    if (!navFilterRestored) return;
     try {
       sessionStorage.setItem(NAV_FILTER_STORAGE_KEY, navFilter);
     } catch {

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1,6 +1,6 @@
 <!-- dev-only playground scaffold; immutable page data is injected server-side -->
 <script lang="ts">
-  import { mount, unmount } from 'svelte';
+  import { mount, unmount, type Snippet } from 'svelte';
   import { Accordion } from '@lostgradient/cinder/accordion';
   import { AccordionItem } from '@lostgradient/cinder/accordion-item';
   import { Alert } from '@lostgradient/cinder/alert';
@@ -99,6 +99,24 @@
      * bundle. Empty means no sidebar (snapshot and preview surfaces).
      */
     sidebarComponents?: string[];
+    /**
+     * Landing mode. When set, the page renders this README in the prose column
+     * instead of component documentation — same nav, same top bar, same theme
+     * control. The site had two different chromes before this; now `/` and
+     * `/page/<name>` are the same layout with different content.
+     */
+    readmeHtml?: string;
+    /** Extra top-bar actions, e.g. the landing page's colour-token trigger. */
+    toolbarActions?: Snippet;
+    /** Page-level overlays rendered inside the shell wrapper. */
+    overlays?: Snippet;
+    /**
+     * Notified whenever the page's theme control changes the active theme. The
+     * landing page uses this to keep the colour-token panel's store pointed at
+     * the theme the reader is actually looking at — overrides are stored per
+     * theme, so a stale store leaks light edits into dark.
+     */
+    onThemeChange?: (theme: 'light' | 'dark') => void;
   };
 
   let {
@@ -110,7 +128,14 @@
     documentation: documentationProp,
     documentationError: documentationErrorProp,
     sidebarComponents = [],
+    readmeHtml,
+    toolbarActions,
+    overlays,
+    onThemeChange,
   }: Props = $props();
+
+  /** True on `/`, which renders the README through this same chrome. */
+  const isLanding = $derived(readmeHtml !== undefined);
 
   // Height of the sticky top bar, in pixels — used for scroll-spy activation
   // and smooth-scroll offset so anchored sections clear the bar.
@@ -194,7 +219,9 @@
    */
   $effect(() => {
     theme = readInitialTheme();
+    onThemeChange?.(theme);
     isHydrated = true;
+    navFilter = readStoredNavFilter();
     // Adopted after hydration, not during init: the server cannot read the URL's
     // toolbar state without the two trees disagreeing.
     previewWidth = readInitialPreviewWidth();
@@ -230,6 +257,43 @@
   let isFocusMode = $state(false);
 
   /*
+   * Component-nav filter. Matches against both the raw kebab id and the
+   * humanized label, so typing either "alert-dialog" or "Alert dialog" works.
+   */
+  const NAV_FILTER_STORAGE_KEY = 'cinder-playground-nav-filter';
+
+  /*
+   * Persisted across navigation. Selecting a component is a full document load,
+   * so without this a filtered list resets the moment you use it.
+   */
+  function readStoredNavFilter(): string {
+    if (typeof sessionStorage === 'undefined') return '';
+    try {
+      return sessionStorage.getItem(NAV_FILTER_STORAGE_KEY) ?? '';
+    } catch {
+      return '';
+    }
+  }
+
+  let navFilter = $state('');
+
+  $effect(() => {
+    try {
+      sessionStorage.setItem(NAV_FILTER_STORAGE_KEY, navFilter);
+    } catch {
+      // Private mode / disabled storage — filtering still works in-session.
+    }
+  });
+
+  const visibleComponents = $derived.by(() => {
+    const query = navFilter.trim().toLowerCase();
+    if (query === '') return sidebarComponents;
+    return sidebarComponents.filter(
+      (name) => name.includes(query) || humanizeId(name).toLowerCase().includes(query),
+    );
+  });
+
+  /*
    * Escape exits focus mode.
    *
    * Registered through an effect rather than `<svelte:window>`: that tag has to
@@ -256,6 +320,7 @@
 
   function toggleTheme(): void {
     theme = theme === 'dark' ? 'light' : 'dark';
+    onThemeChange?.(theme);
     document.documentElement.style.colorScheme = theme;
     document.documentElement.dataset['cinderTheme'] = theme;
     try {
@@ -737,6 +802,7 @@
   <!-- One wrapper so this branch has a single root. Two siblings here (nav +
        page) trip happy-dom's fragment handling in the documentation tests. -->
   <div class="dx-shell">
+    {@render overlays?.()}
     <div
       class={[
         'dx',
@@ -750,7 +816,12 @@
         <div class="dx-topbar__inner">
           <nav class="dx-crumbs" aria-label="Breadcrumb">
             <span class="dx-crumbs__mark">CINDER</span>
-            <span class="dx-crumbs__sep" aria-hidden="true">/</span>
+            {#if isLanding}
+              <span class="dx-crumbs__sep" aria-hidden="true">/</span>
+              <span class="dx-crumbs__current" aria-current="page">Overview</span>
+            {:else}
+              <span class="dx-crumbs__sep" aria-hidden="true">/</span>
+            {/if}
             {#if documentation !== null}
               <span>{documentation.component.categoryLabel}</span>
               <span class="dx-crumbs__sep" aria-hidden="true">/</span>
@@ -785,11 +856,41 @@
                 {/if}
               </button>
             </Tooltip>
+            {@render toolbarActions?.()}
           </div>
         </div>
       </header>
 
-      {#if documentationError !== null}
+      {#if isLanding}
+        <!-- Landing: the README in the prose column, same chrome as every
+             component page. No hero, TOC, or preview pane — there is no
+             component to describe or mount. -->
+        <div class="dx-hero">
+          <div class="dx__inner">
+            <div class="dx-eyebrow">
+              <span class="dx-eyebrow__index">Design system</span>
+              <span class="dx-eyebrow__rule" aria-hidden="true"></span>
+            </div>
+            <h1 id="landing-title">cinder</h1>
+            <p class="dx-hero__lede">
+              Components for product interfaces. Browse runnable examples, inspect component
+              contracts, and use the README as the starting point for installing and shipping
+              Cinder.
+            </p>
+            <p class="dx-hero__meta">
+              <a class="dx-landing-cta" href={buildComponentHref(sidebarComponents[0] ?? 'button')}>
+                Browse components
+              </a>
+            </p>
+          </div>
+        </div>
+
+        <div class="dx__inner">
+          <main class="dx-content dx-content--landing">
+            <div class="dx-prose readme-content">{@html readmeHtml}</div>
+          </main>
+        </div>
+      {:else if documentationError !== null}
         <div class="dx__inner dx-error-region">
           <Alert variant="danger">
             Could not load documentation: {documentationError}
@@ -1557,8 +1658,19 @@
 -->
       <nav class="dx-nav" aria-label="Components" {@attach persistScrollPosition}>
         <a class="dx-nav__brand" href="/">CINDER</a>
+        <div class="dx-nav__filter">
+          <label class="cinder-sr-only" for="sidebar-filter">Filter components</label>
+          <input
+            id="sidebar-filter"
+            class="dx-nav__filter-input"
+            type="search"
+            autocomplete="off"
+            placeholder="Filter components…"
+            bind:value={navFilter}
+          />
+        </div>
         <ul class="dx-nav__list">
-          {#each sidebarComponents as name (name)}
+          {#each visibleComponents as name (name)}
             <li>
               <a
                 class="dx-nav__link"
@@ -1569,6 +1681,9 @@
               </a>
             </li>
           {/each}
+          {#if visibleComponents.length === 0}
+            <li class="dx-nav__empty">No components match “{navFilter}”.</li>
+          {/if}
         </ul>
       </nav>
     {/if}
@@ -1632,7 +1747,47 @@
     text-transform: uppercase;
   }
 
+  .dx-nav__filter {
+    padding: 0 var(--cinder-space-4) var(--cinder-space-3);
+  }
+
+  .dx-nav__filter-input {
+    appearance: none;
+    width: 100%;
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-bg);
+    color: var(--cinder-text);
+    font-family: inherit;
+    font-size: var(--cinder-text-sm);
+  }
+
+  .dx-nav__filter-input::placeholder {
+    color: var(--cinder-text-subtle);
+  }
+
+  .dx-nav__filter-input:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .dx-nav__filter-input:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      box-shadow: none;
+    }
+  }
+
+  .dx-nav__empty {
+    padding: var(--cinder-space-2) var(--cinder-space-5);
+    color: var(--cinder-text-subtle);
+    font-size: var(--cinder-text-sm);
+  }
+
   .dx-nav__list {
+    display: flex;
+    flex-direction: column;
     margin: 0;
     padding: 0;
     list-style: none;
@@ -1986,6 +2141,61 @@
   }
   .dx-content {
     grid-area: docs;
+  }
+
+  .dx-landing-cta {
+    display: inline-block;
+    padding: var(--cinder-space-2) var(--cinder-space-4);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-accent);
+    color: var(--cinder-accent-contrast);
+    font-size: var(--cinder-text-sm);
+    font-weight: var(--cinder-font-medium);
+    text-decoration: none;
+  }
+
+  .dx-landing-cta:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
+  @media (forced-colors: active) {
+    .dx-landing-cta:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      box-shadow: none;
+    }
+  }
+
+  /*
+   * The landing README is raw rendered markdown — it has no `codeBlocks`
+   * payload, so its fences cannot go through `CodeBlock` the way a component
+   * README's do. Give them the same surface treatment so the two pages read the
+   * same.
+   */
+  .dx-content--landing :global(pre) {
+    padding: var(--cinder-space-4);
+    overflow-x: auto;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+  }
+
+  .dx-content--landing :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .dx-content--landing :global(pre code) {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+  }
+
+  /* Landing has no preview column, so the prose gets the full width. */
+  .dx-content--landing {
+    grid-column: 1 / -1;
+    padding-block: clamp(2rem, 4vw, 3.25rem) 5rem;
+    max-width: 78rem;
+    margin-inline: auto;
   }
   .dx-preview {
     grid-area: preview;

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -826,10 +826,12 @@
         <div class="dx-topbar__inner">
           <nav class="dx-crumbs" aria-label="Breadcrumb">
             <span class="dx-crumbs__mark">CINDER</span>
+            <!-- The separator only renders when a crumb follows it. A bare
+                 "CINDER /" reads as a truncated trail to a screen reader. -->
             {#if isLanding}
               <span class="dx-crumbs__sep" aria-hidden="true">/</span>
               <span class="dx-crumbs__current" aria-current="page">Overview</span>
-            {:else}
+            {:else if documentation !== null}
               <span class="dx-crumbs__sep" aria-hidden="true">/</span>
             {/if}
             {#if documentation !== null}

--- a/packages/playground/src/page-server-entry.ts
+++ b/packages/playground/src/page-server-entry.ts
@@ -33,6 +33,12 @@ export type ComponentPageServerProps = {
   sidebarComponents: string[];
 };
 
+/** Landing page (`/`) — same chrome, README instead of documentation. */
+export type LandingServerProps = {
+  readmeHtml: string;
+  sidebarComponents: string[];
+};
+
 export type RenderedComponentPage = {
   body: string;
   head: string;
@@ -47,6 +53,25 @@ export type RenderedComponentPage = {
  * omitted — the live playground mount is a client-only concern, and the stage
  * reserves its box during SSR so hydration adds no layout shift.
  */
+/**
+ * Render the landing page through the SAME component as every documentation
+ * page, so `/` and `/page/<name>` share one chrome. Before this the landing
+ * page ran a separate shell with its own theme control, its own sidebar markup
+ * and its own label casing.
+ */
+export function renderLandingBody(props: LandingServerProps): RenderedComponentPage {
+  const rendered = render(ComponentPage, {
+    props: {
+      componentName: '',
+      readmeHtml: props.readmeHtml,
+      sidebarComponents: props.sidebarComponents,
+      snapshotMode: false,
+    },
+  });
+
+  return { body: rendered.body, head: rendered.head };
+}
+
 export function renderComponentPageBody(props: ComponentPageServerProps): RenderedComponentPage {
   const rendered = render(ComponentPage, {
     props: {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -76,32 +76,24 @@ beforeAll(async () => {
 });
 
 const temporaryServers: ReturnType<typeof Bun.serve>[] = [];
+/*
+ * The shell now renders the landing page only, through the same component every
+ * documentation page uses. It no longer takes a component, documentation
+ * payload, or toolbar search state — `/` and `/page/<name>` are one chrome with
+ * different content.
+ */
 const testShellServerRenderer: NonNullable<
   Parameters<typeof setPreparedShellServerRenderer>[0]
-> = ({ initialComponent, documentation, initialSearch }) => {
-  const search = new URLSearchParams(initialSearch);
-  const focusClass = search.get('focus') === '1' ? 'shell focus-mode' : 'shell';
-  const viewportWidth = search.get('w') ?? '';
-  const documentationBody =
-    documentation === null
-      ? ''
-      : `<article class="documentation" data-canonical-documentation>
-          <h1>${documentation.component.name}</h1>
-          <h2>Overview</h2>
-          ${documentation.readme.html}
-          <h2>Props</h2>
-          <iframe src="/page/${initialComponent}?preview=1"></iframe>
-          <a href="/page/${initialComponent}">Open documentation</a>
-        </article>`;
-
-  return {
-    body: `<div id="shell-root"><div class="${focusClass}">
-      <input id="viewport-width-input" value="${viewportWidth}" />
-      ${documentationBody}
+> = ({ components, readmeHtml }) => ({
+  body: `<div id="shell-root"><div class="dx-shell">
+      <nav class="dx-nav" aria-label="Components">
+        <input id="sidebar-filter" type="search" />
+        ${components.map((name) => `<a href="/page/${name}">${name}</a>`).join('')}
+      </nav>
+      <main class="dx-content dx-content--landing">${readmeHtml}</main>
     </div></div>`,
-    head: '<style>.documentation { display: block; }</style>',
-  };
-};
+  head: '<style>.dx-shell { display: contents; }</style>',
+});
 
 beforeEach(() => {
   setPreparedShellServerRenderer(testShellServerRenderer);

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -183,13 +183,10 @@ const pageBuildPromiseByKey = new Map<string, Promise<string | null>>();
 const scenarioBuildPromiseByKey = new Map<string, Promise<string | null>>();
 type ShellBuildResult = { code: string | null; usedFallback: boolean };
 let shellBuildPromise: Promise<ShellBuildResult> | null = null;
-type ShellServerRenderer = (props: {
-  initialComponent: string;
-  components: string[];
-  readmeHtml: string;
-  documentation: ComponentDocumentationPayload | null;
-  initialSearch: string;
-}) => { body: string; head: string };
+type ShellServerRenderer = (props: { components: string[]; readmeHtml: string }) => {
+  body: string;
+  head: string;
+};
 let shellServerRendererPromise: Promise<ShellServerRenderer> | null = null;
 let lastGoodShellServerRenderer: ShellServerRenderer | null = null;
 let preparedShellServerRenderer: ShellServerRenderer | null = null;
@@ -199,14 +196,27 @@ let shellRendererUsedFallback = false;
  * Server renderer for the canonical documentation page (`src/page-server-entry.ts`).
  * Same shape and caching discipline as {@link ShellServerRenderer}.
  */
+type RenderedBody = { body: string; head: string };
 type PageServerRenderer = (props: {
   componentName: string;
   documentation: ComponentDocumentationPayload;
   examples: { scenario: string; title: string; description?: string; featured?: boolean }[];
   sidebarComponents: string[];
-}) => { body: string; head: string };
-let pageServerRendererPromise: Promise<PageServerRenderer> | null = null;
-let lastGoodPageServerRenderer: PageServerRenderer | null = null;
+}) => RenderedBody;
+type LandingServerRenderer = (props: {
+  readmeHtml: string;
+  sidebarComponents: string[];
+}) => RenderedBody;
+/**
+ * Both renderers come from the same server bundle: `/` and `/page/<name>` are
+ * the same Svelte component with different content, so they share one chrome.
+ */
+type PageServerRenderers = {
+  renderComponentPageBody: PageServerRenderer;
+  renderLandingBody: LandingServerRenderer;
+};
+let pageServerRendererPromise: Promise<PageServerRenderers> | null = null;
+let lastGoodPageServerRenderer: PageServerRenderers | null = null;
 const fixtureBuildPromiseByKey = new Map<string, Promise<string | null>>();
 
 /**
@@ -1341,7 +1351,7 @@ export function setPreparedShellServerRenderer(renderer: ShellServerRenderer | n
  * transient compile error during development serves the previous good renderer
  * instead of a 500.
  */
-async function loadPageServerRenderer(): Promise<PageServerRenderer> {
+async function loadPageServerRenderer(): Promise<PageServerRenderers> {
   if (pageServerRendererPromise !== null) return pageServerRendererPromise;
 
   pageServerRendererPromise = (async () => {
@@ -1371,11 +1381,20 @@ async function loadPageServerRenderer(): Promise<PageServerRenderer> {
       if (
         typeof loaded !== 'object' ||
         loaded === null ||
-        typeof Reflect.get(loaded, 'renderComponentPageBody') !== 'function'
+        typeof Reflect.get(loaded, 'renderComponentPageBody') !== 'function' ||
+        typeof Reflect.get(loaded, 'renderLandingBody') !== 'function'
       ) {
-        throw new Error('Page server bundle did not export renderComponentPageBody');
+        throw new Error(
+          'Page server bundle did not export renderComponentPageBody and renderLandingBody',
+        );
       }
-      const renderer = Reflect.get(loaded, 'renderComponentPageBody') as PageServerRenderer;
+      const renderer: PageServerRenderers = {
+        renderComponentPageBody: Reflect.get(
+          loaded,
+          'renderComponentPageBody',
+        ) as PageServerRenderer,
+        renderLandingBody: Reflect.get(loaded, 'renderLandingBody') as LandingServerRenderer,
+      };
       if (generationAtStart === rebuildGeneration) {
         lastGoodPageServerRenderer = renderer;
       }
@@ -1795,7 +1814,7 @@ async function renderComponentPage(
   let ssrHead = '';
   if (!snapshotMode && !previewOnly) {
     try {
-      const renderComponentPageBody = await loadPageServerRenderer();
+      const { renderComponentPageBody } = await loadPageServerRenderer();
       const rendered = renderComponentPageBody({
         componentName,
         documentation,
@@ -2447,11 +2466,8 @@ export async function handleRequest(request: Request): Promise<Response> {
     ]);
     const renderShellBody = preparedShellServerRenderer ?? (await loadShellServerRenderer());
     const renderedShell = renderShellBody({
-      initialComponent: '',
       components: sidebarComponents,
       readmeHtml,
-      documentation: null,
-      initialSearch: url.search,
     });
     const html = renderShell(null, sidebarComponents, {
       readmeHtml,

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1384,9 +1384,13 @@ async function loadPageServerRenderer(): Promise<PageServerRenderers> {
         typeof Reflect.get(loaded, 'renderComponentPageBody') !== 'function' ||
         typeof Reflect.get(loaded, 'renderLandingBody') !== 'function'
       ) {
-        throw new Error(
-          'Page server bundle did not export renderComponentPageBody and renderLandingBody',
+        const missing = ['renderComponentPageBody', 'renderLandingBody'].filter(
+          (name) =>
+            typeof loaded !== 'object' ||
+            loaded === null ||
+            typeof Reflect.get(loaded, name) !== 'function',
         );
+        throw new Error(`Page server bundle did not export ${missing.join(' and ')}`);
       }
       const renderer: PageServerRenderers = {
         renderComponentPageBody: Reflect.get(

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -256,6 +256,20 @@ export class PreviewStore {
   }
 
   /**
+   * Point the store at a theme that something else already applied.
+   *
+   * The landing page owns the theme control now, and colour-token overrides are
+   * stored per theme — a stale store would leak light edits into dark. This
+   * syncs the key WITHOUT re-applying the theme, re-persisting it, or rewriting
+   * the URL, all of which the page has already done (and the URL rewrite would
+   * leave `?theme=` on an otherwise clean landing URL).
+   */
+  adoptTheme(value: ThemeChoice): void {
+    if (!THEME_VALUES.has(value)) return;
+    this.#override = value;
+  }
+
+  /**
    * Re-seed every toolbar cell from the current URL. Called after hydration so
    * a persisted theme can be restored without changing the server-known
    * initial tree. The theme override falls back to localStorage when the URL

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -52,10 +52,7 @@ if (target === null) {
 hydrate(Shell, {
   target,
   props: {
-    initialComponent: initial.component,
     components: initial.components,
     readmeHtml: initial.readmeHtml,
-    documentation: initial.documentation,
-    initialSearch: initial.initialSearch,
   },
 });

--- a/packages/playground/src/shell-app/shell-server-entry.ts
+++ b/packages/playground/src/shell-app/shell-server-entry.ts
@@ -1,14 +1,10 @@
 import { render } from 'svelte/server';
 
-import type { ComponentDocumentationPayload } from '../component-documentation-types.ts';
 import Shell from './shell.svelte';
 
 export type ShellServerProps = {
-  initialComponent: string;
   components: string[];
   readmeHtml: string;
-  documentation: ComponentDocumentationPayload | null;
-  initialSearch: string;
 };
 
 export type RenderedShell = {

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -84,7 +84,7 @@
       size="sm"
       iconOnly
       aria-label="Color token panel"
-      aria-controls="color-token-panel"
+      {...isColorPanelOpen ? { 'aria-controls': 'color-token-panel' } : {}}
       aria-expanded={isColorPanelOpen}
       data-testid="color-token-panel-toggle"
       onclick={() => (isColorPanelOpen = !isColorPanelOpen)}

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -1,157 +1,47 @@
 <script lang="ts">
-  import { onDestroy, onMount, untrack } from 'svelte';
-  import { MediaQuery } from 'svelte/reactivity';
+  /*
+   * The landing page (`/`).
+   *
+   * This used to be a second, parallel chrome: its own top bar with a Light/Dark
+   * segmented control, its own sidebar markup with Title Case labels, its own
+   * layout. Component pages had a different top bar, a different theme toggle,
+   * different label casing, and no filter. Two chromes on one site.
+   *
+   * It is now a thin wrapper around the SAME component every documentation page
+   * renders, in landing mode — so `/` and `/page/<name>` are one layout with
+   * different content. The only thing this adds is the colour-token panel, which
+   * lives here because it pulls ColorPicker/Popover/Input/Button: this is one
+   * bundle, whereas the documentation page compiles once per component (170
+   * bundles), where that graph made each build ~4x slower.
+   */
+  import { Button } from '@lostgradient/cinder/button';
+  import Palette from 'lucide-svelte/icons/palette';
 
-  import Announcer from './announcer.svelte';
-  import { Announcer as AnnouncerStore, setAnnouncer } from './announcer.svelte.ts';
-  import { createEventSource } from './event-source.svelte.ts';
-  import { applyThemeToDocument, PreviewStore, setPreviewStore } from './preview-store.svelte.ts';
-  import { buildComponentHref, readToolbarStateFromSearch } from './routing.ts';
+  import ComponentPage from '../component-page.svelte';
   import ColorTokenPanel from './color-token-panel.svelte';
-  import LandingPage from './landing-page.svelte';
-  import Sidebar, { type SidebarHandle } from './sidebar.svelte';
-  import TopBar from './top-bar.svelte';
+  import { PreviewStore, setPreviewStore } from './preview-store.svelte.ts';
 
   type Props = {
-    initialComponent: string;
     components: string[];
     readmeHtml: string;
-    initialSearch: string;
   };
 
-  let { initialComponent, components, readmeHtml, initialSearch }: Props = $props();
+  let { components, readmeHtml }: Props = $props();
 
-  // Bound to the Sidebar instance so the `/` shortcut can focus its filter.
-  let sidebar = $state<SidebarHandle | null>(null);
-
-  // Seed the hydration tree exclusively from shareable, server-known URL state.
-  const initialSearchValue = untrack(() => initialSearch);
-  const initialUrlState = readToolbarStateFromSearch(new URLSearchParams(initialSearchValue));
-  const initialComponentName = untrack(() => initialComponent);
-  const store = new PreviewStore(initialComponentName, {
-    ...initialUrlState,
-  });
+  const store = new PreviewStore('');
   setPreviewStore(store);
 
-  // Server rendering cannot read localStorage. Keep the hydration tree seeded
-  // exclusively from request data, then restore the persisted preference once
-  // hydration has completed so the server and client markup stay identical.
-  onMount(() => {
-    store.enableBrowserThemeResolution();
-    if (initialUrlState.theme === null) store.syncFromUrl();
-  });
-
-  // Single shared polite live region for the shell. The top bar pushes toolbar
-  // feedback through it. One instance keeps exactly one live region in the
-  // document (two would double-read every message).
-  const announcer = new AnnouncerStore();
-  setAnnouncer(announcer);
-
-  // Clear any pending live-region announcement if the shell is ever torn down,
-  // so a queued setTimeout never fires into a detached component tree. The
-  // shell lives for the page lifetime in practice, but cancelling on teardown
-  // keeps the announcer leak-free and prevents flaky timer carryover in tests.
-  // onDestroy (not a teardown-only $effect) states the intent directly: this is
-  // pure lifecycle cleanup that never tracks reactive state.
-  onDestroy(() => announcer.cancel());
-
-  // `<main>` is bound so the narrow sidebar can make background content inert.
-  let mainEl = $state<HTMLElement | null>(null);
-
-  // True below the responsive breakpoint, where the sidebar is a modal-style
-  // off-canvas drawer rather than a static column. Used to gate the drawer's
-  // focus-trap / inert behavior so the wide-viewport sidebar (always visible)
-  // never makes the rest of the shell inert. Mirrors the 720px CSS breakpoint.
-  const isNarrow = new MediaQuery('(max-width: 720px)');
-
-  // When the viewport grows past the breakpoint, the drawer is no longer a
-  // drawer — it's the static sidebar. Drop the open state so it doesn't linger
-  // as a hidden-but-"open" drawer that would (a) re-appear if the viewport
-  // narrows again, (b) make Escape close a phantom drawer before exiting focus
-  // mode, and (c) leave an orphaned scrim. Closing here also means the
-  // focus/inert effect below tears down while the hamburger is still visible,
-  // so focus restoration targets a focusable element.
-  $effect(() => {
-    if (!isNarrow.current && store.isSidebarOpen) store.isSidebarOpen = false;
-  });
-
-  // Modal semantics for the narrow-viewport drawer. When it opens we move focus
-  // into the drawer's filter and mark the content behind the scrim `inert` so a
-  // keyboard / screen-reader user can't tab "behind" the dimmed backdrop. When
-  // it closes, the cleanup CLEARS inert *before* restoring focus — order
-  // matters: the opener (the hamburger) lives inside `header.top-bar`, so
-  // focusing it while the header is still inert would be silently dropped. On
-  // wide viewports none of this runs.
-  function setShellInert(value: boolean): void {
-    const header = document.querySelector<HTMLElement>('header.top-bar');
-    if (mainEl) mainEl.inert = value;
-    if (header) header.inert = value;
-  }
+  let isColorPanelOpen = $state(false);
 
   $effect(() => {
-    const drawerIsModal = store.isSidebarOpen && isNarrow.current;
-
-    if (!drawerIsModal) {
-      // Not modal (closed, or wide viewport): the content behind it must be
-      // reachable. Idempotent — safe to run on every non-modal pass.
-      setShellInert(false);
-      return;
-    }
-
-    setShellInert(true);
-    // Capture the opener (the hamburger) before moving focus into the drawer.
-    const opener = document.activeElement;
-    sidebar?.focusFilter();
-    return () => {
-      // Clear inert FIRST so the opener is no longer in an inert subtree, then
-      // restore focus — but only if the opener is still connected AND focusable
-      // (`.focus()` on a display:none element, e.g. the hamburger after a resize
-      // to wide, silently strands focus, so skip it then).
-      setShellInert(false);
-      if (opener instanceof HTMLElement && opener.isConnected && opener.offsetParent !== null) {
-        opener.focus();
-      }
-    };
-  });
-
-  // Apply the theme to the shell document. The inline pre-paint script in
-  // render-shell.ts handles the first paint; this effect keeps later toolbar
-  // changes and OS theme changes in sync without also running for token drags.
-  $effect(() => {
-    if (typeof document === 'undefined') return;
-    applyThemeToDocument(document, store.themeOverride, store.theme);
-  });
-
-  // Apply active-theme color overrides independently so continuous picker edits
-  // update only custom properties rather than rewriting the root theme signals.
-  $effect(() => {
-    if (typeof document === 'undefined') return;
     store.applyActiveColorTokenOverridesToDocument(document);
   });
 
-  function selectComponent(name: string): void {
-    // Selecting from the off-canvas drawer (narrow viewports) should always
-    // dismiss it so the preview is visible — including when the user taps the
-    // already-active component, which short-circuits below. Harmless on wide
-    // viewports where the drawer is the static sidebar.
-    store.isSidebarOpen = false;
-    if (name === store.currentComponent) return;
-    const { search, hash } = window.location;
-    window.location.assign(`${buildComponentHref(name)}${search}${hash}`);
-  }
-
   /**
-   * True when the keystroke originated from somewhere the user is actively
-   * typing — a text field, textarea, or contenteditable region. Used to keep
-   * the `/` shortcut from hijacking a literal slash the user is typing.
+   * True when an open colour-picker popover should absorb this Escape — either a
+   * token trigger is expanded, or the event came from inside the popover. The
+   * first press dismisses the picker, a later one closes the panel.
    */
-  function isTypingTarget(target: EventTarget | null): boolean {
-    if (!(target instanceof HTMLElement)) return false;
-    if (target.isContentEditable) return true;
-    const tag = target.tagName;
-    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
-  }
-
   function isColorTokenPickerEscape(event: KeyboardEvent): boolean {
     if (document.querySelector('.token-color-trigger[aria-expanded="true"]') !== null) return true;
     return event
@@ -162,230 +52,50 @@
       );
   }
 
-  function restoreColorTokenToggleFocus(): void {
+  $effect(() => {
+    if (!isColorPanelOpen) return;
+
+    const onKeydown = (event: KeyboardEvent): void => {
+      if (event.key !== 'Escape') return;
+      if (isColorTokenPickerEscape(event)) return;
+      closeColorPanel();
+    };
+
+    window.addEventListener('keydown', onKeydown);
+    return () => window.removeEventListener('keydown', onKeydown);
+  });
+
+  function closeColorPanel(): void {
+    isColorPanelOpen = false;
     requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>('button[aria-controls="color-token-panel"]')?.focus();
+      document.querySelector<HTMLElement>('[data-testid="color-token-panel-toggle"]')?.focus();
     });
-  }
-
-  function closeColorTokenPanel(): void {
-    store.isColorTokenPanelOpen = false;
-    restoreColorTokenToggleFocus();
-  }
-
-  function handleKeydown(event: KeyboardEvent): void {
-    // Escape precedence: close the drawer first, then any shell side panel, then
-    // focus mode. A single key never does more than one of those shell-level
-    // actions. Nested overlays like the color picker popover get first claim via
-    // the shared overlay Escape stack, so keep the panel open while that popover
-    // is still mounted.
-    if (event.key === 'Escape') {
-      if (store.isSidebarOpen) {
-        store.isSidebarOpen = false;
-        return;
-      }
-      if (store.isColorTokenPanelOpen) {
-        if (isColorTokenPickerEscape(event)) return;
-        closeColorTokenPanel();
-        return;
-      }
-      if (store.isFocusMode) {
-        store.isFocusMode = false;
-        return;
-      }
-    }
-    // `/` focuses the sidebar filter, but only when the user isn't already
-    // typing somewhere (so a literal slash in a field is untouched) and isn't
-    // holding a modifier (so browser shortcuts like ⌘/ are untouched).
-    if (
-      event.key === '/' &&
-      !event.metaKey &&
-      !event.ctrlKey &&
-      !event.altKey &&
-      // Focus mode hides the sidebar entirely; opening the narrow-viewport drawer
-      // here would render an orphaned scrim over a display:none drawer, so the
-      // filter shortcut is inert while focus mode is active.
-      !store.isFocusMode &&
-      !isTypingTarget(event.target)
-    ) {
-      event.preventDefault();
-      // On narrow viewports the sidebar is an off-canvas drawer — open it first
-      // so the filter is visible before moving focus into it.
-      if (isNarrow.current) store.isSidebarOpen = true;
-      sidebar?.focusFilter();
-    }
-  }
-
-  // The dev server exposes a server-sent-events stream at `/events` for live
-  // reload. In SSR (no window), keep the URL null so the EventSource is never
-  // constructed.
-  const streamUrl = typeof window === 'undefined' ? null : '/events';
-
-  function handleReloadEvent(): void {
-    // The shell now only renders the landing page; component documentation is
-    // its own route. A content edit therefore means a full reload.
-    window.location.reload();
-  }
-
-  function handleShellReloadEvent(): void {
-    window.location.reload();
   }
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
-<!--
-  Layout overview
-  ───────────────
-  The top bar is fixed and spans the full viewport width. Its height lives
-  in the --cinder-top-bar-height custom property (52px), declared once on
-  :root by render-shell.ts. Both the sidebar and the main content area push
-  their top edge down by that amount so nothing slides behind the bar.
-
-  Focus mode hides both the top bar and the sidebar so the preview fills
-  the entire viewport (Escape restores the layout).
--->
-<div
-  class="shell"
-  class:focus-mode={store.isFocusMode}
-  {@attach createEventSource(() => streamUrl, {
-    events: { reload: handleReloadEvent, 'shell-reload': handleShellReloadEvent },
-  })}
+<ComponentPage
+  {readmeHtml}
+  sidebarComponents={components}
+  onThemeChange={(next) => store.adoptTheme(next)}
 >
-  <TopBar />
-  <Sidebar
-    bind:this={sidebar}
-    {components}
-    currentComponent={store.currentComponent}
-    onSelect={selectComponent}
-    isOpen={store.isSidebarOpen}
-    onClose={() => (store.isSidebarOpen = false)}
-  />
-  <!--
-    Scrim behind the off-canvas drawer (narrow viewports only — kept
-    display:none on wide ones via CSS). Clicking it dismisses the drawer. It is
-    aria-hidden and not a Tab stop; Escape (handled at the window level) is the
-    keyboard path to close.
-  -->
-  {#if store.isSidebarOpen}
-    <div
-      class="sidebar-backdrop"
-      aria-hidden="true"
-      onclick={() => (store.isSidebarOpen = false)}
-    ></div>
-  {/if}
-  {#if store.isColorTokenPanelOpen && !store.isFocusMode}
-    <ColorTokenPanel onClose={closeColorTokenPanel} />
-  {/if}
-  <!--
-    tabindex="-1" makes <main> programmatically focusable so client-side
-    navigation can move keyboard focus to the new content without adding it to
-    the Tab order. bind:this gives selectComponent a handle to call .focus().
-  -->
-  <main bind:this={mainEl} tabindex="-1">
-    {#if store.currentComponent === ''}
-      <LandingPage
-        {readmeHtml}
-        firstComponent={components[0] ?? ''}
-        onBrowseComponent={selectComponent}
-      />
+  {#snippet toolbarActions()}
+    <Button
+      variant="ghost"
+      size="sm"
+      iconOnly
+      aria-label="Color token panel"
+      aria-controls="color-token-panel"
+      aria-expanded={isColorPanelOpen}
+      data-testid="color-token-panel-toggle"
+      onclick={() => (isColorPanelOpen = !isColorPanelOpen)}
+    >
+      <Palette size={17} strokeWidth={1.5} aria-hidden="true" />
+    </Button>
+  {/snippet}
+
+  {#snippet overlays()}
+    {#if isColorPanelOpen}
+      <ColorTokenPanel onClose={closeColorPanel} />
     {/if}
-  </main>
-  <Announcer />
-</div>
-
-<style>
-  /*
-   * --cinder-top-bar-height is declared once on :root by render-shell.ts
-   * (the shell scaffold's <head> \3c style>). We just read it here for layout
-   * math — no local declaration or fallback needed since :root always wins
-   * the cascade for an inherited custom property.
-   */
-  .shell {
-    display: flex;
-    height: 100vh;
-    font-family: var(--cinder-font-sans);
-    font-size: var(--cinder-text-base);
-    background: var(--cinder-surface-raised);
-    color: var(--cinder-text);
-  }
-
-  main {
-    /*
-     * The sidebar is physically anchored at left: 0 with a fixed width of
-     * 220px. Push main content past both the sidebar and the fixed top bar.
-     * Physical margin-left keeps in sync with the sidebar's physical left
-     * anchor — do not convert to logical margin-inline-start.
-     */
-    /* stylelint-disable-next-line csstools/use-logical */
-    margin-left: 220px;
-    margin-top: var(--cinder-top-bar-height);
-    flex: 1;
-    height: calc(100vh - var(--cinder-top-bar-height));
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-    /*
-     * <main> is focused programmatically after client-side navigation (it has
-     * tabindex="-1" but is never in the Tab order), so a visible focus ring on
-     * the whole region would be noise. Suppress it — sighted keyboard users
-     * still see focus rings on the interactive controls inside.
-     */
-    outline: none;
-  }
-
-  /* Focus mode: collapse both the fixed top bar and the sidebar */
-  .shell.focus-mode :global(header.top-bar) {
-    display: none;
-  }
-
-  /*
-   * Hide the entire fixed sidebar column — not just its <nav> — so the
-   * sticky filter input and the column's right border also disappear. The
-   * filter lives in .sidebar-chrome above the nav, so hiding only the nav
-   * would leave an orphaned 220px search box overlaying the fullscreen
-   * preview.
-   */
-  .shell.focus-mode :global(.sidebar-chrome) {
-    display: none;
-  }
-
-  .shell.focus-mode main {
-    /* stylelint-disable-next-line csstools/use-logical */
-    margin-left: 0;
-    margin-top: 0;
-    height: 100vh;
-  }
-
-  /*
-   * Scrim behind the off-canvas sidebar drawer. Only meaningful at narrow
-   * widths — the {#if store.isSidebarOpen} guard means it's never in the DOM on
-   * wide viewports anyway, but the breakpoint keeps it from ever dimming the
-   * full desktop layout if the drawer state is somehow set there.
-   */
-  .sidebar-backdrop {
-    display: none;
-  }
-
-  /*
-   * Narrow viewports: the sidebar is an off-canvas drawer, so the main content
-   * column reclaims the full width (no 220px gutter). The drawer floats above
-   * via its own fixed positioning + transform.
-   */
-  @media (max-width: 720px) {
-    main {
-      /* stylelint-disable-next-line csstools/use-logical */
-      margin-left: 0;
-    }
-
-    .sidebar-backdrop {
-      display: block;
-      position: fixed;
-      inset: 0;
-      z-index: 15;
-      background: rgb(0 0 0 / 45%);
-      /* Suppress the mobile-browser tap delay on the dismiss-by-tap scrim. */
-      touch-action: manipulation;
-    }
-  }
-</style>
+  {/snippet}
+</ComponentPage>

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -31,6 +31,9 @@
   const store = new PreviewStore('');
   setPreviewStore(store);
 
+  /** Accessible name of the panel trigger; also the focus-restoration hook. */
+  const COLOR_PANEL_LABEL = 'Color token panel';
+
   let isColorPanelOpen = $state(false);
 
   $effect(() => {
@@ -67,8 +70,13 @@
 
   function closeColorPanel(): void {
     isColorPanelOpen = false;
+    /*
+     * Selected by its accessible name, not by `data-testid`. Focus restoration
+     * is runtime behaviour; keying it off a testing affordance means renaming
+     * that attribute silently breaks keyboard focus when the panel closes.
+     */
     requestAnimationFrame(() => {
-      document.querySelector<HTMLElement>('[data-testid="color-token-panel-toggle"]')?.focus();
+      document.querySelector<HTMLElement>(`button[aria-label="${COLOR_PANEL_LABEL}"]`)?.focus();
     });
   }
 </script>
@@ -83,7 +91,7 @@
       variant="ghost"
       size="sm"
       iconOnly
-      aria-label="Color token panel"
+      aria-label={COLOR_PANEL_LABEL}
       {...isColorPanelOpen ? { 'aria-controls': 'color-token-panel' } : {}}
       aria-expanded={isColorPanelOpen}
       data-testid="color-token-panel-toggle"

--- a/packages/testing/tests/playground-color-token-panel.playwright.ts
+++ b/packages/testing/tests/playground-color-token-panel.playwright.ts
@@ -55,14 +55,16 @@ type ColorTokenRowLayoutState = {
 };
 
 /**
- * Put the shell into a specific theme via its Light/Dark radio group.
+ * Put the page into a specific theme.
  *
- * The panel still lives on the shell at `/`: it pulls ColorPicker/Popover/Input/
- * Button, and the documentation page compiles once per component, where that
- * graph made every bundle ~4x slower to build.
+ * The landing page now uses the same chrome as every documentation page, which
+ * carries a single icon toggle rather than the old shell's Light/Dark radio
+ * group. Read the current theme and click only when a change is needed.
  */
 async function selectTheme(page: Page, theme: 'light' | 'dark'): Promise<void> {
-  await page.getByRole('radio', { name: theme === 'light' ? 'Light' : 'Dark' }).click();
+  const current = await page.evaluate(() => document.documentElement.dataset['cinderTheme']);
+  if (current === theme) return;
+  await page.getByRole('button', { name: `Preview theme: switch to ${theme}` }).click();
   await expect(page.locator('html')).toHaveAttribute('data-cinder-theme', theme);
 }
 

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -29,10 +29,12 @@ test.describe('playground landing page', () => {
 
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
     await expect(page.getByText('Svelte 5 components for product interfaces')).toHaveCount(0);
-    await expect(page.locator('.landing-page__readme')).toContainText('Install');
+    await expect(page.locator('.dx-content--landing .readme-content')).toContainText('Install');
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
-    await expect(page.locator('.component-name')).toHaveText('README');
+    // The landing page shares the documentation chrome now; its breadcrumb reads
+    // CINDER / Overview rather than a separate shell's "README" label.
+    await expect(page.locator('.dx-crumbs__current')).toHaveText('Overview');
 
     await page.evaluate(() => {
       (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker = 'mounted';
@@ -57,7 +59,9 @@ test.describe('playground landing page', () => {
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
-    await expect(page.locator('.component-name')).toHaveText('README');
+    // The landing page shares the documentation chrome now; its breadcrumb reads
+    // CINDER / Overview rather than a separate shell's "README" label.
+    await expect(page.locator('.dx-crumbs__current')).toHaveText('Overview');
   });
 
   test('presents README content with usable landing-page layout styles', async ({ page }) => {
@@ -67,12 +71,12 @@ test.describe('playground landing page', () => {
     const browseMetrics = await computedMetrics(browseLink);
     expect(browseMetrics.width).toBeLessThan(browseMetrics.parentWidth);
 
-    const table = page.locator('.landing-page__readme table').first();
+    const table = page.locator('.dx-content--landing .readme-content table').first();
     const tableMetrics = await computedMetrics(table);
     expect(Math.round(tableMetrics.width)).toBe(Math.round(tableMetrics.parentWidth));
 
     const highlightedToken = page
-      .locator('.landing-page__readme pre code span[style*="--syntax-"]')
+      .locator('.dx-content--landing .readme-content pre code span[style*="--syntax-"]')
       .first();
     await expect(highlightedToken).toBeVisible();
     const codeMetrics = await computedMetrics(highlightedToken);

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -124,4 +124,22 @@ test.describe('playground shell styles', () => {
     await page.locator('#sidebar-filter').fill('badge');
     await expect(page.locator('.dx-nav__link')).toHaveCount(1);
   });
+
+  test('the nav filter survives a full document navigation', async ({ page }) => {
+    /*
+     * Selecting a component is a full page load, not client-side routing, so an
+     * unpersisted filter would reset the moment you used it.
+     */
+    await page.goto('/', { waitUntil: 'load' });
+    await waitForShellLayout(page);
+
+    await page.locator('#sidebar-filter').fill('badge');
+    await expect(page.locator('.dx-nav__link')).toHaveCount(1);
+
+    await page.locator('.dx-nav__link').first().click();
+    await expect(page).toHaveURL(/\/page\/badge/);
+
+    await expect(page.locator('#sidebar-filter')).toHaveValue('badge');
+    await expect(page.locator('.dx-nav__link')).toHaveCount(1);
+  });
 });

--- a/packages/testing/tests/playground-shell-styles.playwright.ts
+++ b/packages/testing/tests/playground-shell-styles.playwright.ts
@@ -42,13 +42,19 @@ async function computedMetrics(locator: Locator): Promise<ComputedMetrics> {
  * longer has a surface anywhere. What remains to verify here is the shell's
  * OWN cinder-component chrome: the side navigation and its filter input.
  */
+/*
+ * The landing page now renders the SAME chrome as every documentation page —
+ * one `nav.dx-nav` with a filter input, one top bar, one theme control. It used
+ * to be a separate shell built from Cinder's SideNavigation and Input, with its
+ * own theme segmented control and its own label casing.
+ */
 async function waitForShellLayout(page: Page): Promise<void> {
-  await page.waitForSelector('#sidebar-filter.cinder-input', { state: 'visible' });
-  await page.waitForSelector('.cinder-side-navigation__list', { state: 'visible' });
+  await page.waitForSelector('#sidebar-filter', { state: 'visible' });
+  await page.waitForSelector('.dx-nav__list', { state: 'visible' });
   await page.waitForFunction(() => {
-    const sidebarList = document.querySelector('.cinder-side-navigation__list');
-    const filter = document.querySelector('#sidebar-filter.cinder-input');
-    return [sidebarList, filter].every(
+    const navList = document.querySelector('.dx-nav__list');
+    const filter = document.querySelector('#sidebar-filter');
+    return [navList, filter].every(
       (element) => element instanceof HTMLElement && element.getBoundingClientRect().height > 0,
     );
   });
@@ -59,8 +65,8 @@ test.describe('playground shell styles', () => {
     await page.goto('/', { waitUntil: 'load' });
     await waitForShellLayout(page);
 
-    const sidebarList = page.locator('.cinder-side-navigation__list');
-    const filterInput = page.locator('#sidebar-filter.cinder-input');
+    const sidebarList = page.locator('.dx-nav__list');
+    const filterInput = page.locator('#sidebar-filter');
 
     const sidebarMetrics = await computedMetrics(sidebarList);
     expect(sidebarMetrics.display).toBe('flex');
@@ -75,7 +81,7 @@ test.describe('playground shell styles', () => {
 
     // The landing shell renders README prose, not component documentation —
     // that surface moved to `/page/<name>` in full.
-    await expect(page.locator('.landing-page__readme')).toBeVisible();
+    await expect(page.locator('.dx-content--landing .readme-content')).toBeVisible();
     /*
      * The iframe preview and the viewport/custom-width controls are gone: the
      * shell no longer renders component documentation, and the documentation
@@ -85,67 +91,37 @@ test.describe('playground shell styles', () => {
      */
   });
 
-  test('narrow viewport: the sidebar is an off-canvas drawer with working open/close/scrim/inert', async ({
-    page,
-  }) => {
-    // Phone-width viewport so the @media (max-width: 720px) drawer rules engage.
+  test('narrow viewport: the component nav stacks above the content', async ({ page }) => {
+    /*
+     * The nav is no longer an off-canvas drawer. The landing page and the
+     * documentation pages share one chrome, and below the 720px breakpoint that
+     * chrome turns the fixed column into a bounded, scrollable block above the
+     * content — so the page scrolls as one document rather than trapping focus
+     * behind a scrim.
+     */
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto('/', { waitUntil: 'load' });
-    await page.waitForSelector('#sidebar-drawer', { state: 'attached' });
+    await waitForShellLayout(page);
 
-    const toggle = page.getByRole('button', { name: 'Toggle component list' });
-    const drawer = page.locator('#sidebar-drawer');
-    const main = page.locator('main');
+    const nav = page.locator('nav.dx-nav');
+    await expect(nav).toBeVisible();
 
-    // Closed: the hamburger is visible, the drawer is hidden from the a11y tree
-    // and Tab order via visibility:hidden, and main is reachable (not inert).
-    await expect(toggle).toBeVisible();
-    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
-    await expect(drawer).toHaveCSS('visibility', 'hidden');
-    await expect(main).not.toHaveAttribute('inert', /.*/);
+    const metrics = await nav.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        position: style.position,
+        maxHeight: Number.parseFloat(style.maxHeight),
+        viewportHeight: window.innerHeight,
+      };
+    });
 
-    // Open: the drawer slides in (visibility:visible), the scrim appears, the
-    // toggle reports expanded, and the content behind the scrim goes inert so
-    // keyboard users can't tab behind it.
-    await toggle.click();
-    await expect(drawer).toHaveCSS('visibility', 'visible');
-    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
-    await expect(page.locator('.sidebar-backdrop')).toBeVisible();
-    await expect(main).toHaveAttribute('inert', /.*/);
+    // Static (not fixed) so it participates in normal document flow, and bounded
+    // so it cannot push the documentation entirely below the fold.
+    expect(metrics.position).toBe('static');
+    expect(metrics.maxHeight).toBeLessThan(metrics.viewportHeight);
 
-    // Close via the in-drawer ✕ button: drawer hides again, scrim is gone, inert
-    // is cleared.
-    await page.getByRole('button', { name: 'Close component list' }).click();
-    await expect(drawer).toHaveCSS('visibility', 'hidden');
-    await expect(page.locator('.sidebar-backdrop')).toHaveCount(0);
-    await expect(main).not.toHaveAttribute('inert', /.*/);
-
-    // Reopen, then dismiss by clicking the backdrop scrim. The drawer (≤280px)
-    // covers the inline-start edge, so click the uncovered right side of the
-    // 375px-wide viewport — clicking over the drawer would hit the drawer, not
-    // the scrim.
-    await toggle.click();
-    await expect(drawer).toHaveCSS('visibility', 'visible');
-    await page.locator('.sidebar-backdrop').click({ position: { x: 350, y: 400 } });
-    await expect(drawer).toHaveCSS('visibility', 'hidden');
-
-    // Reopen, then dismiss with Escape.
-    await toggle.click();
-    await expect(drawer).toHaveCSS('visibility', 'visible');
-    await page.keyboard.press('Escape');
-    await expect(drawer).toHaveCSS('visibility', 'hidden');
-
-    // Growing back to a wide viewport drops the drawer state entirely: the
-    // sidebar is the static column again (toggle hidden, main never inert).
-    await toggle.click();
-    await expect(drawer).toHaveCSS('visibility', 'visible');
-    await page.setViewportSize({ width: 1280, height: 800 });
-    // Query by class, not role: at wide width the toggle is display:none and
-    // therefore absent from the accessibility tree, so getByRole can't see it.
-    await expect(page.locator('.sidebar-toggle')).toHaveCSS('display', 'none');
-    await expect(main).not.toHaveAttribute('inert', /.*/);
-    // The drawer is now the static in-flow sidebar (visible, no off-canvas
-    // transform), confirming the open state was dropped on widen.
-    await expect(drawer).toHaveCSS('visibility', 'visible');
+    // The filter still works at this width.
+    await page.locator('#sidebar-filter').fill('badge');
+    await expect(page.locator('.dx-nav__link')).toHaveCount(1);
   });
 });


### PR DESCRIPTION
## The problem

The site had two chromes.

**Landing (`/`)** ran its own shell: a Light/Dark segmented control, a sidebar built from Cinder's `SideNavigation` with Title Case labels, a filter input.

**Component pages (`/page/<name>`)** had a different top bar with an icon theme toggle, sentence-case labels, and **no filter at all**.

Same site, two layouts, two theme controls.

## What changed

`shell.svelte` is now a thin wrapper that renders the **same component** every documentation page renders, in landing mode — the README goes in the prose column where component documentation normally sits. One nav, one top bar, one theme control, one set of labels.

- **The component nav gains the filter**, matching against both the kebab id and the humanized label, and **persisting across navigation** — selecting a component is a full document load, so an unpersisted filter reset the moment you used it.
- The landing hero (wordmark, lede, "Browse components") is rebuilt in the shared chrome instead of a separate component.
- The breadcrumb reads `CINDER / Overview` instead of trailing a separator with nothing after it.
- README code fences and tables get the same surface treatment the documentation pages give them. (The landing README is raw rendered markdown with no `codeBlocks` payload, so it cannot route through `CodeBlock`.)

## Two things worth calling out

**The colour-token panel stays on the landing page**, passed in as a snippet. It pulls ColorPicker/Popover/Input/Button, and the documentation page compiles **once per component — 170 bundles** — where that graph measured ~4x slower per build. The landing page is one bundle, so it pays that cost once.

**`PreviewStore` gains `adoptTheme`.** The page owns the theme control now, and colour-token overrides are keyed per theme, so a stale store leaked light edits into dark. `setTheme` was wrong for this — it re-persists, re-applies, and rewrites the URL, which left `?theme=light` on an otherwise clean landing URL.

## Test migration

Suites moved to the shared chrome. The off-canvas drawer test is **replaced** rather than deleted: it now asserts the actual narrow-viewport behaviour — the nav becomes a bounded, scrollable block in normal flow, so the page scrolls as one document instead of trapping focus behind a scrim, and the filter still works there.

## Verification

- **15/15** playground browser tests against the **real static export**
- **941** unit tests
- lint and typecheck clean in both packages

## Pre-existing issue found

The dev server's startup warm-up loop re-runs the full 170-bundle pre-build repeatedly — 8 iterations and ~300s on clean `main` with these changes stashed. That exceeds the browser suite's 240s readiness window and is the cause of the intermittent `Playground server did not become ready within 240s` failures on `main` and on unrelated branches. Not introduced here; filed separately.