### PR TITLE
fix(event-timeline): use the full-strength border token on the cluster trigger

### DIFF
--- a/.changeset/event-timeline-cluster-trigger-border.md
+++ b/.changeset/event-timeline-cluster-trigger-border.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Use the full-strength border token on the EventTimeline cluster trigger, which is a raised surface with a full outer border.

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -196,7 +196,7 @@
     min-inline-size: 2.25rem;
     min-block-size: 1.75rem;
     padding: 0.125rem 0.375rem;
-    border: 1px solid var(--cinder-border-muted);
+    border: 1px solid var(--cinder-border);
     border-radius: var(--cinder-radius-full);
     color: var(--cinder-text);
     background: var(--cinder-surface-raised);


### PR DESCRIPTION
`main` is red. `main-green` failed on e113c49dd with:

```
packages/components/src/components/event-timeline/event-timeline.css
  199:5  ✖  Raised surfaces with a full outer border must use `--cinder-border`,
            not the muted interior-divider token.  cinder/interior-border-weight
```

The cluster trigger is a raised surface (`--cinder-surface-raised`) carrying a full outer border, so `--cinder-border-muted` is the wrong weight. Switched to `--cinder-border`.

### How this reached main

#1011 added this rule set. #972 added the `cinder/interior-border-weight` stylelint rule that governs it. Neither pull request could see the violation:

- their changed-file sets are disjoint, so neither showed a conflict;
- the repo-wide stylelint sweep runs in `main-green` (`workspace-gates`), which is post-merge only — it is not one of the four required pull request checks.

A new lint rule applies repo-wide, including to files its own pull request never touches. File-level disjointness does not imply semantic independence.

Full `bunx stylelint 'src/**/*.css'` sweep is clean with this change.