### PR TITLE
test(selection-popover): wait for scroll quiescence, not just final offset

### DIFF
--- a/packages/testing/tests/selection-popover-positioning.playwright.ts
+++ b/packages/testing/tests/selection-popover-positioning.playwright.ts
@@ -404,6 +404,39 @@ test('selection flush to viewport top places popover below the selection without
   // the target is 0 — no scroll was needed).
   await page.waitForFunction((expected) => Math.abs(window.scrollY - expected) <= 1, targetScrollY);
 
+  // `scrollY` reaching its target is NOT the same as the browser having finished
+  // dispatching `scroll` events — the event fires asynchronously after the
+  // position updates, so one can still land after the wait above resolves.
+  // SelectionPopover dismisses on `scroll` by design, so a single late event
+  // arriving after Step 2 opens the popover closes it again, and
+  // `data-cinder-position-ready` never flips to 'true'. That raced at roughly a
+  // 40% failure rate locally.
+  //
+  // Wait for scroll QUIESCENCE — no scroll event for two consecutive animation
+  // frames' worth of idle — rather than for the final offset.
+  await page.evaluate(async () => {
+    await new Promise<void>((resolve) => {
+      let lastScrollAt = performance.now();
+      const recordScroll = () => {
+        lastScrollAt = performance.now();
+      };
+
+      window.addEventListener('scroll', recordScroll, { passive: true });
+
+      const checkQuiescence = () => {
+        if (performance.now() - lastScrollAt >= 100) {
+          window.removeEventListener('scroll', recordScroll);
+          resolve();
+          return;
+        }
+
+        requestAnimationFrame(checkQuiescence);
+      };
+
+      requestAnimationFrame(checkQuiescence);
+    });
+  });
+
   // Step 2: now that the frame has settled, create the selection and capture
   // post-scroll geometry. The anchorBox.y must be near 0 because the text is
   // flush with the viewport top.

--- a/packages/testing/tests/selection-popover-positioning.playwright.ts
+++ b/packages/testing/tests/selection-popover-positioning.playwright.ts
@@ -412,8 +412,8 @@ test('selection flush to viewport top places popover below the selection without
   // `data-cinder-position-ready` never flips to 'true'. That raced at roughly a
   // 40% failure rate locally.
   //
-  // Wait for scroll QUIESCENCE — no scroll event for two consecutive animation
-  // frames' worth of idle — rather than for the final offset.
+  // Wait for scroll QUIESCENCE — no scroll event for at least 100ms, checked on
+  // animation frames — rather than only waiting for the final offset.
   await page.evaluate(async () => {
     await new Promise<void>((resolve) => {
       let lastScrollAt = performance.now();


### PR DESCRIPTION
Fixes a genuinely flaky Playwright test — **2 of 5 failures locally (~40%)**, and it took down `browser-tests` on `main` at 476619076.

```
✘ selection flush to viewport top places popover below the selection without overlapping
  Error: expect(locator).toHaveAttribute(expected) failed
  Timeout: 5000ms
  > 459 | await expect(popover).toHaveAttribute('data-cinder-position-ready', 'true');
```

### Root cause

The test scrolls the target text to the viewport top, then waits for `window.scrollY` to reach its target:

```ts
await page.waitForFunction((expected) => Math.abs(window.scrollY - expected) <= 1, targetScrollY);
```

But `scrollY` reaching its target is not the same as the browser having finished dispatching `scroll` **events** — the event fires asynchronously after the position updates, so one can still land after that wait resolves.

SelectionPopover dismisses on `scroll` by design (#981). So a late scroll event arriving after the selection is made closes the popover before it can report `data-cinder-position-ready`, and the assertion times out. Whether the stray event lands before or after the selection is pure timing — hence the flake.

### The fix

Wait for scroll *quiescence* — no scroll event for 100ms of animation frames — before creating the selection.

No assertion was weakened, no timeout raised, nothing skipped. The setup is now deterministic; the test asserts exactly what it did before.

### Verification

```
bun run test:playwright -- selection-popover-positioning.playwright.ts --repeat-each=10 --workers=1
→ 80 passed (27.1s)
```

Against 2 failures in 5 repeats before the change.

No changeset: `@cinder/testing` is private and this touches no shipped source.