### PR TITLE
fix(lint): align array sort rule with ES2022 target

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -59,7 +59,7 @@
         "allow": ["**/*.css"]
       }
     ],
-    "unicorn/no-array-sort": "error",
+    "unicorn/no-array-sort": "off",
     "unicorn/prefer-add-event-listener": "error",
     "no-restricted-imports": [
       "error",

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -451,14 +451,10 @@ export function visibleControlSignatures(source: string): string[] {
               return value === undefined ? name : `${name}=${value}`;
             })
             .filter(Boolean)
-            // eslint-disable-next-line unicorn/no-array-sort -- toSorted() is ES2023; this package targets ES2022. Array is freshly created above, so the mutation is safe.
             .sort()
             .join('|')
         : '';
-      signatures.push(
-        // eslint-disable-next-line unicorn/no-array-sort -- toSorted() is ES2023; this package targets ES2022. Spread creates a fresh array, so the mutation is safe.
-        `${[...controlNames].sort().join(',')}|${attributes}`,
-      );
+      signatures.push(`${[...controlNames].sort().join(',')}|${attributes}`);
     }
   });
   return signatures;

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -172,10 +172,7 @@ const migrationMaps: ReadonlyArray<ReadonlyMap<string, unknown>> = [
 ];
 
 export function missingMigrationRecordPaths(existingPaths: ReadonlySet<string>): string[] {
-  return (
-    [...new Set(migrationMaps.flatMap((records) => [...records.keys()]))]
-      .filter((filePath) => !existingPaths.has(filePath))
-      // eslint-disable-next-line unicorn/no-array-sort -- toSorted() is ES2023; this package targets ES2022. Array is freshly created above, so the mutation is safe.
-      .sort()
-  );
+  return [...new Set(migrationMaps.flatMap((records) => [...records.keys()]))]
+    .filter((filePath) => !existingPaths.has(filePath))
+    .sort();
 }


### PR DESCRIPTION
Closes #1043\n\n## Summary\n- disable the conflicting unicorn/no-array-sort rule so ES2022-compatible Array#sort usage is accepted\n- remove local suppressions that are no longer needed\n\n## Validation\n- bun run lint (from packages/components)\n- bun test scripts/check-primitive-composition.test.ts (from packages/components)