### PR TITLE
fix(playground): log warmup invalidation reasons

### DIFF
--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -290,9 +290,10 @@ describe('startup warmup stability', () => {
   });
 
   it('keeps renderer retries free of a second full page pre-build', async () => {
-    expect(rendererWarmupNeedsPrebuild(false, false)).toBe(false);
-    expect(rendererWarmupNeedsPrebuild(true, false)).toBe(true);
-    expect(rendererWarmupNeedsPrebuild(false, true)).toBe(true);
+    expect(rendererWarmupNeedsPrebuild(false, false, false)).toBe(false);
+    expect(rendererWarmupNeedsPrebuild(true, false, false)).toBe(true);
+    expect(rendererWarmupNeedsPrebuild(false, true, false)).toBe(true);
+    expect(rendererWarmupNeedsPrebuild(false, false, true)).toBe(true);
     const source = await readFile(new URL('./playground-server.ts', import.meta.url), 'utf8');
     const rendererWarmup = source.slice(
       source.indexOf('  // Prepare the SSR shell renderer'),

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { readFile, rm, writeFile } from 'node:fs/promises';
+import { rm, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 import {
@@ -48,6 +48,7 @@ import {
   resolvePreferredPort,
   resolveRendererLoad,
   rewriteRepositoryRelativeReadmeLinks,
+  runGenerationCheckedWarmup,
   scheduleRebuild,
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
@@ -303,6 +304,31 @@ describe('startup warmup stability', () => {
     expect(isWarmupStable(generationAtStart, getRebuildGeneration(), 100, 100)).toBe(true);
   });
 
+  it('rejects retry work when a rebuild settles before the work completes', async () => {
+    const generationBeforeWork = getRebuildGeneration();
+    const attempt = await runGenerationCheckedWarmup(async () => {
+      scheduleRebuild({ kind: 'components' });
+      await waitForPendingRebuild();
+      return 'prebuilt';
+    });
+
+    expect(attempt.value).toBe('prebuilt');
+    expect(attempt.instabilityReasons).toEqual([
+      `rebuild generation changed (${generationBeforeWork} -> ${generationBeforeWork + 1})`,
+    ]);
+  });
+
+  it('rejects retry work while rebuild invalidation is still pending', async () => {
+    const attempt = await runGenerationCheckedWarmup(async () => {
+      scheduleRebuild({ kind: 'components' });
+      return 'prebuilt';
+    });
+
+    expect(attempt.value).toBe('prebuilt');
+    expect(attempt.instabilityReasons).toEqual(['rebuild debounce is pending']);
+    await waitForPendingRebuild();
+  });
+
   it('rejects a warmup when source changes before watcher validation', () => {
     expect(isWarmupStable(4, 4, 100, 101)).toBe(false);
     expect(isWarmupStable(4, 5, 100, 100)).toBe(false);
@@ -319,7 +345,7 @@ describe('startup warmup stability', () => {
     expect(warmupInstabilityReasons(4, 4, 100, 100)).toEqual([]);
   });
 
-  it('only retries the full page pre-build after invalidation or a source change', async () => {
+  it('only requires a full page pre-build after invalidation or a source change', () => {
     expect(rendererWarmupNeedsPrebuild(false, false, false)).toBe(false);
     expect(rendererWarmupNeedsPrebuild(true, false, false)).toBe(true);
     expect(rendererWarmupNeedsPrebuild(false, true, false)).toBe(true);
@@ -328,22 +354,6 @@ describe('startup warmup stability', () => {
     expect(rendererWarmupNeedsCacheInvalidation(true, true, false)).toBe(true);
     expect(rendererWarmupNeedsCacheInvalidation(true, false, false)).toBe(false);
     expect(rendererWarmupNeedsCacheInvalidation(false, false, true)).toBe(true);
-    const source = await readFile(new URL('./playground-server.ts', import.meta.url), 'utf8');
-    const rendererWarmup = source.slice(
-      source.indexOf('  // Prepare the SSR shell renderer'),
-      source.indexOf('  if (!rendererPrepared)') + 1,
-    );
-    expect(rendererWarmup).toContain('rendererWarmupNeedsPrebuild(');
-    expect(rendererWarmup).toContain('if (needsPrebuild)');
-    expect(rendererWarmup).toContain('prebuild = await eagerPrebuildAll()');
-    expect(rendererWarmup).toContain('rendererWarmupNeedsCacheInvalidation(');
-    expect(rendererWarmup).toContain('resetShellRendererWarmupState();\n        continue;');
-    expect(rendererWarmup.indexOf('resetShellRendererWarmupState()')).toBeLessThan(
-      rendererWarmup.indexOf('if (needsPrebuild)'),
-    );
-    expect(
-      rendererWarmup.indexOf("invalidateCachesForChange({ kind: 'components' })"),
-    ).toBeLessThan(rendererWarmup.indexOf('prebuild = await eagerPrebuildAll()'));
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -1467,33 +1467,38 @@ describe('playground build boundaries', () => {
     expect(isPageServerRenderers({ renderComponentPageBody: () => ({}) })).toBe(false);
   });
 
-  it('keeps stale fallback status isolated from a newer renderer result', async () => {
+  it('resolves a stale failed load against the latest renderer result', async () => {
+    type Renderer = () => { body: string; head: string };
+
     let rejectStale!: (error: Error) => void;
-    let resolveCurrent!: (renderer: () => { body: string; head: string }) => void;
-    const staleLoad = resolveRendererLoad<() => { body: string; head: string }>(
+    let resolveCurrent!: (renderer: Renderer) => void;
+    let lastGoodRenderer: Renderer | null = null;
+    const getLastGoodRenderer = (): Renderer | null => lastGoodRenderer;
+    const staleLoad = resolveRendererLoad<Renderer>(
       () =>
         new Promise((_resolve, reject) => {
           rejectStale = reject;
         }),
-      () => ({ body: 'stale fallback', head: '' }),
+      getLastGoodRenderer,
     );
-    const currentLoad = resolveRendererLoad<() => { body: string; head: string }>(
+    const currentLoad = resolveRendererLoad<Renderer>(
       () =>
         new Promise((resolve) => {
           resolveCurrent = resolve;
         }),
-      () => ({ body: 'current fallback', head: '' }),
+      getLastGoodRenderer,
     );
 
     resolveCurrent(() => ({ body: 'current', head: '' }));
     const currentResult = await currentLoad;
     expect(currentResult.usedFallback).toBe(false);
     expect(currentResult.renderer()).toEqual({ body: 'current', head: '' });
+    lastGoodRenderer = currentResult.renderer;
 
     rejectStale(new Error('stale build failed'));
     const staleResult = await staleLoad;
     expect(staleResult.usedFallback).toBe(true);
-    expect(staleResult.renderer()).toEqual({ body: 'stale fallback', head: '' });
+    expect(staleResult.renderer()).toEqual({ body: 'current', head: '' });
     expect(currentResult.usedFallback).toBe(false);
     expect(currentResult.renderer()).toEqual({ body: 'current', head: '' });
   });

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -35,7 +35,10 @@ import {
   createHttpServerOnAvailablePort,
   createSharedDisposer,
   fallbackToLastGood,
+  formatBuildLogs,
   handleRequest,
+  isPageServerRenderers,
+  isShellServerRendererModule,
   isWarmupStable,
   mergeGeneratedSchemaMetadata,
   readGeneratedComponentSchema,
@@ -1334,6 +1337,18 @@ describe('generated schema metadata', () => {
     ).toBeNull();
   });
 
+  it.each([null, 42, 'schema', []])(
+    'rejects a generated schema with the wrong root shape: %p',
+    async (value) => {
+      expect(
+        await readGeneratedComponentSchema({
+          exists: () => Promise.resolve(true),
+          json: () => Promise.resolve(value),
+        }),
+      ).toBeNull();
+    },
+  );
+
   it('overlays defaults without adding private props or losing analyzer-owned bindability', () => {
     const analyzedManifest: ComponentManifest = {
       name: 'Input',
@@ -1384,6 +1399,28 @@ describe('generated schema metadata', () => {
         },
       }).isCompound,
     ).toBe(true);
+  });
+});
+
+describe('playground build boundaries', () => {
+  it('formats structured Bun build logs without object stringification', () => {
+    expect(formatBuildLogs([{ message: 'missing export' }, { message: 'plain failure' }])).toBe(
+      'missing export\nplain failure',
+    );
+  });
+
+  it('narrows dynamically loaded renderer exports with runtime guards', () => {
+    expect(isShellServerRendererModule({ renderShellBody: () => ({ body: '', head: '' }) })).toBe(
+      true,
+    );
+    expect(isShellServerRendererModule({ renderShellBody: 'not a function' })).toBe(false);
+    expect(
+      isPageServerRenderers({
+        renderComponentPageBody: () => ({ body: '', head: '' }),
+        renderLandingBody: () => ({ body: '', head: '' }),
+      }),
+    ).toBe(true);
+    expect(isPageServerRenderers({ renderComponentPageBody: () => ({}) })).toBe(false);
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -301,6 +301,9 @@ describe('startup warmup stability', () => {
     expect(rendererWarmup).toContain('rendererWarmupNeedsPrebuild(');
     expect(rendererWarmup).toContain('if (needsPrebuild)');
     expect(rendererWarmup).toContain('prebuild = await eagerPrebuildAll()');
+    expect(rendererWarmup.indexOf('resetShellRendererWarmupState()')).toBeLessThan(
+      rendererWarmup.indexOf('if (needsPrebuild)'),
+    );
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -45,6 +45,7 @@ import {
   rendererWarmupNeedsCacheInvalidation,
   rendererWarmupNeedsPrebuild,
   resolvePreferredPort,
+  resolveRendererLoad,
   rewriteRepositoryRelativeReadmeLinks,
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
@@ -1349,6 +1350,24 @@ describe('generated schema metadata', () => {
     },
   );
 
+  it.each([
+    { properties: null },
+    { properties: { value: null } },
+    { metadata: null },
+    { metadata: { unsupportedProps: {} } },
+    { metadata: { unsupportedProps: [null] } },
+    { metadata: { unsupportedProps: [{ name: 42 }] } },
+    { metadata: { unsupportedProps: [{ name: 'value', required: 'yes' }] } },
+    { metadata: { unsupportedProps: [{ name: 'value', reason: 42 }] } },
+  ])('rejects an invalid generated schema member shape: %p', async (value) => {
+    expect(
+      await readGeneratedComponentSchema({
+        exists: () => Promise.resolve(true),
+        json: () => Promise.resolve(value),
+      }),
+    ).toBeNull();
+  });
+
   it('overlays defaults without adding private props or losing analyzer-owned bindability', () => {
     const analyzedManifest: ComponentManifest = {
       name: 'Input',
@@ -1421,6 +1440,37 @@ describe('playground build boundaries', () => {
       }),
     ).toBe(true);
     expect(isPageServerRenderers({ renderComponentPageBody: () => ({}) })).toBe(false);
+  });
+
+  it('keeps stale fallback status isolated from a newer renderer result', async () => {
+    let rejectStale!: (error: Error) => void;
+    let resolveCurrent!: (renderer: () => { body: string; head: string }) => void;
+    const staleLoad = resolveRendererLoad<() => { body: string; head: string }>(
+      () =>
+        new Promise((_resolve, reject) => {
+          rejectStale = reject;
+        }),
+      () => ({ body: 'stale fallback', head: '' }),
+    );
+    const currentLoad = resolveRendererLoad<() => { body: string; head: string }>(
+      () =>
+        new Promise((resolve) => {
+          resolveCurrent = resolve;
+        }),
+      () => ({ body: 'current fallback', head: '' }),
+    );
+
+    resolveCurrent(() => ({ body: 'current', head: '' }));
+    const currentResult = await currentLoad;
+    expect(currentResult.usedFallback).toBe(false);
+    expect(currentResult.renderer()).toEqual({ body: 'current', head: '' });
+
+    rejectStale(new Error('stale build failed'));
+    const staleResult = await staleLoad;
+    expect(staleResult.usedFallback).toBe(true);
+    expect(staleResult.renderer()).toEqual({ body: 'stale fallback', head: '' });
+    expect(currentResult.usedFallback).toBe(false);
+    expect(currentResult.renderer()).toEqual({ body: 'current', head: '' });
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -43,6 +43,7 @@ import {
   isWarmupStable,
   mergeGeneratedSchemaMetadata,
   readGeneratedComponentSchema,
+  rendererWarmupAttemptDecision,
   rendererWarmupNeedsCacheInvalidation,
   rendererWarmupNeedsPrebuild,
   resolvePreferredPort,
@@ -377,6 +378,21 @@ describe('startup warmup stability', () => {
     expect(rendererWarmupNeedsCacheInvalidation(true, true, false)).toBe(true);
     expect(rendererWarmupNeedsCacheInvalidation(true, false, false)).toBe(false);
     expect(rendererWarmupNeedsCacheInvalidation(false, false, true)).toBe(true);
+  });
+
+  it('carries cache instability through a renderer fallback', () => {
+    expect(rendererWarmupAttemptDecision(true, true, false, false)).toEqual({
+      accepted: false,
+      needsPrebuild: true,
+    });
+    expect(rendererWarmupAttemptDecision(true, false, false, false)).toEqual({
+      accepted: false,
+      needsPrebuild: false,
+    });
+    expect(rendererWarmupAttemptDecision(false, false, false, false)).toEqual({
+      accepted: true,
+      needsPrebuild: false,
+    });
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -286,17 +286,17 @@ describe('startup warmup stability', () => {
     scheduleRebuild({ kind: 'components' });
 
     expect(getRebuildGeneration()).toBe(generationAtStart);
-    await waitForPendingRebuild();
+    const settledGeneration = await waitForPendingRebuild();
 
-    expect(getRebuildGeneration()).toBe(generationAtStart + 1);
+    expect(settledGeneration).toBe(generationAtStart + 1);
+    expect(getRebuildGeneration()).toBe(settledGeneration);
   });
 
   it('captures the settled generation as a stable prebuild baseline', async () => {
     const generationBeforeDebounce = getRebuildGeneration();
     scheduleRebuild({ kind: 'components' });
 
-    await waitForPendingRebuild();
-    const generationAtStart = getRebuildGeneration();
+    const generationAtStart = await waitForPendingRebuild();
 
     expect(generationAtStart).toBe(generationBeforeDebounce + 1);
     await new Promise((resolve) => setTimeout(resolve, 0));

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -36,6 +36,7 @@ import {
   createSharedDisposer,
   fallbackToLastGood,
   formatBuildLogs,
+  getRebuildGeneration,
   handleRequest,
   isPageServerRenderers,
   isShellServerRendererModule,
@@ -47,9 +48,11 @@ import {
   resolvePreferredPort,
   resolveRendererLoad,
   rewriteRepositoryRelativeReadmeLinks,
+  scheduleRebuild,
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
   triggerReload,
+  waitForPendingRebuild,
   warmupInstabilityReasons,
 } from './playground-server.ts';
 import { jsonForScriptTag } from './render-shell.ts';
@@ -278,6 +281,16 @@ describe('shared disposer', () => {
 });
 
 describe('startup warmup stability', () => {
+  it('settles a pending rebuild before a retry can pre-build bundles', async () => {
+    const generationAtStart = getRebuildGeneration();
+    scheduleRebuild({ kind: 'components' });
+
+    expect(getRebuildGeneration()).toBe(generationAtStart);
+    await waitForPendingRebuild();
+
+    expect(getRebuildGeneration()).toBe(generationAtStart + 1);
+  });
+
   it('rejects a warmup when source changes before watcher validation', () => {
     expect(isWarmupStable(4, 4, 100, 101)).toBe(false);
     expect(isWarmupStable(4, 5, 100, 100)).toBe(false);

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -39,6 +39,7 @@ import {
   isWarmupStable,
   mergeGeneratedSchemaMetadata,
   readGeneratedComponentSchema,
+  rendererWarmupNeedsCacheInvalidation,
   rendererWarmupNeedsPrebuild,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
@@ -289,11 +290,15 @@ describe('startup warmup stability', () => {
     expect(warmupInstabilityReasons(4, 4, 100, 100)).toEqual([]);
   });
 
-  it('keeps renderer retries free of a second full page pre-build', async () => {
+  it('only retries the full page pre-build after invalidation or a source change', async () => {
     expect(rendererWarmupNeedsPrebuild(false, false, false)).toBe(false);
     expect(rendererWarmupNeedsPrebuild(true, false, false)).toBe(true);
     expect(rendererWarmupNeedsPrebuild(false, true, false)).toBe(true);
     expect(rendererWarmupNeedsPrebuild(false, false, true)).toBe(true);
+    expect(rendererWarmupNeedsCacheInvalidation(false, true, false)).toBe(true);
+    expect(rendererWarmupNeedsCacheInvalidation(true, true, false)).toBe(true);
+    expect(rendererWarmupNeedsCacheInvalidation(true, false, false)).toBe(false);
+    expect(rendererWarmupNeedsCacheInvalidation(false, false, true)).toBe(true);
     const source = await readFile(new URL('./playground-server.ts', import.meta.url), 'utf8');
     const rendererWarmup = source.slice(
       source.indexOf('  // Prepare the SSR shell renderer'),
@@ -302,7 +307,7 @@ describe('startup warmup stability', () => {
     expect(rendererWarmup).toContain('rendererWarmupNeedsPrebuild(');
     expect(rendererWarmup).toContain('if (needsPrebuild)');
     expect(rendererWarmup).toContain('prebuild = await eagerPrebuildAll()');
-    expect(rendererWarmup).toContain('if (generationAtStart === rebuildGeneration)');
+    expect(rendererWarmup).toContain('rendererWarmupNeedsCacheInvalidation(');
     expect(rendererWarmup).toContain('resetShellRendererWarmupState();\n        continue;');
     expect(rendererWarmup.indexOf('resetShellRendererWarmupState()')).toBeLessThan(
       rendererWarmup.indexOf('if (needsPrebuild)'),

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { rm, writeFile } from 'node:fs/promises';
+import { readFile, rm, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 import {
@@ -45,7 +45,6 @@ import {
   shellBuildSucceeded,
   triggerReload,
   warmupInstabilityReasons,
-  warmupRetryAction,
 } from './playground-server.ts';
 import { jsonForScriptTag } from './render-shell.ts';
 import {
@@ -289,9 +288,13 @@ describe('startup warmup stability', () => {
     expect(warmupInstabilityReasons(4, 4, 100, 100)).toEqual([]);
   });
 
-  it('does not repeat the full page pre-build after renderer invalidation', () => {
-    expect(warmupRetryAction('eager-prebuild')).toBe('full-prebuild');
-    expect(warmupRetryAction('shell-renderer')).toBe('renderer-only');
+  it('keeps renderer retries free of a second full page pre-build', async () => {
+    const source = await readFile(new URL('./playground-server.ts', import.meta.url), 'utf8');
+    const rendererWarmup = source.slice(
+      source.indexOf('  // Prepare the SSR shell renderer'),
+      source.indexOf('  if (!rendererPrepared)') + 1,
+    );
+    expect(rendererWarmup).not.toContain('eagerPrebuildAll()');
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -45,6 +45,7 @@ import {
   shellBuildSucceeded,
   triggerReload,
   warmupInstabilityReasons,
+  warmupRetryAction,
 } from './playground-server.ts';
 import { jsonForScriptTag } from './render-shell.ts';
 import {
@@ -286,6 +287,11 @@ describe('startup warmup stability', () => {
       'rebuild debounce is pending',
     ]);
     expect(warmupInstabilityReasons(4, 4, 100, 100)).toEqual([]);
+  });
+
+  it('does not repeat the full page pre-build after renderer invalidation', () => {
+    expect(warmupRetryAction('eager-prebuild')).toBe('full-prebuild');
+    expect(warmupRetryAction('shell-renderer')).toBe('renderer-only');
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -44,6 +44,7 @@ import {
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
   triggerReload,
+  warmupInstabilityReasons,
 } from './playground-server.ts';
 import { jsonForScriptTag } from './render-shell.ts';
 import {
@@ -276,6 +277,15 @@ describe('startup warmup stability', () => {
     expect(isWarmupStable(4, 5, 100, 100)).toBe(false);
     expect(isWarmupStable(4, 4, 100, 100, true)).toBe(false);
     expect(isWarmupStable(4, 4, 100, 100)).toBe(true);
+  });
+
+  it('reports every condition that invalidated a warmup pass', () => {
+    expect(warmupInstabilityReasons(4, 5, 100, 101, true)).toEqual([
+      'rebuild generation changed (4 -> 5)',
+      'newest source mtime changed (100 -> 101)',
+      'rebuild debounce is pending',
+    ]);
+    expect(warmupInstabilityReasons(4, 4, 100, 100)).toEqual([]);
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -302,9 +302,14 @@ describe('startup warmup stability', () => {
     expect(rendererWarmup).toContain('rendererWarmupNeedsPrebuild(');
     expect(rendererWarmup).toContain('if (needsPrebuild)');
     expect(rendererWarmup).toContain('prebuild = await eagerPrebuildAll()');
+    expect(rendererWarmup).toContain('if (generationAtStart === rebuildGeneration)');
+    expect(rendererWarmup).toContain('resetShellRendererWarmupState();\n        continue;');
     expect(rendererWarmup.indexOf('resetShellRendererWarmupState()')).toBeLessThan(
       rendererWarmup.indexOf('if (needsPrebuild)'),
     );
+    expect(
+      rendererWarmup.indexOf("invalidateCachesForChange({ kind: 'components' })"),
+    ).toBeLessThan(rendererWarmup.indexOf('prebuild = await eagerPrebuildAll()'));
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -39,6 +39,7 @@ import {
   isWarmupStable,
   mergeGeneratedSchemaMetadata,
   readGeneratedComponentSchema,
+  rendererWarmupNeedsPrebuild,
   resolvePreferredPort,
   rewriteRepositoryRelativeReadmeLinks,
   setPreparedShellServerRenderer,
@@ -289,12 +290,17 @@ describe('startup warmup stability', () => {
   });
 
   it('keeps renderer retries free of a second full page pre-build', async () => {
+    expect(rendererWarmupNeedsPrebuild(false, false)).toBe(false);
+    expect(rendererWarmupNeedsPrebuild(true, false)).toBe(true);
+    expect(rendererWarmupNeedsPrebuild(false, true)).toBe(true);
     const source = await readFile(new URL('./playground-server.ts', import.meta.url), 'utf8');
     const rendererWarmup = source.slice(
       source.indexOf('  // Prepare the SSR shell renderer'),
       source.indexOf('  if (!rendererPrepared)') + 1,
     );
-    expect(rendererWarmup).not.toContain('eagerPrebuildAll()');
+    expect(rendererWarmup).toContain('rendererWarmupNeedsPrebuild(');
+    expect(rendererWarmup).toContain('if (needsPrebuild)');
+    expect(rendererWarmup).toContain('prebuild = await eagerPrebuildAll()');
   });
 });
 

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'bun:test';
-import { rm, writeFile } from 'node:fs/promises';
+import { rm, utimes, writeFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 
 import {
@@ -327,6 +327,29 @@ describe('startup warmup stability', () => {
     expect(attempt.value).toBe('prebuilt');
     expect(attempt.instabilityReasons).toEqual(['rebuild debounce is pending']);
     await waitForPendingRebuild();
+  });
+
+  it('rejects retry work when source changes before watcher invalidation starts', async () => {
+    const temporarySourcePath = join(import.meta.dirname, '.warmup-source-mtime.test-fixture.ts');
+    await rm(temporarySourcePath, { force: true });
+
+    try {
+      const attempt = await runGenerationCheckedWarmup(async () => {
+        await writeFile(temporarySourcePath, 'export {};\n');
+        const futureMtime = new Date(Date.now() + 5_000);
+        await utimes(temporarySourcePath, futureMtime, futureMtime);
+        return 'prebuilt';
+      });
+
+      expect(attempt.value).toBe('prebuilt');
+      expect(
+        attempt.instabilityReasons.some((reason) =>
+          reason.startsWith('newest source mtime changed'),
+        ),
+      ).toBe(true);
+    } finally {
+      await rm(temporarySourcePath, { force: true });
+    }
   });
 
   it('rejects a warmup when source changes before watcher validation', () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -291,6 +291,18 @@ describe('startup warmup stability', () => {
     expect(getRebuildGeneration()).toBe(generationAtStart + 1);
   });
 
+  it('captures the settled generation as a stable prebuild baseline', async () => {
+    const generationBeforeDebounce = getRebuildGeneration();
+    scheduleRebuild({ kind: 'components' });
+
+    await waitForPendingRebuild();
+    const generationAtStart = getRebuildGeneration();
+
+    expect(generationAtStart).toBe(generationBeforeDebounce + 1);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(isWarmupStable(generationAtStart, getRebuildGeneration(), 100, 100)).toBe(true);
+  });
+
   it('rejects a warmup when source changes before watcher validation', () => {
     expect(isWarmupStable(4, 4, 100, 101)).toBe(false);
     expect(isWarmupStable(4, 5, 100, 100)).toBe(false);

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2789,7 +2789,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         console.warn(
           `[playground] shell renderer warmup invalidated on attempt ${attempt + 1}/5: renderer fallback was used`,
         );
-        preparedShellServerRenderer = null;
+        resetShellRendererWarmupState();
         continue;
       }
     } catch (error) {
@@ -2819,6 +2819,9 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       if (needsPrebuild) {
         // Any source change can make the eager browser bundles stale. Restore
         // the bundle guarantee before advertising readiness.
+        if (generationAtStart === rebuildGeneration) {
+          invalidateCachesForChange({ kind: 'components' });
+        }
         prebuild = await eagerPrebuildAll();
         if (!prebuild.shellSucceeded) break;
       }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1420,6 +1420,21 @@ export function rendererWarmupNeedsCacheInvalidation(
   return sourceChanged || (!generationChanged && hasPendingRebuild);
 }
 
+/** Decide whether a renderer attempt is acceptable and whether its bundles must be rebuilt. */
+export function rendererWarmupAttemptDecision(
+  usedFallback: boolean,
+  generationChanged: boolean,
+  sourceChanged: boolean,
+  hasPendingRebuild: boolean,
+): { accepted: boolean; needsPrebuild: boolean } {
+  const needsPrebuild = rendererWarmupNeedsPrebuild(
+    generationChanged,
+    sourceChanged,
+    hasPendingRebuild,
+  );
+  return { accepted: !usedFallback && !needsPrebuild, needsPrebuild };
+}
+
 /**
  * Compile and load the documentation page's server renderer.
  *
@@ -2904,41 +2919,42 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
 
     const generationAtStart = rebuildGeneration;
     const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
+    let rendererResult: ShellServerRendererLoadResult;
     try {
-      const rendererResult = await loadShellServerRenderer();
+      rendererResult = await loadShellServerRenderer();
       preparedShellServerRenderer = rendererResult.renderer;
-      if (rendererResult.usedFallback) {
-        console.warn(
-          `[playground] shell renderer warmup invalidated on attempt ${attempt + 1}/5: renderer fallback was used`,
-        );
-        resetShellRendererWarmupState();
-        continue;
-      }
     } catch (error) {
       await dispose();
       throw new Error('[playground] shell server renderer failed to prepare', { cause: error });
     }
     const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
+    const generationChanged = generationAtStart !== rebuildGeneration;
+    const sourceChanged = sourceMtimeAtStart !== sourceMtimeAtEnd;
+    const hasPendingRebuild = rebuildDebounceTimer !== null;
     const instabilityReasons = warmupInstabilityReasons(
       generationAtStart,
       rebuildGeneration,
       sourceMtimeAtStart,
       sourceMtimeAtEnd,
-      rebuildDebounceTimer !== null,
+      hasPendingRebuild,
     );
-    if (instabilityReasons.length === 0) {
+    const decision = rendererWarmupAttemptDecision(
+      rendererResult.usedFallback,
+      generationChanged,
+      sourceChanged,
+      hasPendingRebuild,
+    );
+    if (decision.accepted) {
       rendererPrepared = true;
     } else {
+      if (rendererResult.usedFallback) {
+        instabilityReasons.unshift('renderer fallback was used');
+      }
       console.warn(
         `[playground] shell renderer warmup invalidated on attempt ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
       );
-      const needsPrebuild = rendererWarmupNeedsPrebuild(
-        generationAtStart !== rebuildGeneration,
-        sourceMtimeAtStart !== sourceMtimeAtEnd,
-        rebuildDebounceTimer !== null,
-      );
       resetShellRendererWarmupState();
-      if (needsPrebuild) {
+      if (decision.needsPrebuild) {
         // Any source change can make the eager browser bundles stale. Restore
         // the bundle guarantee before advertising readiness. The next attempt
         // validates the generation around that prebuild before loading another
@@ -2948,7 +2964,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         if (
           rendererWarmupNeedsCacheInvalidation(
             generationAtStart !== rebuildGeneration,
-            sourceMtimeAtStart !== sourceMtimeAtEnd,
+            sourceChanged,
             false,
           )
         ) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -187,6 +187,16 @@ type ShellServerRenderer = (props: { components: string[]; readmeHtml: string })
   body: string;
   head: string;
 };
+type ShellServerRendererModule = { renderShellBody: ShellServerRenderer };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function isShellServerRendererModule(value: unknown): value is ShellServerRendererModule {
+  return isRecord(value) && typeof value['renderShellBody'] === 'function';
+}
+
 let shellServerRendererPromise: Promise<ShellServerRenderer> | null = null;
 let lastGoodShellServerRenderer: ShellServerRenderer | null = null;
 let preparedShellServerRenderer: ShellServerRenderer | null = null;
@@ -215,6 +225,15 @@ type PageServerRenderers = {
   renderComponentPageBody: PageServerRenderer;
   renderLandingBody: LandingServerRenderer;
 };
+
+export function isPageServerRenderers(value: unknown): value is PageServerRenderers {
+  return (
+    isRecord(value) &&
+    typeof value['renderComponentPageBody'] === 'function' &&
+    typeof value['renderLandingBody'] === 'function'
+  );
+}
+
 let pageServerRendererPromise: Promise<PageServerRenderers> | null = null;
 let lastGoodPageServerRenderer: PageServerRenderers | null = null;
 const fixtureBuildPromiseByKey = new Map<string, Promise<string | null>>();
@@ -1284,6 +1303,10 @@ export function shellBuildSucceeded(code: string | null, usedFallback: boolean):
   return code !== null && !usedFallback;
 }
 
+export function formatBuildLogs(logs: readonly { message: string }[]): string {
+  return logs.map(({ message }) => message).join('\n');
+}
+
 async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
   if (shellServerRendererPromise !== null) return shellServerRendererPromise;
 
@@ -1299,7 +1322,7 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
         splitting: false,
       });
       if (!result.success || result.outputs[0] === undefined) {
-        throw new Error(`Shell server bundle failed:\n${result.logs.join('\n')}`);
+        throw new Error(`Shell server bundle failed:\n${formatBuildLogs(result.logs)}`);
       }
 
       const serverBundleDirectory = join(PLAYGROUND_TEMP_ROOT, randomUUID());
@@ -1311,14 +1334,10 @@ async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
       } finally {
         rmSync(serverBundleDirectory, { recursive: true, force: true });
       }
-      if (
-        typeof loaded !== 'object' ||
-        loaded === null ||
-        typeof Reflect.get(loaded, 'renderShellBody') !== 'function'
-      ) {
+      if (!isShellServerRendererModule(loaded)) {
         throw new Error('Shell server bundle did not export renderShellBody');
       }
-      const renderer = Reflect.get(loaded, 'renderShellBody') as ShellServerRenderer;
+      const renderer = loaded.renderShellBody;
       shellRendererUsedFallback = false;
       if (generationAtStart === rebuildGeneration) {
         lastGoodShellServerRenderer = renderer;
@@ -1388,7 +1407,7 @@ async function loadPageServerRenderer(): Promise<PageServerRenderers> {
         splitting: false,
       });
       if (!result.success || result.outputs[0] === undefined) {
-        throw new Error(`Page server bundle failed:\n${result.logs.join('\n')}`);
+        throw new Error(`Page server bundle failed:\n${formatBuildLogs(result.logs)}`);
       }
 
       const serverBundleDirectory = join(PLAYGROUND_TEMP_ROOT, randomUUID());
@@ -1400,26 +1419,12 @@ async function loadPageServerRenderer(): Promise<PageServerRenderers> {
       } finally {
         rmSync(serverBundleDirectory, { recursive: true, force: true });
       }
-      if (
-        typeof loaded !== 'object' ||
-        loaded === null ||
-        typeof Reflect.get(loaded, 'renderComponentPageBody') !== 'function' ||
-        typeof Reflect.get(loaded, 'renderLandingBody') !== 'function'
-      ) {
-        const missing = ['renderComponentPageBody', 'renderLandingBody'].filter(
-          (name) =>
-            typeof loaded !== 'object' ||
-            loaded === null ||
-            typeof Reflect.get(loaded, name) !== 'function',
-        );
-        throw new Error(`Page server bundle did not export ${missing.join(' and ')}`);
+      if (!isPageServerRenderers(loaded)) {
+        throw new Error('Page server bundle did not export both renderers');
       }
       const renderer: PageServerRenderers = {
-        renderComponentPageBody: Reflect.get(
-          loaded,
-          'renderComponentPageBody',
-        ) as PageServerRenderer,
-        renderLandingBody: Reflect.get(loaded, 'renderLandingBody') as LandingServerRenderer,
+        renderComponentPageBody: loaded.renderComponentPageBody,
+        renderLandingBody: loaded.renderLandingBody,
       };
       if (generationAtStart === rebuildGeneration) {
         lastGoodPageServerRenderer = renderer;
@@ -1553,10 +1558,38 @@ export async function readGeneratedComponentSchema(
 ): Promise<GeneratedComponentSchema | null> {
   try {
     if (!(await generatedSchemaFile.exists())) return null;
-    return (await generatedSchemaFile.json()) as GeneratedComponentSchema;
+    const schema: unknown = await generatedSchemaFile.json();
+    return isGeneratedComponentSchema(schema) ? schema : null;
   } catch {
     return null;
   }
+}
+
+function isGeneratedComponentSchema(value: unknown): value is GeneratedComponentSchema {
+  if (!isRecord(value)) return false;
+
+  if ('properties' in value && value['properties'] !== undefined) {
+    const properties = value['properties'];
+    if (!isRecord(properties)) return false;
+    if (Object.values(properties).some((property) => !isRecord(property))) return false;
+  }
+
+  if ('metadata' in value && value['metadata'] !== undefined) {
+    const metadata = value['metadata'];
+    if (!isRecord(metadata)) return false;
+    const unsupportedProps = metadata['unsupportedProps'];
+    if (unsupportedProps === undefined) return true;
+    if (!Array.isArray(unsupportedProps)) return false;
+    return unsupportedProps.every(
+      (prop) =>
+        isRecord(prop) &&
+        typeof prop['name'] === 'string' &&
+        (prop['required'] === undefined || typeof prop['required'] === 'boolean') &&
+        (prop['reason'] === undefined || typeof prop['reason'] === 'string'),
+    );
+  }
+
+  return true;
 }
 
 export function mergeGeneratedSchemaMetadata(

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2754,7 +2754,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       break;
     }
     console.warn(
-      `[playground] warmup pre-build retry ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
+      `[playground] warmup pre-build invalidated on attempt ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
     );
     invalidateCachesForChange({ kind: 'components' });
   }
@@ -2780,6 +2780,9 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     try {
       preparedShellServerRenderer = await loadShellServerRenderer();
       if (shellRendererUsedFallback) {
+        console.warn(
+          `[playground] shell renderer warmup invalidated on attempt ${attempt + 1}/5: renderer fallback was used`,
+        );
         preparedShellServerRenderer = null;
         continue;
       }
@@ -2799,7 +2802,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       rendererPrepared = true;
     } else {
       console.warn(
-        `[playground] shell renderer warmup retry ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
+        `[playground] shell renderer warmup invalidated on attempt ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
       );
       preparedShellServerRenderer = null;
       invalidateCachesForChange({ kind: 'components' });

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2812,7 +2812,6 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   let prebuild;
   let stable = false;
   for (let attempt = 0; attempt < 5; attempt += 1) {
-    const generationAtStart = rebuildGeneration;
     // Register before the eager build so deletions and edits during warmup
     // advance the generation even when the removed file is no longer present
     // in the end-of-build mtime scan.
@@ -2825,6 +2824,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       }
     }
     await waitForPendingRebuild();
+    const generationAtStart = rebuildGeneration;
     prebuild = await eagerPrebuildAll();
     await getManifests().catch((error: unknown) => {
       console.error('[playground] manifest pre-warm failed:', error);

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1356,6 +1356,14 @@ export function rendererWarmupNeedsPrebuild(
   return generationChanged || sourceChanged || hasPendingRebuild;
 }
 
+export function rendererWarmupNeedsCacheInvalidation(
+  generationChanged: boolean,
+  sourceChanged: boolean,
+  hasPendingRebuild: boolean,
+): boolean {
+  return sourceChanged || (!generationChanged && hasPendingRebuild);
+}
+
 /**
  * Compile and load the documentation page's server renderer.
  *
@@ -2819,7 +2827,13 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       if (needsPrebuild) {
         // Any source change can make the eager browser bundles stale. Restore
         // the bundle guarantee before advertising readiness.
-        if (generationAtStart === rebuildGeneration) {
+        if (
+          rendererWarmupNeedsCacheInvalidation(
+            generationAtStart !== rebuildGeneration,
+            sourceMtimeAtStart !== sourceMtimeAtEnd,
+            rebuildDebounceTimer !== null,
+          )
+        ) {
           invalidateCachesForChange({ kind: 'components' });
         }
         prebuild = await eagerPrebuildAll();

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2686,6 +2686,14 @@ export function warmupInstabilityReasons(
   return reasons;
 }
 
+type WarmupRetryPhase = 'eager-prebuild' | 'shell-renderer';
+type WarmupRetryAction = 'full-prebuild' | 'renderer-only';
+
+/** Page bundles are rebuilt only when the eager pre-build phase itself is invalidated. */
+export function warmupRetryAction(phase: WarmupRetryPhase): WarmupRetryAction {
+  return phase === 'eager-prebuild' ? 'full-prebuild' : 'renderer-only';
+}
+
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
   startupReady = false;
@@ -2795,8 +2803,10 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       );
       preparedShellServerRenderer = null;
       invalidateCachesForChange({ kind: 'components' });
-      prebuild = await eagerPrebuildAll();
-      if (!prebuild.shellSucceeded) break;
+      if (warmupRetryAction('shell-renderer') === 'full-prebuild') {
+        prebuild = await eagerPrebuildAll();
+        if (!prebuild.shellSucceeded) break;
+      }
     }
   }
   if (!rendererPrepared) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1350,9 +1350,10 @@ function resetShellRendererWarmupState(): void {
 
 export function rendererWarmupNeedsPrebuild(
   generationChanged: boolean,
+  sourceChanged: boolean,
   hasPendingRebuild: boolean,
 ): boolean {
-  return generationChanged || hasPendingRebuild;
+  return generationChanged || sourceChanged || hasPendingRebuild;
 }
 
 /**
@@ -2811,18 +2812,15 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       );
       const needsPrebuild = rendererWarmupNeedsPrebuild(
         generationAtStart !== rebuildGeneration,
+        sourceMtimeAtStart !== sourceMtimeAtEnd,
         rebuildDebounceTimer !== null,
       );
       resetShellRendererWarmupState();
       if (needsPrebuild) {
-        // A watcher invalidation cleared the page pointers; restore the eager
-        // browser-bundle guarantee before advertising readiness.
+        // Any source change can make the eager browser bundles stale. Restore
+        // the bundle guarantee before advertising readiness.
         prebuild = await eagerPrebuildAll();
         if (!prebuild.shellSucceeded) break;
-      } else {
-        // A source-mtime-only change does not invalidate page bundles. Reset
-        // only the renderer promise so the already-warmed browser bundles stay
-        // available for the first request.
       }
     }
   }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -202,16 +202,17 @@ type ShellServerRendererLoadResult = {
   usedFallback: boolean;
 };
 
+/** Resolve a renderer load failure against the current last-good renderer. */
 export async function resolveRendererLoad<T>(
   loadRenderer: () => Promise<T>,
-  lastGood: T | null,
+  getLastGood: () => T | null,
   onError?: (error: unknown) => void,
 ): Promise<{ renderer: T; usedFallback: boolean }> {
   try {
     return { renderer: await loadRenderer(), usedFallback: false };
   } catch (error) {
     onError?.(error);
-    return { renderer: fallbackToLastGood(lastGood, error), usedFallback: true };
+    return { renderer: fallbackToLastGood(getLastGood(), error), usedFallback: true };
   }
 }
 let shellServerRendererPromise: Promise<ShellServerRendererLoadResult> | null = null;
@@ -1376,7 +1377,7 @@ async function loadShellServerRenderer(): Promise<ShellServerRendererLoadResult>
 
   shellServerRendererPromise = resolveRendererLoad(
     loadFreshRenderer,
-    lastGoodShellServerRenderer,
+    () => lastGoodShellServerRenderer,
     (error) => {
       console.error(
         '[playground] shell server rebuild failed; serving the last-good renderer:',

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -442,9 +442,10 @@ export function scheduleRebuild(scope: ChangeScope): void {
   }, 100);
 }
 
-/** Wait until the current watcher debounce has applied its cache invalidation. */
-export async function waitForPendingRebuild(): Promise<void> {
+/** Wait for pending invalidation, then return the settled rebuild generation. */
+export async function waitForPendingRebuild(): Promise<number> {
   await rebuildDebouncePromise;
+  return rebuildGeneration;
 }
 
 /** Exposed for behavioral tests that verify debounce ordering. */
@@ -2823,8 +2824,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         throw error;
       }
     }
-    await waitForPendingRebuild();
-    const generationAtStart = rebuildGeneration;
+    const generationAtStart = await waitForPendingRebuild();
     prebuild = await eagerPrebuildAll();
     await getManifests().catch((error: unknown) => {
       console.error('[playground] manifest pre-warm failed:', error);

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2686,14 +2686,6 @@ export function warmupInstabilityReasons(
   return reasons;
 }
 
-type WarmupRetryPhase = 'eager-prebuild' | 'shell-renderer';
-type WarmupRetryAction = 'full-prebuild' | 'renderer-only';
-
-/** Page bundles are rebuilt only when the eager pre-build phase itself is invalidated. */
-export function warmupRetryAction(phase: WarmupRetryPhase): WarmupRetryAction {
-  return phase === 'eager-prebuild' ? 'full-prebuild' : 'renderer-only';
-}
-
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
   startupReady = false;
@@ -2806,10 +2798,6 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       );
       preparedShellServerRenderer = null;
       invalidateCachesForChange({ kind: 'components' });
-      if (warmupRetryAction('shell-renderer') === 'full-prebuild') {
-        prebuild = await eagerPrebuildAll();
-        if (!prebuild.shellSucceeded) break;
-      }
     }
   }
   if (!rendererPrepared) {

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2782,6 +2782,24 @@ export function warmupInstabilityReasons(
   return reasons;
 }
 
+/** Run warmup work after pending invalidation settles and validate its generation boundary. */
+export async function runGenerationCheckedWarmup<T>(
+  work: () => Promise<T>,
+): Promise<{ value: T; instabilityReasons: string[] }> {
+  const generationAtStart = await waitForPendingRebuild();
+  const value = await work();
+  return {
+    value,
+    instabilityReasons: warmupInstabilityReasons(
+      generationAtStart,
+      rebuildGeneration,
+      null,
+      null,
+      rebuildDebounceTimer !== null,
+    ),
+  };
+}
+
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
   startupReady = false;
@@ -2825,18 +2843,15 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         throw error;
       }
     }
-    const generationAtStart = await waitForPendingRebuild();
-    prebuild = await eagerPrebuildAll();
-    await getManifests().catch((error: unknown) => {
-      console.error('[playground] manifest pre-warm failed:', error);
+    const prebuildAttempt = await runGenerationCheckedWarmup(async () => {
+      const result = await eagerPrebuildAll();
+      await getManifests().catch((error: unknown) => {
+        console.error('[playground] manifest pre-warm failed:', error);
+      });
+      return result;
     });
-    const instabilityReasons = warmupInstabilityReasons(
-      generationAtStart,
-      rebuildGeneration,
-      null,
-      null,
-      rebuildDebounceTimer !== null,
-    );
+    prebuild = prebuildAttempt.value;
+    const { instabilityReasons } = prebuildAttempt;
     if (instabilityReasons.length === 0) {
       stable = true;
       break;
@@ -2862,7 +2877,27 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   // Prepare the SSR shell renderer before advertising readiness. Requests must
   // never pay the cold Svelte server compilation cost on the first navigation.
   let rendererPrepared = false;
+  let bundlesNeedPrebuild = false;
   for (let attempt = 0; attempt < 5 && !rendererPrepared; attempt += 1) {
+    if (bundlesNeedPrebuild) {
+      const prebuildAttempt = await runGenerationCheckedWarmup(eagerPrebuildAll);
+      prebuild = prebuildAttempt.value;
+      if (!prebuild.shellSucceeded) {
+        await dispose();
+        throw new Error(
+          '[playground] shell bundle failed to build during renderer retry — see logs above',
+        );
+      }
+      if (prebuildAttempt.instabilityReasons.length > 0) {
+        console.warn(
+          `[playground] renderer retry pre-build invalidated on attempt ${attempt + 1}/5: ${prebuildAttempt.instabilityReasons.join('; ')}`,
+        );
+        invalidateCachesForChange({ kind: 'components' });
+        continue;
+      }
+      bundlesNeedPrebuild = false;
+    }
+
     const generationAtStart = rebuildGeneration;
     const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
     try {
@@ -2901,7 +2936,10 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       resetShellRendererWarmupState();
       if (needsPrebuild) {
         // Any source change can make the eager browser bundles stale. Restore
-        // the bundle guarantee before advertising readiness.
+        // the bundle guarantee before advertising readiness. The next attempt
+        // validates the generation around that prebuild before loading another
+        // renderer, so an edit during the build cannot leave a partially cold
+        // cache behind a stable renderer result.
         await waitForPendingRebuild();
         if (
           rendererWarmupNeedsCacheInvalidation(
@@ -2912,8 +2950,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         ) {
           invalidateCachesForChange({ kind: 'components' });
         }
-        prebuild = await eagerPrebuildAll();
-        if (!prebuild.shellSucceeded) break;
+        bundlesNeedPrebuild = true;
       }
     }
   }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2813,6 +2813,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         generationAtStart !== rebuildGeneration,
         rebuildDebounceTimer !== null,
       );
+      resetShellRendererWarmupState();
       if (needsPrebuild) {
         // A watcher invalidation cleared the page pointers; restore the eager
         // browser-bundle guarantee before advertising readiness.
@@ -2822,7 +2823,6 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         // A source-mtime-only change does not invalidate page bundles. Reset
         // only the renderer promise so the already-warmed browser bundles stay
         // available for the first request.
-        resetShellRendererWarmupState();
       }
     }
   }

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -197,10 +197,26 @@ export function isShellServerRendererModule(value: unknown): value is ShellServe
   return isRecord(value) && typeof value['renderShellBody'] === 'function';
 }
 
-let shellServerRendererPromise: Promise<ShellServerRenderer> | null = null;
+type ShellServerRendererLoadResult = {
+  renderer: ShellServerRenderer;
+  usedFallback: boolean;
+};
+
+export async function resolveRendererLoad<T>(
+  loadRenderer: () => Promise<T>,
+  lastGood: T | null,
+  onError?: (error: unknown) => void,
+): Promise<{ renderer: T; usedFallback: boolean }> {
+  try {
+    return { renderer: await loadRenderer(), usedFallback: false };
+  } catch (error) {
+    onError?.(error);
+    return { renderer: fallbackToLastGood(lastGood, error), usedFallback: true };
+  }
+}
+let shellServerRendererPromise: Promise<ShellServerRendererLoadResult> | null = null;
 let lastGoodShellServerRenderer: ShellServerRenderer | null = null;
 let preparedShellServerRenderer: ShellServerRenderer | null = null;
-let shellRendererUsedFallback = false;
 
 /**
  * Server renderer for the canonical documentation page (`src/page-server-entry.ts`).
@@ -1307,51 +1323,53 @@ export function formatBuildLogs(logs: readonly { message: string }[]): string {
   return logs.map(({ message }) => message).join('\n');
 }
 
-async function loadShellServerRenderer(): Promise<ShellServerRenderer> {
+async function loadShellServerRenderer(): Promise<ShellServerRendererLoadResult> {
   if (shellServerRendererPromise !== null) return shellServerRendererPromise;
 
-  shellServerRendererPromise = (async () => {
-    try {
-      const generationAtStart = rebuildGeneration;
-      const result = await Bun.build({
-        entrypoints: [join(PLAYGROUND_ROOT, 'src', 'shell-app', 'shell-server-entry.ts')],
-        plugins: [sveltePlugin({ generate: 'server' })],
-        target: 'bun',
-        format: 'esm',
-        conditions: ['bun', 'svelte'],
-        splitting: false,
-      });
-      if (!result.success || result.outputs[0] === undefined) {
-        throw new Error(`Shell server bundle failed:\n${formatBuildLogs(result.logs)}`);
-      }
+  const generationAtStart = rebuildGeneration;
+  const loadFreshRenderer = async (): Promise<ShellServerRenderer> => {
+    const result = await Bun.build({
+      entrypoints: [join(PLAYGROUND_ROOT, 'src', 'shell-app', 'shell-server-entry.ts')],
+      plugins: [sveltePlugin({ generate: 'server' })],
+      target: 'bun',
+      format: 'esm',
+      conditions: ['bun', 'svelte'],
+      splitting: false,
+    });
+    if (!result.success || result.outputs[0] === undefined) {
+      throw new Error(`Shell server bundle failed:\n${formatBuildLogs(result.logs)}`);
+    }
 
-      const serverBundleDirectory = join(PLAYGROUND_TEMP_ROOT, randomUUID());
-      const serverBundlePath = join(serverBundleDirectory, 'shell-server.js');
-      let loaded: unknown;
-      try {
-        await Bun.write(serverBundlePath, await result.outputs[0].text());
-        loaded = await import(pathToFileURL(serverBundlePath).href);
-      } finally {
-        rmSync(serverBundleDirectory, { recursive: true, force: true });
-      }
-      if (!isShellServerRendererModule(loaded)) {
-        throw new Error('Shell server bundle did not export renderShellBody');
-      }
-      const renderer = loaded.renderShellBody;
-      shellRendererUsedFallback = false;
-      if (generationAtStart === rebuildGeneration) {
-        lastGoodShellServerRenderer = renderer;
-      }
-      return renderer;
-    } catch (error) {
+    const serverBundleDirectory = join(PLAYGROUND_TEMP_ROOT, randomUUID());
+    const serverBundlePath = join(serverBundleDirectory, 'shell-server.js');
+    let loaded: unknown;
+    try {
+      await Bun.write(serverBundlePath, await result.outputs[0].text());
+      loaded = await import(pathToFileURL(serverBundlePath).href);
+    } finally {
+      rmSync(serverBundleDirectory, { recursive: true, force: true });
+    }
+    if (!isShellServerRendererModule(loaded)) {
+      throw new Error('Shell server bundle did not export renderShellBody');
+    }
+    return loaded.renderShellBody;
+  };
+
+  shellServerRendererPromise = resolveRendererLoad(
+    loadFreshRenderer,
+    lastGoodShellServerRenderer,
+    (error) => {
       console.error(
         '[playground] shell server rebuild failed; serving the last-good renderer:',
         error,
       );
-      shellRendererUsedFallback = true;
-      return fallbackToLastGood(lastGoodShellServerRenderer, error);
+    },
+  ).then((result) => {
+    if (!result.usedFallback && generationAtStart === rebuildGeneration) {
+      lastGoodShellServerRenderer = result.renderer;
     }
-  })();
+    return result;
+  });
 
   return shellServerRendererPromise;
 }
@@ -1364,7 +1382,6 @@ export function setPreparedShellServerRenderer(renderer: ShellServerRenderer | n
 function resetShellRendererWarmupState(): void {
   shellServerRendererPromise = null;
   preparedShellServerRenderer = null;
-  shellRendererUsedFallback = false;
 }
 
 export function rendererWarmupNeedsPrebuild(
@@ -2523,7 +2540,11 @@ export async function handleRequest(request: Request): Promise<Response> {
       discoverSidebarComponents(),
       renderLandingReadmeHtml(),
     ]);
-    const renderShellBody = preparedShellServerRenderer ?? (await loadShellServerRenderer());
+    let renderShellBody = preparedShellServerRenderer;
+    if (renderShellBody === null) {
+      const loadedShellRenderer = await loadShellServerRenderer();
+      renderShellBody = loadedShellRenderer.renderer;
+    }
     const renderedShell = renderShellBody({
       components: sidebarComponents,
       readmeHtml,
@@ -2825,8 +2846,9 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     const generationAtStart = rebuildGeneration;
     const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
     try {
-      preparedShellServerRenderer = await loadShellServerRenderer();
-      if (shellRendererUsedFallback) {
+      const rendererResult = await loadShellServerRenderer();
+      preparedShellServerRenderer = rendererResult.renderer;
+      if (rendererResult.usedFallback) {
         console.warn(
           `[playground] shell renderer warmup invalidated on attempt ${attempt + 1}/5: renderer fallback was used`,
         );

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -374,6 +374,8 @@ let rebuildGeneration = 0;
 
 /** Debounce timer for the watcher. */
 let rebuildDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+let rebuildDebouncePromise: Promise<void> | null = null;
+let settleRebuildDebounce: (() => void) | null = null;
 /** Whether any change in the current debounce window touched shell sources. */
 let pendingShellChanged = false;
 /** Whether any change in the current debounce window touched components-package source. */
@@ -411,12 +413,15 @@ type ChangeScope =
  * (OR the booleans, union the example names) so the final invalidation
  * reflects everything touched during the window, not just the last call.
  */
-function scheduleRebuild(scope: ChangeScope): void {
+export function scheduleRebuild(scope: ChangeScope): void {
   if (scope.kind === 'shell') pendingShellChanged = true;
   else if (scope.kind === 'components') pendingComponentsChanged = true;
   else for (const name of scope.names) pendingExampleNames.add(name);
 
   if (rebuildDebounceTimer !== null) clearTimeout(rebuildDebounceTimer);
+  rebuildDebouncePromise ??= new Promise<void>((resolve) => {
+    settleRebuildDebounce = resolve;
+  });
   rebuildDebounceTimer = setTimeout(() => {
     rebuildDebounceTimer = null;
     const shellChanged = pendingShellChanged;
@@ -431,7 +436,20 @@ function scheduleRebuild(scope: ChangeScope): void {
     else if (exampleNames.size > 0) {
       invalidateCachesForChange({ kind: 'examples', names: exampleNames });
     }
+    settleRebuildDebounce?.();
+    settleRebuildDebounce = null;
+    rebuildDebouncePromise = null;
   }, 100);
+}
+
+/** Wait until the current watcher debounce has applied its cache invalidation. */
+export async function waitForPendingRebuild(): Promise<void> {
+  await rebuildDebouncePromise;
+}
+
+/** Exposed for behavioral tests that verify debounce ordering. */
+export function getRebuildGeneration(): number {
+  return rebuildGeneration;
 }
 
 /**
@@ -2806,6 +2824,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         throw error;
       }
     }
+    await waitForPendingRebuild();
     prebuild = await eagerPrebuildAll();
     await getManifests().catch((error: unknown) => {
       console.error('[playground] manifest pre-warm failed:', error);
@@ -2882,11 +2901,12 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       if (needsPrebuild) {
         // Any source change can make the eager browser bundles stale. Restore
         // the bundle guarantee before advertising readiness.
+        await waitForPendingRebuild();
         if (
           rendererWarmupNeedsCacheInvalidation(
             generationAtStart !== rebuildGeneration,
             sourceMtimeAtStart !== sourceMtimeAtEnd,
-            rebuildDebounceTimer !== null,
+            false,
           )
         ) {
           invalidateCachesForChange({ kind: 'components' });

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2737,6 +2737,14 @@ async function eagerPrebuildAll(): Promise<{
   };
 }
 
+async function eagerPrebuildAndWarmManifests(): ReturnType<typeof eagerPrebuildAll> {
+  const prebuild = await eagerPrebuildAll();
+  await getManifests().catch((error: unknown) => {
+    console.error('[playground] manifest pre-warm failed:', error);
+  });
+  return prebuild;
+}
+
 export function createSharedDisposer(disposeWork: () => Promise<void>): () => Promise<void> {
   let disposePromise: Promise<void> | null = null;
   return () => {
@@ -2787,14 +2795,16 @@ export async function runGenerationCheckedWarmup<T>(
   work: () => Promise<T>,
 ): Promise<{ value: T; instabilityReasons: string[] }> {
   const generationAtStart = await waitForPendingRebuild();
+  const sourceMtimeAtStart = newestSourceMtimeMs(REPO_ROOT);
   const value = await work();
+  const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
   return {
     value,
     instabilityReasons: warmupInstabilityReasons(
       generationAtStart,
       rebuildGeneration,
-      null,
-      null,
+      sourceMtimeAtStart,
+      sourceMtimeAtEnd,
       rebuildDebounceTimer !== null,
     ),
   };
@@ -2843,13 +2853,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
         throw error;
       }
     }
-    const prebuildAttempt = await runGenerationCheckedWarmup(async () => {
-      const result = await eagerPrebuildAll();
-      await getManifests().catch((error: unknown) => {
-        console.error('[playground] manifest pre-warm failed:', error);
-      });
-      return result;
-    });
+    const prebuildAttempt = await runGenerationCheckedWarmup(eagerPrebuildAndWarmManifests);
     prebuild = prebuildAttempt.value;
     const { instabilityReasons } = prebuildAttempt;
     if (instabilityReasons.length === 0) {
@@ -2880,7 +2884,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
   let bundlesNeedPrebuild = false;
   for (let attempt = 0; attempt < 5 && !rendererPrepared; attempt += 1) {
     if (bundlesNeedPrebuild) {
-      const prebuildAttempt = await runGenerationCheckedWarmup(eagerPrebuildAll);
+      const prebuildAttempt = await runGenerationCheckedWarmup(eagerPrebuildAndWarmManifests);
       prebuild = prebuildAttempt.value;
       if (!prebuild.shellSucceeded) {
         await dispose();

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -2657,10 +2657,33 @@ export function isWarmupStable(
   hasPendingRebuild = false,
 ): boolean {
   return (
-    generationAtStart === generationAtEnd &&
-    sourceMtimeAtStart === sourceMtimeAtEnd &&
-    !hasPendingRebuild
+    warmupInstabilityReasons(
+      generationAtStart,
+      generationAtEnd,
+      sourceMtimeAtStart,
+      sourceMtimeAtEnd,
+      hasPendingRebuild,
+    ).length === 0
   );
+}
+
+/** Explain why a warmup pass must be retried, for diagnostics in slow CI. */
+export function warmupInstabilityReasons(
+  generationAtStart: number,
+  generationAtEnd: number,
+  sourceMtimeAtStart: number | null,
+  sourceMtimeAtEnd: number | null,
+  hasPendingRebuild = false,
+): string[] {
+  const reasons: string[] = [];
+  if (generationAtStart !== generationAtEnd) {
+    reasons.push(`rebuild generation changed (${generationAtStart} -> ${generationAtEnd})`);
+  }
+  if (sourceMtimeAtStart !== sourceMtimeAtEnd) {
+    reasons.push(`newest source mtime changed (${sourceMtimeAtStart} -> ${sourceMtimeAtEnd})`);
+  }
+  if (hasPendingRebuild) reasons.push('rebuild debounce is pending');
+  return reasons;
 }
 
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
@@ -2711,10 +2734,20 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     await getManifests().catch((error: unknown) => {
       console.error('[playground] manifest pre-warm failed:', error);
     });
-    if (generationAtStart === rebuildGeneration && rebuildDebounceTimer === null) {
+    const instabilityReasons = warmupInstabilityReasons(
+      generationAtStart,
+      rebuildGeneration,
+      null,
+      null,
+      rebuildDebounceTimer !== null,
+    );
+    if (instabilityReasons.length === 0) {
       stable = true;
       break;
     }
+    console.warn(
+      `[playground] warmup pre-build retry ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
+    );
     invalidateCachesForChange({ kind: 'components' });
   }
   if (!stable || !prebuild) {
@@ -2747,17 +2780,19 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       throw new Error('[playground] shell server renderer failed to prepare', { cause: error });
     }
     const sourceMtimeAtEnd = newestSourceMtimeMs(REPO_ROOT);
-    if (
-      isWarmupStable(
-        generationAtStart,
-        rebuildGeneration,
-        sourceMtimeAtStart,
-        sourceMtimeAtEnd,
-        rebuildDebounceTimer !== null,
-      )
-    ) {
+    const instabilityReasons = warmupInstabilityReasons(
+      generationAtStart,
+      rebuildGeneration,
+      sourceMtimeAtStart,
+      sourceMtimeAtEnd,
+      rebuildDebounceTimer !== null,
+    );
+    if (instabilityReasons.length === 0) {
       rendererPrepared = true;
     } else {
+      console.warn(
+        `[playground] shell renderer warmup retry ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
+      );
       preparedShellServerRenderer = null;
       invalidateCachesForChange({ kind: 'components' });
       prebuild = await eagerPrebuildAll();

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1342,6 +1342,19 @@ export function setPreparedShellServerRenderer(renderer: ShellServerRenderer | n
   preparedShellServerRenderer = renderer;
 }
 
+function resetShellRendererWarmupState(): void {
+  shellServerRendererPromise = null;
+  preparedShellServerRenderer = null;
+  shellRendererUsedFallback = false;
+}
+
+export function rendererWarmupNeedsPrebuild(
+  generationChanged: boolean,
+  hasPendingRebuild: boolean,
+): boolean {
+  return generationChanged || hasPendingRebuild;
+}
+
 /**
  * Compile and load the documentation page's server renderer.
  *
@@ -2796,8 +2809,21 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
       console.warn(
         `[playground] shell renderer warmup invalidated on attempt ${attempt + 1}/5: ${instabilityReasons.join('; ')}`,
       );
-      preparedShellServerRenderer = null;
-      invalidateCachesForChange({ kind: 'components' });
+      const needsPrebuild = rendererWarmupNeedsPrebuild(
+        generationAtStart !== rebuildGeneration,
+        rebuildDebounceTimer !== null,
+      );
+      if (needsPrebuild) {
+        // A watcher invalidation cleared the page pointers; restore the eager
+        // browser-bundle guarantee before advertising readiness.
+        prebuild = await eagerPrebuildAll();
+        if (!prebuild.shellSucceeded) break;
+      } else {
+        // A source-mtime-only change does not invalidate page bundles. Reset
+        // only the renderer promise so the already-warmed browser bundles stay
+        // available for the first request.
+        resetShellRendererWarmupState();
+      }
     }
   }
   if (!rendererPrepared) {


### PR DESCRIPTION
Closes #1042

## Summary
- log every startup warm-up invalidation reason with an accurate attempt number
- keep renderer-only retries lazy while invalidating and rebuilding browser bundles after real source changes
- settle pending watcher debounces before eager prebuild and use the settled generation as the new baseline
- isolate each renderer load result so a stale fallback cannot overwrite a newer successful warm-up
- resolve older failed loads against the latest successfully published renderer at failure time
- validate dynamically loaded build boundaries and generated schema data before use
- preserve the /ready contract by refusing readiness when bundles, manifests, and renderer state do not converge

## Review convergence
- corrected prebuild and renderer retry diagnostics, including the fallback path
- rebuilt browser bundles after generation, mtime-only, pending-debounce, and combined generation-plus-mtime invalidation
- invalidated caches before those rebuilds so eager prebuild cannot short-circuit to stale assets
- awaited pending debounce settlement before prebuild and captured its returned generation as the stable baseline
- reset cached fallback renderer promises before retrying and carry fallback state per asynchronous result
- resolved stale failed loads from the current last-good renderer rather than a start-time snapshot
- validate generation, pending debounce, and source mtime around initial and renderer-retry prebuild work
- warm manifests inside the same validated boundary as bundle prebuilds
- carry renderer fallback through generation, source-mtime, and pending-debounce checks before deciding whether eager bundles must be restored
- added deferred interleaving, debounce-order, settled-generation, failure-time fallback, retry-prebuild, and watcher-lag regressions
- all twelve review threads are resolved in the implemented branch

## Local validation after rebase
- dependency package builds and generated component/export checks
- focused playground server suite with the documented fresh-process harness: 145 pass, 0 fail
- full playground package test runner before the final focused hardening: 962 pass, 0 fail
- bun run --filter=@cinder/playground typecheck: 0 errors
- configured and exact type-aware Oxlint: 0 errors
- targeted Prettier, hooks, and git diff --check