### PR TITLE
fix(event-timeline): constrain cluster surface height

### DIFF
--- a/.changeset/1044-event-timeline-cluster-height.md
+++ b/.changeset/1044-event-timeline-cluster-height.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Constrain EventTimeline cluster surfaces to the available height inside overlay owners.

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -13,6 +13,8 @@ export type AnchoredOverlayOptions = {
   shiftCrossAxis?: () => boolean;
   arrowPadding?: () => number;
   arrowVisible?: () => boolean;
+  /** Constrain the floating panel to the available block space on its resolved side. */
+  size?: () => boolean;
   widthMode?: () => AnchoredOverlayWidthMode;
   strategy?: () => 'fixed' | 'absolute';
 };
@@ -115,6 +117,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     const arrowPadding = options.arrowPadding?.() ?? DEFAULT_ARROW_PADDING;
     const arrow = options.arrow?.();
     const arrowVisible = options.arrowVisible?.() ?? Boolean(arrow);
+    const sizeEnabled = options.size?.() ?? false;
     const widthMode = options.widthMode?.() ?? 'content';
     const strategyOverride = options.strategy?.();
     let cancelled = false;
@@ -128,6 +131,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
         computePosition,
         flip,
         offset: offsetMiddleware,
+        size: sizeMiddleware,
         shift,
       } = await import('@floating-ui/dom');
 
@@ -140,6 +144,15 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
       ];
       if (arrowVisible && arrow) {
         middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
+      }
+      if (sizeEnabled) {
+        middleware.push(
+          sizeMiddleware({
+            apply({ availableHeight, elements }) {
+              elements.floating.style.maxBlockSize = `${Math.max(0, availableHeight)}px`;
+            },
+          }),
+        );
       }
 
       stopAutoUpdate = autoUpdate(anchor, panel, async () => {

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -77,6 +77,13 @@ export function applyAnchoredOverlayMaxBlockSize(
   return value;
 }
 
+export function isAnchoredOverlayGenerationCurrent(
+  positioningGeneration: number,
+  latestGeneration: number,
+): boolean {
+  return positioningGeneration === latestGeneration;
+}
+
 function getArrowStyle(placement: Placement, data: { x?: number; y?: number } | undefined) {
   if (!data) return '';
 
@@ -163,31 +170,29 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
 
       if (cancelled) return;
 
-      const middleware: Middleware[] = [
-        offsetMiddleware(offset),
-        flip(),
-      ];
-      if (sizeEnabled) {
-        middleware.push(
-          sizeMiddleware({
-            apply({ availableHeight }) {
-              availableHeightStyle = applyAnchoredOverlayMaxBlockSize(
-                panel,
-                availableHeight,
-                sizeMaxBlockSize,
-              );
-            },
-          }),
-        );
-      }
-      middleware.push(shift({ padding: shiftPadding, crossAxis: shiftCrossAxis }));
-      if (arrowVisible && arrow) {
-        middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
-      }
-
       stopAutoUpdate = autoUpdate(anchor, panel, async () => {
         if (cancelled) return;
         const currentGeneration = ++generation;
+        const middleware: Middleware[] = [offsetMiddleware(offset), flip()];
+        if (sizeEnabled) {
+          middleware.push(
+            sizeMiddleware({
+              padding: shiftPadding,
+              apply({ availableHeight }) {
+                if (!isAnchoredOverlayGenerationCurrent(currentGeneration, generation)) return;
+                availableHeightStyle = applyAnchoredOverlayMaxBlockSize(
+                  panel,
+                  availableHeight,
+                  sizeMaxBlockSize,
+                );
+              },
+            }),
+          );
+        }
+        middleware.push(shift({ padding: shiftPadding, crossAxis: shiftCrossAxis }));
+        if (arrowVisible && arrow) {
+          middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
+        }
         let result: Awaited<ReturnType<typeof computePosition>>;
         const strategy = strategyOverride ?? (panel.closest('dialog') ? 'absolute' : 'fixed');
         try {

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -160,6 +160,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     let cancelled = false;
     let generation = 0;
     let stopAutoUpdate: (() => void) | undefined;
+    let boundaryResizeObserver: ResizeObserver | undefined;
 
     void (async () => {
       const {
@@ -174,7 +175,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
 
       if (cancelled) return;
 
-      stopAutoUpdate = autoUpdate(anchor, panel, async () => {
+      const updatePosition = async () => {
         if (cancelled) return;
         const currentGeneration = ++generation;
         const middleware: Middleware[] = [
@@ -241,7 +242,21 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
           ? getArrowStyle(result.placement, result.middlewareData.arrow)
           : '';
         positionReady = true;
-      });
+      };
+
+      stopAutoUpdate = autoUpdate(anchor, panel, updatePosition);
+
+      if (
+        boundary &&
+        boundary !== anchor &&
+        boundary !== panel &&
+        typeof ResizeObserver !== 'undefined'
+      ) {
+        boundaryResizeObserver = new ResizeObserver(() => {
+          void updatePosition();
+        });
+        boundaryResizeObserver.observe(boundary);
+      }
     })().catch((error) => {
       if (cancelled) return;
       positionReady = false;
@@ -255,6 +270,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     return () => {
       cancelled = true;
       stopAutoUpdate?.();
+      boundaryResizeObserver?.disconnect();
       panel.style.removeProperty('max-block-size');
       positionReady = false;
       positionStyle = '';

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -207,6 +207,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     return () => {
       cancelled = true;
       stopAutoUpdate?.();
+      panel.style.maxBlockSize = '';
       positionReady = false;
       positionStyle = '';
       arrowStyle = '';

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -18,6 +18,8 @@ export type AnchoredOverlayOptions = {
   sizeMaxBlockSize?: () => string;
   widthMode?: () => AnchoredOverlayWidthMode;
   strategy?: () => 'fixed' | 'absolute';
+  /** Constrain collision calculations to the nearest owning overlay. */
+  boundary?: () => Element | null | undefined;
 };
 
 const DEFAULT_PLACEMENT: Placement = 'bottom-start';
@@ -154,6 +156,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     const sizeMaxBlockSize = options.sizeMaxBlockSize?.() ?? '100%';
     const widthMode = options.widthMode?.() ?? 'content';
     const strategyOverride = options.strategy?.();
+    const boundary = options.boundary?.() ?? undefined;
     let cancelled = false;
     let generation = 0;
     let stopAutoUpdate: (() => void) | undefined;
@@ -174,10 +177,14 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
       stopAutoUpdate = autoUpdate(anchor, panel, async () => {
         if (cancelled) return;
         const currentGeneration = ++generation;
-        const middleware: Middleware[] = [offsetMiddleware(offset), flip()];
+        const middleware: Middleware[] = [
+          offsetMiddleware(offset),
+          flip(boundary ? { boundary } : undefined),
+        ];
         if (sizeEnabled) {
           middleware.push(
             sizeMiddleware({
+              ...(boundary ? { boundary } : {}),
               padding: shiftPadding,
               apply({ availableHeight }) {
                 if (!isAnchoredOverlayWriteCurrent(currentGeneration, generation, cancelled))
@@ -191,7 +198,13 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
             }),
           );
         }
-        middleware.push(shift({ padding: shiftPadding, crossAxis: shiftCrossAxis }));
+        middleware.push(
+          shift({
+            ...(boundary ? { boundary } : {}),
+            padding: shiftPadding,
+            crossAxis: shiftCrossAxis,
+          }),
+        );
         if (arrowVisible && arrow) {
           middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
         }

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -178,6 +178,10 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
       const updatePosition = async () => {
         if (cancelled) return;
         const currentGeneration = ++generation;
+        if (!sizeEnabled) {
+          availableHeightStyle = '';
+          panel.style.removeProperty('max-block-size');
+        }
         const middleware: Middleware[] = [
           offsetMiddleware(offset),
           flip(boundary ? { boundary } : undefined),

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -55,6 +55,10 @@ export function getAnchoredOverlayWidthStyle(
   return 'max-inline-size: min(28rem, calc(100vw - var(--cinder-space-4)));';
 }
 
+export function getAnchoredOverlayAvailableHeightStyle(availableHeight: number): string {
+  return `${Math.max(0, availableHeight)}px`;
+}
+
 function getArrowStyle(placement: Placement, data: { x?: number; y?: number } | undefined) {
   if (!data) return '';
 
@@ -149,7 +153,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
         middleware.push(
           sizeMiddleware({
             apply({ availableHeight, elements }) {
-              elements.floating.style.maxBlockSize = `${Math.max(0, availableHeight)}px`;
+              elements.floating.style.maxBlockSize = getAnchoredOverlayAvailableHeightStyle(availableHeight);
             },
           }),
         );

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -60,6 +60,23 @@ export function getAnchoredOverlayAvailableHeightStyle(availableHeight: number):
   return `${Math.max(0, availableHeight)}px`;
 }
 
+export function getAnchoredOverlayMaxBlockSizeStyle(
+  availableHeight: number,
+  maximumBlockSize: string,
+): string {
+  return `min(${maximumBlockSize}, ${getAnchoredOverlayAvailableHeightStyle(availableHeight)})`;
+}
+
+export function applyAnchoredOverlayMaxBlockSize(
+  panel: HTMLElement,
+  availableHeight: number,
+  maximumBlockSize: string,
+): string {
+  const value = getAnchoredOverlayMaxBlockSizeStyle(availableHeight, maximumBlockSize);
+  panel.style.maxBlockSize = value;
+  return value;
+}
+
 function getArrowStyle(placement: Placement, data: { x?: number; y?: number } | undefined) {
   if (!data) return '';
 
@@ -154,7 +171,11 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
         middleware.push(
           sizeMiddleware({
             apply({ availableHeight }) {
-              availableHeightStyle = `min(${sizeMaxBlockSize}, ${getAnchoredOverlayAvailableHeightStyle(availableHeight)})`;
+              availableHeightStyle = applyAnchoredOverlayMaxBlockSize(
+                panel,
+                availableHeight,
+                sizeMaxBlockSize,
+              );
             },
           }),
         );
@@ -214,6 +235,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     return () => {
       cancelled = true;
       stopAutoUpdate?.();
+      panel.style.removeProperty('max-block-size');
       positionReady = false;
       positionStyle = '';
       availableHeightStyle = '';

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -77,11 +77,12 @@ export function applyAnchoredOverlayMaxBlockSize(
   return value;
 }
 
-export function isAnchoredOverlayGenerationCurrent(
+export function isAnchoredOverlayWriteCurrent(
   positioningGeneration: number,
   latestGeneration: number,
+  cancelled: boolean,
 ): boolean {
-  return positioningGeneration === latestGeneration;
+  return !cancelled && positioningGeneration === latestGeneration;
 }
 
 function getArrowStyle(placement: Placement, data: { x?: number; y?: number } | undefined) {
@@ -179,7 +180,8 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
             sizeMiddleware({
               padding: shiftPadding,
               apply({ availableHeight }) {
-                if (!isAnchoredOverlayGenerationCurrent(currentGeneration, generation)) return;
+                if (!isAnchoredOverlayWriteCurrent(currentGeneration, generation, cancelled))
+                  return;
                 availableHeightStyle = applyAnchoredOverlayMaxBlockSize(
                   panel,
                   availableHeight,

--- a/packages/components/src/_internal/anchored-overlay.svelte.ts
+++ b/packages/components/src/_internal/anchored-overlay.svelte.ts
@@ -15,6 +15,7 @@ export type AnchoredOverlayOptions = {
   arrowVisible?: () => boolean;
   /** Constrain the floating panel to the available block space on its resolved side. */
   size?: () => boolean;
+  sizeMaxBlockSize?: () => string;
   widthMode?: () => AnchoredOverlayWidthMode;
   strategy?: () => 'fixed' | 'absolute';
 };
@@ -93,6 +94,7 @@ function reportAnchoredOverlaySetupError(error: unknown): void {
 export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
   let positionReady = $state(false);
   let positionStyle = $state('');
+  let availableHeightStyle = $state('');
   let resolvedPlacement = $state<Placement>(options.placement?.() ?? DEFAULT_PLACEMENT);
   let arrowStyle = $state('');
 
@@ -100,6 +102,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     if (!options.open()) {
       positionReady = false;
       positionStyle = '';
+      availableHeightStyle = '';
       arrowStyle = '';
       resolvedPlacement = options.placement?.() ?? DEFAULT_PLACEMENT;
       return;
@@ -110,6 +113,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     if (!anchor || !panel) {
       positionReady = false;
       positionStyle = '';
+      availableHeightStyle = '';
       arrowStyle = '';
       return;
     }
@@ -122,6 +126,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     const arrow = options.arrow?.();
     const arrowVisible = options.arrowVisible?.() ?? Boolean(arrow);
     const sizeEnabled = options.size?.() ?? false;
+    const sizeMaxBlockSize = options.sizeMaxBlockSize?.() ?? '100%';
     const widthMode = options.widthMode?.() ?? 'content';
     const strategyOverride = options.strategy?.();
     let cancelled = false;
@@ -144,19 +149,19 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
       const middleware: Middleware[] = [
         offsetMiddleware(offset),
         flip(),
-        shift({ padding: shiftPadding, crossAxis: shiftCrossAxis }),
       ];
-      if (arrowVisible && arrow) {
-        middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
-      }
       if (sizeEnabled) {
         middleware.push(
           sizeMiddleware({
-            apply({ availableHeight, elements }) {
-              elements.floating.style.maxBlockSize = getAnchoredOverlayAvailableHeightStyle(availableHeight);
+            apply({ availableHeight }) {
+              availableHeightStyle = `min(${sizeMaxBlockSize}, ${getAnchoredOverlayAvailableHeightStyle(availableHeight)})`;
             },
           }),
         );
+      }
+      middleware.push(shift({ padding: shiftPadding, crossAxis: shiftCrossAxis }));
+      if (arrowVisible && arrow) {
+        middleware.push(arrowMiddleware({ element: arrow, padding: arrowPadding }));
       }
 
       stopAutoUpdate = autoUpdate(anchor, panel, async () => {
@@ -185,6 +190,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
           `position: ${strategy};`,
           `left: ${result.x}px;`,
           `top: ${result.y}px;`,
+          availableHeightStyle ? `max-block-size: ${availableHeightStyle};` : '',
           widthStyle,
         ]
           .filter(Boolean)
@@ -199,6 +205,7 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
       if (cancelled) return;
       positionReady = false;
       positionStyle = '';
+      availableHeightStyle = '';
       arrowStyle = '';
       resolvedPlacement = placement;
       reportAnchoredOverlaySetupError(error);
@@ -207,9 +214,9 @@ export function createAnchoredOverlay(options: AnchoredOverlayOptions) {
     return () => {
       cancelled = true;
       stopAutoUpdate?.();
-      panel.style.maxBlockSize = '';
       positionReady = false;
       positionStyle = '';
+      availableHeightStyle = '';
       arrowStyle = '';
       resolvedPlacement = placement;
     };

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -7,6 +7,7 @@ import {
   getAnchoredOverlayAvailableHeightStyle,
   getAnchoredOverlayMaxBlockSizeStyle,
   getAnchoredOverlayWidthStyle,
+  isAnchoredOverlayGenerationCurrent,
 } from './anchored-overlay.svelte.ts';
 
 describe('anchored overlay width styles', () => {
@@ -60,9 +61,16 @@ describe('anchored overlay width styles', () => {
     expect(panel.style.maxBlockSize).toBe('');
   });
 
+  test('rejects stale concurrent positioning generations before DOM writes', () => {
+    expect(isAnchoredOverlayGenerationCurrent(3, 3)).toBe(true);
+    expect(isAnchoredOverlayGenerationCurrent(2, 3)).toBe(false);
+  });
+
   test('server compilation omits Floating UI runtime imports', async () => {
     const sourcePath = `${import.meta.dir}/anchored-overlay.svelte.ts`;
     const source = await Bun.file(sourcePath).text();
+    expect(source).toContain('sizeMiddleware({');
+    expect(source).toContain('padding: shiftPadding');
     const moduleSource = new Bun.Transpiler({ loader: 'ts' }).transformSync(source);
     const result = compileModule(moduleSource, {
       filename: sourcePath,

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -1,7 +1,8 @@
 /// <reference lib="dom" />
-import { describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
 import { compileModule } from 'svelte/compiler';
 
+import { setupHappyDom } from '../test/happy-dom.ts';
 import {
   applyAnchoredOverlayMaxBlockSize,
   getAnchoredOverlayAvailableHeightStyle,
@@ -9,6 +10,106 @@ import {
   getAnchoredOverlayWidthStyle,
   isAnchoredOverlayWriteCurrent,
 } from './anchored-overlay.svelte.ts';
+
+setupHappyDom();
+
+class BoundaryResizeObserver implements ResizeObserver {
+  static instances: BoundaryResizeObserver[] = [];
+  readonly callback: ResizeObserverCallback;
+  observed: Element[] = [];
+
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
+    BoundaryResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element): void {
+    this.observed.push(target);
+  }
+
+  unobserve(target: Element): void {
+    this.observed = this.observed.filter((element) => element !== target);
+  }
+
+  disconnect(): void {
+    this.observed = [];
+  }
+
+  trigger(target: Element): void {
+    this.callback([{ target } as ResizeObserverEntry], this as unknown as ResizeObserver);
+  }
+}
+
+const computePositionSpy = mock(async (anchor: Element, panel: HTMLElement, options: unknown) => {
+  const middleware = ((options as { middleware?: unknown[] }).middleware ?? []) as Array<{
+    name?: string;
+    options?: {
+      apply?: (state: {
+        availableHeight: number;
+        elements: { floating: HTMLElement; reference: Element };
+      }) => void;
+      boundary?: Element;
+    };
+  }>;
+  const sizeMiddleware = middleware.find((entry) => entry.name === 'size');
+  const boundary = sizeMiddleware?.options?.boundary;
+  const availableHeight = boundary?.getBoundingClientRect().height ?? 0;
+  sizeMiddleware?.options?.apply?.({
+    availableHeight,
+    elements: { floating: panel, reference: anchor },
+  });
+  return { x: 12, y: 18, placement: 'bottom-start', middlewareData: {} };
+});
+const autoUpdateTeardown = mock(() => {});
+const autoUpdateSpy = mock(
+  (_anchor: Element, _panel: HTMLElement, update: () => void | Promise<void>) => {
+    void update();
+    return autoUpdateTeardown;
+  },
+);
+
+mock.module('@floating-ui/dom', () => ({
+  arrow: () => ({ name: 'arrow', fn: () => ({}) }),
+  autoUpdate: autoUpdateSpy,
+  computePosition: computePositionSpy,
+  flip: (options: unknown) => ({ name: 'flip', options, fn: () => ({}) }),
+  offset: (options: unknown) => ({ name: 'offset', options, fn: () => ({}) }),
+  shift: (options: unknown) => ({ name: 'shift', options, fn: () => ({}) }),
+  size: (options: unknown) => ({ name: 'size', options, fn: () => ({}) }),
+}));
+
+const { cleanup, render, screen, waitFor } = await import('@testing-library/svelte');
+const { default: AnchoredOverlayBoundaryFixture } =
+  await import('../test/fixtures/anchored-overlay-boundary-fixture.svelte');
+
+const originalResizeObserver = globalThis.ResizeObserver;
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: BoundaryResizeObserver,
+    writable: true,
+  });
+});
+
+beforeEach(() => {
+  BoundaryResizeObserver.instances = [];
+  computePositionSpy.mockClear();
+  autoUpdateTeardown.mockClear();
+  autoUpdateSpy.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+afterAll(() => {
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    configurable: true,
+    value: originalResizeObserver,
+    writable: true,
+  });
+});
 
 describe('anchored overlay width styles', () => {
   test('match-anchor locks the floating surface to the anchor width', () => {
@@ -80,5 +181,34 @@ describe('anchored overlay width styles', () => {
     });
 
     expect(result.js.code).not.toContain('@floating-ui/dom');
+  });
+
+  test('recomputes available-height sizing when an explicit boundary changes only height', async () => {
+    let boundaryHeight = 240;
+    render(AnchoredOverlayBoundaryFixture);
+    const boundary = screen.getByTestId('boundary');
+    const panel = screen.getByTestId('panel');
+    boundary.getBoundingClientRect = () =>
+      ({
+        width: 360,
+        height: boundaryHeight,
+      }) as DOMRect;
+
+    await waitFor(() => {
+      expect(computePositionSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const boundaryObserver = BoundaryResizeObserver.instances.find((observer) =>
+      observer.observed.includes(boundary),
+    );
+    expect(boundaryObserver).toBeDefined();
+
+    boundaryHeight = 120;
+    boundaryObserver?.trigger(boundary);
+
+    await waitFor(() => {
+      expect(computePositionSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(panel.getAttribute('style')).toContain('max-block-size: min(24rem, 120px)');
   });
 });

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, test } from 'bun:test';
 import { compileModule } from 'svelte/compiler';
 
 import {
+  applyAnchoredOverlayMaxBlockSize,
   getAnchoredOverlayAvailableHeightStyle,
+  getAnchoredOverlayMaxBlockSizeStyle,
   getAnchoredOverlayWidthStyle,
 } from './anchored-overlay.svelte.ts';
 
@@ -38,6 +40,24 @@ describe('anchored overlay width styles', () => {
   test('available height style clamps negative space and preserves measured space', () => {
     expect(getAnchoredOverlayAvailableHeightStyle(320)).toBe('320px');
     expect(getAnchoredOverlayAvailableHeightStyle(-1)).toBe('0px');
+  });
+
+  test('applies the available-height cap during measurement and supports cleanup', () => {
+    const panel = {
+      style: {
+        maxBlockSize: '',
+        removeProperty(property: string) {
+          if (property === 'max-block-size') this.maxBlockSize = '';
+        },
+      },
+    } as unknown as HTMLElement;
+
+    expect(getAnchoredOverlayMaxBlockSizeStyle(320, '24rem')).toBe('min(24rem, 320px)');
+    expect(applyAnchoredOverlayMaxBlockSize(panel, 320, '24rem')).toBe('min(24rem, 320px)');
+    expect(panel.style.maxBlockSize).toBe('min(24rem, 320px)');
+
+    panel.style.removeProperty('max-block-size');
+    expect(panel.style.maxBlockSize).toBe('');
   });
 
   test('server compilation omits Floating UI runtime imports', async () => {

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -32,6 +32,13 @@ describe('anchored overlay width styles', () => {
     expect(getAnchoredOverlayWidthStyle('none', { width: 320 })).toBe('');
   });
 
+  test('opt-in sizing middleware constrains the floating panel to available height', async () => {
+    const source = await Bun.file(`${import.meta.dir}/anchored-overlay.svelte.ts`).text();
+
+    expect(source).toContain('sizeMiddleware({');
+    expect(source).toContain('elements.floating.style.maxBlockSize');
+  });
+
   test('server compilation omits Floating UI runtime imports', async () => {
     const sourcePath = `${import.meta.dir}/anchored-overlay.svelte.ts`;
     const source = await Bun.file(sourcePath).text();

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -7,7 +7,7 @@ import {
   getAnchoredOverlayAvailableHeightStyle,
   getAnchoredOverlayMaxBlockSizeStyle,
   getAnchoredOverlayWidthStyle,
-  isAnchoredOverlayGenerationCurrent,
+  isAnchoredOverlayWriteCurrent,
 } from './anchored-overlay.svelte.ts';
 
 describe('anchored overlay width styles', () => {
@@ -61,9 +61,10 @@ describe('anchored overlay width styles', () => {
     expect(panel.style.maxBlockSize).toBe('');
   });
 
-  test('rejects stale concurrent positioning generations before DOM writes', () => {
-    expect(isAnchoredOverlayGenerationCurrent(3, 3)).toBe(true);
-    expect(isAnchoredOverlayGenerationCurrent(2, 3)).toBe(false);
+  test('rejects stale or cancelled positioning sessions before DOM writes', () => {
+    expect(isAnchoredOverlayWriteCurrent(3, 3, false)).toBe(true);
+    expect(isAnchoredOverlayWriteCurrent(2, 3, false)).toBe(false);
+    expect(isAnchoredOverlayWriteCurrent(3, 3, true)).toBe(false);
   });
 
   test('server compilation omits Floating UI runtime imports', async () => {

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -211,4 +211,38 @@ describe('anchored overlay width styles', () => {
     });
     expect(panel.getAttribute('style')).toContain('max-block-size: min(24rem, 120px)');
   });
+
+  test('clears available-height sizing when size turns off while open', async () => {
+    const view = render(AnchoredOverlayBoundaryFixture, { size: true });
+    const boundary = screen.getByTestId('boundary');
+    const panel = screen.getByTestId('panel');
+    boundary.getBoundingClientRect = () =>
+      ({
+        width: 360,
+        height: 180,
+      }) as DOMRect;
+
+    await waitFor(() => {
+      expect(panel.getAttribute('style')).toContain('max-block-size: min(24rem, 180px)');
+    });
+
+    await view.rerender({ size: false });
+
+    await waitFor(() => {
+      expect(computePositionSpy).toHaveBeenCalledTimes(2);
+    });
+    expect(panel.getAttribute('style')).not.toContain('max-block-size');
+    expect(panel.style.maxBlockSize).toBe('');
+
+    const boundaryObserver = BoundaryResizeObserver.instances.find((observer) =>
+      observer.observed.includes(boundary),
+    );
+    boundaryObserver?.trigger(boundary);
+
+    await waitFor(() => {
+      expect(computePositionSpy).toHaveBeenCalledTimes(3);
+    });
+    expect(panel.getAttribute('style')).not.toContain('max-block-size');
+    expect(panel.style.maxBlockSize).toBe('');
+  });
 });

--- a/packages/components/src/_internal/anchored-overlay.test.ts
+++ b/packages/components/src/_internal/anchored-overlay.test.ts
@@ -2,7 +2,10 @@
 import { describe, expect, test } from 'bun:test';
 import { compileModule } from 'svelte/compiler';
 
-import { getAnchoredOverlayWidthStyle } from './anchored-overlay.svelte.ts';
+import {
+  getAnchoredOverlayAvailableHeightStyle,
+  getAnchoredOverlayWidthStyle,
+} from './anchored-overlay.svelte.ts';
 
 describe('anchored overlay width styles', () => {
   test('match-anchor locks the floating surface to the anchor width', () => {
@@ -32,11 +35,9 @@ describe('anchored overlay width styles', () => {
     expect(getAnchoredOverlayWidthStyle('none', { width: 320 })).toBe('');
   });
 
-  test('opt-in sizing middleware constrains the floating panel to available height', async () => {
-    const source = await Bun.file(`${import.meta.dir}/anchored-overlay.svelte.ts`).text();
-
-    expect(source).toContain('sizeMiddleware({');
-    expect(source).toContain('elements.floating.style.maxBlockSize');
+  test('available height style clamps negative space and preserves measured space', () => {
+    expect(getAnchoredOverlayAvailableHeightStyle(320)).toBe('320px');
+    expect(getAnchoredOverlayAvailableHeightStyle(-1)).toBe('0px');
   });
 
   test('server compilation omits Floating UI runtime imports', async () => {

--- a/packages/components/src/components/context-menu/context-menu.test.ts
+++ b/packages/components/src/components/context-menu/context-menu.test.ts
@@ -162,7 +162,7 @@ describe('ContextMenu', () => {
       expect(menu?.getAttribute('data-cinder-position-ready')).toBe('false');
       expect(menu?.getAttribute('data-cinder-requested-x')).toBe('24');
       expect(menu?.getAttribute('data-cinder-requested-y')).toBe('36');
-      expect(menu?.getAttribute('style')).toBe('');
+      expect(menu?.style.cssText).toBe('');
     });
   });
 

--- a/packages/components/src/components/event-timeline/event-timeline.css
+++ b/packages/components/src/components/event-timeline/event-timeline.css
@@ -231,7 +231,6 @@
     background: var(--cinder-surface);
     box-shadow: var(--cinder-shadow-md);
     text-align: start;
-    max-block-size: min(24rem, calc(100% - 4rem), calc(100vh - 4rem));
     overflow: auto;
   }
 

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -156,6 +156,7 @@
     shiftPadding: () => 8,
     size: () => true,
     sizeMaxBlockSize: () => '24rem',
+    boundary: () => portalOwner(),
     // Read from state (kept fresh below) rather than recomputing here: `strategy`
     // is captured once when the anchored overlay's autoUpdate session starts, so
     // it must be reactive for the session to notice a containing block appearing

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -155,6 +155,7 @@
     offset: () => 8,
     shiftPadding: () => 8,
     size: () => true,
+    sizeMaxBlockSize: () => '24rem',
     // Read from state (kept fresh below) rather than recomputing here: `strategy`
     // is captured once when the anchored overlay's autoUpdate session starts, so
     // it must be reactive for the session to notice a containing block appearing

--- a/packages/components/src/components/event-timeline/event-timeline.svelte
+++ b/packages/components/src/components/event-timeline/event-timeline.svelte
@@ -154,6 +154,7 @@
     placement: () => 'bottom-start',
     offset: () => 8,
     shiftPadding: () => 8,
+    size: () => true,
     // Read from state (kept fresh below) rather than recomputing here: `strategy`
     // is captured once when the anchored overlay's autoUpdate session starts, so
     // it must be reactive for the session to notice a containing block appearing

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -86,6 +86,7 @@ describe('EventTimeline', () => {
   test('opts cluster surfaces into available-height overlay sizing', () => {
     expect(EVENT_TIMELINE_SOURCE).toContain('size: () => true');
     expect(EVENT_TIMELINE_SOURCE).toContain("sizeMaxBlockSize: () => '24rem'");
+    expect(EVENT_TIMELINE_SOURCE).toContain('boundary: () => portalOwner()');
     expect(EVENT_TIMELINE_CSS).toContain('overflow: auto');
     expect(EVENT_TIMELINE_CSS).not.toContain('max-block-size: min(24rem');
   });

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -85,6 +85,7 @@ afterAll(() => {
 describe('EventTimeline', () => {
   test('opts cluster surfaces into available-height overlay sizing', () => {
     expect(EVENT_TIMELINE_SOURCE).toContain('size: () => true');
+    expect(EVENT_TIMELINE_SOURCE).toContain("sizeMaxBlockSize: () => '24rem'");
     expect(EVENT_TIMELINE_CSS).toContain('overflow: auto');
     expect(EVENT_TIMELINE_CSS).not.toContain('max-block-size: min(24rem');
   });

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -83,6 +83,11 @@ afterAll(() => {
 });
 
 describe('EventTimeline', () => {
+  test('opts cluster surfaces into available-height overlay sizing', () => {
+    expect(EVENT_TIMELINE_SOURCE).toContain('size: () => true');
+    expect(EVENT_TIMELINE_CSS).toContain('overflow: auto');
+  });
+
   const start = '2026-07-03T00:00:00.000Z';
   const end = '2026-07-04T00:00:00.000Z';
 

--- a/packages/components/src/components/event-timeline/event-timeline.test.ts
+++ b/packages/components/src/components/event-timeline/event-timeline.test.ts
@@ -86,6 +86,7 @@ describe('EventTimeline', () => {
   test('opts cluster surfaces into available-height overlay sizing', () => {
     expect(EVENT_TIMELINE_SOURCE).toContain('size: () => true');
     expect(EVENT_TIMELINE_CSS).toContain('overflow: auto');
+    expect(EVENT_TIMELINE_CSS).not.toContain('max-block-size: min(24rem');
   });
 
   const start = '2026-07-03T00:00:00.000Z';

--- a/packages/components/src/test/fixtures/anchored-overlay-boundary-fixture.svelte
+++ b/packages/components/src/test/fixtures/anchored-overlay-boundary-fixture.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
+
+  interface Props {
+    open?: boolean;
+  }
+
+  let { open = true }: Props = $props();
+
+  let anchor = $state<HTMLButtonElement | null>(null);
+  let panel = $state<HTMLDivElement | null>(null);
+  let boundary = $state<HTMLDivElement | null>(null);
+
+  const overlay = createAnchoredOverlay({
+    open: () => open,
+    anchor: () => anchor,
+    panel: () => panel,
+    boundary: () => boundary,
+    size: () => true,
+    sizeMaxBlockSize: () => '24rem',
+  });
+</script>
+
+<div bind:this={boundary} data-testid="boundary">
+  <button bind:this={anchor} type="button">Anchor</button>
+  <div bind:this={panel} data-testid="panel" style={overlay.positionStyle}>Panel</div>
+</div>

--- a/packages/components/src/test/fixtures/anchored-overlay-boundary-fixture.svelte
+++ b/packages/components/src/test/fixtures/anchored-overlay-boundary-fixture.svelte
@@ -3,9 +3,10 @@
 
   interface Props {
     open?: boolean;
+    size?: boolean;
   }
 
-  let { open = true }: Props = $props();
+  let { open = true, size = true }: Props = $props();
 
   let anchor = $state<HTMLButtonElement | null>(null);
   let panel = $state<HTMLDivElement | null>(null);
@@ -16,7 +17,7 @@
     anchor: () => anchor,
     panel: () => panel,
     boundary: () => boundary,
-    size: () => true,
+    size: () => size,
     sizeMaxBlockSize: () => '24rem',
   });
 </script>


### PR DESCRIPTION
Closes #1044

## Summary
- add opt-in Floating UI size middleware to anchored overlays
- constrain EventTimeline cluster surfaces to their explicit portal-owner boundary
- observe boundary-only resizes and generation-guard every size write
- clear reactive and DOM size constraints when sizing is disabled or torn down

## Review convergence
- prevent cancelled or stale positioning sessions from mutating styles
- recompute available height when only the collision boundary height changes
- preserve width-only EventTimeline owner observation without using it as a sizing proxy
- cover enabled-to-disabled sizing transitions and observer cleanup
- resolve all review threads at the implemented head
- make the ContextMenu pre-position assertion check semantic inline style state instead of timing-sensitive attribute presence after the exact-head CI failure

## Validation after rebase
- focused anchored-overlay and EventTimeline unit suites: 50 pass, 0 fail
- focused ContextMenu suite after CI root-cause fix: 31 pass, 0 fail
- rendered EventTimeline Playwright suite: 3 pass, 0 fail
- `bun run --filter=@lostgradient/cinder typecheck`: 0 errors
- package lint: 0 warnings, 0 errors
- components, exports, invariants, Prettier, diff, and push-hook checks pass