### PR TITLE
fix(speed-dial): bridge portaled Tab boundaries

### DIFF
--- a/.changeset/portaled-speed-dial-tab-bridge.md
+++ b/.changeset/portaled-speed-dial-tab-bridge.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep SpeedDial Tab navigation contiguous across its portaled actions, including arrow-focused untabbable actions.

--- a/packages/components/src/components/speed-dial/speed-dial.a11y.md
+++ b/packages/components/src/components/speed-dial/speed-dial.a11y.md
@@ -10,7 +10,23 @@ Keyboard behavior:
 - Enter or Space on the trigger toggles the dial through the native button.
 - Arrow keys on the trigger open the dial and focus the first enabled action.
 - Arrow keys, Home, and End move through enabled actions in the toolbar.
+- Tab from the final sequentially tabbable action returns focus to the trigger;
+  the same bridge applies when the focused final action is `tabindex="-1"` and
+  was reached with arrow-key navigation.
+- Shift+Tab from the first sequentially tabbable action, or from an earlier
+  arrow-focused action, returns focus to the nearest sequentially focusable
+  element before the SpeedDial. Shift+Tab from the open trigger focuses the
+  last sequentially tabbable action.
 - Escape closes the dial and returns focus to the trigger.
 
 Closed actions are kept mounted but inert so exit motion can complete without
 leaving focusable descendants behind.
+
+## Focus interaction review
+
+The portaled toolbar is treated as one sequential-focus region even though its
+DOM position is outside the trigger. The keyboard matrix above covers native
+Tab and Shift+Tab from the trigger and every enabled action, including actions
+excluded from sequential navigation with `tabindex="-1"` but still reachable by
+arrow keys. Focus remains inside the open region at each boundary, and Escape,
+activation, dismissal, or hiding returns focus to the trigger where applicable.

--- a/packages/components/src/components/speed-dial/speed-dial.svelte
+++ b/packages/components/src/components/speed-dial/speed-dial.svelte
@@ -242,6 +242,16 @@
   function handleTriggerKeydown(event: KeyboardEvent): void {
     if (hidden) return;
 
+    if (open && event.key === 'Tab' && event.shiftKey) {
+      const sequentialButtons = getSequentiallyTabbableActionButtons();
+      const lastButton = sequentialButtons.at(-1) ?? getEnabledActionButtons().at(-1);
+      if (lastButton) {
+        event.preventDefault();
+        lastButton.focus();
+      }
+      return;
+    }
+
     if (
       event.key !== 'ArrowUp' &&
       event.key !== 'ArrowDown' &&
@@ -267,13 +277,30 @@
     if (!target) return;
 
     const tabOrderButtons = getSequentiallyTabbableActionButtons();
-    if (event.key === 'Tab' && event.shiftKey && target === tabOrderButtons[0]) {
+    const targetIndex = getEnabledActionButtons().indexOf(target);
+    const firstTabOrderIndex = tabOrderButtons.length
+      ? getEnabledActionButtons().indexOf(tabOrderButtons[0]!)
+      : -1;
+    const lastTabOrderIndex = tabOrderButtons.length
+      ? getEnabledActionButtons().indexOf(tabOrderButtons.at(-1)!)
+      : -1;
+    if (
+      event.key === 'Tab' &&
+      event.shiftKey &&
+      targetIndex !== -1 &&
+      (firstTabOrderIndex === -1 || targetIndex <= firstTabOrderIndex)
+    ) {
       const previousTarget = getFocusTargetBeforeSpeedDial();
       event.preventDefault();
       (previousTarget ?? getTriggerElement())?.focus();
       return;
     }
-    if (event.key === 'Tab' && !event.shiftKey && target === tabOrderButtons.at(-1)) {
+    if (
+      event.key === 'Tab' &&
+      !event.shiftKey &&
+      targetIndex !== -1 &&
+      (lastTabOrderIndex === -1 || targetIndex >= lastTabOrderIndex)
+    ) {
       event.preventDefault();
       getTriggerElement()?.focus();
       return;

--- a/packages/components/src/components/speed-dial/speed-dial.svelte
+++ b/packages/components/src/components/speed-dial/speed-dial.svelte
@@ -147,7 +147,12 @@
   }
 
   function getEnabledActionButtons(): HTMLButtonElement[] {
-    return actionButtons.filter((button) => !button.disabled && isRenderedCandidate(button));
+    const buttons = actionsElement
+      ? Array.from(
+          actionsElement.querySelectorAll<HTMLButtonElement>('button.cinder-floating-action'),
+        )
+      : actionButtons;
+    return buttons.filter((button) => !button.disabled && isRenderedCandidate(button));
   }
 
   // A consumer can forward `tabindex="-1"` to a SpeedDialAction to keep it
@@ -160,8 +165,7 @@
     return getEnabledActionButtons().filter((button) => !hasNegativeTabIndex(button));
   }
 
-  function getKeyboardNavigationButtons(): HTMLButtonElement[] {
-    const enabledButtons = getEnabledActionButtons();
+  function getKeyboardNavigationButtons(enabledButtons: HTMLButtonElement[]): HTMLButtonElement[] {
     return resolvedDirection === 'up' || resolvedDirection === 'left'
       ? [...enabledButtons].reverse()
       : enabledButtons;
@@ -244,11 +248,12 @@
 
     if (open && event.key === 'Tab' && event.shiftKey) {
       const sequentialButtons = getSequentiallyTabbableActionButtons();
-      const lastButton = sequentialButtons.at(-1) ?? getEnabledActionButtons().at(-1);
-      if (lastButton) {
-        event.preventDefault();
-        lastButton.focus();
-      }
+      if (!actionsElement || !anchoredActions.positionReady || actionsElement.hasAttribute('inert'))
+        return;
+      const lastButton = sequentialButtons.at(-1);
+      if (!lastButton) return;
+      event.preventDefault();
+      lastButton.focus();
       return;
     }
 
@@ -276,13 +281,14 @@
     const target = event.target instanceof HTMLButtonElement ? event.target : null;
     if (!target) return;
 
-    const tabOrderButtons = getSequentiallyTabbableActionButtons();
-    const targetIndex = getEnabledActionButtons().indexOf(target);
+    const enabledButtons = getEnabledActionButtons();
+    const tabOrderButtons = enabledButtons.filter((button) => !hasNegativeTabIndex(button));
+    const targetIndex = enabledButtons.indexOf(target);
     const firstTabOrderIndex = tabOrderButtons.length
-      ? getEnabledActionButtons().indexOf(tabOrderButtons[0]!)
+      ? enabledButtons.indexOf(tabOrderButtons[0]!)
       : -1;
     const lastTabOrderIndex = tabOrderButtons.length
-      ? getEnabledActionButtons().indexOf(tabOrderButtons.at(-1)!)
+      ? enabledButtons.indexOf(tabOrderButtons.at(-1)!)
       : -1;
     if (
       event.key === 'Tab' &&
@@ -306,18 +312,18 @@
       return;
     }
 
-    const enabledButtons = getKeyboardNavigationButtons();
-    const currentIndex = enabledButtons.indexOf(target);
+    const keyboardButtons = getKeyboardNavigationButtons(enabledButtons);
+    const currentIndex = keyboardButtons.indexOf(target);
     if (currentIndex === -1) return;
 
-    const nextIndex = handleRovingKeydown(event, currentIndex, enabledButtons.length, {
+    const nextIndex = handleRovingKeydown(event, currentIndex, keyboardButtons.length, {
       horizontal: orientation === 'horizontal',
       vertical: orientation === 'vertical',
     });
     if (nextIndex === null) return;
 
     event.preventDefault();
-    enabledButtons[nextIndex]?.focus();
+    keyboardButtons[nextIndex]?.focus();
   }
 
   function bridgePortaledEvent(event: Event): void {

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -398,6 +398,49 @@ describe('SpeedDial', () => {
     expect(document.activeElement).toBe(precedingButton);
   });
 
+  test('reverse Tab from an arrow-focused untabbable first action returns before the SpeedDial', async () => {
+    const precedingButton = document.createElement('button');
+    precedingButton.textContent = 'Before SpeedDial';
+    document.body.append(precedingButton);
+    render(SpeedDialFixture);
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    const create = screen.getByRole('button', { name: 'Create' });
+    create.setAttribute('tabindex', '-1');
+    create.focus();
+    await fireEvent.keyDown(create, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(precedingButton);
+  });
+
+  test('forward Tab from an arrow-focused untabbable last action moves to the trigger', async () => {
+    render(SpeedDialFixture);
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    const share = screen.getByRole('button', { name: 'Share' });
+    share.setAttribute('tabindex', '-1');
+    share.focus();
+    await fireEvent.keyDown(share, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test('reverse Tab from the open trigger moves to the last sequential action', async () => {
+    render(SpeedDialFixture);
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    trigger.focus();
+    await fireEvent.keyDown(trigger, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Share' }));
+  });
+
   test('skips CSS-hidden controls when reversing from the first action', async () => {
     const hiddenButton = document.createElement('button');
     hiddenButton.style.display = 'none';

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -454,7 +454,12 @@ describe('SpeedDial', () => {
       action.setAttribute('tabindex', '-1');
     }
     trigger.focus();
-    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true });
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
     trigger.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(false);
@@ -466,7 +471,12 @@ describe('SpeedDial', () => {
     const trigger = screen.getByRole('button', { name: 'Quick actions' });
     const toolbar = document.querySelector<HTMLElement>('[role="toolbar"]')!;
     trigger.focus();
-    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true });
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
     trigger.dispatchEvent(event);
 
     expect(toolbar.hasAttribute('inert')).toBe(true);

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -441,6 +441,69 @@ describe('SpeedDial', () => {
     expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Share' }));
   });
 
+  test('leaves reverse Tab native when every action is untabbable', async () => {
+    const precedingButton = document.createElement('button');
+    precedingButton.textContent = 'Before SpeedDial';
+    document.body.append(precedingButton);
+    render(SpeedDialFixture);
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    for (const action of screen.getAllByRole('button').filter((button) => button !== trigger)) {
+      action.setAttribute('tabindex', '-1');
+    }
+    trigger.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true });
+    trigger.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test('leaves reverse Tab native while the portaled toolbar is inert', async () => {
+    render(SpeedDialFixture, { props: { open: true } });
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+    const toolbar = document.querySelector<HTMLElement>('[role="toolbar"]')!;
+    trigger.focus();
+    const event = new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true, bubbles: true });
+    trigger.dispatchEvent(event);
+
+    expect(toolbar.hasAttribute('inert')).toBe(true);
+    expect(event.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(trigger);
+  });
+
+  test('uses the toolbar DOM order after actions are reordered', async () => {
+    render(SpeedDialFixture);
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    const toolbar = screen.getByRole('toolbar', { name: 'Actions' });
+    const create = screen.getByRole('button', { name: 'Create' });
+    toolbar.append(create.closest('.cinder-speed-dial-action')!);
+    trigger.focus();
+    await fireEvent.keyDown(trigger, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(create);
+  });
+
+  test('evaluates rendered action candidates once per keydown', async () => {
+    render(SpeedDialFixture);
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    const create = screen.getByRole('button', { name: 'Create' });
+    const getComputedStyleSpy = spyOn(globalThis, 'getComputedStyle');
+    getComputedStyleSpy.mockClear();
+    await fireEvent.keyDown(create, { key: 'ArrowDown' });
+
+    expect(getComputedStyleSpy).toHaveBeenCalledTimes(12);
+    getComputedStyleSpy.mockRestore();
+  });
+
   test('skips CSS-hidden controls when reversing from the first action', async () => {
     const hiddenButton = document.createElement('button');
     hiddenButton.style.display = 'none';


### PR DESCRIPTION
## Summary

- bridge Tab and Shift+Tab across the portaled SpeedDial toolbar, including arrow-focused `tabindex="-1"` actions
- leave native navigation intact when every action is sequentially untabbable or the portaled toolbar is inert
- derive boundaries from current toolbar DOM order and avoid repeated rendered-candidate scans
- document the focus keyboard matrix and add regression coverage

Closes #1050

## Validation

Exact rebased head: `60c9ff9f0fdb51d0ac854438d97056e394f71513`

- `TZ=UTC LANG=en_US.UTF-8 bun test --preload ./scripts/preload.ts --conditions browser --conditions svelte --parallel=1 src/components/speed-dial/speed-dial.test.ts src/_internal/anchored-overlay.test.ts` - 46 pass
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder typecheck` - 0 errors
- `bun run --filter=@lostgradient/cinder lint:invariants`
- targeted Prettier and `git diff --check`
- pre-push fast sanity checks

The earlier Playwright failure was on the pre-mainline branch and exercised SelectionPopover, not SpeedDial. This exact head is rebased onto current `origin/main`, which contains the merged SelectionPopover and anchored-overlay fixes; fresh exact-head CI is the merge gate.