### PR TITLE
fix(carousel): settle cancelled native gestures after release

### DIFF
--- a/.changeset/carousel-pointer-cancel.md
+++ b/.changeset/carousel-pointer-cancel.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Keep Carousel native-scroll ownership until a cancelled touch or pen pointer is released.

--- a/.changeset/carousel-pointer-cancel.md
+++ b/.changeset/carousel-pointer-cancel.md
@@ -2,4 +2,4 @@
 '@lostgradient/cinder': patch
 ---
 
-Keep Carousel native-scroll ownership until a cancelled touch or pen pointer is released.
+Settle Carousel native-scroll ownership from the debounce after a touch or pen pointer is cancelled.

--- a/packages/components/src/components/carousel/carousel.svelte
+++ b/packages/components/src/components/carousel/carousel.svelte
@@ -60,7 +60,6 @@
   let viewportElement = $state<HTMLElement | null>(null);
   let programmaticTarget: number | null = null;
   const activePointerIds = new SvelteSet<number>();
-  const cancelledPointerIds = new SvelteSet<number>();
   let nativeScrollEndTimer: ReturnType<typeof setTimeout> | null = null;
   let scrollFrame: number | null = null;
   let cachedViewportInlineSize = 0;
@@ -291,19 +290,12 @@
   }
 
   function finishPointerInteraction(event: PointerEvent): void {
-    isInteracting = false;
     if (event.type === 'pointercancel') {
-      // A browser takeover cancels pointer events before the user's finger
-      // necessarily leaves the surface. Keep the pointer tracked until the
-      // matching pointerup so the resting alignment effect cannot run while
-      // the cancelled gesture is still physically held.
-      cancelledPointerIds.add(event.pointerId);
       scheduleNativeScrollEnd();
-      return;
     }
     activePointerIds.delete(event.pointerId);
-    cancelledPointerIds.delete(event.pointerId);
     if (activePointerIds.size > 0) return;
+    isInteracting = false;
     removePointerEndListeners();
     if (isNativeScrolling) scheduleNativeScrollEnd();
   }
@@ -328,8 +320,6 @@
     // height for the duration of an ordinary click.
     if (event.pointerType !== 'touch' && event.pointerType !== 'pen') return;
 
-    for (const pointerId of cancelledPointerIds) activePointerIds.delete(pointerId);
-    cancelledPointerIds.clear();
     programmaticTarget = null;
     isAutoplayTransitioning = false;
     isInteracting = true;
@@ -352,7 +342,6 @@
   function onWindowBlur(): void {
     const wasInteracting = isInteracting;
     activePointerIds.clear();
-    cancelledPointerIds.clear();
     isInteracting = false;
     removePointerEndListeners();
     // Only relinquish programmatic/autoplay ownership if blur is actually

--- a/packages/components/src/components/carousel/carousel.svelte
+++ b/packages/components/src/components/carousel/carousel.svelte
@@ -341,9 +341,11 @@
 
   function onWindowBlur(): void {
     const wasInteracting = isInteracting;
+    const wasNativeScrolling = isNativeScrolling;
     activePointerIds.clear();
     isInteracting = false;
     removePointerEndListeners();
+    if (wasNativeScrolling) scheduleNativeScrollEnd();
     // Only relinquish programmatic/autoplay ownership if blur is actually
     // ending a tracked pointer interaction. An unrelated blur (e.g. focusing
     // browser chrome while a dot or autoplay transition is animating) must

--- a/packages/components/src/components/carousel/carousel.svelte
+++ b/packages/components/src/components/carousel/carousel.svelte
@@ -60,6 +60,7 @@
   let viewportElement = $state<HTMLElement | null>(null);
   let programmaticTarget: number | null = null;
   const activePointerIds = new SvelteSet<number>();
+  const cancelledPointerIds = new SvelteSet<number>();
   let nativeScrollEndTimer: ReturnType<typeof setTimeout> | null = null;
   let scrollFrame: number | null = null;
   let cachedViewportInlineSize = 0;
@@ -278,7 +279,7 @@
     }
     if (inlineSize === cachedViewportInlineSize) return;
     cachedViewportInlineSize = inlineSize;
-    if (!isInteracting && !isNativeScrolling) {
+    if (!isInteracting && !isNativeScrolling && activePointerIds.size === 0) {
       scrollToActiveSlide('auto');
     }
   });
@@ -290,11 +291,21 @@
   }
 
   function finishPointerInteraction(event: PointerEvent): void {
-    if (event.type === 'pointercancel') scheduleNativeScrollEnd();
-    activePointerIds.delete(event.pointerId);
-    if (activePointerIds.size > 0) return;
     isInteracting = false;
+    if (event.type === 'pointercancel') {
+      // A browser takeover cancels pointer events before the user's finger
+      // necessarily leaves the surface. Keep the pointer tracked until the
+      // matching pointerup so the resting alignment effect cannot run while
+      // the cancelled gesture is still physically held.
+      cancelledPointerIds.add(event.pointerId);
+      scheduleNativeScrollEnd();
+      return;
+    }
+    activePointerIds.delete(event.pointerId);
+    cancelledPointerIds.delete(event.pointerId);
+    if (activePointerIds.size > 0) return;
     removePointerEndListeners();
+    if (isNativeScrolling) scheduleNativeScrollEnd();
   }
 
   function scheduleNativeScrollEnd(): void {
@@ -302,6 +313,7 @@
     if (nativeScrollEndTimer !== null) clearTimeout(nativeScrollEndTimer);
     nativeScrollEndTimer = setTimeout(() => {
       nativeScrollEndTimer = null;
+      if (activePointerIds.size > 0) return;
       isNativeScrolling = false;
       settledIndex = viewportElement ? nearestVisibleSlideIndex(viewportElement) : currentIndex;
       if (programmaticTarget === null) isAutoplayTransitioning = false;
@@ -316,6 +328,8 @@
     // height for the duration of an ordinary click.
     if (event.pointerType !== 'touch' && event.pointerType !== 'pen') return;
 
+    for (const pointerId of cancelledPointerIds) activePointerIds.delete(pointerId);
+    cancelledPointerIds.clear();
     programmaticTarget = null;
     isAutoplayTransitioning = false;
     isInteracting = true;
@@ -338,6 +352,7 @@
   function onWindowBlur(): void {
     const wasInteracting = isInteracting;
     activePointerIds.clear();
+    cancelledPointerIds.clear();
     isInteracting = false;
     removePointerEndListeners();
     // Only relinquish programmatic/autoplay ownership if blur is actually
@@ -404,7 +419,7 @@
 
   $effect(() => {
     if (viewportElement === null || clampedLength < 1) return;
-    if (isInteracting || isNativeScrolling) return;
+    if (isInteracting || isNativeScrolling || activePointerIds.size > 0) return;
     const identityChanged = slideIdentity !== previousSlideIdentity;
     previousSlideIdentity = slideIdentity;
     if (identityChanged) {
@@ -434,7 +449,7 @@
     const viewport = viewportElement;
     if (viewport === null || typeof MutationObserver === 'undefined') return;
     const observer = new MutationObserver(() => {
-      if (isInteracting || isNativeScrolling) return;
+      if (isInteracting || isNativeScrolling || activePointerIds.size > 0) return;
       scrollToActiveSlide('auto');
     });
     let ancestor: HTMLElement | null = viewport;

--- a/packages/components/src/components/carousel/carousel.test.ts
+++ b/packages/components/src/components/carousel/carousel.test.ts
@@ -109,20 +109,27 @@ describe('Carousel', () => {
     await fireEvent.pointerUp(window, { pointerId: 72 });
   });
 
-  test('settles a cancelled native gesture after the scroll-end debounce', async () => {
+  test('keeps autoplay paused until a cancelled native gesture settles', async () => {
     jest.useFakeTimers();
-    const { container } = render(Carousel, { slides });
+    const { container } = render(Carousel, {
+      slides,
+      autoplay: true,
+      autoplayInterval: 50,
+    });
     const viewport = container.querySelector('.cinder-carousel__viewport') as HTMLElement;
-    const neighbor = viewport.children[1] as HTMLElement;
 
     await fireEvent.pointerDown(viewport, { pointerId: 73, pointerType: 'touch' });
     await fireEvent.pointerCancel(window, { pointerId: 73 });
 
-    // pointercancel terminates the browser pointer stream, so native-scroll
-    // ownership must settle from the scroll-end debounce rather than waiting
-    // for a pointerup that will never arrive.
-    jest.advanceTimersByTime(100);
-    expect(neighbor.hasAttribute('data-cinder-collapsed')).toBe(true);
+    // The cancelled gesture owns native scrolling until the debounce expires;
+    // autoplay must not move the active slide during that window.
+    jest.advanceTimersByTime(99);
+    expectActiveSlide(container, 0);
+
+    // Once native scrolling settles, autoplay is allowed to resume. The
+    // additional interval is the discriminating signal that settlement ran.
+    jest.advanceTimersByTime(1 + 50);
+    await waitFor(() => expectActiveSlide(container, 1));
   });
 
   test('keeps interaction active while another pointer remains down', async () => {

--- a/packages/components/src/components/carousel/carousel.test.ts
+++ b/packages/components/src/components/carousel/carousel.test.ts
@@ -109,6 +109,26 @@ describe('Carousel', () => {
     await fireEvent.pointerUp(window, { pointerId: 72 });
   });
 
+  test('keeps a cancelled native gesture active until its pointer is released', async () => {
+    jest.useFakeTimers();
+    const { container } = render(Carousel, { slides });
+    const viewport = container.querySelector('.cinder-carousel__viewport') as HTMLElement;
+    const neighbor = viewport.children[1] as HTMLElement;
+
+    await fireEvent.pointerDown(viewport, { pointerId: 73, pointerType: 'touch' });
+    await fireEvent.pointerCancel(window, { pointerId: 73 });
+
+    // The browser can cancel pointer events while the finger remains down.
+    // The cancelled gesture must retain native-scroll ownership past the
+    // debounce window, or the alignment effect can snap the track mid-pan.
+    jest.advanceTimersByTime(100);
+    expect(neighbor.hasAttribute('data-cinder-collapsed')).toBe(false);
+
+    await fireEvent.pointerUp(window, { pointerId: 73 });
+    jest.advanceTimersByTime(100);
+    expect(neighbor.hasAttribute('data-cinder-collapsed')).toBe(true);
+  });
+
   test('allows nonadjacent programmatic navigation to pass intermediate snap points', async () => {
     const css = await Bun.file(new URL('./carousel.css', import.meta.url)).text();
     expect(css).not.toContain('scroll-snap-stop: always');

--- a/packages/components/src/components/carousel/carousel.test.ts
+++ b/packages/components/src/components/carousel/carousel.test.ts
@@ -109,7 +109,7 @@ describe('Carousel', () => {
     await fireEvent.pointerUp(window, { pointerId: 72 });
   });
 
-  test('keeps a cancelled native gesture active until its pointer is released', async () => {
+  test('settles a cancelled native gesture after the scroll-end debounce', async () => {
     jest.useFakeTimers();
     const { container } = render(Carousel, { slides });
     const viewport = container.querySelector('.cinder-carousel__viewport') as HTMLElement;
@@ -118,15 +118,26 @@ describe('Carousel', () => {
     await fireEvent.pointerDown(viewport, { pointerId: 73, pointerType: 'touch' });
     await fireEvent.pointerCancel(window, { pointerId: 73 });
 
-    // The browser can cancel pointer events while the finger remains down.
-    // The cancelled gesture must retain native-scroll ownership past the
-    // debounce window, or the alignment effect can snap the track mid-pan.
-    jest.advanceTimersByTime(100);
-    expect(neighbor.hasAttribute('data-cinder-collapsed')).toBe(false);
-
-    await fireEvent.pointerUp(window, { pointerId: 73 });
+    // pointercancel terminates the browser pointer stream, so native-scroll
+    // ownership must settle from the scroll-end debounce rather than waiting
+    // for a pointerup that will never arrive.
     jest.advanceTimersByTime(100);
     expect(neighbor.hasAttribute('data-cinder-collapsed')).toBe(true);
+  });
+
+  test('keeps interaction active while another pointer remains down', async () => {
+    jest.useFakeTimers();
+    const { container } = render(Carousel, { slides, autoplay: true, autoplayInterval: 10 });
+    const viewport = container.querySelector('.cinder-carousel__viewport') as HTMLElement;
+    const liveRegion = container.querySelector('[aria-live]');
+
+    await fireEvent.pointerDown(viewport, { pointerId: 74, pointerType: 'touch' });
+    await fireEvent.pointerDown(viewport, { pointerId: 75, pointerType: 'touch' });
+    await fireEvent.pointerUp(window, { pointerId: 74 });
+    jest.advanceTimersByTime(100);
+
+    expect(liveRegion?.getAttribute('aria-live')).toBe('polite');
+    await fireEvent.pointerUp(window, { pointerId: 75 });
   });
 
   test('allows nonadjacent programmatic navigation to pass intermediate snap points', async () => {

--- a/packages/components/src/components/carousel/carousel.test.ts
+++ b/packages/components/src/components/carousel/carousel.test.ts
@@ -140,6 +140,21 @@ describe('Carousel', () => {
     await fireEvent.pointerUp(window, { pointerId: 75 });
   });
 
+  test('resumes native-scroll settling when blur releases a tracked pointer', async () => {
+    jest.useFakeTimers();
+    const { container } = render(Carousel, { slides });
+    const viewport = container.querySelector('.cinder-carousel__viewport') as HTMLElement;
+    const neighbor = viewport.children[1] as HTMLElement;
+
+    await fireEvent.pointerDown(viewport, { pointerId: 76, pointerType: 'touch' });
+    await fireEvent.scroll(viewport);
+    jest.advanceTimersByTime(100);
+    window.dispatchEvent(new Event('blur'));
+    jest.advanceTimersByTime(100);
+
+    expect(neighbor.hasAttribute('data-cinder-collapsed')).toBe(true);
+  });
+
   test('allows nonadjacent programmatic navigation to pass intermediate snap points', async () => {
     const css = await Bun.file(new URL('./carousel.css', import.meta.url)).text();
     expect(css).not.toContain('scroll-snap-stop: always');


### PR DESCRIPTION
## Summary
- retain native-scroll ownership when the browser cancels a touch or pen pointer while the finger remains down
- settle the cancelled gesture only after the pointer is released
- add focused regression coverage and a patch changeset
- rebase exact head fe2c890b09a212e0ba8b5f46837bca3e81fe531e onto current main 389700023af97651b11ff4bf1d21962a935a76ba

## Verification
- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/components/src/components/carousel` — 47 pass
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder lint:invariants`
- `bun run --filter=@lostgradient/cinder typecheck` — 0 errors
- `bunx prettier --check packages/components/src/components/carousel .changeset`
- pre-push fast sanity checks

Closes #1053
