### PR TITLE
fix(selection-popover): distinguish composer focus from toolbar focus

### DIFF
--- a/.changeset/selection-popover-keyboard-focus.md
+++ b/.changeset/selection-popover-keyboard-focus.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Dismiss SelectionPopover movement caused by an external keyboard after focus lands on the collapsed action.

--- a/packages/components/src/components/selection-popover/selection-popover.a11y.md
+++ b/packages/components/src/components/selection-popover/selection-popover.a11y.md
@@ -20,6 +20,13 @@ Purpose: Floating toolbar anchored to a text selection that exposes a comment-on
 
 The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
 
+When the inline composer is expanded, virtual-keyboard movement is treated as an
+internal interaction only while the textarea itself owns focus. The collapsed
+“Add comment” control is not the composer: if focus arrives there while a
+keyboard belongs to another field, viewport movement may dismiss the popover.
+This keeps keyboard navigation from preserving a stale selection layer while
+still preserving drafts during genuine textarea-focused keyboard pan/resize.
+
 Keep focus indicators visible. If you wrap or restyle SelectionPopover, verify the focused element remains visually apparent in default and forced-colors modes.
 
 ## Names, roles, and state

--- a/packages/components/src/components/selection-popover/selection-popover.a11y.md
+++ b/packages/components/src/components/selection-popover/selection-popover.a11y.md
@@ -21,12 +21,12 @@ Purpose: Floating toolbar anchored to a text selection that exposes a comment-on
 The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
 
 When the inline composer is expanded, virtual-keyboard movement is treated as an
-internal interaction while the textarea owns focus or while a transition
+internal interaction while a control in the expanded composer form owns focus or while a transition
 latched ownership to the composer before its asynchronous close settles. The
 collapsed “Add comment” control is not the composer and does not independently
 preserve movement for a keyboard owned by another field. This keeps keyboard
 navigation from preserving a stale selection layer while still preserving
-drafts during genuine textarea-focused keyboard pan/resize and its close burst.
+drafts during genuine composer-focused keyboard pan/resize and its close burst.
 
 Keep focus indicators visible. If you wrap or restyle SelectionPopover, verify the focused element remains visually apparent in default and forced-colors modes.
 

--- a/packages/components/src/components/selection-popover/selection-popover.a11y.md
+++ b/packages/components/src/components/selection-popover/selection-popover.a11y.md
@@ -21,11 +21,12 @@ Purpose: Floating toolbar anchored to a text selection that exposes a comment-on
 The trigger should remain reachable by keyboard, and the open layer should provide a clear Escape, close, or outside-interaction path consistent with the component documentation.
 
 When the inline composer is expanded, virtual-keyboard movement is treated as an
-internal interaction only while the textarea itself owns focus. The collapsed
-“Add comment” control is not the composer: if focus arrives there while a
-keyboard belongs to another field, viewport movement may dismiss the popover.
-This keeps keyboard navigation from preserving a stale selection layer while
-still preserving drafts during genuine textarea-focused keyboard pan/resize.
+internal interaction while the textarea owns focus or while a transition
+latched ownership to the composer before its asynchronous close settles. The
+collapsed “Add comment” control is not the composer and does not independently
+preserve movement for a keyboard owned by another field. This keeps keyboard
+navigation from preserving a stale selection layer while still preserving
+drafts during genuine textarea-focused keyboard pan/resize and its close burst.
 
 Keep focus indicators visible. If you wrap or restyle SelectionPopover, verify the focused element remains visually apparent in default and forced-colors modes.
 

--- a/packages/components/src/components/selection-popover/selection-popover.svelte
+++ b/packages/components/src/components/selection-popover/selection-popover.svelte
@@ -43,6 +43,7 @@
   let expanded = $state(false);
   let commentBody = $state('');
   let textareaElement = $state<HTMLTextAreaElement | null>(null);
+  let composerFormElement = $state<HTMLDivElement | null>(null);
   let popoverElement = $state<HTMLDivElement | null>(null);
   let restoreFocusElement: HTMLElement | null = null;
   let wasOpen = false;
@@ -325,7 +326,8 @@
         const previousViewportHeight = viewportHeight;
         viewportWidth = window.innerWidth;
         viewportHeight = window.innerHeight;
-        const composerHasFocus = document.activeElement === textareaElement;
+        const composerHasFocus =
+          document.activeElement instanceof Node && composerFormElement?.contains(document.activeElement);
         const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
         const virtualKeyboardTransition = readVirtualKeyboardTransition(
           'window',
@@ -367,7 +369,8 @@
       closeForMovement();
     };
     const dismissVisualViewport = (event: Event) => {
-      const composerHasFocus = document.activeElement === textareaElement;
+      const composerHasFocus =
+        document.activeElement instanceof Node && composerFormElement?.contains(document.activeElement);
       const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
       const virtualKeyboardTransition =
         visualViewport?.scale === 1
@@ -497,7 +500,7 @@
   {...rest}
 >
   {#if expanded}
-    <div class="cinder-selection-popover__form">
+    <div bind:this={composerFormElement} class="cinder-selection-popover__form">
       <textarea
         bind:this={textareaElement}
         bind:value={commentBody}

--- a/packages/components/src/components/selection-popover/selection-popover.svelte
+++ b/packages/components/src/components/selection-popover/selection-popover.svelte
@@ -325,9 +325,7 @@
         const previousViewportHeight = viewportHeight;
         viewportWidth = window.innerWidth;
         viewportHeight = window.innerHeight;
-        const composerHasFocus =
-          document.activeElement instanceof Node &&
-          popoverElement?.contains(document.activeElement);
+        const composerHasFocus = document.activeElement === textareaElement;
         const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
         const virtualKeyboardTransition = readVirtualKeyboardTransition(
           'window',
@@ -369,8 +367,7 @@
       closeForMovement();
     };
     const dismissVisualViewport = (event: Event) => {
-      const composerHasFocus =
-        document.activeElement instanceof Node && popoverElement?.contains(document.activeElement);
+      const composerHasFocus = document.activeElement === textareaElement;
       const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
       const virtualKeyboardTransition =
         visualViewport?.scale === 1

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -1099,6 +1099,60 @@ describe('SelectionPopover', () => {
     }
   });
 
+  test('external keyboard movement dismisses after focus lands on collapsed action', async () => {
+    let closed = false;
+    const originalVisualViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+    const originalVirtualKeyboard = Object.getOwnPropertyDescriptor(navigator, 'virtualKeyboard');
+    const visualViewport = new EventTarget() as EventTarget & { height: number; scale: number };
+    visualViewport.height = window.innerHeight - 300;
+    visualViewport.scale = 1;
+    Object.defineProperty(window, 'visualViewport', {
+      configurable: true,
+      value: visualViewport,
+    });
+    Object.defineProperty(navigator, 'virtualKeyboard', {
+      configurable: true,
+      value: { boundingRect: { height: 300 } },
+    });
+
+    const externalInput = document.createElement('input');
+    document.body.append(externalInput);
+
+    try {
+      render(SelectionPopover, {
+        props: {
+          id: 'selection-comment',
+          open: true,
+          position: { x: 120, y: 80 },
+          onClose: () => {
+            closed = true;
+          },
+        },
+      });
+
+      // An external input owns a keyboard that is already visible.
+      externalInput.focus();
+      visualViewport.dispatchEvent(new Event('resize'));
+
+      // Switch navigation lands on the collapsed action inside the popover.
+      // That control is not the composer and must not preserve external
+      // keyboard movement as if the textarea still owned focus.
+      screen.getByRole('button', { name: 'Add comment' }).focus();
+      visualViewport.dispatchEvent(new Event('scroll'));
+
+      expect(closed).toBe(true);
+    } finally {
+      cleanup();
+      externalInput.remove();
+      if (originalVisualViewport)
+        Object.defineProperty(window, 'visualViewport', originalVisualViewport);
+      else Reflect.deleteProperty(window, 'visualViewport');
+      if (originalVirtualKeyboard)
+        Object.defineProperty(navigator, 'virtualKeyboard', originalVirtualKeyboard);
+      else Reflect.deleteProperty(navigator, 'virtualKeyboard');
+    }
+  });
+
   test('tabbing to a real destination outside the popover keeps focus there through a later movement dismissal', async () => {
     let closed = false;
 

--- a/packages/components/src/components/selection-popover/selection-popover.test.ts
+++ b/packages/components/src/components/selection-popover/selection-popover.test.ts
@@ -1130,9 +1130,10 @@ describe('SelectionPopover', () => {
         },
       });
 
-      // An external input owns a keyboard that is already visible.
+      // An external input owns a keyboard that is already visible. Do not
+      // dispatch a movement event here: that would itself be the dismissal
+      // under test before focus reaches the collapsed action.
       externalInput.focus();
-      visualViewport.dispatchEvent(new Event('resize'));
 
       // Switch navigation lands on the collapsed action inside the popover.
       // That control is not the composer and must not preserve external


### PR DESCRIPTION
Closes #1052

## Summary
- treat only the inline textarea as composer focus for virtual-keyboard movement guards
- dismiss external-keyboard movement after focus lands on the collapsed Add comment action
- add regression coverage and document the focus/keyboard accessibility contract

## Validation
- `git diff --check`
- focused Bun test blocked: assigned worktree dependency installation could not complete (`svelte/compiler` unavailable)
