### PR TITLE
fix: cover primitive composition analyzer edge cases

### DIFF
--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -244,6 +244,15 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('preserves skipped paths through conditional compound composition', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = ''; if (custom) tag += 'custom-'; tag += 'input';</script><svelte:element this={tag} />",
+        'conditional-compound/conditional-compound.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('rejects an added raw control in a tracked file', () => {
     expect(
       findPrimitiveCompositionViolations('<input /><input />', 'pin-input/pin-input.svelte'),
@@ -572,6 +581,15 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('keeps only the terminal write within a conditional branch', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; if (dense) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; layout = { display: 'block' }; }</script><div style={layout}></div>",
+        'terminal-branch/terminal-branch.svelte',
+      ),
+    ).toEqual([]);
+  });
+
   test('resolves style-object bindings wrapped in a TypeScript `as const` assertion', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -768,6 +786,15 @@ describe('primitive composition guard', () => {
         'negated-tag/negated-tag.css',
       ),
     ).toEqual([]);
+  });
+
+  test('allows overlap when a negation excludes only a compound selector', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        'input { display: grid; } input:not(.disabled) { grid-template-columns: 1fr; }',
+        'compound-negation/compound-negation.css',
+      ),
+    ).toHaveLength(1);
   });
 
   test('allows a negated selector to overlap a generic peer', () => {
@@ -1024,6 +1051,15 @@ describe('primitive composition guard', () => {
         'mutable-field/mutable-field.svelte',
       ),
     ).toHaveLength(1);
+  });
+
+  test('ignores assignments to shadowed field tags', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function helper() { let tag = 'span'; tag = 'label'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'shadowed-field/shadowed-field.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('recognizes modern width range media conditions', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -92,6 +92,15 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('invalidates prior hidden proof after a nested dynamic spread', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '<script>const attrs = { hidden: false };</script><input hidden {...{ ...attrs }} />',
+        'new-control/new-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('allows a later static hidden type to re-establish proof after a dynamic spread', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -634,6 +643,20 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('short-circuits statically unreachable style-object branches', () => {
+    for (const expression of [
+      "false && { display: 'grid', gridTemplateColumns: '1fr' }",
+      "true || { display: 'grid', gridTemplateColumns: '1fr' }",
+      "'block' ?? { display: 'grid', gridTemplateColumns: '1fr' }",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<div style={${expression}}></div>`,
+          'short-circuit-style/short-circuit-style.svelte',
+        ),
+      ).toEqual([]);
+  });
+
   test('preserves top-level conditional style-object assignment branches', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -990,6 +1013,15 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('preserves important declarations over later normal declarations', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '.layout { display: grid !important; display: block; grid-template-columns: 1fr; }',
+        'important-grid/important-grid.css',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('reads only actual Svelte style blocks', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -1151,6 +1183,24 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         '@media not screen { .layout { display: grid; } } @media screen { .layout { grid-template-columns: 1fr; } }',
         'new-layout/new-layout.css',
+      ),
+    ).toEqual([]);
+  });
+
+  test('allows negated media types to overlap different positive types', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media not screen { .layout { display: grid; } } @media print { .layout { grid-template-columns: 1fr; } }',
+        'negated-media-overlap/negated-media-overlap.css',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('treats not all media branches as unreachable', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media not all { .layout { display: grid; } } .layout { grid-template-columns: 1fr; }',
+        'unreachable-media/unreachable-media.css',
       ),
     ).toEqual([]);
   });
@@ -1332,6 +1382,15 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('counts controls in every reachable raw HTML candidate', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let markup = '<div></div>'; function show() { markup = '<input aria-label=\"Name\">'; }</script><button onclick={show}>Show</button>{@html markup}",
+        'mutable-html-control/mutable-html-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('keeps raw HTML field evidence isolated by reachable candidate', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -1495,6 +1554,21 @@ describe('primitive composition guard', () => {
         'returning-control-handler/returning-control-handler.svelte',
       ),
     ).toHaveLength(1);
+  });
+
+  test('ignores raw controls in statically unreachable branches and loops', () => {
+    for (const statement of [
+      "if (false) tag = 'input';",
+      "while (false) tag = 'input';",
+      "for (; false;) tag = 'input';",
+      "for (const item of []) tag = 'input';",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'div'; ${statement}</script><svelte:element this={tag} />`,
+          'unreachable-control-write/unreachable-control-write.svelte',
+        ),
+      ).toEqual([]);
   });
 
   test('treats immediately invoked tag writes as synchronous', () => {
@@ -2132,6 +2206,138 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         '<header><label>Sort</label></header><section><p>Help</p><p>Error log</p></section>',
         'new-field/new-field.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('resolves aliases declared inside control callbacks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show() { const controlTag = 'input'; tag = controlTag; }</script><svelte:element this={tag} />",
+        'callback-control-alias/callback-control-alias.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves mutable control states that leave loops through continue', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; for (let i = 0; i < 1; i++) { if (true) { tag = 'input'; continue; } tag = 'div'; }</script><svelte:element this={tag} />",
+        'continue-control-state/continue-control-state.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('evaluates switch case tests before merging control branches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch ('no') { case (tag = 'input'): break; }</script><svelte:element this={tag} />",
+        'switch-test-control/switch-test-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('discards synchronous IIFE return states after later writes', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; (() => { tag = 'input'; return; })(); tag = 'div';</script><svelte:element this={tag} />",
+        'iife-return-control/iife-return-control.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('preserves field tags from conditionally returning branches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show() { if (true) { tag = 'label'; return; } tag = 'span'; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'conditional-return-field/conditional-return-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves zero-entry field-tag loop states', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'label'; for (const item of []) tag = 'span';</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'zero-entry-field-loop/zero-entry-field-loop.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('keeps only terminal style writes within one callback', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function enable() { layout = { display: 'grid', gridTemplateColumns: '1fr' }; layout = { display: 'block' }; }</script><div style={layout} onclick={enable}></div>",
+        'terminal-callback-style/terminal-callback-style.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('preserves terminal style states from independent callbacks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function enable() { layout = { display: 'grid', gridTemplateColumns: '1fr' }; } function disable() { layout = { display: 'block' }; }</script><div style={layout} onclick={enable} onkeydown={disable}></div>",
+        'independent-callback-style/independent-callback-style.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('discards synchronous nested style writes before a later terminal write', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function outer() { (() => { layout = { display: 'grid', gridTemplateColumns: '1fr' }; })(); layout = { display: 'block' }; }</script><div style={layout} onclick={outer}></div>",
+        'nested-callback-style/nested-callback-style.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('rejects selector pairs under incompatible direct parents', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        'section > .layout { display: grid; } article > .layout { grid-template-columns: 1fr; }',
+        'direct-parent-grid/direct-parent-grid.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        'section.foo > .layout { display: grid; } article.bar > .layout { grid-template-columns: 1fr; }',
+        'direct-parent-grid/direct-parent-grid.css',
+      ),
+    ).toEqual([]);
+  });
+
+  test('merges try and catch as alternative control states', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; try { tag = 'input'; } catch { tag = 'div'; }</script><svelte:element this={tag} />",
+        'try-catch-control/try-catch-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('keeps mutually exclusive template field evidence separate', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '{#if ready}<label>Name</label>{:else}<p>Help</p><p>Error</p>{/if}',
+        'template-field-branches/template-field-branches.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('applies switch-wide lexical shadowing to control tags', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch (1) { case 1: let tag = 'input'; break; }</script><svelte:element this={tag} />",
+        'switch-control-shadow/switch-control-shadow.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('marks conflicting functional tag constraints impossible', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        'input:is(select) { display: grid; grid-template-columns: 1fr; }',
+        'functional-tag-conflict/functional-tag-conflict.css',
       ),
     ).toEqual([]);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -2671,6 +2671,31 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('preserves IIFE returns and skips defaults for definitely supplied values', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; (() => { if (custom) { tag = 'input'; return; } tag = 'div'; })();</script><svelte:element this={tag} />",
+        'iife-control-flow/iife-control-flow.svelte',
+      ),
+    ).toHaveLength(1);
+    for (const argument of ['{}', '[]', 'function supplied() {}', 'class Supplied {}'])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'div'; ((value = (tag = 'input')) => {})(${argument});</script><svelte:element this={tag} />`,
+          'iife-default/iife-default.svelte',
+        ),
+      ).toEqual([]);
+  });
+
+  test('inspects static alternatives in raw HTML expressions', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        `{@html ready ? '<input aria-label="Name">' : '<div></div>'}`,
+        'raw-html-alternatives/raw-html-alternatives.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('models field-tag ternaries, try-catch paths, and bare-block shadowing', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -2684,6 +2709,20 @@ describe('primitive composition guard', () => {
     ])
       expect(
         findPrimitiveCompositionViolations(source, 'field-control-flow/field-control-flow.svelte'),
+      ).toHaveLength(1);
+  });
+
+  test('respects template-local shadows when pruning field IfBlocks', () => {
+    for (const source of [
+      '<script>const ready = true;</script>{#each items as ready}{#if ready}<div>Okay</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/if}{/each}',
+      '<script>const ready = true;</script>{#snippet render(ready)}{#if ready}<div>Okay</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/if}{/snippet}',
+      '<script>const ready = true;</script>{#await promise then ready}{#if ready}<div>Okay</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/if}{/await}',
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          source,
+          'template-field-shadow/template-field-shadow.svelte',
+        ),
       ).toHaveLength(1);
   });
 
@@ -2728,6 +2767,33 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         'input:is(select) { display: grid; grid-template-columns: 1fr; }',
         'functional-tag-conflict/functional-tag-conflict.css',
+      ),
+    ).toEqual([]);
+  });
+
+  test('retains every repeated attribute constraint when checking contradictions', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-x^='a'][data-x$='b'][data-x='cb'] { display: grid; grid-template-columns: 1fr; }",
+        'repeated-attribute-constraints/repeated-attribute-constraints.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-x^='a'][data-x$='b'][data-x='ab'] { display: grid; grid-template-columns: 1fr; }",
+        'repeated-attribute-constraints/repeated-attribute-constraints.css',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-x='ab'] { display: grid; } .layout:not([data-x^='b'][data-x='ab']) { grid-template-columns: 1fr; }",
+        'repeated-attribute-constraints/repeated-attribute-constraints.css',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-x='ab'] { display: grid; } .layout:not([data-x^='a'][data-x='ab']) { grid-template-columns: 1fr; }",
+        'repeated-attribute-constraints/repeated-attribute-constraints.css',
       ),
     ).toEqual([]);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -527,6 +527,14 @@ describe('primitive composition guard', () => {
     ).toBe(0);
   });
 
+  test('preserves conditional query branches joined with or', () => {
+    expect(
+      cssPrimitiveCounts(
+        '@media (width < 40rem) or (width > 80rem) { .layout { display: grid; } } @media (width < 40rem) or (width > 80rem) { .layout { grid-template-columns: 1fr; } }',
+      ).grid,
+    ).toBe(1);
+  });
+
   test('rejects a hand-rolled grid in an inline style', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -2123,6 +2131,18 @@ describe('primitive composition guard', () => {
         'new-layout/new-layout.css',
       ),
     ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media (width <= 40rem) { .layout { display: grid; } } @media (width >= 40rem) { .layout { grid-template-columns: 1fr; } }',
+        'new-layout/new-layout.css',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media (width < 40rem) { .layout { display: grid; } } @media (width > 39.9999995rem) { .layout { grid-template-columns: 1fr; } }',
+        'new-layout/new-layout.css',
+      ),
+    ).toHaveLength(1);
   });
 
   test('recognizes value-first width range media conditions', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -599,6 +599,19 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('does not restore a prior style binding after an unresolved branch overwrite', () => {
+    for (const conditionalWrite of [
+      "if (dense) layout = Object.freeze({ display: 'block' }); else layout = { display: 'block' };",
+      "dense ? layout = Object.freeze({ display: 'block' }) : layout = { display: 'block' };",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; ${conditionalWrite}</script><div style={layout}></div>`,
+          'unknown-branch-style/unknown-branch-style.svelte',
+        ),
+      ).toEqual([]);
+  });
+
   test('resolves style-object bindings wrapped in a TypeScript `as const` assertion', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -819,6 +832,15 @@ describe('primitive composition guard', () => {
     expect(
       findPrimitiveCompositionViolations(
         'input { display: grid; } .layout:not(input.disabled) { grid-template-columns: 1fr; }',
+        'compound-negation/compound-negation.css',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('distinguishes attribute constraints inside a negated compound tag', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "input[data-state='a'] { display: grid; } .layout[data-state='a']:not(input[data-state='b']) { grid-template-columns: 1fr; }",
         'compound-negation/compound-negation.css',
       ),
     ).toHaveLength(1);
@@ -1105,6 +1127,29 @@ describe('primitive composition guard', () => {
         'conditional-field/conditional-field.svelte',
       ),
     ).toHaveLength(1);
+  });
+
+  test('retains both reachable field-tag values across ternary branches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; custom ? (tag = 'label') : (tag = 'span');</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'conditional-field/conditional-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('keeps loop-initializer field tags scoped to the loop', () => {
+    for (const loop of [
+      "for (let tag = 'span'; ready; ready = false) { tag = 'label'; }",
+      "for (let tag of tags) { tag = 'label'; }",
+      "for (let tag in tags) { tag = 'label'; }",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'div'; ${loop}</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>`,
+          'loop-shadow-field/loop-shadow-field.svelte',
+        ),
+      ).toEqual([]);
   });
 
   test('does not report an intermediate raw-control compound tag value', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -1085,13 +1085,13 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
-  test('does not resolve ambiguous mutable HtmlTag field bindings by array order', () => {
+  test('inspects every reachable mutable HtmlTag field binding', () => {
     expect(
       findPrimitiveCompositionViolations(
         "<script>let markup = '<div></div>'; if (custom) markup = '<label>Name</label><p>Help</p><p>Error</p>'; else markup = '<div></div>';</script>{@html markup}",
         'html-field/html-field.svelte',
       ),
-    ).toEqual([]);
+    ).toHaveLength(1);
   });
 
   test('matches completed compound pseudo alternatives', () => {
@@ -1276,6 +1276,187 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>var tag = 'label'; var tag;</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
         'mutable-field/mutable-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('counts field wrappers in every reachable raw HTML candidate', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let markup = '<span>Ready</span>'; function show() { markup = '<label>Name</label><p>Description</p><p>Error message</p>'; }</script>{@html markup}",
+        'mutable-html-field/mutable-html-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('keeps raw HTML field evidence isolated by reachable candidate', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let markup = '<label>Name</label><p>Help</p>'; function show() { markup = '<p>Error message</p>'; }</script>{@html markup}",
+        'branched-html-field/branched-html-field.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('resolves function-local aliases assigned to mutable field tags', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show() { const fieldTag = 'label'; tag = fieldTag; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'local-field-alias/local-field-alias.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('does not treat renamed object-pattern keys as field-tag shadows', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show({ tag: localTag }) { tag = 'label'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'renamed-field-parameter/renamed-field-parameter.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('resolves mutable field aliases in source order', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let fieldTag = 'span'; fieldTag = 'label'; let tag = fieldTag;</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'ordered-field-alias/ordered-field-alias.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves callback field-tag states declared before their binding', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>function show() { tag = 'label'; } let tag = 'div';</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'forward-field-callback/forward-field-callback.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('resolves later-declared aliases inside deferred field callbacks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>function show() { tag = fieldTag; } let fieldTag = 'label'; let tag = 'div';</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'forward-field-alias/forward-field-alias.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('tracks field-tag assignments from inline handlers', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div';</script><button onclick={() => tag = 'label'}>Show</button><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'inline-field-handler/inline-field-handler.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('tracks compound field-tag assignments', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'lab'; tag += 'el';</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'compound-field-tag/compound-field-tag.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves raw controls from abruptly terminated handler branches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function setTag() { if (custom) { tag = 'input'; return; } tag = 'div'; }</script><svelte:element this={tag} />",
+        'returning-control-handler/returning-control-handler.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('treats immediately invoked tag writes as synchronous', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; (() => { tag = 'div'; })();</script><svelte:element this={tag} />",
+        'invoked-control-write/invoked-control-write.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('preserves the skipped path through mutable control loops', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; for (const item of items) tag = 'div';</script><svelte:element this={tag} />",
+        'loop-control-write/loop-control-write.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('applies guaranteed loop writes without retaining stale control states', () => {
+    for (const source of [
+      "<script>let tag = 'input'; for (tag = 'div'; false; ) {}</script><svelte:element this={tag} />",
+      "<script>let tag = 'input'; do { tag = 'div'; } while (false);</script><svelte:element this={tag} />",
+      "<script>let tag = 'div'; for (const tag of ['input']) {}</script><svelte:element this={tag} />",
+      "<script>let tag = 'input'; while (true) { tag = 'div'; break; }</script><svelte:element this={tag} />",
+      "<script>let tag = 'input'; for (; true; ) { tag = 'div'; break; }</script><svelte:element this={tag} />",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(source, 'loop-control-state/loop-control-state.svelte'),
+      ).toEqual([]);
+  });
+
+  test('preserves raw controls across initializer-free var redeclarations', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>var tag = 'input'; var tag;</script><svelte:element this={tag} />",
+        'var-control-redeclaration/var-control-redeclaration.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('merges mutable control switch cases', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch (kind) { case 'edit': tag = 'input'; break; default: tag = 'div'; }</script><svelte:element this={tag} />",
+        'switch-control-write/switch-control-write.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves callback-derived style states across later top-level writes', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function enable() { layout = { display: 'grid', gridTemplateColumns: '1fr' }; } layout = { display: 'block' };</script><div style={layout}></div>",
+        'future-style-state/future-style-state.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('resolves style aliases from source-ordered mutable state', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let base = { display: 'block' }; base = { display: 'grid', gridTemplateColumns: '1fr' }; let layout = base;</script><div style={layout}></div>",
+        'ordered-style-alias/ordered-style-alias.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('keeps post-block callback style writes outside lexical shadows', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function enable() { if (local) { let layout = { display: 'grid', gridTemplateColumns: '1fr' }; } layout = { display: 'grid', gridTemplateColumns: '1fr' }; }</script><div style={layout}></div>",
+        'block-style-shadow/block-style-shadow.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('rejects compound-negation anchors contradicted by the merged selector', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '.foo:not(input.bar) { display: grid; } input.bar { grid-template-columns: 1fr; }',
+        'split-compound-negation/split-compound-negation.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        'input { display: grid; } .foo:not(input.bar) { grid-template-columns: 1fr; }',
+        'valid-compound-negation/valid-compound-negation.css',
       ),
     ).toHaveLength(1);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -1883,6 +1883,12 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
     expect(
       findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; switch (mode) { case 1: if (stop) break; else break; layout = { display: 'grid', gridTemplateColumns: '1fr' }; }</script><div style={layout}></div>",
+        'switch-branch-break-style/switch-branch-break-style.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
         "<script>let layout = { display: 'block' }; switch (1) { case 1: layout = { display: 'block' }; break; case 2: layout = { display: 'grid', gridTemplateColumns: '1fr' }; }</script><div style={layout}></div>",
         'switch-break-style/switch-break-style.svelte',
       ),
@@ -2133,6 +2139,12 @@ describe('primitive composition guard', () => {
         'switch-block-break/switch-block-break.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch (kind) { case 'edit': if (stop) break; else break; tag = 'input'; }</script><svelte:element this={tag} />",
+        'switch-branch-break/switch-branch-break.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('preserves control states from conditional switch breaks', () => {
@@ -2908,6 +2920,12 @@ describe('primitive composition guard', () => {
         'break-field-loop/break-field-loop.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let ready = true; let tag = 'span'; for (; ready; tag = 'label') { if (stop) break; else break; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'branch-break-field-loop/branch-break-field-loop.svelte',
+      ),
+    ).toEqual([]);
     expect(
       findPrimitiveCompositionViolations(
         "<script>let ready = true; let tag = 'span'; for (; ready; tag = 'label') { tag = 'span'; if (stop) break; ready = false; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -92,15 +92,6 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
-  test('invalidates prior hidden proof after a nested unresolvable object spread', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        "<input {...{ type: 'hidden', ...attrs }} />",
-        'new-control/new-control.svelte',
-      ),
-    ).toHaveLength(1);
-  });
-
   test('allows a later static hidden type to re-establish proof after a dynamic spread', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -244,6 +235,15 @@ describe('primitive composition guard', () => {
       ).toHaveLength(1);
   });
 
+  test('preserves conditional predecessors before compound tag composition', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = ''; if (custom) tag = 'custom-'; tag += 'input';</script><svelte:element this={tag} />",
+        'compound-tag/compound-tag.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('rejects an added raw control in a tracked file', () => {
     expect(
       findPrimitiveCompositionViolations('<input /><input />', 'pin-input/pin-input.svelte'),
@@ -346,12 +346,6 @@ describe('primitive composition guard', () => {
       '[data-layout] { display: grid; } [data-layout][data-columns] { grid-template-columns: 1fr; }',
     ])
       expect(cssPrimitiveCounts(source).grid).toBe(1);
-  });
-
-  test('pairs selectors that can overlap through a tag and a class anchor', () => {
-    expect(
-      cssPrimitiveCounts('.layout { display: grid; } section { grid-template-columns: 1fr; }').grid,
-    ).toBe(1);
   });
 
   test('recognizes row, area, auto-column, and grid shorthand layouts', () => {
@@ -545,24 +539,6 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
-  test('keeps a top-level conditional style write reachable with its initializer', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; if (compact) layout = { display: 'block' };</script><div style={layout}></div>",
-        'new-grid/new-grid.svelte',
-      ),
-    ).toHaveLength(1);
-  });
-
-  test('resolves style-object aliases through mutable bindings', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        "<script>const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' }; let layout = gridStyle;</script><div style={layout}></div>",
-        'new-grid/new-grid.svelte',
-      ),
-    ).toHaveLength(1);
-  });
-
   test('resolves a conditional/logical expression assigned to a mutable style-object binding', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -574,6 +550,24 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let layout = { display: 'block' }; layout = dense && { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
         'new-grid/new-grid.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves top-level conditional style-object assignment branches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; dense ? layout = { display: 'grid', gridTemplateColumns: '1fr' } : layout = { display: 'block' };</script><div style={layout}></div>",
+        'conditional-style/conditional-style.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('propagates all reachable mutable style aliases', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let base = { display: 'block' }; function enable() { base = { display: 'grid', gridTemplateColumns: '1fr' }; } let layout; function assign() { layout = base; }</script><div style={layout}></div>",
+        'alias-style/alias-style.svelte',
       ),
     ).toHaveLength(1);
   });
@@ -676,26 +670,6 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
-  test('retains dynamic attributes when matching shared floating targets', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        '.menu[data-open] { position: absolute; z-index: 1; }',
-        'new-menu/new-menu.css',
-        '<script>let open = true;</script><div class="menu cinder-_floating-surface" data-open={open}></div>',
-      ),
-    ).toEqual([]);
-  });
-
-  test('does not exempt a shared selector when an uncomposed sibling also matches', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        '.menu { position: absolute; z-index: 1; }',
-        'new-menu/new-menu.css',
-        '<div class="menu cinder-_floating-surface"></div><div class="menu"></div>',
-      ),
-    ).toHaveLength(1);
-  });
-
   test('scopes the floating-surface exemption to the matching rendered element', () => {
     const floatingCss = '.menu { position: absolute; z-index: 1; }';
     expect(
@@ -787,6 +761,15 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('keeps negated tagged selectors disjoint', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        'input { display: grid; } .layout:not(input) { grid-template-columns: 1fr; }',
+        'negated-tag/negated-tag.css',
+      ),
+    ).toEqual([]);
+  });
+
   test('allows a negated selector to overlap a generic peer', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -854,15 +837,6 @@ describe('primitive composition guard', () => {
         'polymorphic/polymorphic.svelte',
       ),
     ).toHaveLength(1);
-  });
-
-  test('evaluates compound polymorphic tag assignments', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        "<script>let tag = 'custom-'; tag += 'input';</script><svelte:element this={tag} />",
-        'polymorphic/polymorphic.svelte',
-      ),
-    ).toEqual([]);
   });
 
   test('keeps grid style branches independent', () => {
@@ -1006,15 +980,6 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
-  test('resolves mutable polymorphic label bindings for field-wrapper evidence', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        "<script>let tag = 'label';</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
-        'new-field/new-field.svelte',
-      ),
-    ).toHaveLength(1);
-  });
-
   test('recognizes static class objects', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -1050,6 +1015,15 @@ describe('primitive composition guard', () => {
         'polymorphic/polymorphic.svelte',
       ),
     ).toEqual([]);
+  });
+
+  test('follows mutable polymorphic field tags', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; tag = 'label';</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'mutable-field/mutable-field.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('recognizes modern width range media conditions', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -375,6 +375,14 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('associates tag-only selectors with id and attribute selectors across rules', () => {
+    for (const source of [
+      'section { display: grid; } #layout { grid-template-columns: 1fr; }',
+      'section { display: grid; } [data-layout] { grid-template-columns: 1fr; }',
+    ])
+      expect(cssPrimitiveCounts(source).grid).toBe(1);
+  });
+
   test('recognizes row, area, auto-column, and grid shorthand layouts', () => {
     for (const property of [
       'grid-template-rows',
@@ -1384,6 +1392,38 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let tag = 'input'; for (const item of items) tag = 'div';</script><svelte:element this={tag} />",
         'loop-control-write/loop-control-write.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves the skipped path through logical control writes', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; ready && (tag = 'div');</script><svelte:element this={tag} />",
+        'logical-control-write/logical-control-write.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('applies statically guaranteed logical control writes', () => {
+    for (const expression of [
+      "true && (tag = 'div')",
+      "false || (tag = 'div')",
+      "null ?? (tag = 'div')",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'input'; ${expression};</script><svelte:element this={tag} />`,
+          'guaranteed-logical-control-write/guaranteed-logical-control-write.svelte',
+        ),
+      ).toEqual([]);
+  });
+
+  test('tracks mutable control writes in default parameters', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show(unused = (tag = 'input')) {}</script><button onclick={() => show()}>Show</button><svelte:element this={tag} />",
+        'default-parameter-control/default-parameter-control.svelte',
       ),
     ).toHaveLength(1);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -788,6 +788,15 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('does not use negated alternatives as shared selector anchors', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '.layout:not(.disabled) { display: grid; } .disabled { grid-template-columns: 1fr; }',
+        'new-layout/new-layout.css',
+      ),
+    ).toEqual([]);
+  });
+
   test('keeps negated tagged selectors disjoint', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -1103,6 +1112,33 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let tag = ''; if (custom) tag += 'input'; tag += '-wrapper';</script><svelte:element this={tag} />",
         'compound-control/compound-control.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not report a raw-control value overwritten inside one conditional branch', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; if (custom) { tag = 'input'; tag = 'div'; }</script><svelte:element this={tag} />",
+        'terminal-conditional-control/terminal-conditional-control.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not retain an intermediate field tag overwritten inside one conditional branch', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; if (custom) { tag = 'label'; tag = 'span'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'terminal-conditional-field/terminal-conditional-field.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('clears field-tag evidence after an unresolvable overwrite', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'label'; tag = dynamicTag;</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'dynamic-field-tag/dynamic-field-tag.svelte',
       ),
     ).toEqual([]);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -2678,13 +2678,31 @@ describe('primitive composition guard', () => {
         'iife-control-flow/iife-control-flow.svelte',
       ),
     ).toHaveLength(1);
-    for (const argument of ['{}', '[]', 'function supplied() {}', 'class Supplied {}'])
+    for (const argument of [
+      '{}',
+      '[]',
+      'function supplied() {}',
+      'class Supplied {}',
+      '`supplied`',
+      'new Object()',
+    ])
       expect(
         findPrimitiveCompositionViolations(
           `<script>let tag = 'div'; ((value = (tag = 'input')) => {})(${argument});</script><svelte:element this={tag} />`,
           'iife-default/iife-default.svelte',
         ),
       ).toEqual([]);
+  });
+
+  test('preserves try prefixes, local alias alternatives, and pre-await control states', () => {
+    for (const source of [
+      "<script>let tag = 'div'; function show() { try { tag = 'input'; risky(); tag = 'div'; } catch {} }</script><svelte:element this={tag} onclick={show} />",
+      "<script>let tag = 'div'; function show() { const next = ready ? 'input' : 'div'; tag = next; }</script><svelte:element this={tag} onclick={show} />",
+      "<script>let tag = 'div'; async function show() { tag = 'input'; await tick(); tag = 'div'; }</script><svelte:element this={tag} onclick={show} />",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(source, 'observable-control/observable-control.svelte'),
+      ).toHaveLength(1);
   });
 
   test('inspects static alternatives in raw HTML expressions', () => {
@@ -2706,6 +2724,7 @@ describe('primitive composition guard', () => {
     for (const source of [
       "<script>let tag = 'span'; function show() { try { tag = 'label'; } catch { tag = 'span'; } }</script><svelte:element this={tag} onclick={show}>Name</svelte:element><p>Help</p><p>Error</p>",
       "<script>let tag = 'label'; { let tag = 'span'; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+      "<script>let tag = 'span'; function show() { if (custom) { if (cancel) return; tag = 'label'; } }</script><svelte:element this={tag} onclick={show}>Name</svelte:element><p>Help</p><p>Error</p>",
     ])
       expect(
         findPrimitiveCompositionViolations(source, 'field-control-flow/field-control-flow.svelte'),
@@ -2796,6 +2815,27 @@ describe('primitive composition guard', () => {
         'repeated-attribute-constraints/repeated-attribute-constraints.css',
       ),
     ).toEqual([]);
+  });
+
+  test('respects nested functional constraints in negated alternatives', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '.layout:not(:is(.disabled)) { display: grid; grid-template-columns: 1fr; }',
+        'nested-functional-negation/nested-functional-negation.css',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        '.layout:not(:is(.layout)) { display: grid; grid-template-columns: 1fr; }',
+        'nested-functional-negation/nested-functional-negation.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        '.layout:not(:not(.disabled)) { display: grid; grid-template-columns: 1fr; }',
+        'nested-functional-negation/nested-functional-negation.css',
+      ),
+    ).toHaveLength(1);
   });
 
   test('excludes unpublished Svelte fixtures and type tests', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -5,7 +5,7 @@ import {
   missingMigrationRecordPaths,
   shouldCheckComponentSource,
 } from './check-primitive-composition.ts';
-import { cssPrimitiveCounts } from './primitive-composition-css.ts';
+import { conditionalQueryBranches, cssPrimitiveCounts } from './primitive-composition-css.ts';
 import {
   allowedFieldWrapperCounts,
   allowedFloatingCounts,
@@ -700,6 +700,12 @@ describe('primitive composition guard', () => {
         'unreachable-style-assignment/unreachable-style-assignment.svelte',
       ),
     ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; if (getReady()) layout = { display: 'grid', gridTemplateColumns: '1fr' }; if (state.ready) layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
+        'unknown-style-condition/unknown-style-condition.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('preserves top-level conditional style-object assignment branches', () => {
@@ -1733,6 +1739,18 @@ describe('primitive composition guard', () => {
       ).toHaveLength(1);
     expect(
       findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; for (let undefined = false; undefined;) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; break; }</script><div style={layout}></div>",
+        'shadowed-undefined-loop/shadowed-undefined-loop.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let undefined = true; let layout = { display: 'block' }; for (let undefined = false; undefined;) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; break; }</script><div style={layout}></div>",
+        'shadowed-undefined-loop/shadowed-undefined-loop.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
         "<script>let undefined; let layout = { display: 'block' }; for (; undefined;) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; break; }</script><div style={layout}></div>",
         'shadowed-undefined-loop/shadowed-undefined-loop.svelte',
       ),
@@ -1795,6 +1813,12 @@ describe('primitive composition guard', () => {
         'switch-break-style/switch-break-style.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const mode = 'match'; let layout = { display: 'block' }; switch (mode) { default: layout = { display: 'grid', gridTemplateColumns: '1fr' }; case 'match': layout = { display: 'block' }; }</script><div style={layout}></div>",
+        'switch-break-style/switch-break-style.svelte',
+      ),
+    ).toEqual([]);
     expect(
       findPrimitiveCompositionViolations(
         "<script>const match = 'yes'; const block = { display: 'block' }; const grid = { display: 'grid', gridTemplateColumns: '1fr' }; let layout = block; switch ('yes') { case match: layout = grid; break; case 'yes': layout = block; }</script><div style={layout}></div>",
@@ -1945,6 +1969,24 @@ describe('primitive composition guard', () => {
         'labeled-break-control/labeled-break-control.svelte',
       ),
     ).toHaveLength(1);
+  });
+
+  test('preserves raw controls from labeled breaks targeting plain blocks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; outer: { if (ready) { tag = 'input'; break outer; } tag = 'div'; }</script><svelte:element this={tag} />",
+        'labeled-break-block-control/labeled-break-block-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('applies do-while tests to continue states', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; do { tag = 'input'; continue; } while ((tag = 'div', false));</script><svelte:element this={tag} />",
+        'do-while-continue-control/do-while-continue-control.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('preserves raw controls across initializer-free var redeclarations', () => {
@@ -2150,6 +2192,33 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         '@media (40rem < width) { .layout { display: grid; } } @media (width <= 40rem) { .layout { grid-template-columns: 1fr; } }',
         'new-layout/new-layout.css',
+      ),
+    ).toEqual([]);
+  });
+
+  test('inverts negated width feature bounds', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media not (width > 800px) { .layout { display: grid; } } @media (width > 800px) { .layout { grid-template-columns: 1fr; } }',
+        'negated-width/negated-width.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media not (width > 800px) { .layout { display: grid; } } @media (width <= 800px) { .layout { grid-template-columns: 1fr; } }',
+        'negated-width/negated-width.css',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('ignores comment text when splitting top-level media or branches', () => {
+    expect(conditionalQueryBranches('(width > 800px) /* or */ and (width < 400px)')).toEqual([
+      expect.stringContaining('and'),
+    ]);
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media (width > 800px) /* or */ and (width < 400px) { .layout { display: grid; } .layout { grid-template-columns: 1fr; } }',
+        'commented-or/commented-or.css',
       ),
     ).toEqual([]);
   });
@@ -2645,6 +2714,76 @@ describe('primitive composition guard', () => {
         'switch-field-state/switch-field-state.svelte',
       ),
     ).toHaveLength(1);
+  });
+
+  test('stops field switch cases after conditionals whose branches both break', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'span'; function show(kind) { switch (kind) { case 1: if (stop) break; else break; tag = 'label'; } }</script><svelte:element this={tag} onclick={show}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'switch-field-state/switch-field-state.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('preserves potentially matching field switch entries before literal matches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const match = 'yes'; let tag = 'span'; switch ('yes') { case match: tag = 'label'; break; case 'yes': tag = 'span'; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'switch-field-state/switch-field-state.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('invalidates static field booleans assigned through destructuring', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '<script>let ready = true; ({ ready } = { ready: false });</script>{#if ready}<div>Okay</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/if}',
+        'destructured-field-boolean/destructured-field-boolean.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('analyzes each-block field fallbacks without leaking body bindings', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '{#each [] as item}<div>{item}</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/each}',
+        'each-fallback-field/each-fallback-field.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        '<script>const ready = true;</script>{#each [] as ready}<div>Okay</div>{:else}{#if ready}<label>Name</label><p>Help</p><p>Error</p>{/if}{/each}',
+        'each-fallback-field/each-fallback-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('applies field loop updates only to non-break paths', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let ready = true; let tag = 'span'; for (; ready; tag = 'span') { tag = 'label'; if (stop) break; ready = false; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'break-field-loop/break-field-loop.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let ready = true; let tag = 'span'; for (; ready; tag = 'label') { tag = 'span'; if (stop) break; ready = false; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'break-field-loop/break-field-loop.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let ready = true; let tag = 'span'; outer: for (; ready; tag = 'span') { tag = 'label'; if (stop) break outer; ready = false; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'break-field-loop/break-field-loop.svelte',
+      ),
+    ).toHaveLength(1);
+    for (const nestedBreak of ['switch (mode) { case 1: break; }', 'for (;;) { break; }'])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let ready = true; let tag = 'span'; for (; ready; tag = 'span') { tag = 'label'; ${nestedBreak} ready = false; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>`,
+          'nested-break-field-loop/nested-break-field-loop.svelte',
+        ),
+      ).toEqual([]);
   });
 
   test('keeps mutually exclusive template field evidence separate', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -357,6 +357,15 @@ describe('primitive composition guard', () => {
       expect(cssPrimitiveCounts(source).grid).toBe(1);
   });
 
+  test('associates class-only and tag-only selectors across rules', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '.layout { display: grid; } section { grid-template-columns: 1fr; }',
+        'new-layout/new-layout.css',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('recognizes row, area, auto-column, and grid shorthand layouts', () => {
     for (const property of [
       'grid-template-rows',
@@ -576,6 +585,15 @@ describe('primitive composition guard', () => {
     expect(
       findPrimitiveCompositionViolations(
         "<script>let base = { display: 'block' }; function enable() { base = { display: 'grid', gridTemplateColumns: '1fr' }; } let layout; function assign() { layout = base; }</script><div style={layout}></div>",
+        'alias-style/alias-style.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('resolves a top-level mutable style alias initializer', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' }; let layout = gridStyle;</script><div style={layout}></div>",
         'alias-style/alias-style.svelte',
       ),
     ).toHaveLength(1);
@@ -1018,6 +1036,15 @@ describe('primitive composition guard', () => {
         'html-field/html-field.svelte',
       ),
     ).toHaveLength(1);
+  });
+
+  test('does not resolve ambiguous mutable HtmlTag field bindings by array order', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let markup = '<div></div>'; if (custom) markup = '<label>Name</label><p>Help</p><p>Error</p>'; else markup = '<div></div>';</script>{@html markup}",
+        'html-field/html-field.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('matches completed compound pseudo alternatives', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -1659,6 +1659,27 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('ignores style-object writes after an unconditional switch break', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; switch (mode) { case 'block': layout = { display: 'block' }; break; layout = { display: 'grid', gridTemplateColumns: '1fr' }; }</script><div style={layout}></div>",
+        'switch-break-style/switch-break-style.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; switch (1) { case 1: layout = { display: 'block' }; break; case 2: layout = { display: 'grid', gridTemplateColumns: '1fr' }; }</script><div style={layout}></div>",
+        'switch-break-style/switch-break-style.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; switch (mode) { case 1: layout = { display: 'block' }; break; }</script><div style={layout}></div>",
+        'switch-break-style/switch-break-style.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('does not treat a shadowed undefined binding as nullish', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -2235,6 +2256,12 @@ describe('primitive composition guard', () => {
         'switch-test-control/switch-test-control.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch (1) { case 1: break; case (tag = 'input'): break; }</script><svelte:element this={tag} />",
+        'switch-test-control/switch-test-control.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('discards synchronous IIFE return states after later writes', () => {
@@ -2256,12 +2283,32 @@ describe('primitive composition guard', () => {
   });
 
   test('preserves zero-entry field-tag loop states', () => {
-    expect(
-      findPrimitiveCompositionViolations(
-        "<script>let tag = 'label'; for (const item of []) tag = 'span';</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
-        'zero-entry-field-loop/zero-entry-field-loop.svelte',
-      ),
-    ).toHaveLength(1);
+    for (const loop of [
+      "for (const item of []) tag = 'span';",
+      "for (const item of items) tag = 'span';",
+      "for (const key in object) tag = 'span';",
+      "for (; ready;) tag = 'span';",
+      "while (ready) tag = 'span';",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'label'; ${loop}</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>`,
+          'zero-entry-field-loop/zero-entry-field-loop.svelte',
+        ),
+      ).toHaveLength(1);
+
+    for (const loop of [
+      "while (true) { tag = 'span'; break; }",
+      "for (;;) { tag = 'span'; break; }",
+      "for (;; tag = 'label') { tag = 'span'; break; }",
+      "for (const item of [1]) tag = 'span';",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'label'; ${loop}</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>`,
+          'guaranteed-entry-field-loop/guaranteed-entry-field-loop.svelte',
+        ),
+      ).toEqual([]);
   });
 
   test('keeps only terminal style writes within one callback', () => {
@@ -2304,6 +2351,18 @@ describe('primitive composition guard', () => {
         'direct-parent-grid/direct-parent-grid.css',
       ),
     ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        'main section > .layout { display: grid; } main article > .layout { grid-template-columns: 1fr; }',
+        'direct-parent-grid/direct-parent-grid.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        'main section > .layout { display: grid; } aside section > .layout { grid-template-columns: 1fr; }',
+        'direct-parent-grid/direct-parent-grid.css',
+      ),
+    ).toHaveLength(1);
   });
 
   test('merges try and catch as alternative control states', () => {
@@ -2313,6 +2372,12 @@ describe('primitive composition guard', () => {
         'try-catch-control/try-catch-control.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; try { throw 0; } catch (tag) { tag = 'input'; }</script><svelte:element this={tag} />",
+        'try-catch-control/try-catch-control.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('keeps mutually exclusive template field evidence separate', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -332,7 +332,7 @@ describe('primitive composition guard', () => {
   test('tracks the source-diff-viewer line grid without counting its grid container', () => {
     expect(
       findPrimitiveCompositionViolations(
-        '.lines { display: grid; } .line { display: grid; grid-template-columns: 1fr 1fr; }',
+        '.lines { display: grid; } .line { display: grid; grid-template-columns: 1fr 1fr; } .line:not(:has(.line-number)) { grid-template-columns: 1fr; }',
         'source-diff-viewer/source-diff-viewer.css',
       ),
     ).toEqual([]);
@@ -372,6 +372,59 @@ describe('primitive composition guard', () => {
         'new-grid/new-grid.css',
       ),
     ).toHaveLength(1);
+  });
+
+  test('preserves unknown pseudo-state constraints inside :not()', () => {
+    expect(
+      cssPrimitiveCounts(
+        '.layout:not(:hover) { display: grid; } .layout { grid-template-columns: 1fr; }',
+      ).grid,
+    ).toBe(1);
+    expect(
+      cssPrimitiveCounts(
+        '.layout:not(.layout) { display: grid; } .layout { grid-template-columns: 1fr; }',
+      ).grid,
+    ).toBe(0);
+    for (const source of [
+      '.layout:not(:nth-child(2)) { display: grid; } .layout:nth-child(3) { grid-template-columns: 1fr; }',
+      '.layout:not(:lang(fr)) { display: grid; } .layout:lang(en) { grid-template-columns: 1fr; }',
+      '.layout:not(:has(.x)) { display: grid; } .layout:has(.y) { grid-template-columns: 1fr; }',
+    ])
+      expect(cssPrimitiveCounts(source).grid).toBe(1);
+    expect(
+      cssPrimitiveCounts(
+        '.layout:nth-child(2) { display: grid; } .layout:nth-child(3) { grid-template-columns: 1fr; }',
+      ).grid,
+    ).toBe(0);
+    expect(
+      cssPrimitiveCounts(
+        '.layout:nth-of-type(+2) { display: grid; } .layout:nth-of-type(2) { grid-template-columns: 1fr; }',
+      ).grid,
+    ).toBe(1);
+    expect(
+      cssPrimitiveCounts(
+        '.layout:NOT(.disabled) { display: grid; } .layout.disabled { grid-template-columns: 1fr; }',
+      ).grid,
+    ).toBe(0);
+    for (const pseudo of [':IS(#active)', ':WHERE(#active)'])
+      expect(
+        cssPrimitiveCounts(
+          `.layout${pseudo} { display: grid; } .layout#inactive { grid-template-columns: 1fr; }`,
+        ).grid,
+      ).toBe(0);
+  });
+
+  test('allows distinct ids on descendant ancestor chains to overlap when nested', () => {
+    expect(
+      cssPrimitiveCounts(
+        '#outer .layout { display: grid; } #inner .layout { grid-template-columns: 1fr; }',
+      ).grid,
+    ).toBe(1);
+    expect(
+      cssPrimitiveCounts(
+        '#outer.layout { display: grid; } #inner.layout { grid-template-columns: 1fr; }',
+      ).grid,
+    ).toBe(0);
   });
 
   test('counts every compatible grid display and template pairing', () => {
@@ -494,6 +547,39 @@ describe('primitive composition guard', () => {
       ".layout[data-state^='Al'] { display: grid; } .layout[data-state='ALPHA' i] { grid-template-columns: 1fr; }",
     ])
       expect(cssPrimitiveCounts(source).grid).toBe(1);
+  });
+
+  test('recognizes attribute-operator implication with correct case sensitivity', () => {
+    for (const source of [
+      ".layout[data-x^='ab'] { display: grid; } .layout[data-x^='a'] { grid-template-columns: 1fr; }",
+      ".layout[data-x$='ab'] { display: grid; } .layout[data-x$='b'] { grid-template-columns: 1fr; }",
+      ".layout[data-x*='abc'] { display: grid; } .layout[data-x*='a'] { grid-template-columns: 1fr; }",
+      ".layout[data-x|='en-US'] { display: grid; } .layout[data-x|='en'] { grid-template-columns: 1fr; }",
+      ".layout[data-x|='en-US'] { display: grid; } .layout[data-x^='en'] { grid-template-columns: 1fr; }",
+      ".layout[data-x|='en-US'] { display: grid; } .layout[data-x*='-U'] { grid-template-columns: 1fr; }",
+      ".layout[data-x~='foo'] { display: grid; } .layout[data-x*='oo'] { grid-template-columns: 1fr; }",
+    ])
+      expect(cssPrimitiveCounts(source).grid).toBe(1);
+    expect(
+      cssPrimitiveCounts(
+        ".layout[data-x^='ab']:not([data-x^='a']) { display: grid; grid-template-columns: 1fr; }",
+      ).grid,
+    ).toBe(0);
+    expect(
+      cssPrimitiveCounts(
+        ".layout[data-x^='ab' i]:not([data-x^='a']) { display: grid; grid-template-columns: 1fr; }",
+      ).grid,
+    ).toBe(1);
+    expect(
+      cssPrimitiveCounts(
+        ".layout[data-x|='en-US']:not([data-x*='en']) { display: grid; grid-template-columns: 1fr; }",
+      ).grid,
+    ).toBe(0);
+    expect(
+      cssPrimitiveCounts(
+        ".layout[data-x~='foo']:not([data-x*='f']) { display: grid; grid-template-columns: 1fr; }",
+      ).grid,
+    ).toBe(0);
   });
 
   test('does not combine declarations from different conditional scopes', () => {
@@ -692,6 +778,12 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let undefined = dynamic; let layout = { display: 'block' }; if (undefined) layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
         'unreachable-style-assignment/unreachable-style-assignment.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; if (ready) { var nextLayout = { display: 'grid', gridTemplateColumns: '1fr' }; layout = nextLayout; }</script><div style={layout}></div>",
+        'branch-var-style/branch-var-style.svelte',
       ),
     ).toHaveLength(1);
     expect(
@@ -1989,6 +2081,33 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('applies do-while tests to ordinary fallthrough states', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; do { tag = 'input'; } while ((tag = 'div', false));</script><svelte:element this={tag} />",
+        'do-while-fallthrough-test/do-while-fallthrough-test.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; do { tag = 'input'; break; } while ((tag = 'div', false));</script><svelte:element this={tag} />",
+        'do-while-break-control/do-while-break-control.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; do { tag = 'input'; } while (true);</script><svelte:element this={tag} />",
+        'do-while-static-true/do-while-static-true.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; do { tag = 'input'; } while (1);</script><svelte:element this={tag} />",
+        'do-while-truthy-test/do-while-truthy-test.svelte',
+      ),
+    ).toEqual([]);
+  });
+
   test('preserves raw controls across initializer-free var redeclarations', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -2746,6 +2865,30 @@ describe('primitive composition guard', () => {
   test('analyzes each-block field fallbacks without leaking body bindings', () => {
     expect(
       findPrimitiveCompositionViolations(
+        '{#each [1] as item}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/each}',
+        'each-body-field/each-body-field.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        '{#each [1] as item}<div>{item}</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/each}',
+        'unreachable-each-fallback-field/unreachable-each-fallback-field.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        '{#each items as item}<div>{item}</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/each}',
+        'unknown-each-fallback-field/unknown-each-fallback-field.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        '{#each [...items] as item}<div>{item}</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/each}',
+        'spread-each-fallback-field/spread-each-fallback-field.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
         '{#each [] as item}<div>{item}</div>{:else}<label>Name</label><p>Help</p><p>Error</p>{/each}',
         'each-fallback-field/each-fallback-field.svelte',
       ),
@@ -2889,6 +3032,31 @@ describe('primitive composition guard', () => {
         'raw-html-alternatives/raw-html-alternatives.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        `{@html true ? '<div></div>' : '<input aria-label="Name">'}`,
+        'raw-html-static-true/raw-html-static-true.svelte',
+      ),
+    ).toEqual([]);
+    for (const test of ['0', "''", 'null'])
+      expect(
+        findPrimitiveCompositionViolations(
+          `{@html ${test} ? '<input aria-label="Name">' : '<div></div>'}`,
+          'raw-html-static-falsy/raw-html-static-falsy.svelte',
+        ),
+      ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        `<script lang="ts">const enabled = false as const;</script>{@html enabled ? '<input aria-label="Name">' : '<div></div>'}`,
+        'raw-html-static-asserted-boolean/raw-html-static-asserted-boolean.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        `{@html false ? '<input aria-label="Name">' : '<div></div>'}`,
+        'raw-html-static-false/raw-html-static-false.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('models field-tag ternaries, try-catch paths, and bare-block shadowing', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -1081,6 +1081,15 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('ignores rules whose nested conditional scope is internally contradictory', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '@media (min-width: 800px) { @media (max-width: 799px) { .layout { display: grid; grid-template-columns: 1fr; } } }',
+        'contradictory-nested-media/contradictory-nested-media.css',
+      ),
+    ).toEqual([]);
+  });
+
   test('preserves important declarations over later normal declarations', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -2071,6 +2080,15 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('marks repeated conflicting IDs in one compound selector impossible', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '#compact#wide { display: grid; grid-template-columns: 1fr; }',
+        'conflicting-ids/conflicting-ids.css',
+      ),
+    ).toEqual([]);
+  });
+
   test('recognizes modern width range media conditions', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -2630,6 +2648,77 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let tag = 'div'; switch (1) { case 1: let tag = 'input'; break; }</script><svelte:element this={tag} />",
         'switch-control-shadow/switch-control-shadow.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('excludes impossible switch entries and applies finalizers to returned control states', () => {
+    for (const source of [
+      "<script>let tag = 'div'; switch ('yes') { case match: tag = 'div'; break; case 'no': tag = 'input'; break; case 'yes': tag = 'div'; }</script><svelte:element this={tag} />",
+      "<script>let tag = 'div'; function show() { try { tag = 'input'; return; } finally { tag = 'div'; } }</script><svelte:element this={tag} onclick={show} />",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(source, 'control-flow/control-flow.svelte'),
+      ).toEqual([]);
+  });
+
+  test('treats truthy static hidden spread values as boolean attributes', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<input {...{ hidden: 'false' }} />",
+        'hidden-spread/hidden-spread.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('models field-tag ternaries, try-catch paths, and bare-block shadowing', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'span'; true ? (tag = 'span') : (tag = 'label');</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'field-control-flow/field-control-flow.svelte',
+      ),
+    ).toEqual([]);
+    for (const source of [
+      "<script>let tag = 'span'; function show() { try { tag = 'label'; } catch { tag = 'span'; } }</script><svelte:element this={tag} onclick={show}>Name</svelte:element><p>Help</p><p>Error</p>",
+      "<script>let tag = 'label'; { let tag = 'span'; }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(source, 'field-control-flow/field-control-flow.svelte'),
+      ).toHaveLength(1);
+  });
+
+  test('deduplicates equivalent field-evidence branch combinations', () => {
+    const branches = Array.from(
+      { length: 20 },
+      (_, index) => `{#if condition${index}}<span></span>{:else}<span></span>{/if}`,
+    ).join('');
+    expect(
+      findPrimitiveCompositionViolations(
+        `<label>Name</label>${branches}<p>Help</p><p>Error</p>`,
+        'field-branch-stress/field-branch-stress.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('models style ternaries, try-catch paths, continue, and block scope', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; true ? (layout = { display: 'block' }) : (layout = { display: 'grid', gridTemplateColumns: '1fr' });</script><div style={layout}></div>",
+        'style-control-flow/style-control-flow.svelte',
+      ),
+    ).toEqual([]);
+    for (const source of [
+      "<script>let layout = { display: 'block' }; function enable() { try { layout = { display: 'grid', gridTemplateColumns: '1fr' }; } catch { layout = { display: 'block' }; } }</script><div style={layout} onclick={enable}></div>",
+      "<script>let layout = { display: 'block' }; function enable() { for (const item of [1]) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; continue; layout = { display: 'block' }; } }</script><div style={layout} onclick={enable}></div>",
+      "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; { let layout = { display: 'block' }; }</script><div style={layout}></div>",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(source, 'style-control-flow/style-control-flow.svelte'),
+      ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>var layout = { display: 'grid', gridTemplateColumns: '1fr' }; { var layout = { display: 'block' }; }</script><div style={layout}></div>",
+        'style-control-flow/style-control-flow.svelte',
       ),
     ).toEqual([]);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -92,6 +92,15 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('invalidates prior hidden proof after a nested unresolvable object spread', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<input {...{ type: 'hidden', ...attrs }} />",
+        'new-control/new-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('allows a later static hidden type to re-establish proof after a dynamic spread', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -339,6 +348,12 @@ describe('primitive composition guard', () => {
       expect(cssPrimitiveCounts(source).grid).toBe(1);
   });
 
+  test('pairs selectors that can overlap through a tag and a class anchor', () => {
+    expect(
+      cssPrimitiveCounts('.layout { display: grid; } section { grid-template-columns: 1fr; }').grid,
+    ).toBe(1);
+  });
+
   test('recognizes row, area, auto-column, and grid shorthand layouts', () => {
     for (const property of [
       'grid-template-rows',
@@ -530,6 +545,24 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('keeps a top-level conditional style write reachable with its initializer', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; if (compact) layout = { display: 'block' };</script><div style={layout}></div>",
+        'new-grid/new-grid.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('resolves style-object aliases through mutable bindings', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' }; let layout = gridStyle;</script><div style={layout}></div>",
+        'new-grid/new-grid.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('resolves a conditional/logical expression assigned to a mutable style-object binding', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -641,6 +674,26 @@ describe('primitive composition guard', () => {
         `<script>import { classNames } from '../../utilities/class-names.ts'; let className;</script><div class={classNames('cinder-_floating-surface', 'menu', className)}></div>`,
       ),
     ).toEqual([]);
+  });
+
+  test('retains dynamic attributes when matching shared floating targets', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '.menu[data-open] { position: absolute; z-index: 1; }',
+        'new-menu/new-menu.css',
+        '<script>let open = true;</script><div class="menu cinder-_floating-surface" data-open={open}></div>',
+      ),
+    ).toEqual([]);
+  });
+
+  test('does not exempt a shared selector when an uncomposed sibling also matches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        '.menu { position: absolute; z-index: 1; }',
+        'new-menu/new-menu.css',
+        '<div class="menu cinder-_floating-surface"></div><div class="menu"></div>',
+      ),
+    ).toHaveLength(1);
   });
 
   test('scopes the floating-surface exemption to the matching rendered element', () => {
@@ -803,6 +856,15 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('evaluates compound polymorphic tag assignments', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'custom-'; tag += 'input';</script><svelte:element this={tag} />",
+        'polymorphic/polymorphic.svelte',
+      ),
+    ).toEqual([]);
+  });
+
   test('keeps grid style branches independent', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -939,6 +1001,15 @@ describe('primitive composition guard', () => {
     expect(
       findPrimitiveCompositionViolations(
         `<script lang="ts">const tag = 'label' as const;</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>`,
+        'new-field/new-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('resolves mutable polymorphic label bindings for field-wrapper evidence', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'label';</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
         'new-field/new-field.svelte',
       ),
     ).toHaveLength(1);

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -1769,6 +1769,18 @@ describe('primitive composition guard', () => {
         'switch-break-style/switch-break-style.svelte',
       ),
     ).toEqual([]);
+    for (const [initializer, unreachableCase] of [
+      ["'block'", "'grid'"],
+      ['1', '2'],
+      ['true', 'false'],
+      ['null', "'grid'"],
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>const mode = ${initializer}; let layout = { display: 'block' }; switch (mode) { case ${unreachableCase}: layout = { display: 'grid', gridTemplateColumns: '1fr' }; break; default: layout = { display: 'block' }; }</script><div style={layout}></div>`,
+          'switch-break-style/switch-break-style.svelte',
+        ),
+      ).toEqual([]);
     expect(
       findPrimitiveCompositionViolations(
         "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; switch (mode) { case 1: layout = { display: 'block' }; break; }</script><div style={layout}></div>",

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -383,6 +383,41 @@ describe('primitive composition guard', () => {
       expect(cssPrimitiveCounts(source).grid).toBe(1);
   });
 
+  test('rejects tag-to-attribute anchors with contradictory repeated constraints', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "section { display: grid; } [data-state='a'][data-state='b'] { grid-template-columns: 1fr; }",
+        'contradictory-attribute-anchor/contradictory-attribute-anchor.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "section { display: grid; } [data-state='alpha'][data-state^='a'] { grid-template-columns: 1fr; }",
+        'satisfiable-attribute-anchor/satisfiable-attribute-anchor.css',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('resolves repeated prefix, suffix, and language attribute constraints', () => {
+    for (const source of [
+      "section { display: grid; } [data-state^='ab'][data-state^='ac'] { grid-template-columns: 1fr; }",
+      "section { display: grid; } [data-state$='ab'][data-state$='ac'] { grid-template-columns: 1fr; }",
+      "section { display: grid; } [lang|='en'][lang|='fr'] { grid-template-columns: 1fr; }",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(source, 'incompatible-attribute-ranges.css'),
+      ).toEqual([]);
+    for (const source of [
+      "section { display: grid; } [data-state^='a'][data-state^='ab'] { grid-template-columns: 1fr; }",
+      "section { display: grid; } [data-state$='a'][data-state$='ba'] { grid-template-columns: 1fr; }",
+      "section { display: grid; } [lang|='en'][lang|='en-US'] { grid-template-columns: 1fr; }",
+      "section { display: grid; } [data-state^='AB' i][data-state^='ab'] { grid-template-columns: 1fr; }",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(source, 'compatible-attribute-ranges.css'),
+      ).toHaveLength(1);
+  });
+
   test('recognizes row, area, auto-column, and grid shorthand layouts', () => {
     for (const property of [
       'grid-template-rows',
@@ -1405,11 +1440,23 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('uses JavaScript truthiness for literal logical control writes', () => {
+    for (const expression of ["0 && (tag = 'div')", "'ready' || (tag = 'div')"])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'input'; ${expression};</script><svelte:element this={tag} />`,
+          'literal-logical-control-write/literal-logical-control-write.svelte',
+        ),
+      ).toHaveLength(1);
+  });
+
   test('applies statically guaranteed logical control writes', () => {
     for (const expression of [
       "true && (tag = 'div')",
       "false || (tag = 'div')",
       "null ?? (tag = 'div')",
+      "undefined ?? (tag = 'div')",
+      "void 0 ?? (tag = 'div')",
     ])
       expect(
         findPrimitiveCompositionViolations(
@@ -1419,11 +1466,66 @@ describe('primitive composition guard', () => {
       ).toEqual([]);
   });
 
+  test('does not treat a shadowed undefined binding as nullish', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; function show(undefined = 'provided') { undefined ?? (tag = 'div'); }</script><svelte:element this={tag} />",
+        'shadowed-undefined-control/shadowed-undefined-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('tracks mutable control writes in default parameters', () => {
     expect(
       findPrimitiveCompositionViolations(
         "<script>let tag = 'div'; function show(unused = (tag = 'input')) {}</script><button onclick={() => show()}>Show</button><svelte:element this={tag} />",
         'default-parameter-control/default-parameter-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('evaluates default parameters before body var shadowing', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show(unused = (tag = 'input')) { var tag; }</script><button onclick={() => show()}>Show</button><svelte:element this={tag} />",
+        'default-parameter-scope/default-parameter-scope.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show(unused = 1) { var tag; tag = 'input'; }</script><button onclick={() => show()}>Show</button><svelte:element this={tag} />",
+        'default-parameter-scope/default-parameter-scope.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('keeps parameter defaults inside the parameter binding scope', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show(unused = (tag = 'input'), tag) {}</script><button onclick={() => show()}>Show</button><svelte:element this={tag} />",
+        'default-parameter-shadow/default-parameter-shadow.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('only executes IIFE defaults when arguments are absent or undefined', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; ((unused = (tag = 'input')) => {})('provided');</script><svelte:element this={tag} />",
+        'iife-default-argument/iife-default-argument.svelte',
+      ),
+    ).toEqual([]);
+    for (const argument of ['', 'undefined'])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'div'; ((unused = (tag = 'input')) => {})${argument ? `(${argument})` : '()'};</script><svelte:element this={tag} />`,
+          'iife-default-argument/iife-default-argument.svelte',
+        ),
+      ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; let maybe; ((unused = (tag = 'div')) => {})(maybe);</script><svelte:element this={tag} />",
+        'iife-default-argument/iife-default-argument.svelte',
       ),
     ).toHaveLength(1);
   });
@@ -1464,6 +1566,69 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let layout = { display: 'block' }; function enable() { layout = { display: 'grid', gridTemplateColumns: '1fr' }; } layout = { display: 'block' };</script><div style={layout}></div>",
         'future-style-state/future-style-state.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('keeps loop-local style aliases from shadowing the outer binding', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function enable() { for (let layout of layouts) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; } }</script><div style={layout}></div>",
+        'loop-local-style-alias/loop-local-style-alias.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; for (let layout = { display: 'block' }; ready; layout = { display: 'block' }) {}</script><div style={layout}></div>",
+        'loop-local-style-alias/loop-local-style-alias.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; for (let layout = { display: 'block' }; ready; ) {} layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
+        'post-loop-style-write/post-loop-style-write.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves optional loop paths for mutable style objects', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; for (const item of items) layout = { display: 'block' };</script><div style={layout}></div>",
+        'optional-loop-style/optional-loop-style.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; for (; false; layout = { display: 'grid', gridTemplateColumns: '1fr' }) {}</script><div style={layout}></div>",
+        'optional-loop-style/optional-loop-style.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; for (; ready; layout = { display: 'grid', gridTemplateColumns: '1fr' }) {}</script><div style={layout}></div>",
+        'optional-loop-style/optional-loop-style.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; for (const item of []) layout = { display: 'block' };</script><div style={layout}></div>",
+        'empty-loop-style/empty-loop-style.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('keeps guaranteed loop initialization and post-loop writes ordered', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'grid', gridTemplateColumns: '1fr' }; for (layout = { display: 'block' }; false; ) {}</script><div style={layout}></div>",
+        'guaranteed-loop-style/guaranteed-loop-style.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; for (const item of []) {} layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
+        'post-loop-style/post-loop-style.svelte',
       ),
     ).toHaveLength(1);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -1404,6 +1404,90 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('does not overwrite field tags after an abrupt function exit', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function setTag() { tag = 'label'; return; tag = 'span'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'returning-field-handler/returning-field-handler.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('scopes catch parameters while preserving outer field-tag writes', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; try {} catch (tag) { tag = 'span'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'catch-field-shadow/catch-field-shadow.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; try {} catch (error) { tag = 'label'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'catch-field-shadow/catch-field-shadow.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('uses literal truthiness for field-tag logical assignments', () => {
+    for (const expression of ["0 && (tag = 'label')", "'ready' || (tag = 'label')"])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'div'; ${expression};</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>`,
+          'logical-field-tag/logical-field-tag.svelte',
+        ),
+      ).toEqual([]);
+    for (const expression of [
+      "1 && (tag = 'label')",
+      "'' || (tag = 'label')",
+      "ready && (tag = 'label')",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'div'; ${expression};</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>`,
+          'logical-field-tag/logical-field-tag.svelte',
+        ),
+      ).toHaveLength(1);
+  });
+
+  test('uses assigned values for field-tag logical short-circuiting', () => {
+    for (const source of [
+      "let tag = 'div'; (tag = 'span') || (tag = 'label');",
+      "let tag = 'div'; (tag = 'span') ?? (tag = 'label');",
+      "let tag = 'div'; const next = 'span'; (tag = next) || (tag = 'label');",
+      "let tag = 'div'; const next = 'span'; (tag = next) ?? (tag = 'label');",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>${source}</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>`,
+          'logical-assignment-field-tag/logical-assignment-field-tag.svelte',
+        ),
+      ).toEqual([]);
+  });
+
+  test('applies statically determined nullish field-tag writes', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'label'; null ?? (tag = 'span');</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'nullish-field-tag/nullish-field-tag.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'label'; '' ?? (tag = 'span');</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'nullish-field-tag/nullish-field-tag.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('stops field-tag traversal after a nested abrupt block', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show() { { tag = 'label'; return; } tag = 'span'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'nested-return-field-tag/nested-return-field-tag.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('preserves raw controls from abruptly terminated handler branches', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -1464,6 +1548,41 @@ describe('primitive composition guard', () => {
           'guaranteed-logical-control-write/guaranteed-logical-control-write.svelte',
         ),
       ).toEqual([]);
+  });
+
+  test('respects shadowed undefined loop tests and terminal exits', () => {
+    for (const initializer of ['true', 'dynamicValue'])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let undefined = ${initializer}; let layout = { display: 'block' }; for (; undefined;) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; break; }</script><div style={layout}></div>`,
+          'shadowed-undefined-loop/shadowed-undefined-loop.svelte',
+        ),
+      ).toHaveLength(1);
+    for (const exit of ['return;', 'throw new Error()'])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let layout = { display: 'block' }; function show() { for (; ready;) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; ${exit} } }</script><button onclick={show}>Show</button><div style={layout}></div>`,
+          'terminal-loop-exit/terminal-loop-exit.svelte',
+        ),
+      ).toHaveLength(1);
+  });
+
+  test('preserves style-object states from conditional loop breaks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; for (; ready; layout = { display: 'block' }) { if (stop) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; break; } layout = { display: 'block' }; }</script><div style={layout}></div>",
+        'conditional-break-style/conditional-break-style.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves style-object states from labeled switch breaks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; target: switch (kind) { case 'edit': for (; ready; layout = { display: 'block' }) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; break target; } default: layout = { display: 'block' }; }</script><div style={layout}></div>",
+        'labeled-switch-break-style/labeled-switch-break-style.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('does not treat a shadowed undefined binding as nullish', () => {
@@ -1543,6 +1662,42 @@ describe('primitive composition guard', () => {
       ).toEqual([]);
   });
 
+  test('does not execute a loop update after an unconditional break', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; for (; true; tag = 'div') { tag = 'input'; break; }</script><svelte:element this={tag} />",
+        'loop-break-update/loop-break-update.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves control states from conditional loop breaks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; for (; ready; tag = 'div') { tag = 'input'; if (stop) break; ready = false; }</script><svelte:element this={tag} />",
+        'conditional-break-control/conditional-break-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('does not retain non-breaking loop states as interrupted states', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; for (; ready; tag = 'div') { if (stop) { tag = 'div'; break; } tag = 'input'; ready = false; }</script><svelte:element this={tag} />",
+        'conditional-break-control/conditional-break-control.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('preserves raw controls from labeled breaks targeting outer loops', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; outer: for (; ready; tag = 'div') { for (; other; other = false) { tag = 'input'; break outer; } }</script><svelte:element this={tag} />",
+        'labeled-break-control/labeled-break-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('preserves raw controls across initializer-free var redeclarations', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -1557,6 +1712,24 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let tag = 'div'; switch (kind) { case 'edit': tag = 'input'; break; default: tag = 'div'; }</script><svelte:element this={tag} />",
         'switch-control-write/switch-control-write.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('does not fall through after a block-wrapped switch break', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch (kind) { case 'edit': { tag = 'input'; break; } default: tag = 'div'; }</script><svelte:element this={tag} />",
+        'switch-block-break/switch-block-break.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('preserves control states from conditional switch breaks', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch (kind) { case 'edit': if (stop) { tag = 'input'; break; } tag = 'div'; default: tag = 'div'; }</script><svelte:element this={tag} />",
+        'switch-conditional-break/switch-conditional-break.svelte',
       ),
     ).toHaveLength(1);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -261,6 +261,12 @@ describe('primitive composition guard', () => {
         'new-control/new-control.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; true ? (tag = 'div') : (tag = 'input');</script><svelte:element this={tag} />",
+        'new-control/new-control.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('preserves conditional predecessors before compound tag composition', () => {
@@ -1742,6 +1748,12 @@ describe('primitive composition guard', () => {
         'switch-break-style/switch-break-style.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const match = 'yes'; const block = { display: 'block' }; const grid = { display: 'grid', gridTemplateColumns: '1fr' }; let layout = block; switch ('yes') { case match: layout = grid; break; case 'yes': layout = block; }</script><div style={layout}></div>",
+        'switch-break-style/switch-break-style.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('does not treat a shadowed undefined binding as nullish', () => {
@@ -2396,6 +2408,12 @@ describe('primitive composition guard', () => {
         'switch-test-control/switch-test-control.svelte',
       ),
     ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const match = 'yes'; let tag = 'div'; switch ('yes') { case match: tag = 'input'; break; case 'yes': tag = 'div'; }</script><svelte:element this={tag} />",
+        'switch-test-control/switch-test-control.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('discards synchronous IIFE return states after later writes', () => {
@@ -2419,6 +2437,7 @@ describe('primitive composition guard', () => {
   test('preserves zero-entry field-tag loop states', () => {
     for (const loop of [
       "for (const item of []) tag = 'span';",
+      "for (const item of [...[]]) tag = 'span';",
       "for (const item of items) tag = 'span';",
       "for (const key in object) tag = 'span';",
       "for (; ready;) tag = 'span';",
@@ -2436,6 +2455,7 @@ describe('primitive composition guard', () => {
       "for (;;) { tag = 'span'; break; }",
       "for (;; tag = 'label') { tag = 'span'; break; }",
       "for (const item of [1]) tag = 'span';",
+      "for (const item of [,]) tag = 'span';",
     ])
       expect(
         findPrimitiveCompositionViolations(
@@ -2509,6 +2529,12 @@ describe('primitive composition guard', () => {
     expect(
       findPrimitiveCompositionViolations(
         "<script>let tag = 'div'; try { throw 0; } catch (tag) { tag = 'input'; }</script><svelte:element this={tag} />",
+        'try-catch-control/try-catch-control.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; try { tag = 'div'; } finally {}</script><svelte:element this={tag} />",
         'try-catch-control/try-catch-control.svelte',
       ),
     ).toEqual([]);

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -590,6 +590,15 @@ describe('primitive composition guard', () => {
     ).toEqual([]);
   });
 
+  test('retains a style binding introduced only inside a conditional branch', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout; if (dense) layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
+        'conditional-binding/conditional-binding.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('resolves style-object bindings wrapped in a TypeScript `as const` assertion', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -792,6 +801,15 @@ describe('primitive composition guard', () => {
     expect(
       findPrimitiveCompositionViolations(
         'input { display: grid; } input:not(.disabled) { grid-template-columns: 1fr; }',
+        'compound-negation/compound-negation.css',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('allows overlap when a tagless selector negates a compound tag', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        'input { display: grid; } .layout:not(input.disabled) { grid-template-columns: 1fr; }',
         'compound-negation/compound-negation.css',
       ),
     ).toHaveLength(1);
@@ -1058,6 +1076,33 @@ describe('primitive composition guard', () => {
       findPrimitiveCompositionViolations(
         "<script>let tag = 'div'; function helper() { let tag = 'span'; tag = 'label'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
         'shadowed-field/shadowed-field.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('tracks outer field-tag assignments after a block-scoped shadow', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function setTag() { if (local) { let tag = 'span'; } tag = 'label'; }</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'block-shadow-field/block-shadow-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('retains both reachable field-tag values across if branches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; if (custom) tag = 'label'; else tag = 'span';</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'conditional-field/conditional-field.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
+  test('does not report an intermediate raw-control compound tag value', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = ''; if (custom) tag += 'input'; tag += '-wrapper';</script><svelte:element this={tag} />",
+        'compound-control/compound-control.svelte',
       ),
     ).toEqual([]);
   });

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -101,6 +101,16 @@ describe('primitive composition guard', () => {
     ).toHaveLength(1);
   });
 
+  test('resolves nested static hidden spreads', () => {
+    for (const source of [
+      "<input {...{ type: 'text', ...{ type: 'hidden' } }} />",
+      "<input {...{ type: 'text', ...{ ...{ type: 'hidden' } } }} />",
+    ])
+      expect(findPrimitiveCompositionViolations(source, 'new-control/new-control.svelte')).toEqual(
+        [],
+      );
+  });
+
   test('allows a later static hidden type to re-establish proof after a dynamic spread', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -657,6 +667,15 @@ describe('primitive composition guard', () => {
       ).toEqual([]);
   });
 
+  test('ignores statically unreachable style-object assignments', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; if (false) layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
+        'unreachable-style-assignment/unreachable-style-assignment.svelte',
+      ),
+    ).toEqual([]);
+  });
+
   test('preserves top-level conditional style-object assignment branches', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -682,6 +701,37 @@ describe('primitive composition guard', () => {
         'alias-style/alias-style.svelte',
       ),
     ).toHaveLength(1);
+  });
+
+  test('resolves function-local style aliases', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function enable() { const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' }; layout = gridStyle; }</script><div style={layout} onclick={enable}></div>",
+        'callback-style-alias/callback-style-alias.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const gridStyle = { display: 'block' }; let layout = gridStyle; function enable() { const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' }; layout = gridStyle; }</script><div style={layout} onclick={enable}></div>",
+        'callback-style-alias/callback-style-alias.svelte',
+      ),
+    ).toHaveLength(1);
+    for (const functionBody of [
+      "{ const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' }; } layout = gridStyle;",
+      "layout = gridStyle; const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' };",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let layout = { display: 'block' }; function enable() { ${functionBody} }</script><div style={layout} onclick={enable}></div>`,
+          'callback-style-alias/callback-style-alias.svelte',
+        ),
+      ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let layout = { display: 'block' }; function define() { const gridStyle = { display: 'grid', gridTemplateColumns: '1fr' }; } function enable() { layout = gridStyle; }</script><div style={layout} onclick={enable}></div>",
+        'callback-style-alias/callback-style-alias.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('keeps only the terminal write within a conditional branch', () => {
@@ -1624,6 +1674,20 @@ describe('primitive composition guard', () => {
       ).toEqual([]);
   });
 
+  test('tracks logical assignment operators on control tags', () => {
+    for (const source of [
+      "let tag = ''; tag ||= 'input';",
+      "let tag = 'ready'; tag &&= 'input';",
+      "let tag; tag ??= 'input';",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>${source}</script><svelte:element this={tag} />`,
+          'logical-assignment-control/logical-assignment-control.svelte',
+        ),
+      ).toHaveLength(1);
+  });
+
   test('respects shadowed undefined loop tests and terminal exits', () => {
     for (const initializer of ['true', 'dynamicValue'])
       expect(
@@ -1687,6 +1751,37 @@ describe('primitive composition guard', () => {
         'shadowed-undefined-control/shadowed-undefined-control.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; function unrelated(undefined) {} undefined ?? (tag = 'div');</script><svelte:element this={tag} />",
+        'shadowed-undefined-control/shadowed-undefined-control.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; ((undefined = 'provided') => { undefined ?? (tag = 'div'); })();</script><svelte:element this={tag} />",
+        'shadowed-undefined-control/shadowed-undefined-control.svelte',
+      ),
+    ).toHaveLength(1);
+    for (const statement of [
+      "function show() { var undefined = 'provided'; undefined ?? (tag = 'div'); } show();",
+      "try { throw 'provided'; } catch (undefined) { undefined ?? (tag = 'div'); }",
+      "switch (0) { default: { let undefined = 'provided'; undefined ?? (tag = 'div'); } }",
+      "for (let undefined = 'provided'; undefined;) { undefined ?? (tag = 'div'); break; }",
+      "for (let undefined of ['provided']) { undefined ?? (tag = 'div'); }",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let tag = 'input'; ${statement}</script><svelte:element this={tag} />`,
+          'shadowed-undefined-control/shadowed-undefined-control.svelte',
+        ),
+      ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; for (let undefined of ['provided']) { undefined ?? (tag = 'div'); } undefined ?? (tag = 'div');</script><svelte:element this={tag} />",
+        'shadowed-undefined-control/shadowed-undefined-control.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('tracks mutable control writes in default parameters', () => {
@@ -2238,6 +2333,39 @@ describe('primitive composition guard', () => {
         'callback-control-alias/callback-control-alias.svelte',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show(ready) { if (ready) { const controlTag = 'input'; tag = controlTag; } }</script><svelte:element this={tag} />",
+        'callback-control-alias/callback-control-alias.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show(ready) { if (ready) { const controlTag = 'input'; const metadata = {}; tag = controlTag; } }</script><svelte:element this={tag} />",
+        'callback-control-alias/callback-control-alias.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>const controlTag = 'div'; let tag = 'div'; function show(ready) { if (ready) { const controlTag = 'input'; } tag = controlTag; }</script><svelte:element this={tag} />",
+        'callback-control-alias/callback-control-alias.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; function show() { tag = controlTag; const controlTag = 'input'; }</script><svelte:element this={tag} />",
+        'callback-control-alias/callback-control-alias.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('publishes explicit callback writes that equal the declaration-time value', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'input'; function show() { tag = 'input'; } tag = 'div';</script><button onclick={show}>Show</button><svelte:element this={tag} />",
+        'callback-control-write/callback-control-write.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('preserves mutable control states that leave loops through continue', () => {
@@ -2259,6 +2387,12 @@ describe('primitive composition guard', () => {
     expect(
       findPrimitiveCompositionViolations(
         "<script>let tag = 'div'; switch (1) { case 1: break; case (tag = 'input'): break; }</script><svelte:element this={tag} />",
+        'switch-test-control/switch-test-control.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; switch (1) { case 1: tag = 'div'; case (tag = 'input'): break; }</script><svelte:element this={tag} />",
         'switch-test-control/switch-test-control.svelte',
       ),
     ).toEqual([]);
@@ -2378,6 +2512,27 @@ describe('primitive composition guard', () => {
         'try-catch-control/try-catch-control.svelte',
       ),
     ).toEqual([]);
+  });
+
+  test('merges field-tag switch exits independently', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'span'; function show(kind) { switch (kind) { case 'edit': tag = 'label'; break; default: tag = 'span'; } }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'switch-field-state/switch-field-state.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'span'; function show() { switch ('no') { default: tag = 'span'; break; case (tag = 'label'): break; } }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'switch-field-state/switch-field-state.svelte',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'span'; function show() { switch ('no') { default: tag = 'label'; break; case (tag = 'span'): tag = 'div'; } }</script><svelte:element this={tag}>Name</svelte:element><p>Help</p><p>Error</p>",
+        'switch-field-state/switch-field-state.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('keeps mutually exclusive template field evidence separate', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -1723,6 +1723,12 @@ describe('primitive composition guard', () => {
           'shadowed-undefined-loop/shadowed-undefined-loop.svelte',
         ),
       ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let undefined; let layout = { display: 'block' }; for (; undefined;) { layout = { display: 'grid', gridTemplateColumns: '1fr' }; break; }</script><div style={layout}></div>",
+        'shadowed-undefined-loop/shadowed-undefined-loop.svelte',
+      ),
+    ).toEqual([]);
     for (const exit of ['return;', 'throw new Error()'])
       expect(
         findPrimitiveCompositionViolations(

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -418,6 +418,16 @@ describe('primitive composition guard', () => {
     ).toBe(0);
   });
 
+  test('combines mixed-sensitivity attribute selectors symmetrically', () => {
+    for (const source of [
+      ".layout[data-state='A'] { display: grid; } .layout[data-state='a' i] { grid-template-columns: 1fr; }",
+      ".layout[data-state='a' i] { display: grid; } .layout[data-state='A'] { grid-template-columns: 1fr; }",
+      ".layout[data-state='ALPHA'] { display: grid; } .layout[data-state^='al' i] { grid-template-columns: 1fr; }",
+      ".layout[data-state^='Al'] { display: grid; } .layout[data-state='ALPHA' i] { grid-template-columns: 1fr; }",
+    ])
+      expect(cssPrimitiveCounts(source).grid).toBe(1);
+  });
+
   test('does not combine declarations from different conditional scopes', () => {
     expect(
       cssPrimitiveCounts(
@@ -637,6 +647,19 @@ describe('primitive composition guard', () => {
           'unknown-branch-style/unknown-branch-style.svelte',
         ),
       ).toEqual([]);
+  });
+
+  test('keeps outer style-object declarations after every conditional alias branch becomes unresolved', () => {
+    for (const conditionalWrite of [
+      "if (dense) layout = Object.freeze({ display: 'block' }); else layout = Object.seal({ display: 'block' });",
+      "dense ? layout = Object.freeze({ display: 'block' }) : layout = Object.seal({ display: 'block' });",
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          `<script>let layout = { display: 'block' }; ${conditionalWrite}</script><div style={{ ...layout, display: 'grid', gridTemplateColumns: '1fr' }}></div>`,
+          'unknown-conditional-alias/unknown-conditional-alias.svelte',
+        ),
+      ).toHaveLength(1);
   });
 
   test('resolves style-object bindings wrapped in a TypeScript `as const` assertion', () => {
@@ -871,6 +894,21 @@ describe('primitive composition guard', () => {
         'compound-negation/compound-negation.css',
       ),
     ).toHaveLength(1);
+  });
+
+  test('distinguishes case sensitivity in negated attribute constraints', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-state='A' i] { display: grid; } .layout:not([data-state='A']) { grid-template-columns: 1fr; }",
+        'case-insensitive-negation/case-insensitive-negation.css',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-state='A'] { display: grid; } .layout:not([data-state='A' i]) { grid-template-columns: 1fr; }",
+        'case-insensitive-negation/case-insensitive-negation.css',
+      ),
+    ).toEqual([]);
   });
 
   test('allows a negated selector to overlap a generic peer', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -680,6 +680,18 @@ describe('primitive composition guard', () => {
         'unreachable-style-assignment/unreachable-style-assignment.svelte',
       ),
     ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let undefined = dynamic; let layout = { display: 'block' }; if (undefined) layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
+        'unreachable-style-assignment/unreachable-style-assignment.svelte',
+      ),
+    ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let undefined; let layout = { display: 'block' }; if (undefined) layout = { display: 'grid', gridTemplateColumns: '1fr' };</script><div style={layout}></div>",
+        'unreachable-style-assignment/unreachable-style-assignment.svelte',
+      ),
+    ).toEqual([]);
   });
 
   test('preserves top-level conditional style-object assignment branches', () => {
@@ -2039,6 +2051,24 @@ describe('primitive composition guard', () => {
         'valid-compound-negation/valid-compound-negation.css',
       ),
     ).toHaveLength(1);
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-state='a']:not([data-state='a']) { display: grid; } .layout { grid-template-columns: 1fr; }",
+        'split-compound-negation/split-compound-negation.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-state='abc']:not([data-state^='a']) { display: grid; } .layout { grid-template-columns: 1fr; }",
+        'split-compound-negation/split-compound-negation.css',
+      ),
+    ).toEqual([]);
+    expect(
+      findPrimitiveCompositionViolations(
+        ".layout[data-state='abc']:not([data-state^='b']) { display: grid; } .layout { grid-template-columns: 1fr; }",
+        'split-compound-negation/split-compound-negation.css',
+      ),
+    ).toHaveLength(1);
   });
 
   test('recognizes modern width range media conditions', () => {
@@ -2568,6 +2598,31 @@ describe('primitive composition guard', () => {
         'template-field-branches/template-field-branches.svelte',
       ),
     ).toEqual([]);
+    for (const source of [
+      '{#if false}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+      '<script>const ready = false;</script>{#if ready}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+      '<script>let ready = true;</script>{#if ready}<p>Help</p><p>Error</p>{:else}<label>Name</label><p>Help</p><p>Error</p>{/if}',
+      '<script>let ready = false; function helper() { let ready = true; ready = false; }</script>{#if ready}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+      '<script>let ready = false; try {} catch (ready) { ready = true; }</script>{#if ready}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+      '<script>let ready = false; for (let ready = true; ready; ready = false) {}</script>{#if ready}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+      '<script>let ready = false; switch (0) { case 0: let ready = true; ready = false; break; }</script>{#if ready}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          source,
+          'template-field-branches/template-field-branches.svelte',
+        ),
+      ).toEqual([]);
+    for (const source of [
+      '<script>let ready = false; ready = true;</script>{#if ready}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+      '<script>var ready = false; { var ready; ready = true; }</script>{#if ready}<label>Name</label><p>Help</p><p>Error</p>{:else}<div>Okay</div>{/if}',
+    ])
+      expect(
+        findPrimitiveCompositionViolations(
+          source,
+          'template-field-branches/template-field-branches.svelte',
+        ),
+      ).toHaveLength(1);
   });
 
   test('applies switch-wide lexical shadowing to control tags', () => {

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -235,6 +235,15 @@ describe('primitive composition guard', () => {
       ).toHaveLength(1);
   });
 
+  test('counts raw controls assigned through ternary branches', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>let tag = 'div'; editable ? (tag = 'input') : (tag = 'div');</script><svelte:element this={tag} />",
+        'new-control/new-control.svelte',
+      ),
+    ).toHaveLength(1);
+  });
+
   test('preserves conditional predecessors before compound tag composition', () => {
     expect(
       findPrimitiveCompositionViolations(
@@ -1213,6 +1222,24 @@ describe('primitive composition guard', () => {
         'dynamic-field-tag/dynamic-field-tag.svelte',
       ),
     ).toEqual([]);
+  });
+
+  test('clears field-tag evidence after an unresolvable var redeclaration initializer', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>var tag = 'label'; var tag = dynamicTag;</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'dynamic-field-tag/dynamic-field-tag.svelte',
+      ),
+    ).toEqual([]);
+  });
+
+  test('preserves field-tag evidence across a var redeclaration without an initializer', () => {
+    expect(
+      findPrimitiveCompositionViolations(
+        "<script>var tag = 'label'; var tag;</script><svelte:element this={tag} /><p>Description</p><p>Error message</p>",
+        'mutable-field/mutable-field.svelte',
+      ),
+    ).toHaveLength(1);
   });
 
   test('recognizes modern width range media conditions', () => {

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -38,6 +38,21 @@ function isStaticallyTrueExpression(value: unknown): boolean {
   return isRecord(value) && value['type'] === 'Literal' && value['value'] === true;
 }
 
+function literalTruthiness(value: unknown): boolean | undefined {
+  if (!isRecord(value) || value['type'] !== 'Literal') return undefined;
+  return Boolean(value['value']);
+}
+
+function isDefinitelyUndefinedExpression(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  if (value['type'] === 'Identifier') return value['name'] === 'undefined';
+  return value['type'] === 'UnaryExpression' && value['operator'] === 'void';
+}
+
+function isDefinitelyNonUndefinedExpression(value: unknown): boolean {
+  return isRecord(value) && value['type'] === 'Literal';
+}
+
 function walkAst(node: unknown, visit: (record: UnknownRecord) => void): void {
   if (!isRecord(node)) return;
   visit(node);
@@ -238,6 +253,32 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
   if (instanceContent === undefined && !isRecord(root['fragment'])) return new Set();
   const possibleControls = new Set<string>();
   const bindings = staticStringBindings(source);
+  let undefinedCanBeShadowed = false;
+  walkAst(instanceContent, (node) => {
+    if (
+      node['type'] === 'VariableDeclarator' &&
+      bindingPatternIncludesName(node['id'], 'undefined')
+    )
+      undefinedCanBeShadowed = true;
+    if (
+      (node['type'] === 'FunctionDeclaration' ||
+        node['type'] === 'FunctionExpression' ||
+        node['type'] === 'ArrowFunctionExpression') &&
+      Array.isArray(node['params']) &&
+      node['params'].some((parameter) => bindingPatternIncludesName(parameter, 'undefined'))
+    )
+      undefinedCanBeShadowed = true;
+    if (node['type'] === 'CatchClause' && bindingPatternIncludesName(node['param'], 'undefined'))
+      undefinedCanBeShadowed = true;
+  });
+  const isDefinitelyUnshadowedUndefined = (value: unknown): boolean =>
+    isDefinitelyUndefinedExpression(value) &&
+    !(
+      isRecord(value) &&
+      value['type'] === 'Identifier' &&
+      value['name'] === 'undefined' &&
+      undefinedCanBeShadowed
+    );
   const mutableValues = new Set<string>();
   const recordControls = (values: Iterable<string>): void => {
     for (const candidateValue of values) {
@@ -255,22 +296,18 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     mutableValues.clear();
     for (const value of values) mutableValues.add(value);
   };
-  const shadowsBindingInsideFunction = (node: UnknownRecord, shadowed: boolean): boolean =>
+  const shadowsBindingInsideParameters = (node: UnknownRecord, shadowed: boolean): boolean =>
     shadowed ||
     (Array.isArray(node['params']) &&
-      node['params'].some((parameter) => bindingPatternIncludesName(parameter, bindingName))) ||
+      node['params'].some((parameter) => bindingPatternIncludesName(parameter, bindingName)));
+  const shadowsBindingInsideFunction = (node: UnknownRecord, shadowed: boolean): boolean =>
+    shadowsBindingInsideParameters(node, shadowed) ||
     declaresVarBindingWithinFunctionScope(node['body'], bindingName);
   const walkTopLevel = (current: unknown, shadowed = false): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
     let currentShadowed = shadowed;
-    if (
-      type === 'FunctionDeclaration' ||
-      type === 'FunctionExpression' ||
-      type === 'ArrowFunctionExpression'
-    ) {
-      currentShadowed = shadowsBindingInsideFunction(current, currentShadowed);
-    } else if (type === 'BlockStatement') {
+    if (type === 'BlockStatement') {
       currentShadowed ||= declaresLexicalBindingDirectlyInBlock(current, bindingName);
     }
     if (type === 'IfStatement') {
@@ -300,20 +337,22 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (isRecord(left)) walkTopLevel(left, currentShadowed);
       const base = snapshotMutableValues();
       const operator = current['operator'];
-      const leftIsLiteral = isRecord(left) && left['type'] === 'Literal';
-      const leftValue = leftIsLiteral ? left['value'] : undefined;
+      const leftTruthiness = literalTruthiness(left);
+      const leftIsNullish =
+        (isRecord(left) && left['type'] === 'Literal' && left['value'] === null) ||
+        isDefinitelyUnshadowedUndefined(left);
+      const leftIsNonNullishLiteral =
+        isRecord(left) && left['type'] === 'Literal' && left['value'] !== null;
       const skipsRight =
-        leftIsLiteral &&
-        ((operator === '&&' && leftValue === false) ||
-          (operator === '||' && leftValue === true) ||
-          (operator === '??' && leftValue !== null));
+        (leftTruthiness !== undefined &&
+          ((operator === '&&' && !leftTruthiness) || (operator === '||' && leftTruthiness))) ||
+        (operator === '??' && leftIsNonNullishLiteral);
       if (skipsRight) return;
       if (isRecord(current['right'])) walkTopLevel(current['right'], currentShadowed);
       const guaranteesRight =
-        leftIsLiteral &&
-        ((operator === '&&' && leftValue === true) ||
-          (operator === '||' && leftValue === false) ||
-          (operator === '??' && leftValue === null));
+        (leftTruthiness !== undefined &&
+          ((operator === '&&' && leftTruthiness) || (operator === '||' && !leftTruthiness))) ||
+        (operator === '??' && leftIsNullish);
       if (!guaranteesRight) restoreMutableValues([...base, ...mutableValues]);
       return;
     }
@@ -409,11 +448,32 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (Array.isArray(current['arguments']))
         for (const argument of current['arguments']) walkTopLevel(argument, currentShadowed);
       const callee = current['callee'];
-      if (Array.isArray(callee['params']))
-        for (const parameter of callee['params'])
-          walkTopLevel(parameter, shadowsBindingInsideFunction(callee, currentShadowed));
-      if (isRecord(callee['body']))
-        walkTopLevel(callee['body'], shadowsBindingInsideFunction(callee, currentShadowed));
+      const parameterShadowed = shadowsBindingInsideParameters(callee, currentShadowed);
+      const bodyShadowed = shadowsBindingInsideFunction(callee, currentShadowed);
+      if (Array.isArray(callee['params'])) {
+        const argumentsList = Array.isArray(current['arguments']) ? current['arguments'] : [];
+        for (let index = 0; index < callee['params'].length; index += 1) {
+          const parameter = callee['params'][index];
+          if (!isRecord(parameter)) continue;
+          const argument = argumentsList[index];
+          if (parameter['type'] === 'AssignmentPattern') {
+            if (
+              argument !== undefined &&
+              isDefinitelyNonUndefinedExpression(argument) &&
+              !isDefinitelyUndefinedExpression(argument)
+            )
+              continue;
+            if (argument === undefined || isDefinitelyUnshadowedUndefined(argument))
+              walkTopLevel(parameter['right'], parameterShadowed);
+            else {
+              const base = snapshotMutableValues();
+              walkTopLevel(parameter['right'], parameterShadowed);
+              restoreMutableValues([...base, ...mutableValues]);
+            }
+          } else walkTopLevel(parameter, parameterShadowed);
+        }
+      }
+      if (isRecord(callee['body'])) walkTopLevel(callee['body'], bodyShadowed);
       return;
     }
     if (type === 'ReturnStatement' || type === 'ThrowStatement') {
@@ -441,9 +501,15 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       type === 'ArrowFunctionExpression'
     ) {
       const base = snapshotMutableValues();
+      const parameterShadowed = shadowsBindingInsideParameters(current, currentShadowed);
+      const bodyShadowed = shadowsBindingInsideFunction(current, currentShadowed);
       if (Array.isArray(current['params']))
-        for (const parameter of current['params']) walkTopLevel(parameter, currentShadowed);
-      if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+        for (const parameter of current['params']) {
+          if (isRecord(parameter) && parameter['type'] === 'AssignmentPattern')
+            walkTopLevel(parameter['right'], parameterShadowed);
+          else walkTopLevel(parameter, parameterShadowed);
+        }
+      if (isRecord(current['body'])) walkTopLevel(current['body'], bodyShadowed);
       const terminalValues = snapshotMutableValues();
       recordControls(terminalValues);
       restoreMutableValues([...base, ...terminalValues]);

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -34,6 +34,10 @@ function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null;
 }
 
+function isStaticallyTrueExpression(value: unknown): boolean {
+  return isRecord(value) && value['type'] === 'Literal' && value['value'] === true;
+}
+
 function walkAst(node: unknown, visit: (record: UnknownRecord) => void): void {
   if (!isRecord(node)) return;
   visit(node);
@@ -251,6 +255,11 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     mutableValues.clear();
     for (const value of values) mutableValues.add(value);
   };
+  const shadowsBindingInsideFunction = (node: UnknownRecord, shadowed: boolean): boolean =>
+    shadowed ||
+    (Array.isArray(node['params']) &&
+      node['params'].some((parameter) => bindingPatternIncludesName(parameter, bindingName))) ||
+    declaresVarBindingWithinFunctionScope(node['body'], bindingName);
   const walkTopLevel = (current: unknown, shadowed = false): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
@@ -260,13 +269,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       type === 'FunctionExpression' ||
       type === 'ArrowFunctionExpression'
     ) {
-      const declaresBinding =
-        (Array.isArray(current['params']) &&
-          current['params'].some((parameter) =>
-            bindingPatternIncludesName(parameter, bindingName),
-          )) ||
-        declaresVarBindingWithinFunctionScope(current['body'], bindingName);
-      currentShadowed ||= declaresBinding;
+      currentShadowed = shadowsBindingInsideFunction(current, currentShadowed);
     } else if (type === 'BlockStatement') {
       currentShadowed ||= declaresLexicalBindingDirectlyInBlock(current, bindingName);
     }
@@ -292,6 +295,121 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       restoreMutableValues(branches.flatMap((branch) => [...branch]));
       return;
     }
+    if (type === 'SwitchStatement' && Array.isArray(current['cases'])) {
+      if (isRecord(current['discriminant'])) walkTopLevel(current['discriminant'], currentShadowed);
+      const base = snapshotMutableValues();
+      const cases = current['cases'].filter(isRecord);
+      const branches: Set<string>[] = [];
+      for (let startIndex = 0; startIndex < cases.length; startIndex++) {
+        restoreMutableValues(base);
+        let stopped = false;
+        for (let caseIndex = startIndex; caseIndex < cases.length && !stopped; caseIndex++) {
+          const consequent = cases[caseIndex]?.['consequent'];
+          if (!Array.isArray(consequent)) continue;
+          for (const statement of consequent) {
+            walkTopLevel(statement, currentShadowed);
+            if (
+              isRecord(statement) &&
+              (statement['type'] === 'BreakStatement' ||
+                statement['type'] === 'ReturnStatement' ||
+                statement['type'] === 'ThrowStatement')
+            ) {
+              stopped = true;
+              break;
+            }
+          }
+        }
+        branches.push(snapshotMutableValues());
+      }
+      if (!cases.some((switchCase) => switchCase['test'] === null)) branches.push(base);
+      restoreMutableValues(branches.flatMap((branch) => [...branch]));
+      return;
+    }
+    if (type === 'ForStatement') {
+      const initializer = current['init'];
+      const loopShadowed =
+        currentShadowed ||
+        (isRecord(initializer) &&
+          initializer['type'] === 'VariableDeclaration' &&
+          (initializer['kind'] === 'let' || initializer['kind'] === 'const') &&
+          Array.isArray(initializer['declarations']) &&
+          initializer['declarations'].some(
+            (declaration) =>
+              isRecord(declaration) && bindingPatternIncludesName(declaration['id'], bindingName),
+          ));
+      if (isRecord(initializer)) walkTopLevel(initializer, loopShadowed);
+      if (isRecord(current['test'])) walkTopLevel(current['test'], loopShadowed);
+      const base = snapshotMutableValues();
+      if (isRecord(current['body'])) walkTopLevel(current['body'], loopShadowed);
+      if (isRecord(current['update'])) walkTopLevel(current['update'], loopShadowed);
+      if (current['test'] !== null && !isStaticallyTrueExpression(current['test']))
+        restoreMutableValues([...base, ...mutableValues]);
+      return;
+    }
+    if (type === 'ForInStatement' || type === 'ForOfStatement') {
+      if (isRecord(current['right'])) walkTopLevel(current['right'], currentShadowed);
+      const base = snapshotMutableValues();
+      const left = current['left'];
+      const loopShadowed =
+        currentShadowed ||
+        (isRecord(left) &&
+          left['type'] === 'VariableDeclaration' &&
+          (left['kind'] === 'let' || left['kind'] === 'const') &&
+          Array.isArray(left['declarations']) &&
+          left['declarations'].some(
+            (declaration) =>
+              isRecord(declaration) && bindingPatternIncludesName(declaration['id'], bindingName),
+          ));
+      if (isRecord(left)) walkTopLevel(left, loopShadowed);
+      if (isRecord(current['body'])) walkTopLevel(current['body'], loopShadowed);
+      restoreMutableValues([...base, ...mutableValues]);
+      return;
+    }
+    if (type === 'WhileStatement') {
+      if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+      const base = snapshotMutableValues();
+      if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+      if (!isStaticallyTrueExpression(current['test']))
+        restoreMutableValues([...base, ...mutableValues]);
+      return;
+    }
+    if (type === 'DoWhileStatement') {
+      if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+      if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+      return;
+    }
+    if (
+      type === 'CallExpression' &&
+      isRecord(current['callee']) &&
+      (current['callee']['type'] === 'FunctionExpression' ||
+        current['callee']['type'] === 'ArrowFunctionExpression')
+    ) {
+      if (Array.isArray(current['arguments']))
+        for (const argument of current['arguments']) walkTopLevel(argument, currentShadowed);
+      const callee = current['callee'];
+      if (isRecord(callee['body']))
+        walkTopLevel(callee['body'], shadowsBindingInsideFunction(callee, currentShadowed));
+      return;
+    }
+    if (type === 'ReturnStatement' || type === 'ThrowStatement') {
+      if (isRecord(current['argument'])) walkTopLevel(current['argument'], currentShadowed);
+      recordControls(mutableValues);
+      return;
+    }
+    if (type === 'BlockStatement' && Array.isArray(current['body'])) {
+      for (const statement of current['body']) {
+        walkTopLevel(statement, currentShadowed);
+        if (
+          isRecord(statement) &&
+          (statement['type'] === 'ReturnStatement' ||
+            statement['type'] === 'ThrowStatement' ||
+            statement['type'] === 'BreakStatement' ||
+            statement['type'] === 'ContinueStatement')
+        )
+          break;
+      }
+      return;
+    }
     if (
       type === 'FunctionDeclaration' ||
       type === 'FunctionExpression' ||
@@ -312,9 +430,11 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       node['id']['type'] === 'Identifier' &&
       node['id']['name'] === bindingName
     ) {
-      mutableValues.clear();
-      for (const value of possibleStaticStringsFromExpression(node['init'], bindings))
-        mutableValues.add(value);
+      if (node['init'] !== null && node['init'] !== undefined) {
+        mutableValues.clear();
+        for (const value of possibleStaticStringsFromExpression(node['init'], bindings))
+          mutableValues.add(value);
+      }
     }
     if (
       !currentShadowed &&

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -63,7 +63,17 @@ function isDefinitelyUndefinedExpression(value: unknown): boolean {
 }
 
 function isDefinitelyNonUndefinedExpression(value: unknown): boolean {
-  return isRecord(value) && value['type'] === 'Literal';
+  return (
+    isRecord(value) &&
+    [
+      'Literal',
+      'ObjectExpression',
+      'ArrayExpression',
+      'FunctionExpression',
+      'ArrowFunctionExpression',
+      'ClassExpression',
+    ].includes(String(value['type']))
+  );
 }
 
 function walkAst(node: unknown, visit: (record: UnknownRecord) => void): void {
@@ -778,11 +788,14 @@ function possibleMutableControlNames(
       }
       if (isRecord(callee['body'])) {
         const previousSuppression = suppressPublication;
+        returnTargets.push([]);
         suppressPublication = true;
         undefinedShadowFrames.push(shadowsUndefinedInsideFunction(callee));
         walkTopLevel(callee['body'], bodyShadowed);
         undefinedShadowFrames.pop();
         suppressPublication = previousSuppression;
+        const returned = returnTargets.pop() ?? [];
+        restoreMutableValues([...mutableValues, ...returned.flatMap((state) => [...state])]);
       }
       return;
     }
@@ -1087,8 +1100,8 @@ export function visibleControlSignatures(source: string): string[] {
   walkAst(fragment, (node) => {
     if (node['type'] === 'HtmlTag' && isRecord(node['expression'])) {
       const candidates = new Set<string>();
-      const html = staticStringFromExpression(node['expression'], bindings);
-      if (html !== undefined) candidates.add(html);
+      for (const html of possibleStaticStringsFromExpression(node['expression'], bindings))
+        candidates.add(html);
       possibleMutableControlNames(source, node['expression'], (values) => {
         for (const value of values) candidates.add(value);
       });

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -249,7 +249,11 @@ function declaresLexicalBindingDirectlyInBlock(block: UnknownRecord, bindingName
   );
 }
 
-function possibleMutableControlNames(source: string, expression: unknown): Set<string> {
+function possibleMutableControlNames(
+  source: string,
+  expression: unknown,
+  onReachableValues?: (values: ReadonlySet<string>) => void,
+): Set<string> {
   if (
     !isRecord(expression) ||
     expression['type'] !== 'Identifier' ||
@@ -294,6 +298,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     );
   const mutableValues = new Set<string>();
   const recordControls = (values: Iterable<string>): void => {
+    onReachableValues?.(new Set(values));
     for (const candidateValue of values) {
       const normalizedValue = candidateValue.toLowerCase();
       if (
@@ -310,6 +315,43 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     for (const value of values) mutableValues.add(value);
   };
   const breakTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
+  const continueTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
+  const returnTargets: Set<string>[][] = [];
+  let suppressPublication = false;
+  const collectLocalStaticBindings = (node: unknown): Map<string, string> => {
+    const local = new Map<string, string>();
+    const visit = (value: unknown): void => {
+      if (!isRecord(value)) return;
+      if (
+        value['type'] === 'FunctionDeclaration' ||
+        value['type'] === 'FunctionExpression' ||
+        value['type'] === 'ArrowFunctionExpression'
+      )
+        return;
+      if (value['type'] === 'VariableDeclaration' && Array.isArray(value['declarations'])) {
+        for (const declaration of value['declarations']) {
+          if (
+            !isRecord(declaration) ||
+            !isRecord(declaration['id']) ||
+            declaration['id']['type'] !== 'Identifier' ||
+            typeof declaration['id']['name'] !== 'string'
+          )
+            continue;
+          const resolved = staticStringFromExpression(
+            declaration['init'],
+            new Map([...bindings, ...local]),
+          );
+          if (resolved !== undefined) local.set(declaration['id']['name'], resolved);
+        }
+      }
+      for (const child of Object.values(value)) {
+        if (Array.isArray(child)) child.forEach(visit);
+        else if (isRecord(child)) visit(child);
+      }
+    };
+    visit(node);
+    return local;
+  };
   const shadowsBindingInsideParameters = (node: UnknownRecord, shadowed: boolean): boolean =>
     shadowed ||
     (Array.isArray(node['params']) &&
@@ -332,6 +374,17 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       target?.states.push(snapshotMutableValues());
       return;
     }
+    if (type === 'ContinueStatement') {
+      const label =
+        isRecord(current['label']) && typeof current['label']['name'] === 'string'
+          ? current['label']['name']
+          : undefined;
+      const target = label
+        ? continueTargets.findLast((candidate) => candidate.label === label)
+        : continueTargets.at(-1);
+      target?.states.push(snapshotMutableValues());
+      return;
+    }
     if (type === 'LabeledStatement') {
       const label =
         isRecord(current['label']) && typeof current['label']['name'] === 'string'
@@ -346,6 +399,13 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     if (type === 'IfStatement') {
       if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
       const base = snapshotMutableValues();
+      const truthiness = literalTruthiness(current['test']);
+      if (truthiness !== undefined) {
+        restoreMutableValues(base);
+        const branch = truthiness ? current['consequent'] : current['alternate'];
+        if (isRecord(branch)) walkTopLevel(branch, currentShadowed);
+        return;
+      }
       const branches = [current['consequent'], current['alternate']].map((branch) => {
         restoreMutableValues(base);
         if (isRecord(branch)) walkTopLevel(branch, currentShadowed);
@@ -393,6 +453,24 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (isRecord(current['discriminant'])) walkTopLevel(current['discriminant'], currentShadowed);
       const base = snapshotMutableValues();
       const cases = current['cases'].filter(isRecord);
+      const switchShadowed =
+        currentShadowed ||
+        cases.some(
+          (switchCase) =>
+            Array.isArray(switchCase['consequent']) &&
+            switchCase['consequent'].some(
+              (statement) =>
+                isRecord(statement) &&
+                statement['type'] === 'VariableDeclaration' &&
+                (statement['kind'] === 'let' || statement['kind'] === 'const') &&
+                Array.isArray(statement['declarations']) &&
+                statement['declarations'].some(
+                  (declaration) =>
+                    isRecord(declaration) &&
+                    bindingPatternIncludesName(declaration['id'], bindingName),
+                ),
+            ),
+        );
       const branches: Set<string>[] = [];
       for (let startIndex = 0; startIndex < cases.length; startIndex++) {
         restoreMutableValues(base);
@@ -400,10 +478,12 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
         const interruptedStates: Set<string>[] = [];
         breakTargets.push({ label: controlLabel, states: interruptedStates });
         for (let caseIndex = startIndex; caseIndex < cases.length && !stopped; caseIndex++) {
+          const test = cases[caseIndex]?.['test'];
+          if (isRecord(test)) walkTopLevel(test, switchShadowed);
           const consequent = cases[caseIndex]?.['consequent'];
           if (!Array.isArray(consequent)) continue;
           for (const statement of consequent) {
-            walkTopLevel(statement, currentShadowed);
+            walkTopLevel(statement, switchShadowed);
             if (unconditionallyAbruptStatement(statement)) {
               stopped = true;
               break;
@@ -417,6 +497,22 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       }
       if (!cases.some((switchCase) => switchCase['test'] === null)) branches.push(base);
       restoreMutableValues(branches.flatMap((branch) => [...branch]));
+      return;
+    }
+    if (type === 'TryStatement') {
+      const base = snapshotMutableValues();
+      const alternatives: Set<string>[] = [];
+      const tryBlock = current['block'];
+      restoreMutableValues(base);
+      if (isRecord(tryBlock)) walkTopLevel(tryBlock, currentShadowed);
+      alternatives.push(snapshotMutableValues());
+      const handler = current['handler'];
+      restoreMutableValues(base);
+      if (isRecord(handler)) walkTopLevel(handler, currentShadowed);
+      alternatives.push(snapshotMutableValues());
+      restoreMutableValues(alternatives.flatMap((state) => [...state]));
+      const finalizer = current['finalizer'];
+      if (isRecord(finalizer)) walkTopLevel(finalizer, currentShadowed);
       return;
     }
     if (type === 'ForStatement') {
@@ -434,14 +530,36 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (isRecord(initializer)) walkTopLevel(initializer, loopShadowed);
       if (isRecord(current['test'])) walkTopLevel(current['test'], loopShadowed);
       const base = snapshotMutableValues();
+      if (literalTruthiness(current['test']) === false) {
+        restoreMutableValues(base);
+        return;
+      }
       const interruptedStates: Set<string>[] = [];
+      const continuedStates: Set<string>[] = [];
       breakTargets.push({ label: controlLabel, states: interruptedStates });
+      continueTargets.push({ label: controlLabel, states: continuedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], loopShadowed);
+      continueTargets.pop();
       breakTargets.pop();
-      if (!unconditionallyAbruptStatement(current['body']) && isRecord(current['update'])) {
-        walkTopLevel(current['update'], loopShadowed);
+      const fallthroughState = snapshotMutableValues();
+      if (isRecord(current['update'])) {
+        const updateStates: Set<string>[] = [];
+        const paths = unconditionallyAbruptStatement(current['body'])
+          ? continuedStates
+          : [...continuedStates, fallthroughState];
+        for (const path of paths) {
+          restoreMutableValues(path);
+          walkTopLevel(current['update'], loopShadowed);
+          updateStates.push(snapshotMutableValues());
+        }
         restoreMutableValues([
           ...interruptedStates.flatMap((state) => [...state]),
+          ...updateStates.flatMap((state) => [...state]),
+        ]);
+      } else {
+        restoreMutableValues([
+          ...interruptedStates.flatMap((state) => [...state]),
+          ...continuedStates.flatMap((state) => [...state]),
           ...mutableValues,
         ]);
       }
@@ -452,6 +570,15 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     if (type === 'ForInStatement' || type === 'ForOfStatement') {
       if (isRecord(current['right'])) walkTopLevel(current['right'], currentShadowed);
       const base = snapshotMutableValues();
+      if (
+        isRecord(current['right']) &&
+        current['right']['type'] === 'ArrayExpression' &&
+        Array.isArray(current['right']['elements']) &&
+        current['right']['elements'].length === 0
+      ) {
+        restoreMutableValues(base);
+        return;
+      }
       const left = current['left'];
       const loopShadowed =
         currentShadowed ||
@@ -466,11 +593,15 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (isRecord(left)) walkTopLevel(left, loopShadowed);
       const interruptedStates: Set<string>[] = [];
       breakTargets.push({ label: controlLabel, states: interruptedStates });
+      const continuedStates: Set<string>[] = [];
+      continueTargets.push({ label: controlLabel, states: continuedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], loopShadowed);
+      continueTargets.pop();
       breakTargets.pop();
       restoreMutableValues([
         ...base,
         ...interruptedStates.flatMap((state) => [...state]),
+        ...continuedStates.flatMap((state) => [...state]),
         ...mutableValues,
       ]);
       return;
@@ -478,11 +609,22 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     if (type === 'WhileStatement') {
       if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
       const base = snapshotMutableValues();
+      if (literalTruthiness(current['test']) === false) {
+        restoreMutableValues(base);
+        return;
+      }
       const interruptedStates: Set<string>[] = [];
       breakTargets.push({ label: controlLabel, states: interruptedStates });
+      const continuedStates: Set<string>[] = [];
+      continueTargets.push({ label: controlLabel, states: continuedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+      continueTargets.pop();
       breakTargets.pop();
-      restoreMutableValues([...interruptedStates.flatMap((state) => [...state]), ...mutableValues]);
+      restoreMutableValues([
+        ...interruptedStates.flatMap((state) => [...state]),
+        ...continuedStates.flatMap((state) => [...state]),
+        ...mutableValues,
+      ]);
       if (!isStaticallyTrueExpression(current['test']))
         restoreMutableValues([...base, ...mutableValues]);
       return;
@@ -490,10 +632,17 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     if (type === 'DoWhileStatement') {
       const interruptedStates: Set<string>[] = [];
       breakTargets.push({ label: controlLabel, states: interruptedStates });
+      const continuedStates: Set<string>[] = [];
+      continueTargets.push({ label: controlLabel, states: continuedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+      continueTargets.pop();
       breakTargets.pop();
       if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
-      restoreMutableValues([...interruptedStates.flatMap((state) => [...state]), ...mutableValues]);
+      restoreMutableValues([
+        ...interruptedStates.flatMap((state) => [...state]),
+        ...continuedStates.flatMap((state) => [...state]),
+        ...mutableValues,
+      ]);
       return;
     }
     if (
@@ -530,12 +679,18 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
           } else walkTopLevel(parameter, parameterShadowed);
         }
       }
-      if (isRecord(callee['body'])) walkTopLevel(callee['body'], bodyShadowed);
+      if (isRecord(callee['body'])) {
+        const previousSuppression = suppressPublication;
+        suppressPublication = true;
+        walkTopLevel(callee['body'], bodyShadowed);
+        suppressPublication = previousSuppression;
+      }
       return;
     }
     if (type === 'ReturnStatement' || type === 'ThrowStatement') {
       if (isRecord(current['argument'])) walkTopLevel(current['argument'], currentShadowed);
-      recordControls(mutableValues);
+      returnTargets.at(-1)?.push(snapshotMutableValues());
+      if (!suppressPublication) recordControls(mutableValues);
       return;
     }
     if (type === 'BlockStatement' && Array.isArray(current['body'])) {
@@ -558,6 +713,10 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       type === 'ArrowFunctionExpression'
     ) {
       const base = snapshotMutableValues();
+      const previousBindings = new Map(bindings);
+      for (const [name, value] of collectLocalStaticBindings(current['body']))
+        bindings.set(name, value);
+      returnTargets.push([]);
       const parameterShadowed = shadowsBindingInsideParameters(current, currentShadowed);
       const bodyShadowed = shadowsBindingInsideFunction(current, currentShadowed);
       if (Array.isArray(current['params']))
@@ -568,8 +727,14 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
         }
       if (isRecord(current['body'])) walkTopLevel(current['body'], bodyShadowed);
       const terminalValues = snapshotMutableValues();
-      recordControls(terminalValues);
-      restoreMutableValues([...base, ...terminalValues]);
+      const returnedValues = returnTargets.at(-1) ?? [];
+      returnTargets.pop();
+      restoreMutableValues([...terminalValues, ...returnedValues.flatMap((state) => [...state])]);
+      const reachableValues = snapshotMutableValues();
+      if (!suppressPublication) recordControls(reachableValues);
+      restoreMutableValues([...base, ...reachableValues]);
+      bindings.clear();
+      for (const [name, value] of previousBindings) bindings.set(name, value);
       return;
     }
     const node = current;
@@ -699,6 +864,14 @@ function hasStaticHiddenAttribute(
       }
       for (const property of expression['properties']) {
         if (!isRecord(property)) continue;
+        if (property['type'] === 'SpreadElement') {
+          // A nested spread can overwrite either proof with an unknown value;
+          // preserve source order but require a later static attribute/spread
+          // to establish the hidden state again.
+          hiddenState = undefined;
+          typeIsHidden = undefined;
+          continue;
+        }
         const name = staticPropertyName(property);
         if (name === 'hidden')
           hiddenState =
@@ -754,8 +927,13 @@ export function visibleControlSignatures(source: string): string[] {
   const signatures: string[] = [];
   walkAst(fragment, (node) => {
     if (node['type'] === 'HtmlTag' && isRecord(node['expression'])) {
+      const candidates = new Set<string>();
       const html = staticStringFromExpression(node['expression'], bindings);
-      if (html !== undefined) signatures.push(...visibleControlSignatures(html));
+      if (html !== undefined) candidates.add(html);
+      possibleMutableControlNames(source, node['expression'], (values) => {
+        for (const value of values) candidates.add(value);
+      });
+      for (const candidate of candidates) signatures.push(...visibleControlSignatures(candidate));
       return;
     }
     const elementNames = new Set<string>();

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -96,9 +96,11 @@ function parseSvelteFragment(source: string): UnknownRecord | undefined {
   return root['fragment'];
 }
 
+type StaticBinding = { kind: 'boolean'; value: boolean } | { kind: 'string'; value: string };
+
 function staticStringFromExpression(
   expression: unknown,
-  bindings: ReadonlyMap<string, string>,
+  bindings: ReadonlyMap<string, StaticBinding>,
 ): string | undefined {
   if (!isRecord(expression)) return undefined;
   if (expression['type'] === 'Literal' && typeof expression['value'] === 'string')
@@ -113,8 +115,10 @@ function staticStringFromExpression(
     const value = expression['quasis'][0]['value'];
     return isRecord(value) && typeof value['cooked'] === 'string' ? value['cooked'] : undefined;
   }
-  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string')
-    return bindings.get(expression['name']);
+  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
+    const binding = bindings.get(expression['name']);
+    return binding?.kind === 'string' ? binding.value : undefined;
+  }
   if (
     expression['type'] === 'TSAsExpression' ||
     expression['type'] === 'TSSatisfiesExpression' ||
@@ -124,18 +128,73 @@ function staticStringFromExpression(
   return undefined;
 }
 
+function staticTruthinessFromExpression(
+  expression: unknown,
+  bindings: ReadonlyMap<string, StaticBinding>,
+): boolean | undefined {
+  if (!isRecord(expression)) return undefined;
+  if (expression['type'] === 'Literal') return Boolean(expression['value']);
+  if (
+    expression['type'] === 'TemplateLiteral' &&
+    Array.isArray(expression['expressions']) &&
+    expression['expressions'].length === 0 &&
+    Array.isArray(expression['quasis']) &&
+    isRecord(expression['quasis'][0])
+  ) {
+    const value = expression['quasis'][0]['value'];
+    if (isRecord(value) && typeof value['cooked'] === 'string') return Boolean(value['cooked']);
+  }
+  if (
+    expression['type'] === 'TSAsExpression' ||
+    expression['type'] === 'TSSatisfiesExpression' ||
+    expression['type'] === 'TSNonNullExpression'
+  )
+    return staticTruthinessFromExpression(expression['expression'], bindings);
+  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
+    const binding = bindings.get(expression['name']);
+    if (binding !== undefined) return Boolean(binding.value);
+  }
+  return undefined;
+}
+
+function staticBooleanFromExpression(
+  expression: unknown,
+  bindings: ReadonlyMap<string, StaticBinding>,
+): boolean | undefined {
+  if (!isRecord(expression)) return undefined;
+  if (expression['type'] === 'Literal' && typeof expression['value'] === 'boolean')
+    return expression['value'];
+  if (
+    expression['type'] === 'TSAsExpression' ||
+    expression['type'] === 'TSSatisfiesExpression' ||
+    expression['type'] === 'TSNonNullExpression'
+  )
+    return staticBooleanFromExpression(expression['expression'], bindings);
+  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
+    const binding = bindings.get(expression['name']);
+    return binding?.kind === 'boolean' ? binding.value : undefined;
+  }
+  return undefined;
+}
+
 function possibleStaticStringsFromExpression(
   expression: unknown,
-  bindings: ReadonlyMap<string, string>,
+  bindings: ReadonlyMap<string, StaticBinding>,
 ): Set<string> {
   const directValue = staticStringFromExpression(expression, bindings);
   if (directValue !== undefined) return new Set([directValue]);
   if (!isRecord(expression)) return new Set();
-  if (expression['type'] === 'ConditionalExpression')
+  if (expression['type'] === 'ConditionalExpression') {
+    const truthiness = staticTruthinessFromExpression(expression['test'], bindings);
+    if (truthiness === true)
+      return possibleStaticStringsFromExpression(expression['consequent'], bindings);
+    if (truthiness === false)
+      return possibleStaticStringsFromExpression(expression['alternate'], bindings);
     return new Set([
       ...possibleStaticStringsFromExpression(expression['consequent'], bindings),
       ...possibleStaticStringsFromExpression(expression['alternate'], bindings),
     ]);
+  }
   if (expression['type'] === 'LogicalExpression')
     return new Set([
       ...possibleStaticStringsFromExpression(expression['left'], bindings),
@@ -144,9 +203,9 @@ function possibleStaticStringsFromExpression(
   return new Set();
 }
 
-function staticStringBindings(source: string): Map<string, string> {
+function staticStringBindings(source: string): Map<string, StaticBinding> {
   const root: unknown = parseSvelte(source, { modern: true });
-  const bindings = new Map<string, string>();
+  const bindings = new Map<string, StaticBinding>();
   if (!isRecord(root) || !isRecord(root['instance']) || !isRecord(root['instance']['content']))
     return bindings;
   const body = root['instance']['content']['body'];
@@ -169,13 +228,15 @@ function staticStringBindings(source: string): Map<string, string> {
       )
         continue;
       const value = staticStringFromExpression(declaration['init'], bindings);
-      if (value !== undefined) bindings.set(declaration['id']['name'], value);
-      else if (
-        isRecord(declaration['init']) &&
-        declaration['init']['type'] === 'Literal' &&
-        typeof declaration['init']['value'] === 'boolean'
-      )
-        bindings.set(declaration['id']['name'], String(declaration['init']['value']));
+      if (value !== undefined) bindings.set(declaration['id']['name'], { kind: 'string', value });
+      else {
+        const booleanValue = staticBooleanFromExpression(declaration['init'], bindings);
+        if (booleanValue === undefined) continue;
+        bindings.set(declaration['id']['name'], {
+          kind: 'boolean',
+          value: booleanValue,
+        });
+      }
     }
   }
   return bindings;
@@ -768,6 +829,7 @@ function possibleMutableControlNames(
       return;
     }
     if (type === 'DoWhileStatement') {
+      const testCanExit = literalTruthiness(current['test']) !== true;
       const interruptedStates: Set<string>[] = [];
       breakTargets.push({ label: controlLabel, states: interruptedStates });
       const continuedStates: Set<string>[] = [];
@@ -776,15 +838,21 @@ function possibleMutableControlNames(
       continueTargets.pop();
       breakTargets.pop();
       const continuedAfterTest: Set<string>[] = [];
-      for (const state of continuedStates) {
-        restoreMutableValues(state);
+      if (testCanExit)
+        for (const state of continuedStates) {
+          restoreMutableValues(state);
+          if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+          continuedAfterTest.push(snapshotMutableValues());
+        }
+      const fallthroughAfterTest: Set<string>[] = [];
+      if (testCanExit && !unconditionallyAbruptStatement(current['body'])) {
         if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
-        continuedAfterTest.push(snapshotMutableValues());
+        fallthroughAfterTest.push(snapshotMutableValues());
       }
       restoreMutableValues([
         ...interruptedStates.flatMap((state) => [...state]),
         ...continuedAfterTest.flatMap((state) => [...state]),
-        ...mutableValues,
+        ...fallthroughAfterTest.flatMap((state) => [...state]),
       ]);
       return;
     }
@@ -1016,7 +1084,7 @@ function staticAttributeValue(attribute: UnknownRecord): string | undefined {
 
 function attributeValueWithDynamics(
   attribute: UnknownRecord,
-  bindings: ReadonlyMap<string, string> = new Map(),
+  bindings: ReadonlyMap<string, StaticBinding> = new Map(),
 ): string | undefined {
   const value = attribute['value'];
   if (value === true) return undefined;
@@ -1052,7 +1120,7 @@ function staticPropertyName(property: UnknownRecord): string | undefined {
 function hasStaticHiddenAttribute(
   element: UnknownRecord,
   elementNames: ReadonlySet<string>,
-  bindings: ReadonlyMap<string, string>,
+  bindings: ReadonlyMap<string, StaticBinding>,
 ): boolean {
   const attributes = element['attributes'];
   if (!Array.isArray(attributes)) return false;
@@ -1124,7 +1192,7 @@ function hasStaticHiddenAttribute(
       }
       if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
         const bound = bindings.get(expression['name']);
-        if (bound === 'true' || bound === 'false') hiddenState = bound === 'true';
+        if (bound?.kind === 'boolean') hiddenState = bound.value;
       }
       continue;
     }
@@ -1192,7 +1260,7 @@ export function visibleControlSignatures(source: string): string[] {
 
 function elementClassSet(
   element: UnknownRecord,
-  bindings: ReadonlyMap<string, string>,
+  bindings: ReadonlyMap<string, StaticBinding>,
 ): Set<string> {
   const attributes = element['attributes'];
   if (!Array.isArray(attributes)) return new Set();
@@ -1207,7 +1275,8 @@ function elementClassSet(
         attribute['expression']['value'] === true) ||
         (attribute['expression']['type'] === 'Identifier' &&
           typeof attribute['expression']['name'] === 'string' &&
-          bindings.get(attribute['expression']['name']) === 'true'))
+          bindings.get(attribute['expression']['name'])?.kind === 'boolean' &&
+          bindings.get(attribute['expression']['name'])?.value === true))
     )
       classes.add(attribute['name']);
     if (attribute['type'] !== 'Attribute' || attribute['name'] !== 'class') continue;

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -43,6 +43,19 @@ function literalTruthiness(value: unknown): boolean | undefined {
   return Boolean(value['value']);
 }
 
+function unconditionallyAbruptStatement(statement: unknown): boolean {
+  if (!isRecord(statement)) return false;
+  if (
+    statement['type'] === 'BreakStatement' ||
+    statement['type'] === 'ReturnStatement' ||
+    statement['type'] === 'ThrowStatement'
+  )
+    return true;
+  if (statement['type'] !== 'BlockStatement' || !Array.isArray(statement['body'])) return false;
+  for (const child of statement['body']) if (unconditionallyAbruptStatement(child)) return true;
+  return false;
+}
+
 function isDefinitelyUndefinedExpression(value: unknown): boolean {
   if (!isRecord(value)) return false;
   if (value['type'] === 'Identifier') return value['name'] === 'undefined';
@@ -296,6 +309,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     mutableValues.clear();
     for (const value of values) mutableValues.add(value);
   };
+  const breakTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
   const shadowsBindingInsideParameters = (node: UnknownRecord, shadowed: boolean): boolean =>
     shadowed ||
     (Array.isArray(node['params']) &&
@@ -303,10 +317,29 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
   const shadowsBindingInsideFunction = (node: UnknownRecord, shadowed: boolean): boolean =>
     shadowsBindingInsideParameters(node, shadowed) ||
     declaresVarBindingWithinFunctionScope(node['body'], bindingName);
-  const walkTopLevel = (current: unknown, shadowed = false): void => {
+  const walkTopLevel = (current: unknown, shadowed = false, controlLabel?: string): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
     let currentShadowed = shadowed;
+    if (type === 'BreakStatement') {
+      const label =
+        isRecord(current['label']) && typeof current['label']['name'] === 'string'
+          ? current['label']['name']
+          : undefined;
+      const target = label
+        ? breakTargets.findLast((candidate) => candidate.label === label)
+        : breakTargets.at(-1);
+      target?.states.push(snapshotMutableValues());
+      return;
+    }
+    if (type === 'LabeledStatement') {
+      const label =
+        isRecord(current['label']) && typeof current['label']['name'] === 'string'
+          ? current['label']['name']
+          : undefined;
+      if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed, label);
+      return;
+    }
     if (type === 'BlockStatement') {
       currentShadowed ||= declaresLexicalBindingDirectlyInBlock(current, bindingName);
     }
@@ -364,23 +397,23 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       for (let startIndex = 0; startIndex < cases.length; startIndex++) {
         restoreMutableValues(base);
         let stopped = false;
+        const interruptedStates: Set<string>[] = [];
+        breakTargets.push({ label: controlLabel, states: interruptedStates });
         for (let caseIndex = startIndex; caseIndex < cases.length && !stopped; caseIndex++) {
           const consequent = cases[caseIndex]?.['consequent'];
           if (!Array.isArray(consequent)) continue;
           for (const statement of consequent) {
             walkTopLevel(statement, currentShadowed);
-            if (
-              isRecord(statement) &&
-              (statement['type'] === 'BreakStatement' ||
-                statement['type'] === 'ReturnStatement' ||
-                statement['type'] === 'ThrowStatement')
-            ) {
+            if (unconditionallyAbruptStatement(statement)) {
               stopped = true;
               break;
             }
           }
         }
-        branches.push(snapshotMutableValues());
+        breakTargets.pop();
+        branches.push(
+          new Set([...mutableValues, ...interruptedStates.flatMap((state) => [...state])]),
+        );
       }
       if (!cases.some((switchCase) => switchCase['test'] === null)) branches.push(base);
       restoreMutableValues(branches.flatMap((branch) => [...branch]));
@@ -401,8 +434,17 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (isRecord(initializer)) walkTopLevel(initializer, loopShadowed);
       if (isRecord(current['test'])) walkTopLevel(current['test'], loopShadowed);
       const base = snapshotMutableValues();
+      const interruptedStates: Set<string>[] = [];
+      breakTargets.push({ label: controlLabel, states: interruptedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], loopShadowed);
-      if (isRecord(current['update'])) walkTopLevel(current['update'], loopShadowed);
+      breakTargets.pop();
+      if (!unconditionallyAbruptStatement(current['body']) && isRecord(current['update'])) {
+        walkTopLevel(current['update'], loopShadowed);
+        restoreMutableValues([
+          ...interruptedStates.flatMap((state) => [...state]),
+          ...mutableValues,
+        ]);
+      }
       if (current['test'] !== null && !isStaticallyTrueExpression(current['test']))
         restoreMutableValues([...base, ...mutableValues]);
       return;
@@ -422,21 +464,36 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
               isRecord(declaration) && bindingPatternIncludesName(declaration['id'], bindingName),
           ));
       if (isRecord(left)) walkTopLevel(left, loopShadowed);
+      const interruptedStates: Set<string>[] = [];
+      breakTargets.push({ label: controlLabel, states: interruptedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], loopShadowed);
-      restoreMutableValues([...base, ...mutableValues]);
+      breakTargets.pop();
+      restoreMutableValues([
+        ...base,
+        ...interruptedStates.flatMap((state) => [...state]),
+        ...mutableValues,
+      ]);
       return;
     }
     if (type === 'WhileStatement') {
       if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
       const base = snapshotMutableValues();
+      const interruptedStates: Set<string>[] = [];
+      breakTargets.push({ label: controlLabel, states: interruptedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+      breakTargets.pop();
+      restoreMutableValues([...interruptedStates.flatMap((state) => [...state]), ...mutableValues]);
       if (!isStaticallyTrueExpression(current['test']))
         restoreMutableValues([...base, ...mutableValues]);
       return;
     }
     if (type === 'DoWhileStatement') {
+      const interruptedStates: Set<string>[] = [];
+      breakTargets.push({ label: controlLabel, states: interruptedStates });
       if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+      breakTargets.pop();
       if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+      restoreMutableValues([...interruptedStates.flatMap((state) => [...state]), ...mutableValues]);
       return;
     }
     if (

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -453,6 +453,28 @@ function possibleMutableControlNames(
       if (isRecord(current['discriminant'])) walkTopLevel(current['discriminant'], currentShadowed);
       const base = snapshotMutableValues();
       const cases = current['cases'].filter(isRecord);
+      const discriminant = current['discriminant'];
+      const knownDiscriminant =
+        isRecord(discriminant) && discriminant['type'] === 'Literal'
+          ? discriminant['value']
+          : undefined;
+      const hasKnownDiscriminant = isRecord(discriminant) && discriminant['type'] === 'Literal';
+      let knownStartIndex: number | undefined;
+      if (hasKnownDiscriminant) {
+        let defaultIndex: number | undefined;
+        for (let index = 0; index < cases.length; index += 1) {
+          const test = cases[index]?.['test'];
+          if (test === null) {
+            defaultIndex = index;
+            continue;
+          }
+          if (isRecord(test) && test['type'] === 'Literal' && test['value'] === knownDiscriminant) {
+            knownStartIndex = index;
+            break;
+          }
+        }
+        if (knownStartIndex === undefined) knownStartIndex = defaultIndex ?? -1;
+      }
       const switchShadowed =
         currentShadowed ||
         cases.some(
@@ -472,14 +494,31 @@ function possibleMutableControlNames(
             ),
         );
       const branches: Set<string>[] = [];
-      for (let startIndex = 0; startIndex < cases.length; startIndex++) {
+      const startIndices =
+        knownStartIndex === undefined
+          ? cases.map((_, index) => index)
+          : knownStartIndex < 0
+            ? [-1]
+            : [knownStartIndex];
+      for (const startIndex of startIndices) {
         restoreMutableValues(base);
+        if (knownStartIndex !== undefined) {
+          const lastTestIndex = startIndex < 0 ? cases.length - 1 : startIndex;
+          for (let caseIndex = 0; caseIndex <= lastTestIndex; caseIndex += 1) {
+            const test = cases[caseIndex]?.['test'];
+            if (isRecord(test)) walkTopLevel(test, switchShadowed);
+          }
+          if (startIndex < 0) {
+            branches.push(snapshotMutableValues());
+            continue;
+          }
+        }
         let stopped = false;
         const interruptedStates: Set<string>[] = [];
         breakTargets.push({ label: controlLabel, states: interruptedStates });
         for (let caseIndex = startIndex; caseIndex < cases.length && !stopped; caseIndex++) {
           const test = cases[caseIndex]?.['test'];
-          if (isRecord(test)) walkTopLevel(test, switchShadowed);
+          if (knownStartIndex === undefined && isRecord(test)) walkTopLevel(test, switchShadowed);
           const consequent = cases[caseIndex]?.['consequent'];
           if (!Array.isArray(consequent)) continue;
           for (const statement of consequent) {
@@ -508,7 +547,11 @@ function possibleMutableControlNames(
       alternatives.push(snapshotMutableValues());
       const handler = current['handler'];
       restoreMutableValues(base);
-      if (isRecord(handler)) walkTopLevel(handler, currentShadowed);
+      if (isRecord(handler)) {
+        const catchShadowed =
+          currentShadowed || bindingPatternIncludesName(handler['param'], bindingName);
+        walkTopLevel(handler, catchShadowed);
+      }
       alternatives.push(snapshotMutableValues());
       restoreMutableValues(alternatives.flatMap((state) => [...state]));
       const finalizer = current['finalizer'];

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -295,6 +295,28 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       restoreMutableValues(branches.flatMap((branch) => [...branch]));
       return;
     }
+    if (type === 'LogicalExpression') {
+      const left = current['left'];
+      if (isRecord(left)) walkTopLevel(left, currentShadowed);
+      const base = snapshotMutableValues();
+      const operator = current['operator'];
+      const leftIsLiteral = isRecord(left) && left['type'] === 'Literal';
+      const leftValue = leftIsLiteral ? left['value'] : undefined;
+      const skipsRight =
+        leftIsLiteral &&
+        ((operator === '&&' && leftValue === false) ||
+          (operator === '||' && leftValue === true) ||
+          (operator === '??' && leftValue !== null));
+      if (skipsRight) return;
+      if (isRecord(current['right'])) walkTopLevel(current['right'], currentShadowed);
+      const guaranteesRight =
+        leftIsLiteral &&
+        ((operator === '&&' && leftValue === true) ||
+          (operator === '||' && leftValue === false) ||
+          (operator === '??' && leftValue === null));
+      if (!guaranteesRight) restoreMutableValues([...base, ...mutableValues]);
+      return;
+    }
     if (type === 'SwitchStatement' && Array.isArray(current['cases'])) {
       if (isRecord(current['discriminant'])) walkTopLevel(current['discriminant'], currentShadowed);
       const base = snapshotMutableValues();
@@ -387,6 +409,9 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (Array.isArray(current['arguments']))
         for (const argument of current['arguments']) walkTopLevel(argument, currentShadowed);
       const callee = current['callee'];
+      if (Array.isArray(callee['params']))
+        for (const parameter of callee['params'])
+          walkTopLevel(parameter, shadowsBindingInsideFunction(callee, currentShadowed));
       if (isRecord(callee['body']))
         walkTopLevel(callee['body'], shadowsBindingInsideFunction(callee, currentShadowed));
       return;
@@ -416,6 +441,8 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       type === 'ArrowFunctionExpression'
     ) {
       const base = snapshotMutableValues();
+      if (Array.isArray(current['params']))
+        for (const parameter of current['params']) walkTopLevel(parameter, currentShadowed);
       if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
       const terminalValues = snapshotMutableValues();
       recordControls(terminalValues);

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -270,31 +270,13 @@ function possibleMutableControlNames(
   if (instanceContent === undefined && !isRecord(root['fragment'])) return new Set();
   const possibleControls = new Set<string>();
   const bindings = staticStringBindings(source);
-  let undefinedCanBeShadowed = false;
-  walkAst(instanceContent, (node) => {
-    if (
-      node['type'] === 'VariableDeclarator' &&
-      bindingPatternIncludesName(node['id'], 'undefined')
-    )
-      undefinedCanBeShadowed = true;
-    if (
-      (node['type'] === 'FunctionDeclaration' ||
-        node['type'] === 'FunctionExpression' ||
-        node['type'] === 'ArrowFunctionExpression') &&
-      Array.isArray(node['params']) &&
-      node['params'].some((parameter) => bindingPatternIncludesName(parameter, 'undefined'))
-    )
-      undefinedCanBeShadowed = true;
-    if (node['type'] === 'CatchClause' && bindingPatternIncludesName(node['param'], 'undefined'))
-      undefinedCanBeShadowed = true;
-  });
-  const isDefinitelyUnshadowedUndefined = (value: unknown): boolean =>
+  const isDefinitelyUnshadowedUndefined = (value: unknown, shadowed = false): boolean =>
     isDefinitelyUndefinedExpression(value) &&
     !(
       isRecord(value) &&
       value['type'] === 'Identifier' &&
       value['name'] === 'undefined' &&
-      undefinedCanBeShadowed
+      shadowed
     );
   const mutableValues = new Set<string>();
   const recordControls = (values: Iterable<string>): void => {
@@ -317,40 +299,16 @@ function possibleMutableControlNames(
   const breakTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
   const continueTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
   const returnTargets: Set<string>[][] = [];
+  const explicitWrites: boolean[] = [];
+  const localAliasFrames: Map<string, string>[] = [];
+  const undefinedShadowFrames: boolean[] = [];
+  const undefinedIsShadowed = (): boolean => undefinedShadowFrames.some(Boolean);
   let suppressPublication = false;
-  const collectLocalStaticBindings = (node: unknown): Map<string, string> => {
-    const local = new Map<string, string>();
-    const visit = (value: unknown): void => {
-      if (!isRecord(value)) return;
-      if (
-        value['type'] === 'FunctionDeclaration' ||
-        value['type'] === 'FunctionExpression' ||
-        value['type'] === 'ArrowFunctionExpression'
-      )
-        return;
-      if (value['type'] === 'VariableDeclaration' && Array.isArray(value['declarations'])) {
-        for (const declaration of value['declarations']) {
-          if (
-            !isRecord(declaration) ||
-            !isRecord(declaration['id']) ||
-            declaration['id']['type'] !== 'Identifier' ||
-            typeof declaration['id']['name'] !== 'string'
-          )
-            continue;
-          const resolved = staticStringFromExpression(
-            declaration['init'],
-            new Map([...bindings, ...local]),
-          );
-          if (resolved !== undefined) local.set(declaration['id']['name'], resolved);
-        }
-      }
-      for (const child of Object.values(value)) {
-        if (Array.isArray(child)) child.forEach(visit);
-        else if (isRecord(child)) visit(child);
-      }
-    };
-    visit(node);
-    return local;
+  const visibleBindings = (): Map<string, string> => {
+    const visible = new Map(bindings);
+    for (const frame of localAliasFrames)
+      for (const [name, value] of frame) visible.set(name, value);
+    return visible;
   };
   const shadowsBindingInsideParameters = (node: UnknownRecord, shadowed: boolean): boolean =>
     shadowed ||
@@ -359,6 +317,10 @@ function possibleMutableControlNames(
   const shadowsBindingInsideFunction = (node: UnknownRecord, shadowed: boolean): boolean =>
     shadowsBindingInsideParameters(node, shadowed) ||
     declaresVarBindingWithinFunctionScope(node['body'], bindingName);
+  const shadowsUndefinedInsideFunction = (node: UnknownRecord): boolean =>
+    (Array.isArray(node['params']) &&
+      node['params'].some((parameter) => bindingPatternIncludesName(parameter, 'undefined'))) ||
+    declaresVarBindingWithinFunctionScope(node['body'], 'undefined');
   const walkTopLevel = (current: unknown, shadowed = false, controlLabel?: string): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
@@ -395,6 +357,7 @@ function possibleMutableControlNames(
     }
     if (type === 'BlockStatement') {
       currentShadowed ||= declaresLexicalBindingDirectlyInBlock(current, bindingName);
+      undefinedShadowFrames.push(declaresLexicalBindingDirectlyInBlock(current, 'undefined'));
     }
     if (type === 'IfStatement') {
       if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
@@ -433,7 +396,11 @@ function possibleMutableControlNames(
       const leftTruthiness = literalTruthiness(left);
       const leftIsNullish =
         (isRecord(left) && left['type'] === 'Literal' && left['value'] === null) ||
-        isDefinitelyUnshadowedUndefined(left);
+        (isRecord(left) &&
+          left['type'] === 'Identifier' &&
+          left['name'] === 'undefined' &&
+          !undefinedIsShadowed()) ||
+        isDefinitelyUnshadowedUndefined(left, undefinedIsShadowed());
       const leftIsNonNullishLiteral =
         isRecord(left) && left['type'] === 'Literal' && left['value'] !== null;
       const skipsRight =
@@ -451,6 +418,24 @@ function possibleMutableControlNames(
     }
     if (type === 'SwitchStatement' && Array.isArray(current['cases'])) {
       if (isRecord(current['discriminant'])) walkTopLevel(current['discriminant'], currentShadowed);
+      undefinedShadowFrames.push(
+        current['cases'].some(
+          (switchCase) =>
+            Array.isArray(switchCase['consequent']) &&
+            switchCase['consequent'].some(
+              (statement) =>
+                isRecord(statement) &&
+                statement['type'] === 'VariableDeclaration' &&
+                (statement['kind'] === 'let' || statement['kind'] === 'const') &&
+                Array.isArray(statement['declarations']) &&
+                statement['declarations'].some(
+                  (declaration) =>
+                    isRecord(declaration) &&
+                    bindingPatternIncludesName(declaration['id'], 'undefined'),
+                ),
+            ),
+        ),
+      );
       const base = snapshotMutableValues();
       const cases = current['cases'].filter(isRecord);
       const discriminant = current['discriminant'];
@@ -536,6 +521,7 @@ function possibleMutableControlNames(
       }
       if (!cases.some((switchCase) => switchCase['test'] === null)) branches.push(base);
       restoreMutableValues(branches.flatMap((branch) => [...branch]));
+      undefinedShadowFrames.pop();
       return;
     }
     if (type === 'TryStatement') {
@@ -550,7 +536,9 @@ function possibleMutableControlNames(
       if (isRecord(handler)) {
         const catchShadowed =
           currentShadowed || bindingPatternIncludesName(handler['param'], bindingName);
+        undefinedShadowFrames.push(bindingPatternIncludesName(handler['param'], 'undefined'));
         walkTopLevel(handler, catchShadowed);
+        undefinedShadowFrames.pop();
       }
       alternatives.push(snapshotMutableValues());
       restoreMutableValues(alternatives.flatMap((state) => [...state]));
@@ -570,11 +558,22 @@ function possibleMutableControlNames(
             (declaration) =>
               isRecord(declaration) && bindingPatternIncludesName(declaration['id'], bindingName),
           ));
+      const loopUndefinedShadowed =
+        isRecord(initializer) &&
+        initializer['type'] === 'VariableDeclaration' &&
+        (initializer['kind'] === 'let' || initializer['kind'] === 'const') &&
+        Array.isArray(initializer['declarations']) &&
+        initializer['declarations'].some(
+          (declaration) =>
+            isRecord(declaration) && bindingPatternIncludesName(declaration['id'], 'undefined'),
+        );
+      undefinedShadowFrames.push(loopUndefinedShadowed);
       if (isRecord(initializer)) walkTopLevel(initializer, loopShadowed);
       if (isRecord(current['test'])) walkTopLevel(current['test'], loopShadowed);
       const base = snapshotMutableValues();
       if (literalTruthiness(current['test']) === false) {
         restoreMutableValues(base);
+        undefinedShadowFrames.pop();
         return;
       }
       const interruptedStates: Set<string>[] = [];
@@ -608,6 +607,7 @@ function possibleMutableControlNames(
       }
       if (current['test'] !== null && !isStaticallyTrueExpression(current['test']))
         restoreMutableValues([...base, ...mutableValues]);
+      undefinedShadowFrames.pop();
       return;
     }
     if (type === 'ForInStatement' || type === 'ForOfStatement') {
@@ -623,6 +623,15 @@ function possibleMutableControlNames(
         return;
       }
       const left = current['left'];
+      const loopUndefinedShadowed =
+        isRecord(left) &&
+        left['type'] === 'VariableDeclaration' &&
+        (left['kind'] === 'let' || left['kind'] === 'const') &&
+        Array.isArray(left['declarations']) &&
+        left['declarations'].some(
+          (declaration) =>
+            isRecord(declaration) && bindingPatternIncludesName(declaration['id'], 'undefined'),
+        );
       const loopShadowed =
         currentShadowed ||
         (isRecord(left) &&
@@ -633,6 +642,7 @@ function possibleMutableControlNames(
             (declaration) =>
               isRecord(declaration) && bindingPatternIncludesName(declaration['id'], bindingName),
           ));
+      undefinedShadowFrames.push(loopUndefinedShadowed);
       if (isRecord(left)) walkTopLevel(left, loopShadowed);
       const interruptedStates: Set<string>[] = [];
       breakTargets.push({ label: controlLabel, states: interruptedStates });
@@ -647,6 +657,7 @@ function possibleMutableControlNames(
         ...continuedStates.flatMap((state) => [...state]),
         ...mutableValues,
       ]);
+      undefinedShadowFrames.pop();
       return;
     }
     if (type === 'WhileStatement') {
@@ -712,7 +723,10 @@ function possibleMutableControlNames(
               !isDefinitelyUndefinedExpression(argument)
             )
               continue;
-            if (argument === undefined || isDefinitelyUnshadowedUndefined(argument))
+            if (
+              argument === undefined ||
+              isDefinitelyUnshadowedUndefined(argument, undefinedIsShadowed())
+            )
               walkTopLevel(parameter['right'], parameterShadowed);
             else {
               const base = snapshotMutableValues();
@@ -725,7 +739,9 @@ function possibleMutableControlNames(
       if (isRecord(callee['body'])) {
         const previousSuppression = suppressPublication;
         suppressPublication = true;
+        undefinedShadowFrames.push(shadowsUndefinedInsideFunction(callee));
         walkTopLevel(callee['body'], bodyShadowed);
+        undefinedShadowFrames.pop();
         suppressPublication = previousSuppression;
       }
       return;
@@ -737,6 +753,7 @@ function possibleMutableControlNames(
       return;
     }
     if (type === 'BlockStatement' && Array.isArray(current['body'])) {
+      localAliasFrames.push(new Map());
       for (const statement of current['body']) {
         walkTopLevel(statement, currentShadowed);
         if (
@@ -748,6 +765,8 @@ function possibleMutableControlNames(
         )
           break;
       }
+      localAliasFrames.pop();
+      undefinedShadowFrames.pop();
       return;
     }
     if (
@@ -757,25 +776,37 @@ function possibleMutableControlNames(
     ) {
       const base = snapshotMutableValues();
       const previousBindings = new Map(bindings);
-      for (const [name, value] of collectLocalStaticBindings(current['body']))
-        bindings.set(name, value);
+      localAliasFrames.push(new Map());
       returnTargets.push([]);
+      explicitWrites.push(false);
       const parameterShadowed = shadowsBindingInsideParameters(current, currentShadowed);
       const bodyShadowed = shadowsBindingInsideFunction(current, currentShadowed);
+      undefinedShadowFrames.push(
+        Array.isArray(current['params']) &&
+          current['params'].some((parameter) => bindingPatternIncludesName(parameter, 'undefined')),
+      );
       if (Array.isArray(current['params']))
         for (const parameter of current['params']) {
           if (isRecord(parameter) && parameter['type'] === 'AssignmentPattern')
             walkTopLevel(parameter['right'], parameterShadowed);
           else walkTopLevel(parameter, parameterShadowed);
         }
+      undefinedShadowFrames.pop();
+      undefinedShadowFrames.push(shadowsUndefinedInsideFunction(current));
       if (isRecord(current['body'])) walkTopLevel(current['body'], bodyShadowed);
       const terminalValues = snapshotMutableValues();
       const returnedValues = returnTargets.at(-1) ?? [];
       returnTargets.pop();
+      const hadExplicitWrite = explicitWrites.pop() ?? false;
       restoreMutableValues([...terminalValues, ...returnedValues.flatMap((state) => [...state])]);
       const reachableValues = snapshotMutableValues();
-      if (!suppressPublication) recordControls(reachableValues);
+      const changed =
+        reachableValues.size !== base.size ||
+        [...reachableValues].some((value) => !base.has(value));
+      if (!suppressPublication && (changed || hadExplicitWrite)) recordControls(reachableValues);
       restoreMutableValues([...base, ...reachableValues]);
+      localAliasFrames.pop();
+      undefinedShadowFrames.pop();
       bindings.clear();
       for (const [name, value] of previousBindings) bindings.set(name, value);
       return;
@@ -796,17 +827,29 @@ function possibleMutableControlNames(
     }
     if (
       !currentShadowed &&
+      node['type'] === 'VariableDeclarator' &&
+      isRecord(node['id']) &&
+      node['id']['type'] === 'Identifier' &&
+      typeof node['id']['name'] === 'string' &&
+      localAliasFrames.length > 0
+    ) {
+      const resolved = staticStringFromExpression(node['init'], visibleBindings());
+      if (resolved !== undefined) localAliasFrames.at(-1)?.set(node['id']['name'], resolved);
+    }
+    if (
+      !currentShadowed &&
       node['type'] === 'AssignmentExpression' &&
       node['operator'] === '+=' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
       node['left']['name'] === bindingName
     ) {
-      const rightValues = possibleStaticStringsFromExpression(node['right'], bindings);
+      const rightValues = possibleStaticStringsFromExpression(node['right'], visibleBindings());
       const combined = new Set<string>();
       for (const previous of mutableValues)
         for (const right of rightValues) combined.add(previous + right);
       restoreMutableValues(combined);
+      if (explicitWrites.length > 0) explicitWrites[explicitWrites.length - 1] = true;
     }
     if (
       !currentShadowed &&
@@ -816,8 +859,31 @@ function possibleMutableControlNames(
       node['left']['type'] === 'Identifier' &&
       node['left']['name'] === bindingName
     ) {
-      const values = possibleStaticStringsFromExpression(node['right'], bindings);
+      const values = possibleStaticStringsFromExpression(node['right'], visibleBindings());
       restoreMutableValues(values);
+      if (explicitWrites.length > 0) explicitWrites[explicitWrites.length - 1] = true;
+    }
+    if (
+      !currentShadowed &&
+      node['type'] === 'AssignmentExpression' &&
+      (node['operator'] === '||=' || node['operator'] === '&&=' || node['operator'] === '??=') &&
+      isRecord(node['left']) &&
+      node['left']['type'] === 'Identifier' &&
+      node['left']['name'] === bindingName
+    ) {
+      const rightValues = possibleStaticStringsFromExpression(node['right'], visibleBindings());
+      const previousValues = [...mutableValues];
+      const result = new Set<string>();
+      for (const previous of previousValues) {
+        const truthy = Boolean(previous);
+        if (node['operator'] === '??=') result.add(previous);
+        else if (node['operator'] === '||=' ? !truthy : truthy) {
+          for (const right of rightValues) result.add(right);
+        } else result.add(previous);
+      }
+      if (previousValues.length === 0) for (const right of rightValues) result.add(right);
+      restoreMutableValues(result);
+      if (explicitWrites.length > 0) explicitWrites[explicitWrites.length - 1] = true;
     }
     for (const child of Object.values(current)) {
       if (Array.isArray(child)) child.forEach((item) => walkTopLevel(item, currentShadowed));
@@ -891,6 +957,34 @@ function hasStaticHiddenAttribute(
   const soloInput = elementNames.size === 1 && elementNames.has('input');
   let hiddenState: boolean | undefined;
   let typeIsHidden: boolean | undefined;
+  const applyObjectProperties = (properties: unknown[]): void => {
+    for (const property of properties) {
+      if (!isRecord(property)) continue;
+      if (property['type'] === 'SpreadElement') {
+        const nested = property['argument'];
+        if (
+          isRecord(nested) &&
+          nested['type'] === 'ObjectExpression' &&
+          Array.isArray(nested['properties'])
+        )
+          applyObjectProperties(nested['properties']);
+        else {
+          hiddenState = undefined;
+          typeIsHidden = undefined;
+        }
+        continue;
+      }
+      const name = staticPropertyName(property);
+      if (name === 'hidden')
+        hiddenState =
+          isRecord(property['value']) &&
+          property['value']['type'] === 'Literal' &&
+          property['value']['value'] === true;
+      else if (soloInput && name === 'type')
+        typeIsHidden =
+          staticStringFromExpression(property['value'], bindings)?.toLowerCase() === 'hidden';
+    }
+  };
 
   for (const attribute of attributes) {
     if (!isRecord(attribute)) continue;
@@ -905,26 +999,7 @@ function hasStaticHiddenAttribute(
         typeIsHidden = undefined;
         continue;
       }
-      for (const property of expression['properties']) {
-        if (!isRecord(property)) continue;
-        if (property['type'] === 'SpreadElement') {
-          // A nested spread can overwrite either proof with an unknown value;
-          // preserve source order but require a later static attribute/spread
-          // to establish the hidden state again.
-          hiddenState = undefined;
-          typeIsHidden = undefined;
-          continue;
-        }
-        const name = staticPropertyName(property);
-        if (name === 'hidden')
-          hiddenState =
-            isRecord(property['value']) &&
-            property['value']['type'] === 'Literal' &&
-            property['value']['value'] === true;
-        else if (soloInput && name === 'type')
-          typeIsHidden =
-            staticStringFromExpression(property['value'], bindings)?.toLowerCase() === 'hidden';
-      }
+      applyObjectProperties(expression['properties']);
       continue;
     }
     if (attribute['type'] !== 'Attribute') continue;

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -52,6 +52,13 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
     statement['type'] === 'ThrowStatement'
   )
     return true;
+  if (statement['type'] === 'IfStatement')
+    return (
+      isRecord(statement['consequent']) &&
+      unconditionallyAbruptStatement(statement['consequent']) &&
+      isRecord(statement['alternate']) &&
+      unconditionallyAbruptStatement(statement['alternate'])
+    );
   if (statement['type'] !== 'BlockStatement' || !Array.isArray(statement['body'])) return false;
   return unconditionallyAbruptStatement(statement['body'].at(-1));
 }

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -281,6 +281,17 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       restoreMutableValues(branches.flatMap((branch) => [...branch]));
       return;
     }
+    if (type === 'ConditionalExpression') {
+      if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+      const base = snapshotMutableValues();
+      const branches = [current['consequent'], current['alternate']].map((branch) => {
+        restoreMutableValues(base);
+        if (isRecord(branch)) walkTopLevel(branch, currentShadowed);
+        return snapshotMutableValues();
+      });
+      restoreMutableValues(branches.flatMap((branch) => [...branch]));
+      return;
+    }
     if (
       type === 'FunctionDeclaration' ||
       type === 'FunctionExpression' ||

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -299,6 +299,7 @@ function possibleMutableControlNames(
   const breakTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
   const continueTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
   const returnTargets: Set<string>[][] = [];
+  let finallyDepth = 0;
   const explicitWrites: boolean[] = [];
   const localAliasFrames: Map<string, string>[] = [];
   const undefinedShadowFrames: boolean[] = [];
@@ -492,7 +493,21 @@ function possibleMutableControlNames(
       const defaultIndex = cases.findIndex((switchCase) => switchCase['test'] === null);
       const startIndices =
         knownStartIndex === undefined
-          ? [...cases.map((_, index) => index), ...(defaultIndex < 0 ? [-1] : [])]
+          ? [
+              ...cases
+                .map((switchCase, index) => ({ switchCase, index }))
+                .filter(({ switchCase }) => {
+                  const test = switchCase['test'];
+                  return !(
+                    hasKnownDiscriminant &&
+                    isRecord(test) &&
+                    test['type'] === 'Literal' &&
+                    test['value'] !== knownDiscriminant
+                  );
+                })
+                .map(({ index }) => index),
+              ...(defaultIndex < 0 ? [-1] : []),
+            ]
           : knownStartIndex < 0
             ? [-1]
             : [knownStartIndex];
@@ -533,6 +548,10 @@ function possibleMutableControlNames(
     }
     if (type === 'TryStatement') {
       const base = snapshotMutableValues();
+      const returnFrame = returnTargets.at(-1);
+      const returnStart = returnFrame?.length ?? 0;
+      const hasFinalizer = isRecord(current['finalizer']);
+      if (hasFinalizer) finallyDepth += 1;
       const alternatives: Set<string>[] = [];
       const tryBlock = current['block'];
       restoreMutableValues(base);
@@ -550,7 +569,21 @@ function possibleMutableControlNames(
       }
       restoreMutableValues(alternatives.flatMap((state) => [...state]));
       const finalizer = current['finalizer'];
-      if (isRecord(finalizer)) walkTopLevel(finalizer, currentShadowed);
+      if (isRecord(finalizer)) {
+        walkTopLevel(finalizer, currentShadowed);
+        if (returnFrame) {
+          const captured = returnFrame.slice(returnStart);
+          for (const [index, capturedState] of captured.entries()) {
+            restoreMutableValues(capturedState);
+            walkTopLevel(finalizer, currentShadowed);
+            const finalizedState = snapshotMutableValues();
+            captured[index] = finalizedState;
+            recordControls(finalizedState);
+          }
+          returnFrame.splice(returnStart, captured.length, ...captured);
+        }
+        finallyDepth -= 1;
+      }
       return;
     }
     if (type === 'ForStatement') {
@@ -756,7 +789,7 @@ function possibleMutableControlNames(
     if (type === 'ReturnStatement' || type === 'ThrowStatement') {
       if (isRecord(current['argument'])) walkTopLevel(current['argument'], currentShadowed);
       returnTargets.at(-1)?.push(snapshotMutableValues());
-      if (!suppressPublication) recordControls(mutableValues);
+      if (!suppressPublication && finallyDepth === 0) recordControls(mutableValues);
       return;
     }
     if (type === 'BlockStatement' && Array.isArray(current['body'])) {
@@ -810,7 +843,8 @@ function possibleMutableControlNames(
       const changed =
         reachableValues.size !== base.size ||
         [...reachableValues].some((value) => !base.has(value));
-      if (!suppressPublication && (changed || hadExplicitWrite)) recordControls(reachableValues);
+      if (!suppressPublication && (changed || (hadExplicitWrite && returnedValues.length === 0)))
+        recordControls(reachableValues);
       restoreMutableValues([...base, ...reachableValues]);
       localAliasFrames.pop();
       undefinedShadowFrames.pop();
@@ -986,7 +1020,7 @@ function hasStaticHiddenAttribute(
         hiddenState =
           isRecord(property['value']) &&
           property['value']['type'] === 'Literal' &&
-          property['value']['value'] === true;
+          Boolean(property['value']['value']);
       else if (soloInput && name === 'type')
         typeIsHidden =
           staticStringFromExpression(property['value'], bindings)?.toLowerCase() === 'hidden';

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -302,7 +302,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       const combined = new Set<string>();
       for (const previous of mutableValues)
         for (const right of rightValues) combined.add(previous + right);
-      mutableValues.clear();
+      if (!conditional) mutableValues.clear();
       for (const value of combined) mutableValues.add(value);
       candidate = undefined;
     }

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -246,7 +246,12 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
         possibleControls.add(normalizedValue);
     }
   };
-  const walkTopLevel = (current: unknown, shadowed = false, conditional = false): void => {
+  const snapshotMutableValues = (): Set<string> => new Set(mutableValues);
+  const restoreMutableValues = (values: Iterable<string>): void => {
+    mutableValues.clear();
+    for (const value of values) mutableValues.add(value);
+  };
+  const walkTopLevel = (current: unknown, shadowed = false): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
     let currentShadowed = shadowed;
@@ -266,22 +271,29 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       currentShadowed ||= declaresLexicalBindingDirectlyInBlock(current, bindingName);
     }
     if (type === 'IfStatement') {
-      if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed, conditional);
-      if (isRecord(current['consequent']))
-        walkTopLevel(current['consequent'], currentShadowed, true);
-      if (isRecord(current['alternate'])) walkTopLevel(current['alternate'], currentShadowed, true);
+      if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+      const base = snapshotMutableValues();
+      const branches = [current['consequent'], current['alternate']].map((branch) => {
+        restoreMutableValues(base);
+        if (isRecord(branch)) walkTopLevel(branch, currentShadowed);
+        return snapshotMutableValues();
+      });
+      restoreMutableValues(branches.flatMap((branch) => [...branch]));
+      return;
+    }
+    if (
+      type === 'FunctionDeclaration' ||
+      type === 'FunctionExpression' ||
+      type === 'ArrowFunctionExpression'
+    ) {
+      const base = snapshotMutableValues();
+      if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
+      const terminalValues = snapshotMutableValues();
+      recordControls(terminalValues);
+      restoreMutableValues([...base, ...terminalValues]);
       return;
     }
     const node = current;
-    let candidate: unknown;
-    if (
-      !currentShadowed &&
-      node['type'] === 'VariableDeclarator' &&
-      isRecord(node['id']) &&
-      node['id']['type'] === 'Identifier' &&
-      node['id']['name'] === bindingName
-    )
-      candidate = node['init'];
     if (
       !currentShadowed &&
       node['type'] === 'VariableDeclarator' &&
@@ -296,15 +308,6 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     if (
       !currentShadowed &&
       node['type'] === 'AssignmentExpression' &&
-      node['operator'] === '=' &&
-      isRecord(node['left']) &&
-      node['left']['type'] === 'Identifier' &&
-      node['left']['name'] === bindingName
-    )
-      candidate = node['right'];
-    if (
-      !currentShadowed &&
-      node['type'] === 'AssignmentExpression' &&
       node['operator'] === '+=' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
@@ -314,9 +317,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       const combined = new Set<string>();
       for (const previous of mutableValues)
         for (const right of rightValues) combined.add(previous + right);
-      if (!conditional) mutableValues.clear();
-      for (const value of combined) mutableValues.add(value);
-      candidate = undefined;
+      restoreMutableValues(combined);
     }
     if (
       !currentShadowed &&
@@ -327,17 +328,11 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       node['left']['name'] === bindingName
     ) {
       const values = possibleStaticStringsFromExpression(node['right'], bindings);
-      if (conditional) for (const value of values) mutableValues.add(value);
-      else {
-        mutableValues.clear();
-        for (const value of values) mutableValues.add(value);
-      }
+      restoreMutableValues(values);
     }
-    recordControls(possibleStaticStringsFromExpression(candidate, bindings));
     for (const child of Object.values(current)) {
-      if (Array.isArray(child))
-        child.forEach((item) => walkTopLevel(item, currentShadowed, conditional));
-      else if (isRecord(child)) walkTopLevel(child, currentShadowed, conditional);
+      if (Array.isArray(child)) child.forEach((item) => walkTopLevel(item, currentShadowed));
+      else if (isRecord(child)) walkTopLevel(child, currentShadowed);
     }
   };
   if (instanceContent !== undefined) walkTopLevel(instanceContent);

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -380,6 +380,13 @@ function possibleMutableControlNames(
     if (type === 'ConditionalExpression') {
       if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
       const base = snapshotMutableValues();
+      const truthiness = literalTruthiness(current['test']);
+      if (truthiness !== undefined) {
+        restoreMutableValues(base);
+        const branch = truthiness ? current['consequent'] : current['alternate'];
+        if (isRecord(branch)) walkTopLevel(branch, currentShadowed);
+        return;
+      }
       const branches = [current['consequent'], current['alternate']].map((branch) => {
         restoreMutableValues(base);
         if (isRecord(branch)) walkTopLevel(branch, currentShadowed);
@@ -447,6 +454,7 @@ function possibleMutableControlNames(
       let knownStartIndex: number | undefined;
       if (hasKnownDiscriminant) {
         let defaultIndex: number | undefined;
+        let hasUnresolvedCaseTest = false;
         for (let index = 0; index < cases.length; index += 1) {
           const test = cases[index]?.['test'];
           if (test === null) {
@@ -454,11 +462,13 @@ function possibleMutableControlNames(
             continue;
           }
           if (isRecord(test) && test['type'] === 'Literal' && test['value'] === knownDiscriminant) {
-            knownStartIndex = index;
+            if (!hasUnresolvedCaseTest) knownStartIndex = index;
             break;
           }
+          if (!isRecord(test) || test['type'] !== 'Literal') hasUnresolvedCaseTest = true;
         }
-        if (knownStartIndex === undefined) knownStartIndex = defaultIndex ?? -1;
+        if (knownStartIndex === undefined && !hasUnresolvedCaseTest)
+          knownStartIndex = defaultIndex ?? -1;
       }
       const switchShadowed =
         currentShadowed ||
@@ -479,31 +489,29 @@ function possibleMutableControlNames(
             ),
         );
       const branches: Set<string>[] = [];
+      const defaultIndex = cases.findIndex((switchCase) => switchCase['test'] === null);
       const startIndices =
         knownStartIndex === undefined
-          ? cases.map((_, index) => index)
+          ? [...cases.map((_, index) => index), ...(defaultIndex < 0 ? [-1] : [])]
           : knownStartIndex < 0
             ? [-1]
             : [knownStartIndex];
       for (const startIndex of startIndices) {
         restoreMutableValues(base);
-        if (knownStartIndex !== undefined) {
-          const lastTestIndex = startIndex < 0 ? cases.length - 1 : startIndex;
-          for (let caseIndex = 0; caseIndex <= lastTestIndex; caseIndex += 1) {
-            const test = cases[caseIndex]?.['test'];
-            if (isRecord(test)) walkTopLevel(test, switchShadowed);
-          }
-          if (startIndex < 0) {
-            branches.push(snapshotMutableValues());
-            continue;
-          }
+        const lastTestIndex =
+          startIndex < 0 || startIndex === defaultIndex ? cases.length - 1 : startIndex;
+        for (let caseIndex = 0; caseIndex <= lastTestIndex; caseIndex += 1) {
+          const test = cases[caseIndex]?.['test'];
+          if (isRecord(test)) walkTopLevel(test, switchShadowed);
+        }
+        if (startIndex < 0) {
+          branches.push(snapshotMutableValues());
+          continue;
         }
         let stopped = false;
         const interruptedStates: Set<string>[] = [];
         breakTargets.push({ label: controlLabel, states: interruptedStates });
         for (let caseIndex = startIndex; caseIndex < cases.length && !stopped; caseIndex++) {
-          const test = cases[caseIndex]?.['test'];
-          if (knownStartIndex === undefined && isRecord(test)) walkTopLevel(test, switchShadowed);
           const consequent = cases[caseIndex]?.['consequent'];
           if (!Array.isArray(consequent)) continue;
           for (const statement of consequent) {
@@ -519,7 +527,6 @@ function possibleMutableControlNames(
           new Set([...mutableValues, ...interruptedStates.flatMap((state) => [...state])]),
         );
       }
-      if (!cases.some((switchCase) => switchCase['test'] === null)) branches.push(base);
       restoreMutableValues(branches.flatMap((branch) => [...branch]));
       undefinedShadowFrames.pop();
       return;
@@ -532,15 +539,15 @@ function possibleMutableControlNames(
       if (isRecord(tryBlock)) walkTopLevel(tryBlock, currentShadowed);
       alternatives.push(snapshotMutableValues());
       const handler = current['handler'];
-      restoreMutableValues(base);
       if (isRecord(handler)) {
+        restoreMutableValues(base);
         const catchShadowed =
           currentShadowed || bindingPatternIncludesName(handler['param'], bindingName);
         undefinedShadowFrames.push(bindingPatternIncludesName(handler['param'], 'undefined'));
         walkTopLevel(handler, catchShadowed);
         undefinedShadowFrames.pop();
+        alternatives.push(snapshotMutableValues());
       }
-      alternatives.push(snapshotMutableValues());
       restoreMutableValues(alternatives.flatMap((state) => [...state]));
       const finalizer = current['finalizer'];
       if (isRecord(finalizer)) walkTopLevel(finalizer, currentShadowed);

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -389,7 +389,13 @@ function possibleMutableControlNames(
         isRecord(current['label']) && typeof current['label']['name'] === 'string'
           ? current['label']['name']
           : undefined;
-      if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed, label);
+      if (isRecord(current['body'])) {
+        const states: Set<string>[] = [];
+        breakTargets.push({ label, states });
+        walkTopLevel(current['body'], currentShadowed, label);
+        breakTargets.pop();
+        restoreMutableValues([...mutableValues, ...states.flatMap((state) => [...state])]);
+      }
       return;
     }
     if (type === 'BlockStatement') {
@@ -769,10 +775,15 @@ function possibleMutableControlNames(
       if (isRecord(current['body'])) walkTopLevel(current['body'], currentShadowed);
       continueTargets.pop();
       breakTargets.pop();
-      if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+      const continuedAfterTest: Set<string>[] = [];
+      for (const state of continuedStates) {
+        restoreMutableValues(state);
+        if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed);
+        continuedAfterTest.push(snapshotMutableValues());
+      }
       restoreMutableValues([
         ...interruptedStates.flatMap((state) => [...state]),
-        ...continuedStates.flatMap((state) => [...state]),
+        ...continuedAfterTest.flatMap((state) => [...state]),
         ...mutableValues,
       ]);
       return;

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -234,6 +234,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
   if (instanceContent === undefined && !isRecord(root['fragment'])) return new Set();
   const possibleControls = new Set<string>();
   const bindings = staticStringBindings(source);
+  const mutableValues = new Map<string, Set<string>>();
   const walkTopLevel = (current: unknown, shadowed = false): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
@@ -271,6 +272,50 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       node['left']['name'] === bindingName
     )
       candidate = node['right'];
+    if (
+      !currentShadowed &&
+      node['type'] === 'AssignmentExpression' &&
+      isRecord(node['left']) &&
+      node['left']['type'] === 'Identifier' &&
+      node['left']['name'] === bindingName &&
+      node['operator'] !== '=' &&
+      node['operator'] === '+='
+    ) {
+      const rightValues = possibleStaticStringsFromExpression(node['right'], bindings);
+      const previousValues = mutableValues.get(bindingName) ?? new Set<string>();
+      const combined = new Set<string>();
+      for (const previous of previousValues)
+        for (const right of rightValues) combined.add(previous + right);
+      candidate = undefined;
+      mutableValues.set(bindingName, combined);
+      for (const value of combined) {
+        const normalizedValue = value.toLowerCase();
+        if (
+          normalizedValue === 'input' ||
+          normalizedValue === 'select' ||
+          normalizedValue === 'textarea'
+        )
+          possibleControls.add(normalizedValue);
+      }
+    }
+    if (
+      !currentShadowed &&
+      node['type'] === 'VariableDeclarator' &&
+      isRecord(node['id']) &&
+      node['id']['type'] === 'Identifier' &&
+      node['id']['name'] === bindingName
+    ) {
+      mutableValues.set(bindingName, possibleStaticStringsFromExpression(node['init'], bindings));
+    } else if (
+      !currentShadowed &&
+      node['type'] === 'AssignmentExpression' &&
+      isRecord(node['left']) &&
+      node['left']['type'] === 'Identifier' &&
+      node['left']['name'] === bindingName &&
+      node['operator'] === '='
+    ) {
+      mutableValues.set(bindingName, possibleStaticStringsFromExpression(node['right'], bindings));
+    }
     for (const candidateValue of possibleStaticStringsFromExpression(candidate, bindings)) {
       const normalizedValue = candidateValue.toLowerCase();
       if (
@@ -365,18 +410,35 @@ function hasStaticHiddenAttribute(
         typeIsHidden = undefined;
         continue;
       }
-      for (const property of expression['properties']) {
-        if (!isRecord(property)) continue;
-        const name = staticPropertyName(property);
-        if (name === 'hidden')
-          hiddenState =
-            isRecord(property['value']) &&
-            property['value']['type'] === 'Literal' &&
-            property['value']['value'] === true;
-        else if (soloInput && name === 'type')
-          typeIsHidden =
-            staticStringFromExpression(property['value'], bindings)?.toLowerCase() === 'hidden';
-      }
+      const applyObjectProperties = (properties: unknown[]): void => {
+        for (const property of properties) {
+          if (!isRecord(property)) continue;
+          if (property['type'] === 'SpreadElement') {
+            const nested = property['argument'];
+            if (
+              isRecord(nested) &&
+              nested['type'] === 'ObjectExpression' &&
+              Array.isArray(nested['properties'])
+            )
+              applyObjectProperties(nested['properties']);
+            else {
+              hiddenState = undefined;
+              typeIsHidden = undefined;
+            }
+            continue;
+          }
+          const name = staticPropertyName(property);
+          if (name === 'hidden')
+            hiddenState =
+              isRecord(property['value']) &&
+              property['value']['type'] === 'Literal' &&
+              property['value']['value'] === true;
+          else if (soloInput && name === 'type')
+            typeIsHidden =
+              staticStringFromExpression(property['value'], bindings)?.toLowerCase() === 'hidden';
+        }
+      };
+      applyObjectProperties(expression['properties']);
       continue;
     }
     if (attribute['type'] !== 'Attribute') continue;
@@ -563,7 +625,7 @@ function collectSharedFloatingTargets(source: string): SharedFloatingTarget[] {
   walkAst(fragment, (node) => {
     if (node['type'] !== 'RegularElement' && node['type'] !== 'SvelteElement') return;
     const classes = elementClassSet(node, bindings);
-    if (!classes.has('cinder-_floating-surface')) return;
+    const shared = classes.has('cinder-_floating-surface');
     const attributes = new Map<string, string | true>();
     let id: string | undefined;
     if (Array.isArray(node['attributes']))
@@ -575,8 +637,8 @@ function collectSharedFloatingTargets(source: string): SharedFloatingTarget[] {
           attribute['name'] === 'class'
         )
           continue;
-        const value = attribute['value'] === true ? true : staticAttributeValue(attribute);
-        if (value === undefined) continue;
+        const value =
+          attribute['value'] === true ? true : (staticAttributeValue(attribute) ?? true);
         attributes.set(attribute['name'].toLowerCase(), value);
         if (attribute['name'] === 'id' && typeof value === 'string') id = value;
       }
@@ -592,6 +654,7 @@ function collectSharedFloatingTargets(source: string): SharedFloatingTarget[] {
         ...(id === undefined ? {} : { id }),
         classes,
         attributes,
+        shared,
       });
   });
   return targets;

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -234,8 +234,8 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
   if (instanceContent === undefined && !isRecord(root['fragment'])) return new Set();
   const possibleControls = new Set<string>();
   const bindings = staticStringBindings(source);
-  const mutableValues = new Map<string, Set<string>>();
-  const walkTopLevel = (current: unknown, shadowed = false): void => {
+  const mutableValues = new Set<string>();
+  const walkTopLevel = (current: unknown, shadowed = false, conditional = false): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
     let currentShadowed = shadowed;
@@ -254,6 +254,13 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     } else if (type === 'BlockStatement') {
       currentShadowed ||= declaresLexicalBindingDirectlyInBlock(current, bindingName);
     }
+    if (type === 'IfStatement') {
+      if (isRecord(current['test'])) walkTopLevel(current['test'], currentShadowed, conditional);
+      if (isRecord(current['consequent']))
+        walkTopLevel(current['consequent'], currentShadowed, true);
+      if (isRecord(current['alternate'])) walkTopLevel(current['alternate'], currentShadowed, true);
+      return;
+    }
     const node = current;
     let candidate: unknown;
     if (
@@ -266,6 +273,17 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       candidate = node['init'];
     if (
       !currentShadowed &&
+      node['type'] === 'VariableDeclarator' &&
+      isRecord(node['id']) &&
+      node['id']['type'] === 'Identifier' &&
+      node['id']['name'] === bindingName
+    ) {
+      mutableValues.clear();
+      for (const value of possibleStaticStringsFromExpression(node['init'], bindings))
+        mutableValues.add(value);
+    }
+    if (
+      !currentShadowed &&
       node['type'] === 'AssignmentExpression' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
@@ -275,46 +293,33 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     if (
       !currentShadowed &&
       node['type'] === 'AssignmentExpression' &&
+      node['operator'] === '+=' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
-      node['left']['name'] === bindingName &&
-      node['operator'] !== '=' &&
-      node['operator'] === '+='
+      node['left']['name'] === bindingName
     ) {
       const rightValues = possibleStaticStringsFromExpression(node['right'], bindings);
-      const previousValues = mutableValues.get(bindingName) ?? new Set<string>();
       const combined = new Set<string>();
-      for (const previous of previousValues)
+      for (const previous of mutableValues)
         for (const right of rightValues) combined.add(previous + right);
+      mutableValues.clear();
+      for (const value of combined) mutableValues.add(value);
       candidate = undefined;
-      mutableValues.set(bindingName, combined);
-      for (const value of combined) {
-        const normalizedValue = value.toLowerCase();
-        if (
-          normalizedValue === 'input' ||
-          normalizedValue === 'select' ||
-          normalizedValue === 'textarea'
-        )
-          possibleControls.add(normalizedValue);
-      }
     }
     if (
       !currentShadowed &&
-      node['type'] === 'VariableDeclarator' &&
-      isRecord(node['id']) &&
-      node['id']['type'] === 'Identifier' &&
-      node['id']['name'] === bindingName
-    ) {
-      mutableValues.set(bindingName, possibleStaticStringsFromExpression(node['init'], bindings));
-    } else if (
-      !currentShadowed &&
       node['type'] === 'AssignmentExpression' &&
+      node['operator'] === '=' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
-      node['left']['name'] === bindingName &&
-      node['operator'] === '='
+      node['left']['name'] === bindingName
     ) {
-      mutableValues.set(bindingName, possibleStaticStringsFromExpression(node['right'], bindings));
+      const values = possibleStaticStringsFromExpression(node['right'], bindings);
+      if (conditional) for (const value of values) mutableValues.add(value);
+      else {
+        mutableValues.clear();
+        for (const value of values) mutableValues.add(value);
+      }
     }
     for (const candidateValue of possibleStaticStringsFromExpression(candidate, bindings)) {
       const normalizedValue = candidateValue.toLowerCase();
@@ -325,9 +330,19 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       )
         possibleControls.add(normalizedValue);
     }
+    for (const candidateValue of mutableValues) {
+      const normalizedValue = candidateValue.toLowerCase();
+      if (
+        normalizedValue === 'input' ||
+        normalizedValue === 'select' ||
+        normalizedValue === 'textarea'
+      )
+        possibleControls.add(normalizedValue);
+    }
     for (const child of Object.values(current)) {
-      if (Array.isArray(child)) child.forEach((item) => walkTopLevel(item, currentShadowed));
-      else if (isRecord(child)) walkTopLevel(child, currentShadowed);
+      if (Array.isArray(child))
+        child.forEach((item) => walkTopLevel(item, currentShadowed, conditional));
+      else if (isRecord(child)) walkTopLevel(child, currentShadowed, conditional);
     }
   };
   if (instanceContent !== undefined) walkTopLevel(instanceContent);
@@ -410,35 +425,18 @@ function hasStaticHiddenAttribute(
         typeIsHidden = undefined;
         continue;
       }
-      const applyObjectProperties = (properties: unknown[]): void => {
-        for (const property of properties) {
-          if (!isRecord(property)) continue;
-          if (property['type'] === 'SpreadElement') {
-            const nested = property['argument'];
-            if (
-              isRecord(nested) &&
-              nested['type'] === 'ObjectExpression' &&
-              Array.isArray(nested['properties'])
-            )
-              applyObjectProperties(nested['properties']);
-            else {
-              hiddenState = undefined;
-              typeIsHidden = undefined;
-            }
-            continue;
-          }
-          const name = staticPropertyName(property);
-          if (name === 'hidden')
-            hiddenState =
-              isRecord(property['value']) &&
-              property['value']['type'] === 'Literal' &&
-              property['value']['value'] === true;
-          else if (soloInput && name === 'type')
-            typeIsHidden =
-              staticStringFromExpression(property['value'], bindings)?.toLowerCase() === 'hidden';
-        }
-      };
-      applyObjectProperties(expression['properties']);
+      for (const property of expression['properties']) {
+        if (!isRecord(property)) continue;
+        const name = staticPropertyName(property);
+        if (name === 'hidden')
+          hiddenState =
+            isRecord(property['value']) &&
+            property['value']['type'] === 'Literal' &&
+            property['value']['value'] === true;
+        else if (soloInput && name === 'type')
+          typeIsHidden =
+            staticStringFromExpression(property['value'], bindings)?.toLowerCase() === 'hidden';
+      }
       continue;
     }
     if (attribute['type'] !== 'Attribute') continue;
@@ -625,7 +623,7 @@ function collectSharedFloatingTargets(source: string): SharedFloatingTarget[] {
   walkAst(fragment, (node) => {
     if (node['type'] !== 'RegularElement' && node['type'] !== 'SvelteElement') return;
     const classes = elementClassSet(node, bindings);
-    const shared = classes.has('cinder-_floating-surface');
+    if (!classes.has('cinder-_floating-surface')) return;
     const attributes = new Map<string, string | true>();
     let id: string | undefined;
     if (Array.isArray(node['attributes']))
@@ -637,8 +635,8 @@ function collectSharedFloatingTargets(source: string): SharedFloatingTarget[] {
           attribute['name'] === 'class'
         )
           continue;
-        const value =
-          attribute['value'] === true ? true : (staticAttributeValue(attribute) ?? true);
+        const value = attribute['value'] === true ? true : staticAttributeValue(attribute);
+        if (value === undefined) continue;
         attributes.set(attribute['name'].toLowerCase(), value);
         if (attribute['name'] === 'id' && typeof value === 'string') id = value;
       }
@@ -654,7 +652,6 @@ function collectSharedFloatingTargets(source: string): SharedFloatingTarget[] {
         ...(id === undefined ? {} : { id }),
         classes,
         attributes,
-        shared,
       });
   });
   return targets;

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -235,6 +235,17 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
   const possibleControls = new Set<string>();
   const bindings = staticStringBindings(source);
   const mutableValues = new Set<string>();
+  const recordControls = (values: Iterable<string>): void => {
+    for (const candidateValue of values) {
+      const normalizedValue = candidateValue.toLowerCase();
+      if (
+        normalizedValue === 'input' ||
+        normalizedValue === 'select' ||
+        normalizedValue === 'textarea'
+      )
+        possibleControls.add(normalizedValue);
+    }
+  };
   const walkTopLevel = (current: unknown, shadowed = false, conditional = false): void => {
     if (!isRecord(current)) return;
     const type = current['type'];
@@ -285,6 +296,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
     if (
       !currentShadowed &&
       node['type'] === 'AssignmentExpression' &&
+      node['operator'] === '=' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
       node['left']['name'] === bindingName
@@ -321,24 +333,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
         for (const value of values) mutableValues.add(value);
       }
     }
-    for (const candidateValue of possibleStaticStringsFromExpression(candidate, bindings)) {
-      const normalizedValue = candidateValue.toLowerCase();
-      if (
-        normalizedValue === 'input' ||
-        normalizedValue === 'select' ||
-        normalizedValue === 'textarea'
-      )
-        possibleControls.add(normalizedValue);
-    }
-    for (const candidateValue of mutableValues) {
-      const normalizedValue = candidateValue.toLowerCase();
-      if (
-        normalizedValue === 'input' ||
-        normalizedValue === 'select' ||
-        normalizedValue === 'textarea'
-      )
-        possibleControls.add(normalizedValue);
-    }
+    recordControls(possibleStaticStringsFromExpression(candidate, bindings));
     for (const child of Object.values(current)) {
       if (Array.isArray(child))
         child.forEach((item) => walkTopLevel(item, currentShadowed, conditional));
@@ -355,6 +350,7 @@ function possibleMutableControlNames(source: string, expression: unknown): Set<s
       if (node['type'] === 'ExpressionTag' && isRecord(node['expression']))
         walkTopLevel(node['expression']);
     });
+  recordControls(mutableValues);
   return possibleControls;
 }
 

--- a/packages/components/scripts/check-primitive-composition.ts
+++ b/packages/components/scripts/check-primitive-composition.ts
@@ -47,13 +47,13 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
   if (!isRecord(statement)) return false;
   if (
     statement['type'] === 'BreakStatement' ||
+    statement['type'] === 'ContinueStatement' ||
     statement['type'] === 'ReturnStatement' ||
     statement['type'] === 'ThrowStatement'
   )
     return true;
   if (statement['type'] !== 'BlockStatement' || !Array.isArray(statement['body'])) return false;
-  for (const child of statement['body']) if (unconditionallyAbruptStatement(child)) return true;
-  return false;
+  return unconditionallyAbruptStatement(statement['body'].at(-1));
 }
 
 function isDefinitelyUndefinedExpression(value: unknown): boolean {
@@ -67,11 +67,13 @@ function isDefinitelyNonUndefinedExpression(value: unknown): boolean {
     isRecord(value) &&
     [
       'Literal',
+      'TemplateLiteral',
       'ObjectExpression',
       'ArrayExpression',
       'FunctionExpression',
       'ArrowFunctionExpression',
       'ClassExpression',
+      'NewExpression',
     ].includes(String(value['type']))
   );
 }
@@ -309,17 +311,41 @@ function possibleMutableControlNames(
   const breakTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
   const continueTargets: Array<{ label: string | undefined; states: Set<string>[] }> = [];
   const returnTargets: Set<string>[][] = [];
+  const tryPrefixTargets: Set<string>[][] = [];
   let finallyDepth = 0;
   const explicitWrites: boolean[] = [];
-  const localAliasFrames: Map<string, string>[] = [];
+  const localAliasFrames: Map<string, ReadonlySet<string>>[] = [];
   const undefinedShadowFrames: boolean[] = [];
   const undefinedIsShadowed = (): boolean => undefinedShadowFrames.some(Boolean);
   let suppressPublication = false;
-  const visibleBindings = (): Map<string, string> => {
-    const visible = new Map(bindings);
-    for (const frame of localAliasFrames)
-      for (const [name, value] of frame) visible.set(name, value);
-    return visible;
+  const possibleVisibleStrings = (valueExpression: unknown): Set<string> => {
+    if (!isRecord(valueExpression)) return new Set();
+    if (valueExpression['type'] === 'Identifier' && typeof valueExpression['name'] === 'string') {
+      for (let index = localAliasFrames.length - 1; index >= 0; index -= 1) {
+        const values = localAliasFrames[index]?.get(valueExpression['name']);
+        if (values !== undefined) return new Set(values);
+      }
+    }
+    if (
+      valueExpression['type'] === 'TSAsExpression' ||
+      valueExpression['type'] === 'TSSatisfiesExpression' ||
+      valueExpression['type'] === 'TSNonNullExpression'
+    )
+      return possibleVisibleStrings(valueExpression['expression']);
+    if (valueExpression['type'] === 'ConditionalExpression')
+      return new Set([
+        ...possibleVisibleStrings(valueExpression['consequent']),
+        ...possibleVisibleStrings(valueExpression['alternate']),
+      ]);
+    if (valueExpression['type'] === 'LogicalExpression')
+      return new Set([
+        ...possibleVisibleStrings(valueExpression['left']),
+        ...possibleVisibleStrings(valueExpression['right']),
+      ]);
+    return possibleStaticStringsFromExpression(valueExpression, bindings);
+  };
+  const captureTryPrefix = (): void => {
+    for (const states of tryPrefixTargets) states.push(snapshotMutableValues());
   };
   const shadowsBindingInsideParameters = (node: UnknownRecord, shadowed: boolean): boolean =>
     shadowed ||
@@ -565,11 +591,13 @@ function possibleMutableControlNames(
       const alternatives: Set<string>[] = [];
       const tryBlock = current['block'];
       restoreMutableValues(base);
+      tryPrefixTargets.push([]);
       if (isRecord(tryBlock)) walkTopLevel(tryBlock, currentShadowed);
+      const tryPrefixes = tryPrefixTargets.pop() ?? [];
       alternatives.push(snapshotMutableValues());
       const handler = current['handler'];
       if (isRecord(handler)) {
-        restoreMutableValues(base);
+        restoreMutableValues([...base, ...tryPrefixes.flatMap((state) => [...state])]);
         const catchShadowed =
           currentShadowed || bindingPatternIncludesName(handler['param'], bindingName);
         undefinedShadowFrames.push(bindingPatternIncludesName(handler['param'], 'undefined'));
@@ -805,6 +833,11 @@ function possibleMutableControlNames(
       if (!suppressPublication && finallyDepth === 0) recordControls(mutableValues);
       return;
     }
+    if (type === 'AwaitExpression') {
+      if (isRecord(current['argument'])) walkTopLevel(current['argument'], currentShadowed);
+      recordControls(mutableValues);
+      return;
+    }
     if (type === 'BlockStatement' && Array.isArray(current['body'])) {
       localAliasFrames.push(new Map());
       for (const statement of current['body']) {
@@ -877,6 +910,7 @@ function possibleMutableControlNames(
         mutableValues.clear();
         for (const value of possibleStaticStringsFromExpression(node['init'], bindings))
           mutableValues.add(value);
+        captureTryPrefix();
       }
     }
     if (
@@ -887,8 +921,8 @@ function possibleMutableControlNames(
       typeof node['id']['name'] === 'string' &&
       localAliasFrames.length > 0
     ) {
-      const resolved = staticStringFromExpression(node['init'], visibleBindings());
-      if (resolved !== undefined) localAliasFrames.at(-1)?.set(node['id']['name'], resolved);
+      const resolved = possibleVisibleStrings(node['init']);
+      if (resolved.size > 0) localAliasFrames.at(-1)?.set(node['id']['name'], resolved);
     }
     if (
       !currentShadowed &&
@@ -898,11 +932,12 @@ function possibleMutableControlNames(
       node['left']['type'] === 'Identifier' &&
       node['left']['name'] === bindingName
     ) {
-      const rightValues = possibleStaticStringsFromExpression(node['right'], visibleBindings());
+      const rightValues = possibleVisibleStrings(node['right']);
       const combined = new Set<string>();
       for (const previous of mutableValues)
         for (const right of rightValues) combined.add(previous + right);
       restoreMutableValues(combined);
+      captureTryPrefix();
       if (explicitWrites.length > 0) explicitWrites[explicitWrites.length - 1] = true;
     }
     if (
@@ -913,8 +948,9 @@ function possibleMutableControlNames(
       node['left']['type'] === 'Identifier' &&
       node['left']['name'] === bindingName
     ) {
-      const values = possibleStaticStringsFromExpression(node['right'], visibleBindings());
+      const values = possibleVisibleStrings(node['right']);
       restoreMutableValues(values);
+      captureTryPrefix();
       if (explicitWrites.length > 0) explicitWrites[explicitWrites.length - 1] = true;
     }
     if (
@@ -925,7 +961,7 @@ function possibleMutableControlNames(
       node['left']['type'] === 'Identifier' &&
       node['left']['name'] === bindingName
     ) {
-      const rightValues = possibleStaticStringsFromExpression(node['right'], visibleBindings());
+      const rightValues = possibleVisibleStrings(node['right']);
       const previousValues = [...mutableValues];
       const result = new Set<string>();
       for (const previous of previousValues) {
@@ -937,6 +973,7 @@ function possibleMutableControlNames(
       }
       if (previousValues.length === 0) for (const right of rightValues) result.add(right);
       restoreMutableValues(result);
+      captureTryPrefix();
       if (explicitWrites.length > 0) explicitWrites[explicitWrites.length - 1] = true;
     }
     for (const child of Object.values(current)) {

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -11,7 +11,6 @@ export type SharedFloatingTarget = {
   id?: string;
   classes: ReadonlySet<string>;
   attributes: ReadonlyMap<string, string | true>;
-  shared?: boolean;
 };
 
 export const gridDefinitionProperties = [
@@ -178,6 +177,13 @@ function selectorTargets(selector: string): SelectorTarget[] {
 }
 
 function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget): boolean {
+  const negatesTag = (target: SelectorTarget, other: SelectorTarget): boolean =>
+    other.tag !== undefined &&
+    target.functionalConstraints.some(
+      ({ kind, alternatives }) =>
+        kind === 'not' && alternatives.some((alternative) => alternative.tag === other.tag),
+    );
+  if (negatesTag(left, right) || negatesTag(right, left)) return false;
   const leftAncestorIds = [...(left.ancestorSignature?.matchAll(/#([\w-]+)/g) ?? [])].map(
     (match) => match[1],
   );
@@ -218,13 +224,8 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
       kind === 'any' &&
       alternatives.some((alternative) => targetsCanMatchSameElement(alternative, right)),
   );
-  const tagCrossAnchor =
-    (left.tag !== undefined &&
-      (right.id !== undefined || right.classes.size > 0 || right.attributes.size > 0)) ||
-    (right.tag !== undefined &&
-      (left.id !== undefined || left.classes.size > 0 || left.attributes.size > 0));
   return (
-    (shareAnchor || tagCrossAnchor || functionalAnchor) &&
+    (shareAnchor || functionalAnchor) &&
     !hasConflictingAttribute &&
     (left.id === undefined || right.id === undefined || left.id === right.id) &&
     (left.tag === undefined || right.tag === undefined || left.tag === right.tag)
@@ -534,14 +535,11 @@ export function cssPrimitiveCounts(
             ([positionTarget, zIndexTarget]) => {
               if (isInternalLayerTarget(positionTarget) || isInternalLayerTarget(zIndexTarget))
                 return false;
-              const matchingTargets = sharedTargets.filter(
+              const sharedPair = sharedTargets.some(
                 (sharedTarget) =>
                   targetMatchesSharedFloatingElement(positionTarget, sharedTarget) &&
                   targetMatchesSharedFloatingElement(zIndexTarget, sharedTarget),
               );
-              const sharedPair =
-                matchingTargets.length > 0 &&
-                matchingTargets.every((target) => target.shared !== false);
               const bothExplicitlyShared =
                 positionTarget.classes.has('cinder-_floating-surface') &&
                 zIndexTarget.classes.has('cinder-_floating-surface');

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -181,7 +181,12 @@ function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
     other.tag !== undefined &&
     target.functionalConstraints.some(
       ({ kind, alternatives }) =>
-        kind === 'not' && alternatives.some((alternative) => alternative.tag === other.tag),
+        kind === 'not' &&
+        alternatives.some(
+          (alternative) =>
+            alternative.tag === other.tag &&
+            (target.tag === undefined || targetNecessarilyMatches(other, alternative)),
+        ),
     )
   );
 }

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -125,7 +125,7 @@ function attributeConstraintNecessarilyMatches(
 }
 
 function targetNecessarilyMatches(peer: SelectorTarget, alternative: SelectorTarget): boolean {
-  return (
+  const basicMatch =
     (alternative.tag === undefined || peer.tag === alternative.tag) &&
     (alternative.id === undefined || peer.id === alternative.id) &&
     [...alternative.classes].every((className) => peer.classes.has(className)) &&
@@ -135,8 +135,54 @@ function targetNecessarilyMatches(peer: SelectorTarget, alternative: SelectorTar
           attributeConstraintNecessarilyMatches(peerConstraint, constraint),
         ),
       ),
-    )
+    );
+  if (!basicMatch) return false;
+  return alternative.functionalConstraints.every(({ kind, alternatives }) =>
+    kind === 'not'
+      ? alternatives.every((nested) => targetsNecessarilyDisjoint(peer, nested))
+      : alternatives.some((nested) => targetNecessarilyMatches(peer, nested)),
   );
+}
+
+function targetsNecessarilyDisjoint(left: SelectorTarget, right: SelectorTarget): boolean {
+  if (left.impossible || right.impossible) return true;
+  if (left.tag !== undefined && right.tag !== undefined && left.tag !== right.tag) return true;
+  if (left.id !== undefined && right.id !== undefined && left.id !== right.id) return true;
+  if (
+    [...left.attributeConstraints].some(([name, constraints]) =>
+      constraints.some((leftConstraint) =>
+        attributeConstraintsFor(right, name).some((rightConstraint) =>
+          attributeConstraintsContradict(leftConstraint, rightConstraint),
+        ),
+      ),
+    )
+  )
+    return true;
+  for (const constraint of left.functionalConstraints) {
+    if (
+      constraint.kind === 'not' &&
+      constraint.alternatives.some((alternative) => targetNecessarilyMatches(right, alternative))
+    )
+      return true;
+    if (
+      constraint.kind === 'any' &&
+      constraint.alternatives.every((alternative) => targetsNecessarilyDisjoint(alternative, right))
+    )
+      return true;
+  }
+  for (const constraint of right.functionalConstraints) {
+    if (
+      constraint.kind === 'not' &&
+      constraint.alternatives.some((alternative) => targetNecessarilyMatches(left, alternative))
+    )
+      return true;
+    if (
+      constraint.kind === 'any' &&
+      constraint.alternatives.every((alternative) => targetsNecessarilyDisjoint(left, alternative))
+    )
+      return true;
+  }
+  return false;
 }
 
 function mediaType(query: string): { name: string; negated: boolean } | undefined {

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -177,6 +177,10 @@ function selectorTargets(selector: string): SelectorTarget[] {
 }
 
 function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
+  const alternativeAddsConstraints = (alternative: SelectorTarget): boolean =>
+    (alternative.id !== undefined && alternative.id !== target.id) ||
+    [...alternative.classes].some((className) => !target.classes.has(className)) ||
+    [...alternative.attributes].some(([name]) => !target.attributes.has(name));
   return (
     other.tag !== undefined &&
     target.functionalConstraints.some(
@@ -184,8 +188,10 @@ function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
         kind === 'not' &&
         alternatives.some(
           (alternative) =>
-            alternative.tag === other.tag &&
-            (target.tag === undefined || targetNecessarilyMatches(other, alternative)),
+            (alternative.tag === other.tag &&
+              target.tag === undefined &&
+              !alternativeAddsConstraints(alternative)) ||
+            targetNecessarilyMatches(other, alternative),
         ),
     )
   );
@@ -228,13 +234,22 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
     (left.tag !== undefined && left.tag === right.tag) ||
     [...left.classes].some((className) => right.classes.has(className)) ||
     [...left.attributes.keys()].some((attribute) => right.attributes.has(attribute));
-  const functionalAnchor = left.functionalConstraints.some(
-    ({ kind, alternatives }) =>
-      kind === 'any' &&
-      alternatives.some((alternative) => targetsCanMatchSameElement(alternative, right)),
+  const functionalAnchor = left.functionalConstraints.some(({ alternatives }) =>
+    alternatives.some(
+      (alternative) =>
+        targetsCanMatchSameElement(alternative, right) ||
+        (alternative.tag !== undefined && alternative.tag === right.tag),
+    ),
+  );
+  const reverseFunctionalAnchor = right.functionalConstraints.some(({ alternatives }) =>
+    alternatives.some(
+      (alternative) =>
+        targetsCanMatchSameElement(alternative, left) ||
+        (alternative.tag !== undefined && alternative.tag === left.tag),
+    ),
   );
   return (
-    (shareAnchor || functionalAnchor) &&
+    (shareAnchor || functionalAnchor || reverseFunctionalAnchor) &&
     !hasConflictingAttribute &&
     (left.id === undefined || right.id === undefined || left.id === right.id) &&
     (left.tag === undefined || right.tag === undefined || left.tag === right.tag)

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -259,6 +259,8 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
   const shareAnchor =
     (left.id !== undefined && left.id === right.id) ||
     (left.tag !== undefined && left.tag === right.tag) ||
+    (left.tag !== undefined && right.classes.size > 0) ||
+    (right.tag !== undefined && left.classes.size > 0) ||
     [...left.classes].some((className) => right.classes.has(className)) ||
     [...left.attributes.keys()].some((attribute) => right.attributes.has(attribute)) ||
     hasCompoundNegatedTagAnchor(left, right) ||

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -522,39 +522,47 @@ type WidthBound = {
 function widthBounds(parameters: string): WidthBound[] {
   const bounds: WidthBound[] = [];
   for (const match of parameters.matchAll(
-    /\(\s*(min|max)-width\s*:\s*(\d+(?:\.\d+)?)\s*(px|r?em)\s*\)/gi,
+    /(\bnot\s+)?\(\s*(min|max)-width\s*:\s*(\d+(?:\.\d+)?)\s*(px|r?em)\s*\)/gi,
   )) {
-    if (match[1] === undefined || match[2] === undefined || match[3] === undefined) continue;
+    if (match[2] === undefined || match[3] === undefined || match[4] === undefined) continue;
+    const negated = match[1] !== undefined;
+    const kind = match[2].toLowerCase() === 'min' ? 'minimum' : 'maximum';
     bounds.push({
-      kind: match[1].toLowerCase() === 'min' ? 'minimum' : 'maximum',
-      value: Number(match[2]),
-      inclusive: true,
+      kind: negated ? (kind === 'minimum' ? 'maximum' : 'minimum') : kind,
+      value: Number(match[3]),
+      inclusive: !negated,
       // Media-query em and rem units both resolve against the initial root font size.
-      unit: match[3].toLowerCase() === 'px' ? 'px' : 'root-em',
+      unit: match[4].toLowerCase() === 'px' ? 'px' : 'root-em',
     });
   }
   for (const match of parameters.matchAll(
-    /\(\s*width\s*(<|<=|>|>=)\s*(\d+(?:\.\d+)?)\s*(px|r?em)\s*\)/gi,
+    /(\bnot\s+)?\(\s*width\s*(<|<=|>|>=)\s*(\d+(?:\.\d+)?)\s*(px|r?em)\s*\)/gi,
   )) {
-    if (match[1] === undefined || match[2] === undefined || match[3] === undefined) continue;
-    const operator = match[1];
+    if (match[2] === undefined || match[3] === undefined || match[4] === undefined) continue;
+    const negated = match[1] !== undefined;
+    const operator = negated
+      ? ({ '<': '>=', '<=': '>', '>': '<=', '>=': '<' }[match[2]] ?? match[2])
+      : match[2];
     bounds.push({
       kind: operator.startsWith('>') ? 'minimum' : 'maximum',
-      value: Number(match[2]),
+      value: Number(match[3]),
       inclusive: operator.includes('='),
-      unit: match[3].toLowerCase() === 'px' ? 'px' : 'root-em',
+      unit: match[4].toLowerCase() === 'px' ? 'px' : 'root-em',
     });
   }
   for (const match of parameters.matchAll(
-    /\(\s*(\d+(?:\.\d+)?)\s*(px|r?em)\s*(<|<=|>|>=)\s*width\s*\)/gi,
+    /(\bnot\s+)?\(\s*(\d+(?:\.\d+)?)\s*(px|r?em)\s*(<|<=|>|>=)\s*width\s*\)/gi,
   )) {
-    if (match[1] === undefined || match[2] === undefined || match[3] === undefined) continue;
-    const operator = match[3];
+    if (match[2] === undefined || match[3] === undefined || match[4] === undefined) continue;
+    const negated = match[1] !== undefined;
+    const operator = negated
+      ? ({ '<': '>=', '<=': '>', '>': '<=', '>=': '<' }[match[4]] ?? match[4])
+      : match[4];
     bounds.push({
       kind: operator.startsWith('<') ? 'minimum' : 'maximum',
-      value: Number(match[1]),
+      value: Number(match[2]),
       inclusive: operator.includes('='),
-      unit: match[2].toLowerCase() === 'px' ? 'px' : 'root-em',
+      unit: match[3].toLowerCase() === 'px' ? 'px' : 'root-em',
     });
   }
   return bounds;
@@ -570,7 +578,8 @@ function discreteConditions(parameters: string): Map<string, string> {
   return conditions;
 }
 
-function conditionalQueryBranches(parameters: string): string[] {
+export function conditionalQueryBranches(parameters: string): string[] {
+  parameters = parameters.replace(/\/\*[\s\S]*?\*\//g, (comment) => ' '.repeat(comment.length));
   const branches: string[] = [];
   let parenthesisDepth = 0;
   let branchStart = 0;

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -280,8 +280,10 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
   const shareAnchor =
     (left.id !== undefined && left.id === right.id) ||
     (left.tag !== undefined && left.tag === right.tag) ||
-    (left.tag !== undefined && right.classes.size > 0) ||
-    (right.tag !== undefined && left.classes.size > 0) ||
+    (left.tag !== undefined &&
+      (right.id !== undefined || right.classes.size > 0 || right.attributes.size > 0)) ||
+    (right.tag !== undefined &&
+      (left.id !== undefined || left.classes.size > 0 || left.attributes.size > 0)) ||
     [...left.classes].some((className) => right.classes.has(className)) ||
     [...left.attributes.keys()].some((attribute) => right.attributes.has(attribute)) ||
     hasCompoundNegatedTagAnchor(left, right) ||

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -62,6 +62,7 @@ type AttributeConstraint = {
 
 type SelectorTarget = {
   ancestorSignature?: string;
+  directParentTag?: string;
   tag?: string;
   id?: string;
   impossible?: boolean;
@@ -233,7 +234,15 @@ function selectorTargets(selector: string): SelectorTarget[] {
           .map((node) => node.toString())
           .join('')
           .trim();
-        if (ancestorSignature) target.ancestorSignature = ancestorSignature;
+        if (ancestorSignature) {
+          target.ancestorSignature = ancestorSignature;
+          const combinator = selectorNode.nodes[lastCombinator];
+          if (combinator?.type === 'combinator' && combinator.value.trim() === '>') {
+            const parentCompound = ancestorSignature.split(/\s+/).at(-1) ?? '';
+            const directParentTag = parentCompound.match(/^[a-z][\w-]*/i)?.[0].toLowerCase();
+            if (directParentTag !== undefined) target.directParentTag = directParentTag;
+          }
+        }
       }
       targets.push(target);
     });
@@ -299,12 +308,9 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
   if (left.impossible || right.impossible) return false;
   if (negatesTag(left, right) || negatesTag(right, left)) return false;
   if (
-    left.ancestorSignature !== undefined &&
-    right.ancestorSignature !== undefined &&
-    /^[a-z][\w-]*/i.test(left.ancestorSignature) &&
-    /^[a-z][\w-]*/i.test(right.ancestorSignature) &&
-    left.ancestorSignature.match(/^[a-z][\w-]*/i)?.[0].toLowerCase() !==
-      right.ancestorSignature.match(/^[a-z][\w-]*/i)?.[0].toLowerCase()
+    left.directParentTag !== undefined &&
+    right.directParentTag !== undefined &&
+    left.directParentTag !== right.directParentTag
   )
     return false;
   const leftAncestorIds = [...(left.ancestorSignature?.matchAll(/#([\w-]+)/g) ?? [])].map(

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -541,13 +541,7 @@ export function cssPrimitiveCounts(
               );
               const sharedPair =
                 matchingTargets.length > 0 &&
-                sharedTargets
-                  .filter(
-                    (target) =>
-                      targetMatchesSharedFloatingElement(positionTarget, target) &&
-                      targetMatchesSharedFloatingElement(zIndexTarget, target),
-                  )
-                  .every((target) => target.shared !== false);
+                matchingTargets.every((target) => target.shared !== false);
               const bothExplicitlyShared =
                 positionTarget.classes.has('cinder-_floating-surface') &&
                 zIndexTarget.classes.has('cinder-_floating-surface');

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -81,6 +81,21 @@ function attributeOperatorMatches(
   return true;
 }
 
+function attributeConstraintNecessarilyMatches(
+  peer: AttributeConstraint,
+  alternative: AttributeConstraint,
+): boolean {
+  if (alternative.operator === undefined) return true;
+  if (
+    peer.operator !== alternative.operator ||
+    peer.value === undefined ||
+    alternative.value === undefined
+  )
+    return false;
+  if (alternative.insensitive) return peer.value.toLowerCase() === alternative.value.toLowerCase();
+  return !peer.insensitive && peer.value === alternative.value;
+}
+
 function targetNecessarilyMatches(peer: SelectorTarget, alternative: SelectorTarget): boolean {
   return (
     (alternative.tag === undefined || peer.tag === alternative.tag) &&
@@ -90,8 +105,7 @@ function targetNecessarilyMatches(peer: SelectorTarget, alternative: SelectorTar
       const peerConstraint = peer.attributes.get(name);
       return (
         peerConstraint !== undefined &&
-        peerConstraint.operator === constraint.operator &&
-        peerConstraint.value === constraint.value
+        attributeConstraintNecessarilyMatches(peerConstraint, constraint)
       );
     })
   );
@@ -244,8 +258,9 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
     const leftValue = leftConstraint.value;
     const rightValue = rightConstraint.value;
     if (leftValue === undefined || rightValue === undefined) return false;
-    const leftNormalized = normalizeAttributeValue(leftValue, leftConstraint.insensitive);
-    const rightNormalized = normalizeAttributeValue(rightValue, rightConstraint.insensitive);
+    const insensitive = leftConstraint.insensitive || rightConstraint.insensitive;
+    const leftNormalized = normalizeAttributeValue(leftValue, insensitive);
+    const rightNormalized = normalizeAttributeValue(rightValue, insensitive);
     if (leftConstraint.operator === '=' && rightConstraint.operator !== '=')
       return !attributeOperatorMatches(rightConstraint.operator, leftNormalized, rightNormalized);
     if (rightConstraint.operator === '=' && leftConstraint.operator !== '=')

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -176,11 +176,15 @@ function selectorTargets(selector: string): SelectorTarget[] {
   return targets;
 }
 
-function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
-  const alternativeAddsConstraints = (alternative: SelectorTarget): boolean =>
+function alternativeAddsConstraints(target: SelectorTarget, alternative: SelectorTarget): boolean {
+  return (
     (alternative.id !== undefined && alternative.id !== target.id) ||
     [...alternative.classes].some((className) => !target.classes.has(className)) ||
-    [...alternative.attributes].some(([name]) => !target.attributes.has(name));
+    [...alternative.attributes].some(([name]) => !target.attributes.has(name))
+  );
+}
+
+function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
   return (
     other.tag !== undefined &&
     target.functionalConstraints.some(
@@ -190,8 +194,23 @@ function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
           (alternative) =>
             (alternative.tag === other.tag &&
               target.tag === undefined &&
-              !alternativeAddsConstraints(alternative)) ||
+              !alternativeAddsConstraints(target, alternative)) ||
             targetNecessarilyMatches(other, alternative),
+        ),
+    )
+  );
+}
+
+function hasCompoundNegatedTagAnchor(target: SelectorTarget, other: SelectorTarget): boolean {
+  return (
+    target.tag === undefined &&
+    other.tag !== undefined &&
+    target.functionalConstraints.some(
+      ({ kind, alternatives }) =>
+        kind === 'not' &&
+        alternatives.some(
+          (alternative) =>
+            alternative.tag === other.tag && alternativeAddsConstraints(target, alternative),
         ),
     )
   );
@@ -233,20 +252,26 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
     (left.id !== undefined && left.id === right.id) ||
     (left.tag !== undefined && left.tag === right.tag) ||
     [...left.classes].some((className) => right.classes.has(className)) ||
-    [...left.attributes.keys()].some((attribute) => right.attributes.has(attribute));
-  const functionalAnchor = left.functionalConstraints.some(({ alternatives }) =>
-    alternatives.some(
-      (alternative) =>
-        targetsCanMatchSameElement(alternative, right) ||
-        (alternative.tag !== undefined && alternative.tag === right.tag),
-    ),
+    [...left.attributes.keys()].some((attribute) => right.attributes.has(attribute)) ||
+    hasCompoundNegatedTagAnchor(left, right) ||
+    hasCompoundNegatedTagAnchor(right, left);
+  const functionalAnchor = left.functionalConstraints.some(
+    ({ kind, alternatives }) =>
+      kind === 'any' &&
+      alternatives.some(
+        (alternative) =>
+          targetsCanMatchSameElement(alternative, right) ||
+          (alternative.tag !== undefined && alternative.tag === right.tag),
+      ),
   );
-  const reverseFunctionalAnchor = right.functionalConstraints.some(({ alternatives }) =>
-    alternatives.some(
-      (alternative) =>
-        targetsCanMatchSameElement(alternative, left) ||
-        (alternative.tag !== undefined && alternative.tag === left.tag),
-    ),
+  const reverseFunctionalAnchor = right.functionalConstraints.some(
+    ({ kind, alternatives }) =>
+      kind === 'any' &&
+      alternatives.some(
+        (alternative) =>
+          targetsCanMatchSameElement(alternative, left) ||
+          (alternative.tag !== undefined && alternative.tag === left.tag),
+      ),
   );
   return (
     (shareAnchor || functionalAnchor || reverseFunctionalAnchor) &&

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -54,6 +54,7 @@ type SelectorTarget = {
   ancestorSignature?: string;
   tag?: string;
   id?: string;
+  impossible?: boolean;
   classes: Set<string>;
   attributes: Map<string, AttributeConstraint>;
   functionalConstraints: Array<{
@@ -119,12 +120,41 @@ function mediaType(query: string): { name: string; negated: boolean } | undefine
 
 function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): SelectorTarget {
   return {
+    ...(outer.impossible || inner.impossible ? { impossible: true } : {}),
     ...((outer.tag ?? inner.tag) ? { tag: outer.tag ?? inner.tag } : {}),
     ...((outer.id ?? inner.id) ? { id: outer.id ?? inner.id } : {}),
     classes: new Set([...outer.classes, ...inner.classes]),
     attributes: new Map([...outer.attributes, ...inner.attributes]),
     functionalConstraints: [...outer.functionalConstraints, ...inner.functionalConstraints],
   };
+}
+
+function attributeConstraintsContradict(
+  left: AttributeConstraint,
+  right: AttributeConstraint,
+): boolean {
+  if (left.value === undefined || right.value === undefined) return false;
+  const insensitive = left.insensitive || right.insensitive;
+  const leftValue = normalizeAttributeValue(left.value, insensitive);
+  const rightValue = normalizeAttributeValue(right.value, insensitive);
+  if (left.operator === '=' && right.operator === '=') return leftValue !== rightValue;
+  if (left.operator === '=' && right.operator !== undefined)
+    return !attributeOperatorMatches(right.operator, leftValue, rightValue);
+  if (right.operator === '=' && left.operator !== undefined)
+    return !attributeOperatorMatches(left.operator, rightValue, leftValue);
+  if (left.operator === right.operator) {
+    if (left.operator === '^=')
+      return !leftValue.startsWith(rightValue) && !rightValue.startsWith(leftValue);
+    if (left.operator === '$=')
+      return !leftValue.endsWith(rightValue) && !rightValue.endsWith(leftValue);
+    if (left.operator === '|=')
+      return !(
+        leftValue === rightValue ||
+        leftValue.startsWith(`${rightValue}-`) ||
+        rightValue.startsWith(`${leftValue}-`)
+      );
+  }
+  return false;
 }
 
 function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): SelectorTarget {
@@ -137,12 +167,18 @@ function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): Selecto
     if (node.type === 'class') target.classes.add(node.value);
     if (node.type === 'id') target.id = node.value;
     if (node.type === 'tag') target.tag = node.value.toLowerCase();
-    if (node.type === 'attribute')
-      target.attributes.set(node.attribute.toLowerCase(), {
+    if (node.type === 'attribute') {
+      const name = node.attribute.toLowerCase();
+      const constraint = {
         operator: node.operator,
         value: node.value,
         insensitive: node.insensitive === true,
-      });
+      } satisfies AttributeConstraint;
+      const previous = target.attributes.get(name);
+      if (previous !== undefined && attributeConstraintsContradict(previous, constraint))
+        target.impossible = true;
+      target.attributes.set(name, constraint);
+    }
   }
   for (const node of nodes) {
     if (
@@ -245,6 +281,7 @@ function hasCompoundNegatedTagAnchor(target: SelectorTarget, other: SelectorTarg
 }
 
 function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget): boolean {
+  if (left.impossible || right.impossible) return false;
   if (negatesTag(left, right) || negatesTag(right, left)) return false;
   const leftAncestorIds = [...(left.ancestorSignature?.matchAll(/#([\w-]+)/g) ?? [])].map(
     (match) => match[1],

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -180,7 +180,15 @@ function alternativeAddsConstraints(target: SelectorTarget, alternative: Selecto
   return (
     (alternative.id !== undefined && alternative.id !== target.id) ||
     [...alternative.classes].some((className) => !target.classes.has(className)) ||
-    [...alternative.attributes].some(([name]) => !target.attributes.has(name))
+    [...alternative.attributes].some(([name, constraint]) => {
+      const targetConstraint = target.attributes.get(name);
+      return (
+        targetConstraint === undefined ||
+        targetConstraint.operator !== constraint.operator ||
+        targetConstraint.value !== constraint.value ||
+        targetConstraint.insensitive !== constraint.insensitive
+      );
+    })
   );
 }
 

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -11,6 +11,7 @@ export type SharedFloatingTarget = {
   id?: string;
   classes: ReadonlySet<string>;
   attributes: ReadonlyMap<string, string | true>;
+  shared?: boolean;
 };
 
 export const gridDefinitionProperties = [
@@ -217,8 +218,13 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
       kind === 'any' &&
       alternatives.some((alternative) => targetsCanMatchSameElement(alternative, right)),
   );
+  const tagCrossAnchor =
+    (left.tag !== undefined &&
+      (right.id !== undefined || right.classes.size > 0 || right.attributes.size > 0)) ||
+    (right.tag !== undefined &&
+      (left.id !== undefined || left.classes.size > 0 || left.attributes.size > 0));
   return (
-    (shareAnchor || functionalAnchor) &&
+    (shareAnchor || tagCrossAnchor || functionalAnchor) &&
     !hasConflictingAttribute &&
     (left.id === undefined || right.id === undefined || left.id === right.id) &&
     (left.tag === undefined || right.tag === undefined || left.tag === right.tag)
@@ -528,11 +534,20 @@ export function cssPrimitiveCounts(
             ([positionTarget, zIndexTarget]) => {
               if (isInternalLayerTarget(positionTarget) || isInternalLayerTarget(zIndexTarget))
                 return false;
-              const sharedPair = sharedTargets.some(
+              const matchingTargets = sharedTargets.filter(
                 (sharedTarget) =>
                   targetMatchesSharedFloatingElement(positionTarget, sharedTarget) &&
                   targetMatchesSharedFloatingElement(zIndexTarget, sharedTarget),
               );
+              const sharedPair =
+                matchingTargets.length > 0 &&
+                sharedTargets
+                  .filter(
+                    (target) =>
+                      targetMatchesSharedFloatingElement(positionTarget, target) &&
+                      targetMatchesSharedFloatingElement(zIndexTarget, target),
+                  )
+                  .every((target) => target.shared !== false);
               const bothExplicitlyShared =
                 positionTarget.classes.has('cinder-_floating-surface') &&
                 zIndexTarget.classes.has('cinder-_floating-surface');

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -25,8 +25,18 @@ export const gridDefinitionProperties = [
 
 export function declarationMap(rule: Rule): Map<string, string> {
   const declarations = new Map<string, string>();
+  const importantProperties = new Set<string>();
   rule.each((node) => {
-    if (node.type === 'decl') declarations.set(node.prop.toLowerCase(), node.value.toLowerCase());
+    if (node.type !== 'decl') return;
+    const property = node.prop.toLowerCase();
+    const important = node.important || /!important\s*$/i.test(node.value);
+    if (!important && importantProperties.has(property)) return;
+    const value = node.value
+      .replace(/\s*!important\s*$/i, '')
+      .trim()
+      .toLowerCase();
+    declarations.set(property, value);
+    if (important) importantProperties.add(property);
   });
   return declarations;
 }
@@ -120,7 +130,12 @@ function mediaType(query: string): { name: string; negated: boolean } | undefine
 
 function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): SelectorTarget {
   return {
-    ...(outer.impossible || inner.impossible ? { impossible: true } : {}),
+    ...(outer.impossible ||
+    inner.impossible ||
+    (outer.tag !== undefined && inner.tag !== undefined && outer.tag !== inner.tag) ||
+    (outer.id !== undefined && inner.id !== undefined && outer.id !== inner.id)
+      ? { impossible: true }
+      : {}),
     ...((outer.tag ?? inner.tag) ? { tag: outer.tag ?? inner.tag } : {}),
     ...((outer.id ?? inner.id) ? { id: outer.id ?? inner.id } : {}),
     classes: new Set([...outer.classes, ...inner.classes]),
@@ -283,6 +298,15 @@ function hasCompoundNegatedTagAnchor(target: SelectorTarget, other: SelectorTarg
 function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget): boolean {
   if (left.impossible || right.impossible) return false;
   if (negatesTag(left, right) || negatesTag(right, left)) return false;
+  if (
+    left.ancestorSignature !== undefined &&
+    right.ancestorSignature !== undefined &&
+    /^[a-z][\w-]*/i.test(left.ancestorSignature) &&
+    /^[a-z][\w-]*/i.test(right.ancestorSignature) &&
+    left.ancestorSignature.match(/^[a-z][\w-]*/i)?.[0].toLowerCase() !==
+      right.ancestorSignature.match(/^[a-z][\w-]*/i)?.[0].toLowerCase()
+  )
+    return false;
   const leftAncestorIds = [...(left.ancestorSignature?.matchAll(/#([\w-]+)/g) ?? [])].map(
     (match) => match[1],
   );
@@ -470,10 +494,19 @@ function conditionalQueryBranchesConflict(left: string, right: string): boolean 
   const leftType = mediaType(left);
   const rightType = mediaType(right);
   if (
+    (leftType?.negated === true && leftType.name === 'all') ||
+    (rightType?.negated === true && rightType.name === 'all')
+  )
+    return true;
+  if (
     leftType !== undefined &&
     rightType !== undefined &&
-    ((leftType.name !== 'all' && rightType.name !== 'all' && leftType.name !== rightType.name) ||
-      leftType.negated !== rightType.negated)
+    (leftType.negated !== rightType.negated
+      ? leftType.name === rightType.name && leftType.name !== 'all'
+      : !leftType.negated &&
+        leftType.name !== 'all' &&
+        rightType.name !== 'all' &&
+        leftType.name !== rightType.name)
   )
     return true;
   const bounds = [...widthBounds(left), ...widthBounds(right)];
@@ -522,6 +555,17 @@ function conditionalScopesConflict(left: ConditionalScope, right: ConditionalSco
 function conditionalScopesCanOverlap(left: Rule, right: Rule): boolean {
   const leftScope = conditionalScope(left);
   const rightScope = conditionalScope(right);
+  if (
+    [...leftScope, ...rightScope].some(
+      (condition) =>
+        condition.name === 'media' &&
+        conditionalQueryBranches(condition.parameters).every((branch) => {
+          const type = mediaType(branch);
+          return type?.negated === true && type.name === 'all';
+        }),
+    )
+  )
+    return false;
   return !leftScope.some((leftCondition) =>
     rightScope.some((rightCondition) => conditionalScopesConflict(leftCondition, rightCondition)),
   );
@@ -534,7 +578,10 @@ function compatibleSelectorTargetPairs(
   if (!conditionalScopesCanOverlap(left, right)) return [];
   const leftTargets = selectorTargets(left.selector);
   const rightTargets = selectorTargets(right.selector);
-  if (left === right) return leftTargets.map((target) => [target, target] as const);
+  if (left === right)
+    return leftTargets
+      .filter((target) => functionalConstraintsCanOverlap(target, target))
+      .map((target) => [target, target] as const);
   return leftTargets.flatMap((leftTarget) =>
     rightTargets
       .filter(

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -195,7 +195,10 @@ function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): Selecto
   };
   for (const node of nodes) {
     if (node.type === 'class') target.classes.add(node.value);
-    if (node.type === 'id') target.id = node.value;
+    if (node.type === 'id') {
+      if (target.id !== undefined && target.id !== node.value) target.impossible = true;
+      target.id = node.value;
+    }
     if (node.type === 'tag') target.tag = node.value.toLowerCase();
     if (node.type === 'attribute') {
       const name = node.attribute.toLowerCase();
@@ -580,6 +583,11 @@ function conditionalScopesConflict(left: ConditionalScope, right: ConditionalSco
 function conditionalScopesCanOverlap(left: Rule, right: Rule): boolean {
   const leftScope = conditionalScope(left);
   const rightScope = conditionalScope(right);
+  const internallyContradictory = (scope: ConditionalScope[]): boolean =>
+    scope.some((condition, index) =>
+      scope.slice(index + 1).some((other) => conditionalScopesConflict(condition, other)),
+    );
+  if (internallyContradictory(leftScope) || internallyContradictory(rightScope)) return false;
   if (
     [...leftScope, ...rightScope].some(
       (condition) =>
@@ -605,7 +613,7 @@ function compatibleSelectorTargetPairs(
   const rightTargets = selectorTargets(right.selector);
   if (left === right)
     return leftTargets
-      .filter((target) => functionalConstraintsCanOverlap(target, target))
+      .filter((target) => !target.impossible && functionalConstraintsCanOverlap(target, target))
       .map((target) => [target, target] as const);
   return leftTargets.flatMap((leftTarget) =>
     rightTargets

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -207,6 +207,7 @@ function alternativeAddsConstraints(target: SelectorTarget, alternative: Selecto
 }
 
 function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
+  const mergedTarget = mergeSelectorTargets(target, other);
   return (
     other.tag !== undefined &&
     target.functionalConstraints.some(
@@ -217,6 +218,8 @@ function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
             (alternative.tag === other.tag &&
               target.tag === undefined &&
               !alternativeAddsConstraints(target, alternative)) ||
+            (alternative.tag === other.tag &&
+              targetNecessarilyMatches(mergedTarget, alternative)) ||
             targetNecessarilyMatches(other, alternative),
         ),
     )
@@ -224,6 +227,7 @@ function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
 }
 
 function hasCompoundNegatedTagAnchor(target: SelectorTarget, other: SelectorTarget): boolean {
+  const mergedTarget = mergeSelectorTargets(target, other);
   return (
     target.tag === undefined &&
     other.tag !== undefined &&
@@ -232,7 +236,9 @@ function hasCompoundNegatedTagAnchor(target: SelectorTarget, other: SelectorTarg
         kind === 'not' &&
         alternatives.some(
           (alternative) =>
-            alternative.tag === other.tag && alternativeAddsConstraints(target, alternative),
+            alternative.tag === other.tag &&
+            alternativeAddsConstraints(target, alternative) &&
+            !targetNecessarilyMatches(mergedTarget, alternative),
         ),
     )
   );

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -512,7 +512,12 @@ function conditionalScope(rule: Rule): ConditionalScope[] {
   return scope;
 }
 
-type WidthBound = { kind: 'minimum' | 'maximum'; value: number; unit: 'px' | 'root-em' };
+type WidthBound = {
+  kind: 'minimum' | 'maximum';
+  value: number;
+  inclusive: boolean;
+  unit: 'px' | 'root-em';
+};
 
 function widthBounds(parameters: string): WidthBound[] {
   const bounds: WidthBound[] = [];
@@ -523,6 +528,7 @@ function widthBounds(parameters: string): WidthBound[] {
     bounds.push({
       kind: match[1].toLowerCase() === 'min' ? 'minimum' : 'maximum',
       value: Number(match[2]),
+      inclusive: true,
       // Media-query em and rem units both resolve against the initial root font size.
       unit: match[3].toLowerCase() === 'px' ? 'px' : 'root-em',
     });
@@ -534,7 +540,8 @@ function widthBounds(parameters: string): WidthBound[] {
     const operator = match[1];
     bounds.push({
       kind: operator.startsWith('>') ? 'minimum' : 'maximum',
-      value: Number(match[2]) + (operator === '>' ? 0.000001 : operator === '<' ? -0.000001 : 0),
+      value: Number(match[2]),
+      inclusive: operator.includes('='),
       unit: match[3].toLowerCase() === 'px' ? 'px' : 'root-em',
     });
   }
@@ -545,7 +552,8 @@ function widthBounds(parameters: string): WidthBound[] {
     const operator = match[3];
     bounds.push({
       kind: operator.startsWith('<') ? 'minimum' : 'maximum',
-      value: Number(match[1]) + (operator === '<' ? 0.000001 : operator === '>' ? -0.000001 : 0),
+      value: Number(match[1]),
+      inclusive: operator.includes('='),
       unit: match[2].toLowerCase() === 'px' ? 'px' : 'root-em',
     });
   }
@@ -570,9 +578,16 @@ function conditionalQueryBranches(parameters: string): string[] {
     const character = parameters[index];
     if (character === '(') parenthesisDepth++;
     if (character === ')') parenthesisDepth--;
-    if (character !== ',' || parenthesisDepth !== 0) continue;
+    if (parenthesisDepth !== 0) continue;
+    const isComma = character === ',';
+    const isOr =
+      parameters.slice(index, index + 2).toLowerCase() === 'or' &&
+      !/[\w-]/.test(parameters[index - 1] ?? '') &&
+      !/[\w-]/.test(parameters[index + 2] ?? '');
+    if (!isComma && !isOr) continue;
     branches.push(parameters.slice(branchStart, index).trim());
-    branchStart = index + 1;
+    branchStart = index + (isOr ? 2 : 1);
+    if (isOr) index += 1;
   }
   branches.push(parameters.slice(branchStart).trim());
   return branches.filter(Boolean);
@@ -600,15 +615,19 @@ function conditionalQueryBranchesConflict(left: string, right: string): boolean 
   const bounds = [...widthBounds(left), ...widthBounds(right)];
   for (const unit of ['px', 'root-em'] as const) {
     const comparableBounds = bounds.filter((bound) => bound.unit === unit);
-    const minimum = Math.max(
-      ...comparableBounds.filter((bound) => bound.kind === 'minimum').map((bound) => bound.value),
-      -Infinity,
-    );
-    const maximum = Math.min(
-      ...comparableBounds.filter((bound) => bound.kind === 'maximum').map((bound) => bound.value),
-      Infinity,
-    );
+    const minimumBounds = comparableBounds.filter((bound) => bound.kind === 'minimum');
+    const maximumBounds = comparableBounds.filter((bound) => bound.kind === 'maximum');
+    const minimum = Math.max(...minimumBounds.map((bound) => bound.value), -Infinity);
+    const maximum = Math.min(...maximumBounds.map((bound) => bound.value), Infinity);
     if (minimum > maximum) return true;
+    if (
+      minimum === maximum &&
+      (!minimumBounds
+        .filter((bound) => bound.value === minimum)
+        .every((bound) => bound.inclusive) ||
+        !maximumBounds.filter((bound) => bound.value === maximum).every((bound) => bound.inclusive))
+    )
+      return true;
   }
   const leftDiscrete = discreteConditions(left);
   const rightDiscrete = discreteConditions(right);

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -68,11 +68,22 @@ type SelectorTarget = {
   impossible?: boolean;
   classes: Set<string>;
   attributes: Map<string, AttributeConstraint>;
+  attributeConstraints: Map<string, AttributeConstraint[]>;
   functionalConstraints: Array<{
     kind: 'not' | 'any';
     alternatives: SelectorTarget[];
   }>;
 };
+
+function attributeConstraintsFor(
+  target: SelectorTarget,
+  name: string,
+): readonly AttributeConstraint[] {
+  return (
+    target.attributeConstraints.get(name) ??
+    (target.attributes.get(name) ? [target.attributes.get(name)!] : [])
+  );
+}
 
 function normalizeAttributeValue(value: string, insensitive: boolean): string {
   return insensitive ? value.toLowerCase() : value;
@@ -118,13 +129,13 @@ function targetNecessarilyMatches(peer: SelectorTarget, alternative: SelectorTar
     (alternative.tag === undefined || peer.tag === alternative.tag) &&
     (alternative.id === undefined || peer.id === alternative.id) &&
     [...alternative.classes].every((className) => peer.classes.has(className)) &&
-    [...alternative.attributes].every(([name, constraint]) => {
-      const peerConstraint = peer.attributes.get(name);
-      return (
-        peerConstraint !== undefined &&
-        attributeConstraintNecessarilyMatches(peerConstraint, constraint)
-      );
-    })
+    [...alternative.attributeConstraints].every(([name, constraints]) =>
+      constraints.every((constraint) =>
+        attributeConstraintsFor(peer, name).some((peerConstraint) =>
+          attributeConstraintNecessarilyMatches(peerConstraint, constraint),
+        ),
+      ),
+    )
   );
 }
 
@@ -136,11 +147,20 @@ function mediaType(query: string): { name: string; negated: boolean } | undefine
 
 function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): SelectorTarget {
   const attributes = new Map(outer.attributes);
+  const attributeConstraints = new Map<string, AttributeConstraint[]>(
+    [...outer.attributeConstraints].map(([name, constraints]) => [name, [...constraints]]),
+  );
   let contradictoryAttributes = false;
-  for (const [name, constraint] of inner.attributes) {
-    const previous = attributes.get(name);
-    if (previous !== undefined && attributeConstraintsContradict(previous, constraint))
-      contradictoryAttributes = true;
+  for (const [name, constraints] of inner.attributeConstraints) {
+    const constraint = constraints.at(-1);
+    if (constraint === undefined) continue;
+    const previousConstraints = attributeConstraints.get(name) ?? [];
+    for (const current of constraints) {
+      if (previousConstraints.some((previous) => attributeConstraintsContradict(previous, current)))
+        contradictoryAttributes = true;
+      previousConstraints.push(current);
+    }
+    attributeConstraints.set(name, previousConstraints);
     attributes.set(name, constraint);
   }
   return {
@@ -155,6 +175,7 @@ function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): Sel
     ...((outer.id ?? inner.id) ? { id: outer.id ?? inner.id } : {}),
     classes: new Set([...outer.classes, ...inner.classes]),
     attributes,
+    attributeConstraints,
     functionalConstraints: [...outer.functionalConstraints, ...inner.functionalConstraints],
   };
 }
@@ -191,6 +212,7 @@ function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): Selecto
   const target: SelectorTarget = {
     classes: new Set(),
     attributes: new Map(),
+    attributeConstraints: new Map(),
     functionalConstraints: [],
   };
   for (const node of nodes) {
@@ -207,9 +229,12 @@ function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): Selecto
         value: node.value,
         insensitive: node.insensitive === true,
       } satisfies AttributeConstraint;
-      const previous = target.attributes.get(name);
-      if (previous !== undefined && attributeConstraintsContradict(previous, constraint))
+      const previousConstraints = target.attributeConstraints.get(name) ?? [];
+      if (
+        previousConstraints.some((previous) => attributeConstraintsContradict(previous, constraint))
+      )
         target.impossible = true;
+      target.attributeConstraints.set(name, [...previousConstraints, constraint]);
       target.attributes.set(name, constraint);
     }
   }
@@ -276,15 +301,16 @@ function alternativeAddsConstraints(target: SelectorTarget, alternative: Selecto
   return (
     (alternative.id !== undefined && alternative.id !== target.id) ||
     [...alternative.classes].some((className) => !target.classes.has(className)) ||
-    [...alternative.attributes].some(([name, constraint]) => {
-      const targetConstraint = target.attributes.get(name);
-      return (
-        targetConstraint === undefined ||
-        targetConstraint.operator !== constraint.operator ||
-        targetConstraint.value !== constraint.value ||
-        targetConstraint.insensitive !== constraint.insensitive
-      );
-    })
+    [...alternative.attributeConstraints].some(([name, constraints]) =>
+      constraints.some((constraint) =>
+        attributeConstraintsFor(target, name).every(
+          (targetConstraint) =>
+            targetConstraint.operator !== constraint.operator ||
+            targetConstraint.value !== constraint.value ||
+            targetConstraint.insensitive !== constraint.insensitive,
+        ),
+      ),
+    )
   );
 }
 
@@ -347,23 +373,11 @@ function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget)
     !leftAncestorIds.some((id) => rightAncestorIds.includes(id))
   )
     return false;
-  const hasConflictingAttribute = [...left.attributes].some(([attribute, leftConstraint]) => {
-    const rightConstraint = right.attributes.get(attribute);
-    if (rightConstraint === undefined) return false;
-    const leftValue = leftConstraint.value;
-    const rightValue = rightConstraint.value;
-    if (leftValue === undefined || rightValue === undefined) return false;
-    const insensitive = leftConstraint.insensitive || rightConstraint.insensitive;
-    const leftNormalized = normalizeAttributeValue(leftValue, insensitive);
-    const rightNormalized = normalizeAttributeValue(rightValue, insensitive);
-    if (leftConstraint.operator === '=' && rightConstraint.operator !== '=')
-      return !attributeOperatorMatches(rightConstraint.operator, leftNormalized, rightNormalized);
-    if (rightConstraint.operator === '=' && leftConstraint.operator !== '=')
-      return !attributeOperatorMatches(leftConstraint.operator, rightNormalized, leftNormalized);
-    return (
-      leftConstraint.operator === '=' &&
-      rightConstraint.operator === '=' &&
-      leftNormalized !== rightNormalized
+  const hasConflictingAttribute = [...left.attributes.keys()].some((attribute) => {
+    return attributeConstraintsFor(left, attribute).some((leftAttributeConstraint) =>
+      attributeConstraintsFor(right, attribute).some((rightAttributeConstraint) =>
+        attributeConstraintsContradict(leftAttributeConstraint, rightAttributeConstraint),
+      ),
     );
   });
   const shareAnchor =
@@ -663,8 +677,10 @@ function targetMatchesSharedFloatingElement(
     (target.tag === undefined || target.tag === sharedTarget.tag) &&
     (target.id === undefined || target.id === sharedTarget.id) &&
     [...target.classes].every((className) => sharedTarget.classes.has(className)) &&
-    [...target.attributes].every(([name, constraint]) =>
-      attributeConstraintMatches(sharedTarget.attributes.get(name), constraint),
+    [...target.attributeConstraints].every(([name, constraints]) =>
+      constraints.every((constraint) =>
+        attributeConstraintMatches(sharedTarget.attributes.get(name), constraint),
+      ),
     ) &&
     target.functionalConstraints.every(({ kind, alternatives }) =>
       kind === 'not'

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -98,12 +98,17 @@ function attributeConstraintNecessarilyMatches(
   alternative: AttributeConstraint,
 ): boolean {
   if (alternative.operator === undefined) return true;
-  if (
-    peer.operator !== alternative.operator ||
-    peer.value === undefined ||
-    alternative.value === undefined
-  )
-    return false;
+  if (peer.value === undefined || alternative.value === undefined) return false;
+  if (peer.operator === '=') {
+    if (!alternative.insensitive && peer.insensitive) return false;
+    const insensitive = alternative.insensitive || peer.insensitive;
+    const peerValue = normalizeAttributeValue(peer.value, insensitive);
+    const alternativeValue = normalizeAttributeValue(alternative.value, insensitive);
+    return alternative.operator === '='
+      ? peerValue === alternativeValue
+      : attributeOperatorMatches(alternative.operator, peerValue, alternativeValue);
+  }
+  if (peer.operator !== alternative.operator) return false;
   if (alternative.insensitive) return peer.value.toLowerCase() === alternative.value.toLowerCase();
   return !peer.insensitive && peer.value === alternative.value;
 }
@@ -130,9 +135,18 @@ function mediaType(query: string): { name: string; negated: boolean } | undefine
 }
 
 function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): SelectorTarget {
+  const attributes = new Map(outer.attributes);
+  let contradictoryAttributes = false;
+  for (const [name, constraint] of inner.attributes) {
+    const previous = attributes.get(name);
+    if (previous !== undefined && attributeConstraintsContradict(previous, constraint))
+      contradictoryAttributes = true;
+    attributes.set(name, constraint);
+  }
   return {
     ...(outer.impossible ||
     inner.impossible ||
+    contradictoryAttributes ||
     (outer.tag !== undefined && inner.tag !== undefined && outer.tag !== inner.tag) ||
     (outer.id !== undefined && inner.id !== undefined && outer.id !== inner.id)
       ? { impossible: true }
@@ -140,7 +154,7 @@ function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): Sel
     ...((outer.tag ?? inner.tag) ? { tag: outer.tag ?? inner.tag } : {}),
     ...((outer.id ?? inner.id) ? { id: outer.id ?? inner.id } : {}),
     classes: new Set([...outer.classes, ...inner.classes]),
-    attributes: new Map([...outer.attributes, ...inner.attributes]),
+    attributes,
     functionalConstraints: [...outer.functionalConstraints, ...inner.functionalConstraints],
   };
 }
@@ -201,13 +215,18 @@ function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): Selecto
       node.type === 'pseudo' &&
       (node.value === ':not' || node.value === ':is' || node.value === ':where') &&
       Array.isArray(node.nodes)
-    )
-      target.functionalConstraints.push({
-        kind: node.value === ':not' ? 'not' : 'any',
-        alternatives: node.nodes.map((selectorNode) =>
-          mergeSelectorTargets(target, selectorTargetFromNodes(selectorNode.nodes)),
-        ),
-      });
+    ) {
+      const kind = node.value === ':not' ? 'not' : 'any';
+      const alternatives = node.nodes.map((selectorNode) =>
+        mergeSelectorTargets(target, selectorTargetFromNodes(selectorNode.nodes)),
+      );
+      target.functionalConstraints.push({ kind, alternatives });
+      if (
+        kind === 'not' &&
+        alternatives.some((alternative) => targetNecessarilyMatches(target, alternative))
+      )
+        target.impossible = true;
+    }
   }
   return target;
 }

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -63,6 +63,7 @@ type AttributeConstraint = {
 type SelectorTarget = {
   ancestorSignature?: string;
   directParentTag?: string;
+  directParentId?: string;
   tag?: string;
   id?: string;
   impossible?: boolean;
@@ -73,6 +74,7 @@ type SelectorTarget = {
     kind: 'not' | 'any';
     alternatives: SelectorTarget[];
   }>;
+  unknownPseudos: Set<string>;
 };
 
 function attributeConstraintsFor(
@@ -87,6 +89,29 @@ function attributeConstraintsFor(
 
 function normalizeAttributeValue(value: string, insensitive: boolean): string {
   return insensitive ? value.toLowerCase() : value;
+}
+
+function exactPositionalPseudo(pseudo: string): { axis: string; position: number } | undefined {
+  const match = pseudo.match(
+    /^:(nth-child|nth-last-child|nth-of-type|nth-last-of-type)\(\s*([+-]?\d+)\s*\)$/,
+  );
+  if (match?.[1] === undefined || match[2] === undefined) return undefined;
+  return { axis: match[1], position: Number(match[2]) };
+}
+
+function positionalPseudosConflict(
+  leftPseudos: ReadonlySet<string>,
+  rightPseudos: ReadonlySet<string>,
+): boolean {
+  const leftPositions = [...leftPseudos]
+    .map(exactPositionalPseudo)
+    .filter((value) => value !== undefined);
+  const rightPositions = [...rightPseudos]
+    .map(exactPositionalPseudo)
+    .filter((value) => value !== undefined);
+  return leftPositions.some((left) =>
+    rightPositions.some((right) => left.axis === right.axis && left.position !== right.position),
+  );
 }
 
 function attributeOperatorMatches(
@@ -110,18 +135,36 @@ function attributeConstraintNecessarilyMatches(
 ): boolean {
   if (alternative.operator === undefined) return true;
   if (peer.value === undefined || alternative.value === undefined) return false;
-  if (peer.operator === '=') {
-    if (!alternative.insensitive && peer.insensitive) return false;
-    const insensitive = alternative.insensitive || peer.insensitive;
-    const peerValue = normalizeAttributeValue(peer.value, insensitive);
-    const alternativeValue = normalizeAttributeValue(alternative.value, insensitive);
-    return alternative.operator === '='
-      ? peerValue === alternativeValue
-      : attributeOperatorMatches(alternative.operator, peerValue, alternativeValue);
-  }
-  if (peer.operator !== alternative.operator) return false;
-  if (alternative.insensitive) return peer.value.toLowerCase() === alternative.value.toLowerCase();
-  return !peer.insensitive && peer.value === alternative.value;
+  if (!alternative.insensitive && peer.insensitive) return false;
+  const insensitive = alternative.insensitive || peer.insensitive;
+  const peerValue = normalizeAttributeValue(peer.value, insensitive);
+  const alternativeValue = normalizeAttributeValue(alternative.value, insensitive);
+  if (peer.operator === '=')
+    return attributeOperatorMatches(alternative.operator, peerValue, alternativeValue);
+  if (peer.operator === undefined) return false;
+  if (alternative.operator === '^=')
+    return (
+      (peer.operator === '^=' || peer.operator === '|=') && peerValue.startsWith(alternativeValue)
+    );
+  if (alternative.operator === '$=')
+    return peer.operator === '$=' && peerValue.endsWith(alternativeValue);
+  if (alternative.operator === '*=')
+    return (
+      (peer.operator === '^=' ||
+        peer.operator === '$=' ||
+        peer.operator === '*=' ||
+        peer.operator === '|=' ||
+        peer.operator === '~=') &&
+      peerValue.includes(alternativeValue)
+    );
+  if (alternative.operator === '|=')
+    return (
+      peer.operator === '|=' &&
+      (peerValue === alternativeValue || peerValue.startsWith(`${alternativeValue}-`))
+    );
+  if (alternative.operator === '~=')
+    return peer.operator === '~=' && peerValue === alternativeValue;
+  return false;
 }
 
 function targetNecessarilyMatches(peer: SelectorTarget, alternative: SelectorTarget): boolean {
@@ -129,6 +172,7 @@ function targetNecessarilyMatches(peer: SelectorTarget, alternative: SelectorTar
     (alternative.tag === undefined || peer.tag === alternative.tag) &&
     (alternative.id === undefined || peer.id === alternative.id) &&
     [...alternative.classes].every((className) => peer.classes.has(className)) &&
+    [...alternative.unknownPseudos].every((pseudo) => peer.unknownPseudos.has(pseudo)) &&
     [...alternative.attributeConstraints].every(([name, constraints]) =>
       constraints.every((constraint) =>
         attributeConstraintsFor(peer, name).some((peerConstraint) =>
@@ -148,6 +192,7 @@ function targetsNecessarilyDisjoint(left: SelectorTarget, right: SelectorTarget)
   if (left.impossible || right.impossible) return true;
   if (left.tag !== undefined && right.tag !== undefined && left.tag !== right.tag) return true;
   if (left.id !== undefined && right.id !== undefined && left.id !== right.id) return true;
+  if (positionalPseudosConflict(left.unknownPseudos, right.unknownPseudos)) return true;
   if (
     [...left.attributeConstraints].some(([name, constraints]) =>
       constraints.some((leftConstraint) =>
@@ -209,12 +254,14 @@ function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): Sel
     attributeConstraints.set(name, previousConstraints);
     attributes.set(name, constraint);
   }
+  const unknownPseudos = new Set([...outer.unknownPseudos, ...inner.unknownPseudos]);
   return {
     ...(outer.impossible ||
     inner.impossible ||
     contradictoryAttributes ||
     (outer.tag !== undefined && inner.tag !== undefined && outer.tag !== inner.tag) ||
-    (outer.id !== undefined && inner.id !== undefined && outer.id !== inner.id)
+    (outer.id !== undefined && inner.id !== undefined && outer.id !== inner.id) ||
+    positionalPseudosConflict(unknownPseudos, unknownPseudos)
       ? { impossible: true }
       : {}),
     ...((outer.tag ?? inner.tag) ? { tag: outer.tag ?? inner.tag } : {}),
@@ -223,6 +270,7 @@ function mergeSelectorTargets(outer: SelectorTarget, inner: SelectorTarget): Sel
     attributes,
     attributeConstraints,
     functionalConstraints: [...outer.functionalConstraints, ...inner.functionalConstraints],
+    unknownPseudos,
   };
 }
 
@@ -260,6 +308,7 @@ function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): Selecto
     attributes: new Map(),
     attributeConstraints: new Map(),
     functionalConstraints: [],
+    unknownPseudos: new Set(),
   };
   for (const node of nodes) {
     if (node.type === 'class') target.classes.add(node.value);
@@ -285,20 +334,34 @@ function selectorTargetFromNodes(nodes: readonly selectorParser.Node[]): Selecto
     }
   }
   for (const node of nodes) {
+    const pseudoName = node.type === 'pseudo' ? node.value.toLowerCase() : undefined;
     if (
       node.type === 'pseudo' &&
-      (node.value === ':not' || node.value === ':is' || node.value === ':where') &&
+      (pseudoName === ':not' || pseudoName === ':is' || pseudoName === ':where') &&
       Array.isArray(node.nodes)
     ) {
-      const kind = node.value === ':not' ? 'not' : 'any';
-      const alternatives = node.nodes.map((selectorNode) =>
-        mergeSelectorTargets(target, selectorTargetFromNodes(selectorNode.nodes)),
+      const kind = pseudoName === ':not' ? 'not' : 'any';
+      const nestedTargets = node.nodes.map((selectorNode) =>
+        selectorTargetFromNodes(selectorNode.nodes),
+      );
+      const alternatives = nestedTargets.map((nestedTarget) =>
+        mergeSelectorTargets(target, nestedTarget),
       );
       target.functionalConstraints.push({ kind, alternatives });
       if (
         kind === 'not' &&
-        alternatives.some((alternative) => targetNecessarilyMatches(target, alternative))
+        nestedTargets.some((nestedTarget) => targetNecessarilyMatches(target, nestedTarget))
       )
+        target.impossible = true;
+    } else if (node.type === 'pseudo' && !node.value.startsWith('::')) {
+      const serialized = node.toString();
+      const pseudo = `${node.value.toLowerCase()}${serialized.slice(node.value.length)}`;
+      const position = exactPositionalPseudo(pseudo);
+      target.unknownPseudos.add(
+        position === undefined ? pseudo : `:${position.axis}(${position.position})`,
+      );
+      if (position !== undefined && position.position <= 0) target.impossible = true;
+      if (positionalPseudosConflict(target.unknownPseudos, target.unknownPseudos))
         target.impossible = true;
     }
   }
@@ -334,6 +397,8 @@ function selectorTargets(selector: string): SelectorTarget[] {
             const parentCompound = ancestorSignature.split(/\s+/).at(-1) ?? '';
             const directParentTag = parentCompound.match(/^[a-z][\w-]*/i)?.[0].toLowerCase();
             if (directParentTag !== undefined) target.directParentTag = directParentTag;
+            const directParentId = parentCompound.match(/#([\w-]+)/)?.[1];
+            if (directParentId !== undefined) target.directParentId = directParentId;
           }
         }
       }
@@ -401,22 +466,17 @@ function hasCompoundNegatedTagAnchor(target: SelectorTarget, other: SelectorTarg
 function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget): boolean {
   if (left.impossible || right.impossible) return false;
   if (negatesTag(left, right) || negatesTag(right, left)) return false;
+  if (positionalPseudosConflict(left.unknownPseudos, right.unknownPseudos)) return false;
   if (
     left.directParentTag !== undefined &&
     right.directParentTag !== undefined &&
     left.directParentTag !== right.directParentTag
   )
     return false;
-  const leftAncestorIds = [...(left.ancestorSignature?.matchAll(/#([\w-]+)/g) ?? [])].map(
-    (match) => match[1],
-  );
-  const rightAncestorIds = [...(right.ancestorSignature?.matchAll(/#([\w-]+)/g) ?? [])].map(
-    (match) => match[1],
-  );
   if (
-    leftAncestorIds.length > 0 &&
-    rightAncestorIds.length > 0 &&
-    !leftAncestorIds.some((id) => rightAncestorIds.includes(id))
+    left.directParentId !== undefined &&
+    right.directParentId !== undefined &&
+    left.directParentId !== right.directParentId
   )
     return false;
   const hasConflictingAttribute = [...left.attributes.keys()].some((attribute) => {

--- a/packages/components/scripts/primitive-composition-css.ts
+++ b/packages/components/scripts/primitive-composition-css.ts
@@ -176,13 +176,17 @@ function selectorTargets(selector: string): SelectorTarget[] {
   return targets;
 }
 
-function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget): boolean {
-  const negatesTag = (target: SelectorTarget, other: SelectorTarget): boolean =>
+function negatesTag(target: SelectorTarget, other: SelectorTarget): boolean {
+  return (
     other.tag !== undefined &&
     target.functionalConstraints.some(
       ({ kind, alternatives }) =>
         kind === 'not' && alternatives.some((alternative) => alternative.tag === other.tag),
-    );
+    )
+  );
+}
+
+function targetsCanMatchSameElement(left: SelectorTarget, right: SelectorTarget): boolean {
   if (negatesTag(left, right) || negatesTag(right, left)) return false;
   const leftAncestorIds = [...(left.ancestorSignature?.matchAll(/#([\w-]+)/g) ?? [])].map(
     (match) => match[1],

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -94,6 +94,22 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
   return statement['body'].some(unconditionallyAbruptStatement);
 }
 
+function unconditionallyExitsBeforeLoopUpdate(statement: unknown): boolean {
+  if (!isRecord(statement)) return false;
+  if (
+    statement['type'] === 'BreakStatement' ||
+    statement['type'] === 'ReturnStatement' ||
+    statement['type'] === 'ThrowStatement'
+  )
+    return true;
+  return (
+    statement['type'] === 'BlockStatement' &&
+    Array.isArray(statement['body']) &&
+    statement['body'].length > 0 &&
+    unconditionallyExitsBeforeLoopUpdate(statement['body'][statement['body'].length - 1])
+  );
+}
+
 function collectPatternNames(pattern: unknown, into: Set<string>): void {
   if (!isRecord(pattern)) return;
   if (pattern['type'] === 'Identifier' && typeof pattern['name'] === 'string') {
@@ -276,37 +292,75 @@ function staticStringBindings(source: string): Map<string, string[]> {
       }
       return;
     }
+    if (node['type'] === 'WhileStatement') {
+      if (isRecord(node['test'])) walk(node['test'], currentShadowed);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const truthiness = staticTruthiness(node['test'], bindings);
+      if (truthiness === false) return;
+      if (isRecord(node['body'])) walk(node['body'], currentShadowed);
+      if (truthiness !== true) {
+        const names = new Set([...base.keys(), ...bindings.keys()]);
+        for (const name of names)
+          bindings.set(name, mergeStringValues(base.get(name) ?? [], bindings.get(name) ?? []));
+      }
+      return;
+    }
     if (
       node['type'] === 'ForStatement' ||
       node['type'] === 'ForInStatement' ||
       node['type'] === 'ForOfStatement'
     ) {
-      if (
-        (node['type'] === 'ForInStatement' || node['type'] === 'ForOfStatement') &&
-        isRecord(node['right']) &&
-        node['right']['type'] === 'ArrayExpression' &&
-        Array.isArray(node['right']['elements']) &&
-        node['right']['elements'].length === 0
-      ) {
-        return;
-      }
       const declaration = node['type'] === 'ForStatement' ? node['init'] : node['left'];
+      const localNames = new Set<string>();
       if (
         isRecord(declaration) &&
         declaration['type'] === 'VariableDeclaration' &&
         (declaration['kind'] === 'let' || declaration['kind'] === 'const') &&
         Array.isArray(declaration['declarations'])
-      ) {
-        const localNames = new Set<string>();
+      )
         for (const declarator of declaration['declarations'])
           if (isRecord(declarator)) collectPatternNames(declarator['id'], localNames);
-        const loopShadowed = new Set([...currentShadowed, ...localNames]);
-        for (const child of Object.values(node)) {
-          if (Array.isArray(child)) for (const item of child) walk(item, loopShadowed);
-          else if (isRecord(child)) walk(child, loopShadowed);
-        }
-        return;
+      const loopShadowed = new Set([...currentShadowed, ...localNames]);
+      if (node['type'] === 'ForStatement') {
+        if (isRecord(node['init'])) walk(node['init'], loopShadowed);
+        if (isRecord(node['test'])) walk(node['test'], loopShadowed);
+      } else {
+        if (isRecord(node['right'])) walk(node['right'], currentShadowed);
+        if (isRecord(node['left'])) walk(node['left'], loopShadowed);
       }
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const testTruthiness =
+        node['type'] === 'ForStatement'
+          ? node['test'] === null
+            ? true
+            : staticTruthiness(node['test'], bindings)
+          : undefined;
+      const emptyIterable =
+        (node['type'] === 'ForInStatement' || node['type'] === 'ForOfStatement') &&
+        isRecord(node['right']) &&
+        node['right']['type'] === 'ArrayExpression' &&
+        Array.isArray(node['right']['elements']) &&
+        node['right']['elements'].length === 0;
+      const guaranteedIterable =
+        node['type'] === 'ForOfStatement' &&
+        isRecord(node['right']) &&
+        node['right']['type'] === 'ArrayExpression' &&
+        Array.isArray(node['right']['elements']) &&
+        node['right']['elements'].length > 0;
+      if (testTruthiness === false || emptyIterable) return;
+      if (isRecord(node['body'])) walk(node['body'], loopShadowed);
+      if (
+        node['type'] === 'ForStatement' &&
+        isRecord(node['update']) &&
+        !unconditionallyExitsBeforeLoopUpdate(node['body'])
+      )
+        walk(node['update'], loopShadowed);
+      if (testTruthiness !== true && !emptyIterable && !guaranteedIterable) {
+        const names = new Set([...base.keys(), ...bindings.keys()]);
+        for (const name of names)
+          bindings.set(name, mergeStringValues(base.get(name) ?? [], bindings.get(name) ?? []));
+      }
+      return;
     }
     if (
       node['type'] === 'FunctionDeclaration' ||

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -877,6 +877,7 @@ function qualifyingFieldLabelBranches(
   source: string,
   bindings: ReadonlyMap<string, readonly string[]>,
   booleanBindings: ReadonlyMap<string, boolean> = new Map(),
+  templateShadowed: ReadonlySet<string> = new Set(),
 ): FieldEvidence[] {
   if (!isRecord(node)) return [emptyFieldEvidence()];
   if (node['type'] === 'IfBlock') {
@@ -885,7 +886,8 @@ function qualifyingFieldLabelBranches(
       isRecord(test) &&
       test['type'] === 'Identifier' &&
       typeof test['name'] === 'string' &&
-      booleanBindings.has(test['name'])
+      booleanBindings.has(test['name']) &&
+      !templateShadowed.has(test['name'])
         ? booleanBindings.get(test['name'])
         : staticTruthiness(test, bindings);
     const branches =
@@ -898,8 +900,47 @@ function qualifyingFieldLabelBranches(
     return reachableBranches.length === 0
       ? [emptyFieldEvidence()]
       : reachableBranches.flatMap((branch) =>
-          qualifyingFieldLabelBranches(branch, source, bindings, booleanBindings),
+          qualifyingFieldLabelBranches(branch, source, bindings, booleanBindings, templateShadowed),
         );
+  }
+  if (node['type'] === 'EachBlock' || node['type'] === 'SnippetBlock') {
+    const names = new Set(templateShadowed);
+    if (isRecord(node['context'])) collectPatternNames(node['context'], names);
+    if (isRecord(node['index'])) collectPatternNames(node['index'], names);
+    if (Array.isArray(node['parameters']))
+      for (const parameter of node['parameters']) collectPatternNames(parameter, names);
+    const body = node['body'] ?? node['fragment'];
+    return isRecord(body)
+      ? qualifyingFieldLabelBranches(body, source, bindings, booleanBindings, names)
+      : [emptyFieldEvidence()];
+  }
+  if (node['type'] === 'AwaitBlock') {
+    const evidence: FieldEvidence[] = [];
+    if (isRecord(node['pending']))
+      evidence.push(
+        ...qualifyingFieldLabelBranches(
+          node['pending'],
+          source,
+          bindings,
+          booleanBindings,
+          templateShadowed,
+        ),
+      );
+    if (isRecord(node['then'])) {
+      const names = new Set(templateShadowed);
+      if (isRecord(node['value'])) collectPatternNames(node['value'], names);
+      evidence.push(
+        ...qualifyingFieldLabelBranches(node['then'], source, bindings, booleanBindings, names),
+      );
+    }
+    if (isRecord(node['catch'])) {
+      const names = new Set(templateShadowed);
+      if (isRecord(node['error'])) collectPatternNames(node['error'], names);
+      evidence.push(
+        ...qualifyingFieldLabelBranches(node['catch'], source, bindings, booleanBindings, names),
+      );
+    }
+    return evidence.length > 0 ? evidence : [emptyFieldEvidence()];
   }
   // A canonical `<FormField>`'s own props (label/description/error) aren't
   // hand-rolled evidence — but its rendered children (a child snippet can
@@ -912,7 +953,7 @@ function qualifyingFieldLabelBranches(
         const nested = parseSvelteFragment(html);
         return nested === undefined
           ? []
-          : qualifyingFieldLabelBranches(nested, html, bindings, booleanBindings);
+          : qualifyingFieldLabelBranches(nested, html, bindings, booleanBindings, templateShadowed);
       },
     );
     if (evidences.length > 0) return evidences;
@@ -924,7 +965,13 @@ function qualifyingFieldLabelBranches(
     const children = Array.isArray(value) ? value : [value];
     for (const child of children) {
       if (!isRecord(child)) continue;
-      const branches = qualifyingFieldLabelBranches(child, source, bindings, booleanBindings);
+      const branches = qualifyingFieldLabelBranches(
+        child,
+        source,
+        bindings,
+        booleanBindings,
+        templateShadowed,
+      );
       combinations = combinations.flatMap((combination) =>
         branches.map((branch) => [...combination, branch]),
       );

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -152,12 +152,47 @@ function staticStringBindings(source: string): Map<string, string[]> {
       bindings.clear();
       const names = new Set([...base.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
       for (const name of names) {
-        const previous = base.get(name) ?? [];
-        bindings.set(name, [
-          ...new Set(branches.flatMap((branch) => branch.get(name) ?? previous)),
-        ]);
+        bindings.set(name, [...new Set(branches.flatMap((branch) => branch.get(name) ?? []))]);
       }
       return;
+    }
+    if (node['type'] === 'ConditionalExpression') {
+      if (isRecord(node['test'])) walk(node['test'], currentShadowed);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const branches = [node['consequent'], node['alternate']].map((branch) => {
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        if (isRecord(branch)) walk(branch, currentShadowed);
+        return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      });
+      bindings.clear();
+      const names = new Set([...base.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
+      for (const name of names)
+        bindings.set(name, [...new Set(branches.flatMap((branch) => branch.get(name) ?? []))]);
+      return;
+    }
+    if (
+      node['type'] === 'ForStatement' ||
+      node['type'] === 'ForInStatement' ||
+      node['type'] === 'ForOfStatement'
+    ) {
+      const declaration = node['type'] === 'ForStatement' ? node['init'] : node['left'];
+      if (
+        isRecord(declaration) &&
+        declaration['type'] === 'VariableDeclaration' &&
+        (declaration['kind'] === 'let' || declaration['kind'] === 'const') &&
+        Array.isArray(declaration['declarations'])
+      ) {
+        const localNames = new Set<string>();
+        for (const declarator of declaration['declarations'])
+          if (isRecord(declarator)) collectPatternNames(declarator['id'], localNames);
+        const loopShadowed = new Set([...currentShadowed, ...localNames]);
+        for (const child of Object.values(node)) {
+          if (Array.isArray(child)) for (const item of child) walk(item, loopShadowed);
+          else if (isRecord(child)) walk(child, loopShadowed);
+        }
+        return;
+      }
     }
     if (
       node['type'] === 'FunctionDeclaration' ||

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -601,6 +601,134 @@ function staticStringBindings(source: string): Map<string, string[]> {
   return bindings;
 }
 
+function staticBooleanBindings(source: string): Map<string, boolean> {
+  const root: unknown = parseSvelte(source, { modern: true });
+  const result = new Map<string, boolean>();
+  const mutableNames = new Set<string>();
+  const assignedNames = new Set<string>();
+  const body =
+    isRecord(root) && isRecord(root['instance']) && isRecord(root['instance']['content'])
+      ? root['instance']['content']['body']
+      : undefined;
+  if (!Array.isArray(body)) return result;
+  for (const statement of body) {
+    if (!isRecord(statement) || statement['type'] !== 'VariableDeclaration') continue;
+    if (!Array.isArray(statement['declarations'])) continue;
+    for (const declaration of statement['declarations']) {
+      const id = isRecord(declaration) ? declaration['id'] : undefined;
+      const init = isRecord(declaration) ? declaration['init'] : undefined;
+      if (
+        isRecord(id) &&
+        id['type'] === 'Identifier' &&
+        typeof id['name'] === 'string' &&
+        isRecord(init) &&
+        init['type'] === 'Literal' &&
+        typeof init['value'] === 'boolean'
+      ) {
+        result.set(id['name'], init['value']);
+        if (statement['kind'] !== 'const') mutableNames.add(id['name']);
+      }
+    }
+  }
+  const collectAssignments = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {
+    if (!isRecord(node)) return;
+    if (
+      node['type'] === 'FunctionDeclaration' ||
+      node['type'] === 'FunctionExpression' ||
+      node['type'] === 'ArrowFunctionExpression'
+    ) {
+      const localNames = new Set<string>(shadowed);
+      if (Array.isArray(node['params']))
+        for (const parameter of node['params']) collectPatternNames(parameter, localNames);
+      if (isRecord(node['body'])) collectFunctionScopedNames(node['body'], localNames);
+      if (isRecord(node['body'])) collectAssignments(node['body'], localNames);
+      return;
+    }
+    let currentShadowed = shadowed;
+    if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
+      const localNames = new Set<string>(shadowed);
+      for (const statement of node['body'])
+        if (
+          isRecord(statement) &&
+          statement['type'] === 'VariableDeclaration' &&
+          (statement['kind'] === 'let' || statement['kind'] === 'const')
+        )
+          if (Array.isArray(statement['declarations']))
+            for (const declaration of statement['declarations'])
+              if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
+      currentShadowed = localNames;
+    }
+    if (node['type'] === 'CatchClause') {
+      const localNames = new Set<string>(shadowed);
+      if (isRecord(node['param'])) collectPatternNames(node['param'], localNames);
+      currentShadowed = localNames;
+    }
+    if (
+      node['type'] === 'ForStatement' ||
+      node['type'] === 'ForInStatement' ||
+      node['type'] === 'ForOfStatement'
+    ) {
+      const header = node['type'] === 'ForStatement' ? node['init'] : node['left'];
+      if (
+        isRecord(header) &&
+        header['type'] === 'VariableDeclaration' &&
+        header['kind'] !== 'var'
+      ) {
+        const localNames = new Set<string>(shadowed);
+        if (Array.isArray(header['declarations']))
+          for (const declaration of header['declarations'])
+            if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
+        currentShadowed = localNames;
+      }
+    }
+    if (node['type'] === 'SwitchStatement' && Array.isArray(node['cases'])) {
+      const localNames = new Set<string>(shadowed);
+      for (const switchCase of node['cases'])
+        if (isRecord(switchCase) && Array.isArray(switchCase['consequent']))
+          for (const statement of switchCase['consequent'])
+            if (
+              isRecord(statement) &&
+              statement['type'] === 'VariableDeclaration' &&
+              (statement['kind'] === 'let' || statement['kind'] === 'const') &&
+              Array.isArray(statement['declarations'])
+            )
+              for (const declaration of statement['declarations'])
+                if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
+      currentShadowed = localNames;
+    }
+    if (
+      node['type'] === 'AssignmentExpression' &&
+      isRecord(node['left']) &&
+      node['left']['type'] === 'Identifier' &&
+      typeof node['left']['name'] === 'string'
+    )
+      if (!currentShadowed.has(node['left']['name'])) assignedNames.add(node['left']['name']);
+    if (
+      node['type'] === 'UpdateExpression' &&
+      isRecord(node['argument']) &&
+      node['argument']['type'] === 'Identifier' &&
+      typeof node['argument']['name'] === 'string'
+    )
+      if (!currentShadowed.has(node['argument']['name']))
+        assignedNames.add(node['argument']['name']);
+    if (
+      node['type'] === 'BindDirective' &&
+      isRecord(node['expression']) &&
+      node['expression']['type'] === 'Identifier' &&
+      typeof node['expression']['name'] === 'string'
+    )
+      if (!currentShadowed.has(node['expression']['name']))
+        assignedNames.add(node['expression']['name']);
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) value.forEach((item) => collectAssignments(item, currentShadowed));
+      else if (isRecord(value)) collectAssignments(value, currentShadowed);
+    }
+  };
+  collectAssignments(root);
+  for (const name of mutableNames) if (assignedNames.has(name)) result.delete(name);
+  return result;
+}
+
 function isCanonicalFieldComponent(node: UnknownRecord): boolean {
   if (node['type'] !== 'Component' || typeof node['name'] !== 'string') return false;
   return node['name'] === 'FormField' || node['name'].startsWith('FormField.');
@@ -701,13 +829,30 @@ function qualifyingFieldLabelBranches(
   node: unknown,
   source: string,
   bindings: ReadonlyMap<string, readonly string[]>,
+  booleanBindings: ReadonlyMap<string, boolean> = new Map(),
 ): FieldEvidence[] {
   if (!isRecord(node)) return [emptyFieldEvidence()];
   if (node['type'] === 'IfBlock') {
-    const branches = [node['consequent'], node['alternate']].filter(isRecord);
-    return branches.length === 0
+    const test = node['test'];
+    const truthiness =
+      isRecord(test) &&
+      test['type'] === 'Identifier' &&
+      typeof test['name'] === 'string' &&
+      booleanBindings.has(test['name'])
+        ? booleanBindings.get(test['name'])
+        : staticTruthiness(test, bindings);
+    const branches =
+      truthiness === true
+        ? [node['consequent']]
+        : truthiness === false
+          ? [node['alternate']]
+          : [node['consequent'], node['alternate']];
+    const reachableBranches = branches.filter(isRecord);
+    return reachableBranches.length === 0
       ? [emptyFieldEvidence()]
-      : branches.flatMap((branch) => qualifyingFieldLabelBranches(branch, source, bindings));
+      : reachableBranches.flatMap((branch) =>
+          qualifyingFieldLabelBranches(branch, source, bindings, booleanBindings),
+        );
   }
   // A canonical `<FormField>`'s own props (label/description/error) aren't
   // hand-rolled evidence — but its rendered children (a child snippet can
@@ -718,7 +863,9 @@ function qualifyingFieldLabelBranches(
     const evidences = staticStringValuesFromExpression(node['expression'], bindings).flatMap(
       (html) => {
         const nested = parseSvelteFragment(html);
-        return nested === undefined ? [] : qualifyingFieldLabelBranches(nested, html, bindings);
+        return nested === undefined
+          ? []
+          : qualifyingFieldLabelBranches(nested, html, bindings, booleanBindings);
       },
     );
     if (evidences.length > 0) return evidences;
@@ -730,7 +877,7 @@ function qualifyingFieldLabelBranches(
     const children = Array.isArray(value) ? value : [value];
     for (const child of children) {
       if (!isRecord(child)) continue;
-      const branches = qualifyingFieldLabelBranches(child, source, bindings);
+      const branches = qualifyingFieldLabelBranches(child, source, bindings, booleanBindings);
       combinations = combinations.flatMap((combination) =>
         branches.map((branch) => [...combination, branch]),
       );
@@ -745,8 +892,11 @@ export function fieldWrapperCount(source: string): number {
     ? 0
     : Math.max(
         0,
-        ...qualifyingFieldLabelBranches(fragment, source, staticStringBindings(source)).map(
-          (evidence) => evidence.count,
-        ),
+        ...qualifyingFieldLabelBranches(
+          fragment,
+          source,
+          staticStringBindings(source),
+          staticBooleanBindings(source),
+        ).map((evidence) => evidence.count),
       );
 }

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -33,7 +33,7 @@ function unwrapTypeExpression(expression: unknown): unknown {
 
 function staticStringFromExpression(
   rawExpression: unknown,
-  bindings: ReadonlyMap<string, string>,
+  bindings: ReadonlyMap<string, readonly string[]>,
 ): string | undefined {
   const expression = unwrapTypeExpression(rawExpression);
   if (!isRecord(expression)) return undefined;
@@ -50,8 +50,31 @@ function staticStringFromExpression(
     return isRecord(value) && typeof value['cooked'] === 'string' ? value['cooked'] : undefined;
   }
   if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string')
-    return bindings.get(expression['name']);
+    return bindings.get(expression['name'])?.[0];
   return undefined;
+}
+
+function staticStringValuesFromExpression(
+  rawExpression: unknown,
+  bindings: ReadonlyMap<string, readonly string[]>,
+): string[] {
+  const expression = unwrapTypeExpression(rawExpression);
+  if (!isRecord(expression)) return [];
+  if (expression['type'] === 'Literal' && typeof expression['value'] === 'string')
+    return [expression['value']];
+  if (
+    expression['type'] === 'TemplateLiteral' &&
+    Array.isArray(expression['expressions']) &&
+    expression['expressions'].length === 0 &&
+    Array.isArray(expression['quasis']) &&
+    isRecord(expression['quasis'][0])
+  ) {
+    const value = expression['quasis'][0]['value'];
+    return isRecord(value) && typeof value['cooked'] === 'string' ? [value['cooked']] : [];
+  }
+  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string')
+    return [...(bindings.get(expression['name']) ?? [])];
+  return [];
 }
 
 function collectPatternNames(pattern: unknown, into: Set<string>): void {
@@ -74,7 +97,11 @@ function collectFunctionScopedNames(node: unknown, into: Set<string>): void {
     node['type'] === 'ArrowFunctionExpression'
   )
     return;
-  if (node['type'] === 'VariableDeclaration' && Array.isArray(node['declarations']))
+  if (
+    node['type'] === 'VariableDeclaration' &&
+    node['kind'] === 'var' &&
+    Array.isArray(node['declarations'])
+  )
     for (const declaration of node['declarations']) collectPatternNames(declaration, into);
   for (const value of Object.values(node)) {
     if (Array.isArray(value)) for (const item of value) collectFunctionScopedNames(item, into);
@@ -82,9 +109,9 @@ function collectFunctionScopedNames(node: unknown, into: Set<string>): void {
   }
 }
 
-function staticStringBindings(source: string): Map<string, string> {
+function staticStringBindings(source: string): Map<string, string[]> {
   const root: unknown = parseSvelte(source, { modern: true });
-  const bindings = new Map<string, string>();
+  const bindings = new Map<string, string[]>();
   if (!isRecord(root) || !isRecord(root['instance']) || !isRecord(root['instance']['content']))
     return bindings;
   const body = root['instance']['content']['body'];
@@ -106,18 +133,45 @@ function staticStringBindings(source: string): Map<string, string> {
         typeof declaration['id']['name'] !== 'string'
       )
         continue;
-      const value = staticStringFromExpression(declaration['init'], bindings);
-      if (value !== undefined) bindings.set(declaration['id']['name'], value);
+      const values = staticStringValuesFromExpression(declaration['init'], bindings);
+      if (values.length > 0) bindings.set(declaration['id']['name'], values);
     }
   }
-  const walk = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {
+  const walk = (
+    node: unknown,
+    shadowed: ReadonlySet<string> = new Set(),
+    insideFunction = false,
+    conditional = false,
+  ): void => {
     if (!isRecord(node)) return;
     let currentShadowed = shadowed;
+    let currentInsideFunction = insideFunction;
+    if (node['type'] === 'IfStatement') {
+      if (isRecord(node['test']))
+        walk(node['test'], currentShadowed, currentInsideFunction, conditional);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const branches = [node['consequent'], node['alternate']].map((branch) => {
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction, true);
+        return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      });
+      bindings.clear();
+      const names = new Set([...base.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
+      for (const name of names) {
+        const previous = base.get(name) ?? [];
+        bindings.set(name, [
+          ...new Set(branches.flatMap((branch) => branch.get(name) ?? previous)),
+        ]);
+      }
+      return;
+    }
     if (
       node['type'] === 'FunctionDeclaration' ||
       node['type'] === 'FunctionExpression' ||
       node['type'] === 'ArrowFunctionExpression'
     ) {
+      currentInsideFunction = true;
       const localNames = new Set<string>();
       if (Array.isArray(node['params']))
         for (const parameter of node['params']) collectPatternNames(parameter, localNames);
@@ -144,12 +198,21 @@ function staticStringBindings(source: string): Map<string, string> {
       typeof node['left']['name'] === 'string' &&
       !currentShadowed.has(node['left']['name'])
     ) {
-      const value = staticStringFromExpression(node['right'], bindings);
-      if (value !== undefined) bindings.set(node['left']['name'], value);
+      const values = staticStringValuesFromExpression(node['right'], bindings);
+      if (values.length > 0) {
+        const name = node['left']['name'];
+        bindings.set(
+          name,
+          currentInsideFunction || conditional
+            ? [...new Set([...(bindings.get(name) ?? []), ...values])]
+            : values,
+        );
+      }
     }
     for (const child of Object.values(node)) {
-      if (Array.isArray(child)) for (const item of child) walk(item, currentShadowed);
-      else if (isRecord(child)) walk(child, currentShadowed);
+      if (Array.isArray(child))
+        for (const item of child) walk(item, currentShadowed, currentInsideFunction, conditional);
+      else if (isRecord(child)) walk(child, currentShadowed, currentInsideFunction, conditional);
     }
   };
   for (const statement of body) walk(statement);
@@ -164,19 +227,18 @@ function isCanonicalFieldComponent(node: UnknownRecord): boolean {
 function localMarkupEvidence(
   node: unknown,
   source: string,
-  bindings: ReadonlyMap<string, string>,
+  bindings: ReadonlyMap<string, readonly string[]>,
 ): { labelCount: number; terms: string } {
   if (!isRecord(node) || isCanonicalFieldComponent(node)) return { labelCount: 0, terms: '' };
-  const resolvedElementName =
+  const resolvedElementNames =
     node['type'] === 'RegularElement'
-      ? node['name']
+      ? typeof node['name'] === 'string'
+        ? [node['name']]
+        : []
       : node['type'] === 'SvelteElement'
-        ? staticStringFromExpression(node['tag'], bindings)
-        : undefined;
-  const labelCount =
-    typeof resolvedElementName === 'string' && resolvedElementName.toLowerCase() === 'label'
-      ? 1
-      : 0;
+        ? staticStringValuesFromExpression(node['tag'], bindings)
+        : [];
+  const labelCount = resolvedElementNames.filter((name) => name.toLowerCase() === 'label').length;
   const terms: string[] = [];
   if (node['type'] === 'Text' && typeof node['data'] === 'string') terms.push(node['data']);
   if (
@@ -203,7 +265,7 @@ function localMarkupEvidence(
 function qualifyingFieldLabels(
   node: unknown,
   source: string,
-  bindings: ReadonlyMap<string, string>,
+  bindings: ReadonlyMap<string, readonly string[]>,
 ): FieldEvidence {
   if (!isRecord(node))
     return {

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -155,6 +155,7 @@ function staticStringBindings(source: string): Map<string, string[]> {
     node: UnknownRecord;
     shadowed: ReadonlySet<string>;
   }> = [];
+  const preservedAbruptStates: Array<Map<string, string[]>> = [];
   let deferFunctions = true;
   if (!isRecord(root)) return bindings;
   const walk = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {
@@ -195,10 +196,24 @@ function staticStringBindings(source: string): Map<string, string[]> {
     if (node['type'] === 'IfStatement') {
       if (isRecord(node['test'])) walk(node['test'], currentShadowed);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const knownTruthiness = staticTruthiness(node['test'], bindings);
+      if (knownTruthiness !== undefined) {
+        const branch = knownTruthiness ? node['consequent'] : node['alternate'];
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        if (isRecord(branch)) walk(branch, currentShadowed);
+        return;
+      }
       const branches = [node['consequent'], node['alternate']].map((branch) => {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
         if (isRecord(branch)) walk(branch, currentShadowed);
+        if (isRecord(branch) && unconditionallyAbruptStatement(branch)) {
+          const preserved = preservedAbruptStates.at(-1);
+          if (preserved)
+            for (const [name, values] of bindings)
+              preserved.set(name, mergeStringValues(preserved.get(name) ?? [], values));
+        }
         return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       });
       bindings.clear();
@@ -266,6 +281,15 @@ function staticStringBindings(source: string): Map<string, string[]> {
       node['type'] === 'ForInStatement' ||
       node['type'] === 'ForOfStatement'
     ) {
+      if (
+        (node['type'] === 'ForInStatement' || node['type'] === 'ForOfStatement') &&
+        isRecord(node['right']) &&
+        node['right']['type'] === 'ArrayExpression' &&
+        Array.isArray(node['right']['elements']) &&
+        node['right']['elements'].length === 0
+      ) {
+        return;
+      }
       const declaration = node['type'] === 'ForStatement' ? node['init'] : node['left'];
       if (
         isRecord(declaration) &&
@@ -345,9 +369,33 @@ function staticStringBindings(source: string): Map<string, string[]> {
           for (const declaration of statement['declarations'])
             if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
       currentShadowed = new Set([...shadowed, ...localNames]);
+      preservedAbruptStates.push(new Map());
       for (const statement of node['body']) {
         if (isRecord(statement)) walk(statement, currentShadowed);
+        if (
+          isRecord(statement) &&
+          statement['type'] === 'IfStatement' &&
+          isRecord(statement['test'])
+        ) {
+          const truthiness = staticTruthiness(statement['test'], bindings);
+          const branch =
+            truthiness === true
+              ? statement['consequent']
+              : truthiness === false
+                ? statement['alternate']
+                : undefined;
+          if (isRecord(branch) && unconditionallyAbruptStatement(branch)) break;
+        }
         if (unconditionallyAbruptStatement(statement)) break;
+      }
+      const preserved = preservedAbruptStates.pop();
+      if (preserved) {
+        for (const [name, values] of preserved)
+          bindings.set(name, mergeStringValues(bindings.get(name) ?? [], values));
+        const parent = preservedAbruptStates.at(-1);
+        if (parent)
+          for (const [name, values] of preserved)
+            parent.set(name, mergeStringValues(parent.get(name) ?? [], values));
       }
       return;
     }
@@ -510,6 +558,12 @@ function qualifyingFieldLabelBranches(
   bindings: ReadonlyMap<string, readonly string[]>,
 ): FieldEvidence[] {
   if (!isRecord(node)) return [emptyFieldEvidence()];
+  if (node['type'] === 'IfBlock') {
+    const branches = [node['consequent'], node['alternate']].filter(isRecord);
+    return branches.length === 0
+      ? [emptyFieldEvidence()]
+      : branches.flatMap((branch) => qualifyingFieldLabelBranches(branch, source, bindings));
+  }
   // A canonical `<FormField>`'s own props (label/description/error) aren't
   // hand-rolled evidence — but its rendered children (a child snippet can
   // still hand-roll a label/description/error wrapper) must keep being

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -1004,19 +1004,40 @@ function qualifyingFieldLabelBranches(
     if (Array.isArray(node['parameters']))
       for (const parameter of node['parameters']) collectPatternNames(parameter, names);
     const body = node['body'] ?? node['fragment'];
-    const evidence = isRecord(body)
-      ? qualifyingFieldLabelBranches(body, source, bindings, booleanBindings, names)
-      : [];
-    if (isRecord(node['fallback']))
-      evidence.push(
-        ...qualifyingFieldLabelBranches(
-          node['fallback'],
-          source,
-          bindings,
-          booleanBindings,
-          templateShadowed,
-        ),
-      );
+    const expression = node['expression'];
+    const arrayElements =
+      isRecord(expression) &&
+      expression['type'] === 'ArrayExpression' &&
+      Array.isArray(expression['elements'])
+        ? expression['elements']
+        : undefined;
+    const reachability =
+      arrayElements === undefined
+        ? 'unknown'
+        : arrayElements.length === 0
+          ? 'fallback'
+          : arrayElements.some(
+                (element) => !isRecord(element) || element['type'] !== 'SpreadElement',
+              )
+            ? 'body'
+            : 'unknown';
+    const evidence =
+      reachability === 'fallback'
+        ? []
+        : isRecord(body)
+          ? qualifyingFieldLabelBranches(body, source, bindings, booleanBindings, names)
+          : [];
+    if (reachability !== 'body')
+      if (isRecord(node['fallback']))
+        evidence.push(
+          ...qualifyingFieldLabelBranches(
+            node['fallback'],
+            source,
+            bindings,
+            booleanBindings,
+            templateShadowed,
+          ),
+        );
     return evidence.length > 0 ? evidence : [emptyFieldEvidence()];
   }
   if (node['type'] === 'AwaitBlock') {

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -137,6 +137,8 @@ function staticStringBindings(source: string): Map<string, string[]> {
         continue;
       const values = staticStringValuesFromExpression(declaration['init'], bindings);
       if (values.length > 0) bindings.set(declaration['id']['name'], values);
+      else if (declaration['init'] !== null && declaration['init'] !== undefined)
+        bindings.delete(declaration['id']['name']);
     }
   }
   const walk = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -65,7 +65,7 @@ function staticStringBindings(source: string): Map<string, string> {
     if (
       !isRecord(statement) ||
       statement['type'] !== 'VariableDeclaration' ||
-      statement['kind'] !== 'const'
+      !['const', 'let', 'var'].includes(String(statement['kind']))
     )
       continue;
     const declarations = statement['declarations'];

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -54,6 +54,34 @@ function staticStringFromExpression(
   return undefined;
 }
 
+function collectPatternNames(pattern: unknown, into: Set<string>): void {
+  if (!isRecord(pattern)) return;
+  if (pattern['type'] === 'Identifier' && typeof pattern['name'] === 'string')
+    into.add(pattern['name']);
+  else if (pattern['type'] === 'VariableDeclarator') collectPatternNames(pattern['id'], into);
+  else
+    for (const value of Object.values(pattern)) {
+      if (Array.isArray(value)) for (const item of value) collectPatternNames(item, into);
+      else if (isRecord(value)) collectPatternNames(value, into);
+    }
+}
+
+function collectFunctionScopedNames(node: unknown, into: Set<string>): void {
+  if (!isRecord(node)) return;
+  if (
+    node['type'] === 'FunctionDeclaration' ||
+    node['type'] === 'FunctionExpression' ||
+    node['type'] === 'ArrowFunctionExpression'
+  )
+    return;
+  if (node['type'] === 'VariableDeclaration' && Array.isArray(node['declarations']))
+    for (const declaration of node['declarations']) collectPatternNames(declaration, into);
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) for (const item of value) collectFunctionScopedNames(item, into);
+    else if (isRecord(value)) collectFunctionScopedNames(value, into);
+  }
+}
+
 function staticStringBindings(source: string): Map<string, string> {
   const root: unknown = parseSvelte(source, { modern: true });
   const bindings = new Map<string, string>();
@@ -82,21 +110,46 @@ function staticStringBindings(source: string): Map<string, string> {
       if (value !== undefined) bindings.set(declaration['id']['name'], value);
     }
   }
-  const walk = (node: unknown): void => {
+  const walk = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {
     if (!isRecord(node)) return;
+    let currentShadowed = shadowed;
+    if (
+      node['type'] === 'FunctionDeclaration' ||
+      node['type'] === 'FunctionExpression' ||
+      node['type'] === 'ArrowFunctionExpression'
+    ) {
+      const localNames = new Set<string>();
+      if (Array.isArray(node['params']))
+        for (const parameter of node['params']) collectPatternNames(parameter, localNames);
+      if (isRecord(node['body'])) collectFunctionScopedNames(node['body'], localNames);
+      currentShadowed = new Set([...shadowed, ...localNames]);
+    } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
+      const localNames = new Set<string>();
+      for (const statement of node['body'])
+        if (
+          isRecord(statement) &&
+          statement['type'] === 'VariableDeclaration' &&
+          (statement['kind'] === 'let' || statement['kind'] === 'const') &&
+          Array.isArray(statement['declarations'])
+        )
+          for (const declaration of statement['declarations'])
+            if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
+      currentShadowed = new Set([...shadowed, ...localNames]);
+    }
     if (
       node['type'] === 'AssignmentExpression' &&
       node['operator'] === '=' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
-      typeof node['left']['name'] === 'string'
+      typeof node['left']['name'] === 'string' &&
+      !currentShadowed.has(node['left']['name'])
     ) {
       const value = staticStringFromExpression(node['right'], bindings);
       if (value !== undefined) bindings.set(node['left']['name'], value);
     }
     for (const child of Object.values(node)) {
-      if (Array.isArray(child)) for (const item of child) walk(item);
-      else if (isRecord(child)) walk(child);
+      if (Array.isArray(child)) for (const item of child) walk(item, currentShadowed);
+      else if (isRecord(child)) walk(child, currentShadowed);
     }
   };
   for (const statement of body) walk(statement);

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -58,6 +58,42 @@ function mergeStringValues(...values: (readonly string[])[]): string[] {
   return [...new Set(values.flat())];
 }
 
+function staticTruthiness(
+  value: unknown,
+  bindings: ReadonlyMap<string, readonly string[]>,
+): boolean | undefined {
+  const result = expressionResult(value);
+  if (isRecord(result) && result['type'] === 'Literal') return Boolean(result['value']);
+  const values = staticStringValuesFromExpression(result, bindings);
+  if (values.length === 0) return undefined;
+  const truthiness = new Set(values.map(Boolean));
+  return truthiness.size === 1 ? truthiness.values().next().value : undefined;
+}
+
+function expressionResult(value: unknown): unknown {
+  const expression = unwrapTypeExpression(value);
+  if (
+    isRecord(expression) &&
+    expression['type'] === 'AssignmentExpression' &&
+    expression['operator'] === '='
+  )
+    return expressionResult(expression['right']);
+  return expression;
+}
+
+function unconditionallyAbruptStatement(statement: unknown): boolean {
+  if (!isRecord(statement)) return false;
+  if (
+    statement['type'] === 'BreakStatement' ||
+    statement['type'] === 'ContinueStatement' ||
+    statement['type'] === 'ReturnStatement' ||
+    statement['type'] === 'ThrowStatement'
+  )
+    return true;
+  if (statement['type'] !== 'BlockStatement' || !Array.isArray(statement['body'])) return false;
+  return statement['body'].some(unconditionallyAbruptStatement);
+}
+
 function collectPatternNames(pattern: unknown, into: Set<string>): void {
   if (!isRecord(pattern)) return;
   if (pattern['type'] === 'Identifier' && typeof pattern['name'] === 'string') {
@@ -187,6 +223,44 @@ function staticStringBindings(source: string): Map<string, string[]> {
         bindings.set(name, [...new Set(branches.flatMap((branch) => branch.get(name) ?? []))]);
       return;
     }
+    if (node['type'] === 'LogicalExpression') {
+      if (isRecord(node['left'])) walk(node['left'], currentShadowed);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const truthiness = staticTruthiness(node['left'], bindings);
+      const operator = node['operator'];
+      const leftResult = expressionResult(node['left']);
+      const leftIsNullish =
+        (isRecord(leftResult) &&
+          leftResult['type'] === 'Literal' &&
+          leftResult['value'] === null) ||
+        (isRecord(leftResult) &&
+          leftResult['type'] === 'UnaryExpression' &&
+          leftResult['operator'] === 'void') ||
+        (isRecord(leftResult) &&
+          leftResult['type'] === 'Identifier' &&
+          leftResult['name'] === 'undefined' &&
+          !currentShadowed.has('undefined') &&
+          !bindings.has('undefined'));
+      const leftIsNonNullishLiteral =
+        isRecord(leftResult) && leftResult['type'] === 'Literal' && leftResult['value'] !== null;
+      const leftIsKnownString = staticStringValuesFromExpression(leftResult, bindings).length > 0;
+      const skipsRight =
+        (truthiness !== undefined &&
+          ((operator === '&&' && !truthiness) || (operator === '||' && truthiness))) ||
+        (operator === '??' && (leftIsNonNullishLiteral || leftIsKnownString));
+      if (skipsRight) return;
+      if (isRecord(node['right'])) walk(node['right'], currentShadowed);
+      const guaranteesRight =
+        (truthiness !== undefined &&
+          ((operator === '&&' && truthiness) || (operator === '||' && !truthiness))) ||
+        (operator === '??' && leftIsNullish);
+      if (!guaranteesRight) {
+        const names = new Set([...base.keys(), ...bindings.keys()]);
+        for (const name of names)
+          bindings.set(name, mergeStringValues(base.get(name) ?? [], bindings.get(name) ?? []));
+      }
+      return;
+    }
     if (
       node['type'] === 'ForStatement' ||
       node['type'] === 'ForInStatement' ||
@@ -254,6 +328,11 @@ function staticStringBindings(source: string): Map<string, string[]> {
         bindings.set(name, mergeStringValues(baseValues, callbackBindings.get(name) ?? []));
       }
       return;
+    } else if (node['type'] === 'CatchClause') {
+      const catchShadowed = new Set(currentShadowed);
+      if (isRecord(node['param'])) collectPatternNames(node['param'], catchShadowed);
+      if (isRecord(node['body'])) walk(node['body'], catchShadowed);
+      return;
     } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
       const localNames = new Set<string>();
       for (const statement of node['body'])
@@ -266,6 +345,11 @@ function staticStringBindings(source: string): Map<string, string[]> {
           for (const declaration of statement['declarations'])
             if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
       currentShadowed = new Set([...shadowed, ...localNames]);
+      for (const statement of node['body']) {
+        if (isRecord(statement)) walk(statement, currentShadowed);
+        if (unconditionallyAbruptStatement(statement)) break;
+      }
+      return;
     }
     if (
       node['type'] === 'AssignmentExpression' &&

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -49,8 +49,10 @@ function staticStringFromExpression(
     const value = expression['quasis'][0]['value'];
     return isRecord(value) && typeof value['cooked'] === 'string' ? value['cooked'] : undefined;
   }
-  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string')
-    return bindings.get(expression['name'])?.[0];
+  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
+    const values = bindings.get(expression['name']);
+    return values?.length === 1 ? values[0] : undefined;
+  }
   return undefined;
 }
 

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -137,23 +137,16 @@ function staticStringBindings(source: string): Map<string, string[]> {
       if (values.length > 0) bindings.set(declaration['id']['name'], values);
     }
   }
-  const walk = (
-    node: unknown,
-    shadowed: ReadonlySet<string> = new Set(),
-    insideFunction = false,
-    conditional = false,
-  ): void => {
+  const walk = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {
     if (!isRecord(node)) return;
     let currentShadowed = shadowed;
-    let currentInsideFunction = insideFunction;
     if (node['type'] === 'IfStatement') {
-      if (isRecord(node['test']))
-        walk(node['test'], currentShadowed, currentInsideFunction, conditional);
+      if (isRecord(node['test'])) walk(node['test'], currentShadowed);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       const branches = [node['consequent'], node['alternate']].map((branch) => {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
-        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction, true);
+        if (isRecord(branch)) walk(branch, currentShadowed);
         return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       });
       bindings.clear();
@@ -171,12 +164,21 @@ function staticStringBindings(source: string): Map<string, string[]> {
       node['type'] === 'FunctionExpression' ||
       node['type'] === 'ArrowFunctionExpression'
     ) {
-      currentInsideFunction = true;
       const localNames = new Set<string>();
       if (Array.isArray(node['params']))
         for (const parameter of node['params']) collectPatternNames(parameter, localNames);
       if (isRecord(node['body'])) collectFunctionScopedNames(node['body'], localNames);
       currentShadowed = new Set([...shadowed, ...localNames]);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      if (isRecord(node['body'])) walk(node['body'], currentShadowed);
+      const terminal = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      bindings.clear();
+      const names = new Set([...base.keys(), ...terminal.keys()]);
+      for (const name of names)
+        bindings.set(name, [
+          ...new Set([...(base.get(name) ?? []), ...(terminal.get(name) ?? [])]),
+        ]);
+      return;
     } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
       const localNames = new Set<string>();
       for (const statement of node['body'])
@@ -198,21 +200,14 @@ function staticStringBindings(source: string): Map<string, string[]> {
       typeof node['left']['name'] === 'string' &&
       !currentShadowed.has(node['left']['name'])
     ) {
+      const name = node['left']['name'];
       const values = staticStringValuesFromExpression(node['right'], bindings);
-      if (values.length > 0) {
-        const name = node['left']['name'];
-        bindings.set(
-          name,
-          currentInsideFunction || conditional
-            ? [...new Set([...(bindings.get(name) ?? []), ...values])]
-            : values,
-        );
-      }
+      if (values.length > 0) bindings.set(name, values);
+      else bindings.delete(name);
     }
     for (const child of Object.values(node)) {
-      if (Array.isArray(child))
-        for (const item of child) walk(item, currentShadowed, currentInsideFunction, conditional);
-      else if (isRecord(child)) walk(child, currentShadowed, currentInsideFunction, conditional);
+      if (Array.isArray(child)) for (const item of child) walk(item, currentShadowed);
+      else if (isRecord(child)) walk(child, currentShadowed);
     }
   };
   for (const statement of body) walk(statement);

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -110,6 +110,17 @@ function unconditionallyExitsBeforeLoopUpdate(statement: unknown): boolean {
   );
 }
 
+function staticallyGuaranteesNonEmptyArray(expression: unknown): boolean {
+  if (!isRecord(expression) || expression['type'] !== 'ArrayExpression') return false;
+  if (!Array.isArray(expression['elements'])) return false;
+  return expression['elements'].some((element) => {
+    if (element === null) return true;
+    if (!isRecord(element)) return false;
+    if (element['type'] !== 'SpreadElement') return true;
+    return staticallyGuaranteesNonEmptyArray(element['argument']);
+  });
+}
+
 function collectPatternNames(pattern: unknown, into: Set<string>): void {
   if (!isRecord(pattern)) return;
   if (pattern['type'] === 'Identifier' && typeof pattern['name'] === 'string') {
@@ -426,11 +437,7 @@ function staticStringBindings(source: string): Map<string, string[]> {
         Array.isArray(node['right']['elements']) &&
         node['right']['elements'].length === 0;
       const guaranteedIterable =
-        node['type'] === 'ForOfStatement' &&
-        isRecord(node['right']) &&
-        node['right']['type'] === 'ArrayExpression' &&
-        Array.isArray(node['right']['elements']) &&
-        node['right']['elements'].length > 0;
+        node['type'] === 'ForOfStatement' && staticallyGuaranteesNonEmptyArray(node['right']);
       if (testTruthiness === false || emptyIterable) return;
       if (isRecord(node['body'])) walk(node['body'], loopShadowed);
       if (

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -91,7 +91,8 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
   )
     return true;
   if (statement['type'] !== 'BlockStatement' || !Array.isArray(statement['body'])) return false;
-  return statement['body'].some(unconditionallyAbruptStatement);
+  const last = statement['body'].at(-1);
+  return unconditionallyAbruptStatement(last);
 }
 
 function unconditionallyExitsBeforeLoopUpdate(statement: unknown): boolean {

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -110,6 +110,13 @@ function unconditionallyExitsBeforeLoopUpdate(statement: unknown): boolean {
     statement['type'] === 'ThrowStatement'
   )
     return true;
+  if (statement['type'] === 'IfStatement')
+    return (
+      isRecord(statement['consequent']) &&
+      unconditionallyExitsBeforeLoopUpdate(statement['consequent']) &&
+      isRecord(statement['alternate']) &&
+      unconditionallyExitsBeforeLoopUpdate(statement['alternate'])
+    );
   return (
     statement['type'] === 'BlockStatement' &&
     Array.isArray(statement['body']) &&

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -305,6 +305,90 @@ function staticStringBindings(source: string): Map<string, string[]> {
       }
       return;
     }
+    if (node['type'] === 'SwitchStatement' && Array.isArray(node['cases'])) {
+      if (isRecord(node['discriminant'])) walk(node['discriminant'], currentShadowed);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const cases = node['cases'].filter(isRecord);
+      const switchNames = new Set<string>();
+      for (const switchCase of cases)
+        if (Array.isArray(switchCase['consequent']))
+          for (const statement of switchCase['consequent'])
+            if (
+              isRecord(statement) &&
+              statement['type'] === 'VariableDeclaration' &&
+              (statement['kind'] === 'let' || statement['kind'] === 'const') &&
+              Array.isArray(statement['declarations'])
+            )
+              for (const declaration of statement['declarations'])
+                if (isRecord(declaration)) collectPatternNames(declaration['id'], switchNames);
+      const switchShadowed = new Set([...currentShadowed, ...switchNames]);
+      const branches: Map<string, string[]>[] = [];
+      let hasDefault = false;
+      const discriminant = node['discriminant'];
+      const knownValue =
+        isRecord(discriminant) && discriminant['type'] === 'Literal'
+          ? discriminant['value']
+          : undefined;
+      const knownDiscriminant = isRecord(discriminant) && discriminant['type'] === 'Literal';
+      let knownStart: number | undefined;
+      if (knownDiscriminant) {
+        let defaultStart: number | undefined;
+        for (let index = 0; index < cases.length; index += 1) {
+          const test = cases[index]?.['test'];
+          if (test === null) {
+            defaultStart = index;
+            continue;
+          }
+          if (isRecord(test) && test['type'] === 'Literal' && test['value'] === knownValue) {
+            knownStart = index;
+            break;
+          }
+        }
+        if (knownStart === undefined) knownStart = defaultStart ?? -1;
+      }
+      const starts =
+        knownStart === undefined
+          ? cases.map((_, index) => index)
+          : knownStart < 0
+            ? [-1]
+            : [knownStart];
+      for (const start of starts) {
+        const branch = new Map([...base].map(([name, values]) => [name, [...values]] as const));
+        bindings.clear();
+        for (const [name, values] of branch) bindings.set(name, [...values]);
+        for (let index = 0; index <= (start < 0 ? cases.length - 1 : start); index += 1) {
+          const test = cases[index]?.['test'];
+          if (test === null) hasDefault = true;
+          else if (isRecord(test)) walk(test, switchShadowed);
+        }
+        if (start < 0) {
+          branches.push(
+            new Map([...bindings].map(([name, values]) => [name, [...values]] as const)),
+          );
+          continue;
+        }
+        let stopped = false;
+        for (let index = start; index < cases.length && !stopped; index += 1) {
+          const consequent = cases[index]?.['consequent'];
+          if (!Array.isArray(consequent)) continue;
+          for (const statement of consequent) {
+            walk(statement, switchShadowed);
+            if (unconditionallyAbruptStatement(statement)) {
+              stopped = true;
+              break;
+            }
+          }
+        }
+        branches.push(new Map([...bindings].map(([name, values]) => [name, [...values]] as const)));
+      }
+      if (!hasDefault)
+        branches.push(new Map([...base].map(([name, values]) => [name, [...values]] as const)));
+      bindings.clear();
+      const names = new Set(branches.flatMap((branch) => [...branch.keys()]));
+      for (const name of names)
+        bindings.set(name, mergeStringValues(...branches.map((branch) => branch.get(name) ?? [])));
+      return;
+    }
     if (
       node['type'] === 'ForStatement' ||
       node['type'] === 'ForInStatement' ||

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -253,6 +253,14 @@ function staticStringBindings(source: string): Map<string, string[]> {
     if (node['type'] === 'ConditionalExpression') {
       if (isRecord(node['test'])) walk(node['test'], currentShadowed);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const knownTruthiness = staticTruthiness(node['test'], bindings);
+      if (knownTruthiness !== undefined) {
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        const branch = knownTruthiness ? node['consequent'] : node['alternate'];
+        if (isRecord(branch)) walk(branch, currentShadowed);
+        return;
+      }
       const branches = [node['consequent'], node['alternate']].map((branch) => {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
@@ -314,6 +322,37 @@ function staticStringBindings(source: string): Map<string, string[]> {
         for (const name of names)
           bindings.set(name, mergeStringValues(base.get(name) ?? [], bindings.get(name) ?? []));
       }
+      return;
+    }
+    if (node['type'] === 'TryStatement') {
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const alternatives: Map<string, string[]>[] = [];
+      if (isRecord(node['block'])) {
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        walk(node['block'], currentShadowed);
+        alternatives.push(
+          new Map([...bindings].map(([name, values]) => [name, [...values]] as const)),
+        );
+      }
+      if (isRecord(node['handler'])) {
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        const catchShadowed = new Set(currentShadowed);
+        if (isRecord(node['handler']['param']))
+          collectPatternNames(node['handler']['param'], catchShadowed);
+        walk(node['handler']['body'], catchShadowed);
+        alternatives.push(
+          new Map([...bindings].map(([name, values]) => [name, [...values]] as const)),
+        );
+      }
+      bindings.clear();
+      for (const name of new Set(alternatives.flatMap((branch) => [...branch.keys()])))
+        bindings.set(
+          name,
+          mergeStringValues(...alternatives.map((branch) => branch.get(name) ?? [])),
+        );
+      if (isRecord(node['finalizer'])) walk(node['finalizer'], currentShadowed);
       return;
     }
     if (node['type'] === 'SwitchStatement' && Array.isArray(node['cases'])) {
@@ -503,6 +542,9 @@ function staticStringBindings(source: string): Map<string, string[]> {
       if (isRecord(node['body'])) walk(node['body'], catchShadowed);
       return;
     } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
+      const blockBase = new Map(
+        [...bindings].map(([name, values]) => [name, [...values]] as const),
+      );
       const localNames = new Set<string>();
       for (const statement of node['body'])
         if (
@@ -541,6 +583,11 @@ function staticStringBindings(source: string): Map<string, string[]> {
         if (parent)
           for (const [name, values] of preserved)
             parent.set(name, mergeStringValues(parent.get(name) ?? [], values));
+      }
+      for (const name of localNames) {
+        const previous = blockBase.get(name);
+        if (previous === undefined) bindings.delete(name);
+        else bindings.set(name, [...previous]);
       }
       return;
     }
@@ -881,6 +928,22 @@ function qualifyingFieldLabelBranches(
       combinations = combinations.flatMap((combination) =>
         branches.map((branch) => [...combination, branch]),
       );
+      if (combinations.length > 256) {
+        const unique = new Map<string, FieldEvidence[]>();
+        for (const combination of combinations) {
+          const aggregate = summarizeFieldEvidence(localEvidence, combination);
+          const signatureKey = [
+            aggregate.count,
+            aggregate.isolatedMessages,
+            aggregate.labelCount,
+            aggregate.rootLabelCount,
+            /description|help|hint|assist/i.test(aggregate.terms),
+            /error|validation|invalid|message/i.test(aggregate.terms),
+          ].join(',');
+          if (!unique.has(signatureKey)) unique.set(signatureKey, combination);
+        }
+        combinations = [...unique.values()];
+      }
     }
   }
   return combinations.map((childEvidence) => summarizeFieldEvidence(localEvidence, childEvidence));

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -90,6 +90,13 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
     statement['type'] === 'ThrowStatement'
   )
     return true;
+  if (statement['type'] === 'IfStatement')
+    return (
+      isRecord(statement['consequent']) &&
+      unconditionallyAbruptStatement(statement['consequent']) &&
+      isRecord(statement['alternate']) &&
+      unconditionallyAbruptStatement(statement['alternate'])
+    );
   if (statement['type'] !== 'BlockStatement' || !Array.isArray(statement['body'])) return false;
   const last = statement['body'].at(-1);
   return unconditionallyAbruptStatement(last);
@@ -184,10 +191,59 @@ function staticStringBindings(source: string): Map<string, string[]> {
     shadowed: ReadonlySet<string>;
   }> = [];
   const preservedAbruptStates: Array<Map<string, string[]>> = [];
+  const breakTargets: Array<{
+    kind: 'boundary' | 'for-update';
+    label: string | undefined;
+    states: Array<Map<string, string[]>>;
+  }> = [];
+  let currentPathCapturedBreak = false;
   let deferFunctions = true;
   if (!isRecord(root)) return bindings;
-  const walk = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {
+  const walk = (
+    node: unknown,
+    shadowed: ReadonlySet<string> = new Set(),
+    controlLabel?: string,
+  ): void => {
     if (!isRecord(node)) return;
+    if (node['type'] === 'LabeledStatement') {
+      const label =
+        isRecord(node['label']) && typeof node['label']['name'] === 'string'
+          ? node['label']['name']
+          : undefined;
+      const body = node['body'];
+      if (
+        isRecord(body) &&
+        (body['type'] === 'ForStatement' ||
+          body['type'] === 'ForInStatement' ||
+          body['type'] === 'ForOfStatement' ||
+          body['type'] === 'WhileStatement' ||
+          body['type'] === 'DoWhileStatement' ||
+          body['type'] === 'SwitchStatement')
+      )
+        walk(body, shadowed, label);
+      else {
+        breakTargets.push({ kind: 'boundary', label, states: [] });
+        if (isRecord(body)) walk(body, shadowed);
+        breakTargets.pop();
+      }
+      return;
+    }
+    if (node['type'] === 'BreakStatement') {
+      const label =
+        isRecord(node['label']) && typeof node['label']['name'] === 'string'
+          ? node['label']['name']
+          : undefined;
+      const target = label
+        ? breakTargets.findLast((candidate) => candidate.label === label)
+        : breakTargets.at(-1);
+      if (target?.kind === 'for-update') {
+        target.states.push(
+          new Map([...bindings].map(([name, values]) => [name, [...values]] as const)),
+        );
+        currentPathCapturedBreak = true;
+      }
+      return;
+    }
     if (
       deferFunctions &&
       (node['type'] === 'FunctionDeclaration' ||
@@ -232,23 +288,31 @@ function staticStringBindings(source: string): Map<string, string[]> {
         if (isRecord(branch)) walk(branch, currentShadowed);
         return;
       }
-      const branches = [node['consequent'], node['alternate']].map((branch) => {
-        bindings.clear();
-        for (const [name, values] of base) bindings.set(name, [...values]);
-        if (isRecord(branch)) walk(branch, currentShadowed);
-        if (isRecord(branch) && unconditionallyAbruptStatement(branch)) {
-          const preserved = preservedAbruptStates.at(-1);
-          if (preserved)
-            for (const [name, values] of bindings)
-              preserved.set(name, mergeStringValues(preserved.get(name) ?? [], values));
-        }
-        return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
-      });
+      const branches = [node['consequent'], node['alternate']]
+        .map((branch) => {
+          bindings.clear();
+          for (const [name, values] of base) bindings.set(name, [...values]);
+          const outerCapturedBreak = currentPathCapturedBreak;
+          currentPathCapturedBreak = false;
+          if (isRecord(branch)) walk(branch, currentShadowed);
+          const branchCapturedBreak = currentPathCapturedBreak;
+          currentPathCapturedBreak = outerCapturedBreak;
+          if (branchCapturedBreak) return undefined;
+          if (isRecord(branch) && unconditionallyAbruptStatement(branch)) {
+            const preserved = preservedAbruptStates.at(-1);
+            if (preserved)
+              for (const [name, values] of bindings)
+                preserved.set(name, mergeStringValues(preserved.get(name) ?? [], values));
+          }
+          return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+        })
+        .filter((branch): branch is Map<string, string[]> => branch !== undefined);
       bindings.clear();
       const names = new Set([...base.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
       for (const name of names) {
         bindings.set(name, [...new Set(branches.flatMap((branch) => branch.get(name) ?? []))]);
       }
+      currentPathCapturedBreak = branches.length === 0;
       return;
     }
     if (node['type'] === 'ConditionalExpression') {
@@ -312,12 +376,21 @@ function staticStringBindings(source: string): Map<string, string[]> {
       }
       return;
     }
+    if (node['type'] === 'DoWhileStatement') {
+      breakTargets.push({ kind: 'boundary', label: controlLabel, states: [] });
+      if (isRecord(node['body'])) walk(node['body'], currentShadowed);
+      breakTargets.pop();
+      if (isRecord(node['test'])) walk(node['test'], currentShadowed);
+      return;
+    }
     if (node['type'] === 'WhileStatement') {
       if (isRecord(node['test'])) walk(node['test'], currentShadowed);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       const truthiness = staticTruthiness(node['test'], bindings);
       if (truthiness === false) return;
+      breakTargets.push({ kind: 'boundary', label: controlLabel, states: [] });
       if (isRecord(node['body'])) walk(node['body'], currentShadowed);
+      breakTargets.pop();
       if (truthiness !== true) {
         const names = new Set([...base.keys(), ...bindings.keys()]);
         for (const name of names)
@@ -374,6 +447,7 @@ function staticStringBindings(source: string): Map<string, string[]> {
                 if (isRecord(declaration)) collectPatternNames(declaration['id'], switchNames);
       const switchShadowed = new Set([...currentShadowed, ...switchNames]);
       const branches: Map<string, string[]>[] = [];
+      breakTargets.push({ kind: 'boundary', label: controlLabel, states: [] });
       let hasDefault = false;
       const discriminant = node['discriminant'];
       const knownValue =
@@ -384,18 +458,22 @@ function staticStringBindings(source: string): Map<string, string[]> {
       let knownStart: number | undefined;
       if (knownDiscriminant) {
         let defaultStart: number | undefined;
+        let unresolvedBeforeMatch = false;
+        let ambiguousMatch = false;
         for (let index = 0; index < cases.length; index += 1) {
           const test = cases[index]?.['test'];
           if (test === null) {
             defaultStart = index;
             continue;
           }
+          if (!isRecord(test) || test['type'] !== 'Literal') unresolvedBeforeMatch = true;
           if (isRecord(test) && test['type'] === 'Literal' && test['value'] === knownValue) {
-            knownStart = index;
+            if (unresolvedBeforeMatch) ambiguousMatch = true;
+            else knownStart = index;
             break;
           }
         }
-        if (knownStart === undefined) knownStart = defaultStart ?? -1;
+        if (!ambiguousMatch && knownStart === undefined) knownStart = defaultStart ?? -1;
       }
       const starts =
         knownStart === undefined
@@ -438,6 +516,7 @@ function staticStringBindings(source: string): Map<string, string[]> {
       const names = new Set(branches.flatMap((branch) => [...branch.keys()]));
       for (const name of names)
         bindings.set(name, mergeStringValues(...branches.map((branch) => branch.get(name) ?? [])));
+      breakTargets.pop();
       return;
     }
     if (
@@ -479,13 +558,28 @@ function staticStringBindings(source: string): Map<string, string[]> {
       const guaranteedIterable =
         node['type'] === 'ForOfStatement' && staticallyGuaranteesNonEmptyArray(node['right']);
       if (testTruthiness === false || emptyIterable) return;
+      const breakTarget = {
+        kind: node['type'] === 'ForStatement' ? ('for-update' as const) : ('boundary' as const),
+        label: controlLabel,
+        states: [] as Array<Map<string, string[]>>,
+      };
+      const outerCapturedBreak = currentPathCapturedBreak;
+      currentPathCapturedBreak = false;
+      breakTargets.push(breakTarget);
       if (isRecord(node['body'])) walk(node['body'], loopShadowed);
+      breakTargets.pop();
+      const bodyCapturedBreak = currentPathCapturedBreak;
+      currentPathCapturedBreak = outerCapturedBreak;
       if (
         node['type'] === 'ForStatement' &&
         isRecord(node['update']) &&
+        !bodyCapturedBreak &&
         !unconditionallyExitsBeforeLoopUpdate(node['body'])
       )
         walk(node['update'], loopShadowed);
+      for (const state of breakTarget.states)
+        for (const [name, values] of state)
+          bindings.set(name, mergeStringValues(bindings.get(name) ?? [], values));
       if (testTruthiness !== true && !emptyIterable && !guaranteedIterable) {
         const names = new Set([...base.keys(), ...bindings.keys()]);
         for (const name of names)
@@ -560,6 +654,7 @@ function staticStringBindings(source: string): Map<string, string[]> {
       preservedAbruptStates.push(new Map());
       for (const statement of node['body']) {
         if (isRecord(statement)) walk(statement, currentShadowed);
+        if (currentPathCapturedBreak) break;
         if (
           isRecord(statement) &&
           statement['type'] === 'IfStatement' &&
@@ -744,13 +839,11 @@ function staticBooleanBindings(source: string): Map<string, boolean> {
                 if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
       currentShadowed = localNames;
     }
-    if (
-      node['type'] === 'AssignmentExpression' &&
-      isRecord(node['left']) &&
-      node['left']['type'] === 'Identifier' &&
-      typeof node['left']['name'] === 'string'
-    )
-      if (!currentShadowed.has(node['left']['name'])) assignedNames.add(node['left']['name']);
+    if (node['type'] === 'AssignmentExpression' && isRecord(node['left'])) {
+      const names = new Set<string>();
+      collectPatternNames(node['left'], names);
+      for (const name of names) if (!currentShadowed.has(name)) assignedNames.add(name);
+    }
     if (
       node['type'] === 'UpdateExpression' &&
       isRecord(node['argument']) &&
@@ -911,9 +1004,20 @@ function qualifyingFieldLabelBranches(
     if (Array.isArray(node['parameters']))
       for (const parameter of node['parameters']) collectPatternNames(parameter, names);
     const body = node['body'] ?? node['fragment'];
-    return isRecord(body)
+    const evidence = isRecord(body)
       ? qualifyingFieldLabelBranches(body, source, bindings, booleanBindings, names)
-      : [emptyFieldEvidence()];
+      : [];
+    if (isRecord(node['fallback']))
+      evidence.push(
+        ...qualifyingFieldLabelBranches(
+          node['fallback'],
+          source,
+          bindings,
+          booleanBindings,
+          templateShadowed,
+        ),
+      );
+    return evidence.length > 0 ? evidence : [emptyFieldEvidence()];
   }
   if (node['type'] === 'AwaitBlock') {
     const evidence: FieldEvidence[] = [];

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -31,31 +31,6 @@ function unwrapTypeExpression(expression: unknown): unknown {
   return expression;
 }
 
-function staticStringFromExpression(
-  rawExpression: unknown,
-  bindings: ReadonlyMap<string, readonly string[]>,
-): string | undefined {
-  const expression = unwrapTypeExpression(rawExpression);
-  if (!isRecord(expression)) return undefined;
-  if (expression['type'] === 'Literal' && typeof expression['value'] === 'string')
-    return expression['value'];
-  if (
-    expression['type'] === 'TemplateLiteral' &&
-    Array.isArray(expression['expressions']) &&
-    expression['expressions'].length === 0 &&
-    Array.isArray(expression['quasis']) &&
-    isRecord(expression['quasis'][0])
-  ) {
-    const value = expression['quasis'][0]['value'];
-    return isRecord(value) && typeof value['cooked'] === 'string' ? value['cooked'] : undefined;
-  }
-  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
-    const values = bindings.get(expression['name']);
-    return values?.length === 1 ? values[0] : undefined;
-  }
-  return undefined;
-}
-
 function staticStringValuesFromExpression(
   rawExpression: unknown,
   bindings: ReadonlyMap<string, readonly string[]>,
@@ -79,16 +54,41 @@ function staticStringValuesFromExpression(
   return [];
 }
 
+function mergeStringValues(...values: (readonly string[])[]): string[] {
+  return [...new Set(values.flat())];
+}
+
 function collectPatternNames(pattern: unknown, into: Set<string>): void {
   if (!isRecord(pattern)) return;
-  if (pattern['type'] === 'Identifier' && typeof pattern['name'] === 'string')
+  if (pattern['type'] === 'Identifier' && typeof pattern['name'] === 'string') {
     into.add(pattern['name']);
-  else if (pattern['type'] === 'VariableDeclarator') collectPatternNames(pattern['id'], into);
-  else
-    for (const value of Object.values(pattern)) {
-      if (Array.isArray(value)) for (const item of value) collectPatternNames(item, into);
-      else if (isRecord(value)) collectPatternNames(value, into);
+    return;
+  }
+  if (pattern['type'] === 'VariableDeclarator') {
+    collectPatternNames(pattern['id'], into);
+    return;
+  }
+  if (pattern['type'] === 'RestElement') {
+    collectPatternNames(pattern['argument'], into);
+    return;
+  }
+  if (pattern['type'] === 'AssignmentPattern') {
+    collectPatternNames(pattern['left'], into);
+    return;
+  }
+  if (pattern['type'] === 'ArrayPattern' && Array.isArray(pattern['elements'])) {
+    for (const element of pattern['elements']) collectPatternNames(element, into);
+    return;
+  }
+  if (pattern['type'] === 'ObjectPattern' && Array.isArray(pattern['properties'])) {
+    for (const property of pattern['properties']) {
+      if (!isRecord(property)) continue;
+      collectPatternNames(
+        property['type'] === 'RestElement' ? property['argument'] : property['value'],
+        into,
+      );
     }
+  }
 }
 
 function collectFunctionScopedNames(node: unknown, into: Set<string>): void {
@@ -114,36 +114,48 @@ function collectFunctionScopedNames(node: unknown, into: Set<string>): void {
 function staticStringBindings(source: string): Map<string, string[]> {
   const root: unknown = parseSvelte(source, { modern: true });
   const bindings = new Map<string, string[]>();
-  if (!isRecord(root) || !isRecord(root['instance']) || !isRecord(root['instance']['content']))
-    return bindings;
-  const body = root['instance']['content']['body'];
-  if (!Array.isArray(body)) return bindings;
-  for (const statement of body) {
-    if (
-      !isRecord(statement) ||
-      statement['type'] !== 'VariableDeclaration' ||
-      !['const', 'let', 'var'].includes(String(statement['kind']))
-    )
-      continue;
-    const declarations = statement['declarations'];
-    if (!Array.isArray(declarations)) continue;
-    for (const declaration of declarations) {
-      if (
-        !isRecord(declaration) ||
-        !isRecord(declaration['id']) ||
-        declaration['id']['type'] !== 'Identifier' ||
-        typeof declaration['id']['name'] !== 'string'
-      )
-        continue;
-      const values = staticStringValuesFromExpression(declaration['init'], bindings);
-      if (values.length > 0) bindings.set(declaration['id']['name'], values);
-      else if (declaration['init'] !== null && declaration['init'] !== undefined)
-        bindings.delete(declaration['id']['name']);
-    }
-  }
+  const callbackBindings = new Map<string, string[]>();
+  const deferredFunctions: Array<{
+    node: UnknownRecord;
+    shadowed: ReadonlySet<string>;
+  }> = [];
+  let deferFunctions = true;
+  if (!isRecord(root)) return bindings;
   const walk = (node: unknown, shadowed: ReadonlySet<string> = new Set()): void => {
     if (!isRecord(node)) return;
+    if (
+      deferFunctions &&
+      (node['type'] === 'FunctionDeclaration' ||
+        node['type'] === 'FunctionExpression' ||
+        node['type'] === 'ArrowFunctionExpression')
+    ) {
+      deferredFunctions.push({ node, shadowed: new Set(shadowed) });
+      return;
+    }
     let currentShadowed = shadowed;
+    if (
+      node['type'] === 'VariableDeclaration' &&
+      ['const', 'let', 'var'].includes(String(node['kind'])) &&
+      Array.isArray(node['declarations'])
+    ) {
+      for (const declaration of node['declarations']) {
+        if (
+          !isRecord(declaration) ||
+          !isRecord(declaration['id']) ||
+          declaration['id']['type'] !== 'Identifier' ||
+          typeof declaration['id']['name'] !== 'string'
+        )
+          continue;
+        const name = declaration['id']['name'];
+        const values = staticStringValuesFromExpression(declaration['init'], bindings);
+        const callbackValues = callbackBindings.get(name) ?? [];
+        if (values.length > 0) bindings.set(name, mergeStringValues(values, callbackValues));
+        else if (declaration['init'] === null || declaration['init'] === undefined) {
+          if (node['kind'] !== 'var' || !bindings.has(name)) bindings.set(name, []);
+        } else if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
+        else bindings.delete(name);
+      }
+    }
     if (node['type'] === 'IfStatement') {
       if (isRecord(node['test'])) walk(node['test'], currentShadowed);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
@@ -206,17 +218,41 @@ function staticStringBindings(source: string): Map<string, string[]> {
       const localNames = new Set<string>();
       if (Array.isArray(node['params']))
         for (const parameter of node['params']) collectPatternNames(parameter, localNames);
-      if (isRecord(node['body'])) collectFunctionScopedNames(node['body'], localNames);
+      if (isRecord(node['body'])) {
+        collectFunctionScopedNames(node['body'], localNames);
+        if (node['body']['type'] === 'BlockStatement' && Array.isArray(node['body']['body']))
+          for (const statement of node['body']['body'])
+            if (
+              isRecord(statement) &&
+              statement['type'] === 'VariableDeclaration' &&
+              (statement['kind'] === 'let' || statement['kind'] === 'const') &&
+              Array.isArray(statement['declarations'])
+            )
+              for (const declaration of statement['declarations'])
+                if (isRecord(declaration)) collectPatternNames(declaration['id'], localNames);
+      }
       currentShadowed = new Set([...shadowed, ...localNames]);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       if (isRecord(node['body'])) walk(node['body'], currentShadowed);
       const terminal = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       bindings.clear();
       const names = new Set([...base.keys(), ...terminal.keys()]);
-      for (const name of names)
-        bindings.set(name, [
-          ...new Set([...(base.get(name) ?? []), ...(terminal.get(name) ?? [])]),
-        ]);
+      for (const name of names) {
+        if (localNames.has(name)) {
+          if (base.has(name)) bindings.set(name, [...base.get(name)!]);
+          continue;
+        }
+        const baseValues = base.get(name) ?? [];
+        const callbackValues = (terminal.get(name) ?? []).filter(
+          (value) => !baseValues.includes(value),
+        );
+        if (callbackValues.length > 0)
+          callbackBindings.set(
+            name,
+            mergeStringValues(callbackBindings.get(name) ?? [], callbackValues),
+          );
+        bindings.set(name, mergeStringValues(baseValues, callbackBindings.get(name) ?? []));
+      }
       return;
     } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
       const localNames = new Set<string>();
@@ -233,6 +269,24 @@ function staticStringBindings(source: string): Map<string, string[]> {
     }
     if (
       node['type'] === 'AssignmentExpression' &&
+      node['operator'] === '+=' &&
+      isRecord(node['left']) &&
+      node['left']['type'] === 'Identifier' &&
+      typeof node['left']['name'] === 'string' &&
+      !currentShadowed.has(node['left']['name'])
+    ) {
+      const name = node['left']['name'];
+      const rightValues = staticStringValuesFromExpression(node['right'], bindings);
+      const combined = (bindings.get(name) ?? []).flatMap((previous) =>
+        rightValues.map((right) => previous + right),
+      );
+      const callbackValues = callbackBindings.get(name) ?? [];
+      if (combined.length > 0) bindings.set(name, mergeStringValues(combined, callbackValues));
+      else if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
+      else bindings.delete(name);
+    }
+    if (
+      node['type'] === 'AssignmentExpression' &&
       node['operator'] === '=' &&
       isRecord(node['left']) &&
       node['left']['type'] === 'Identifier' &&
@@ -241,7 +295,9 @@ function staticStringBindings(source: string): Map<string, string[]> {
     ) {
       const name = node['left']['name'];
       const values = staticStringValuesFromExpression(node['right'], bindings);
-      if (values.length > 0) bindings.set(name, values);
+      const callbackValues = callbackBindings.get(name) ?? [];
+      if (values.length > 0) bindings.set(name, mergeStringValues(values, callbackValues));
+      else if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
       else bindings.delete(name);
     }
     for (const child of Object.values(node)) {
@@ -249,7 +305,22 @@ function staticStringBindings(source: string): Map<string, string[]> {
       else if (isRecord(child)) walk(child, currentShadowed);
     }
   };
-  for (const statement of body) walk(statement);
+  const body =
+    isRecord(root['instance']) && isRecord(root['instance']['content'])
+      ? root['instance']['content']['body']
+      : undefined;
+  if (Array.isArray(body)) for (const statement of body) walk(statement);
+  deferFunctions = false;
+  for (const deferred of deferredFunctions) walk(deferred.node, deferred.shadowed);
+  const walkTemplateExpressions = (node: unknown): void => {
+    if (!isRecord(node)) return;
+    if (node['type'] === 'ExpressionTag' && isRecord(node['expression'])) walk(node['expression']);
+    for (const value of Object.values(node)) {
+      if (Array.isArray(value)) for (const child of value) walkTemplateExpressions(child);
+      else if (isRecord(value)) walkTemplateExpressions(value);
+    }
+  };
+  walkTemplateExpressions(root['fragment']);
   return bindings;
 }
 
@@ -296,53 +367,24 @@ function localMarkupEvidence(
   return { labelCount, terms: terms.join(' ') };
 }
 
-function qualifyingFieldLabels(
-  node: unknown,
-  source: string,
-  bindings: ReadonlyMap<string, readonly string[]>,
+function emptyFieldEvidence(): FieldEvidence {
+  return {
+    count: 0,
+    isolatedMessages: false,
+    labelCount: 0,
+    rootLabelCount: 0,
+    terms: '',
+  };
+}
+
+function summarizeFieldEvidence(
+  localEvidence: { labelCount: number; terms: string },
+  childEvidence: readonly FieldEvidence[],
 ): FieldEvidence {
-  if (!isRecord(node))
-    return {
-      count: 0,
-      isolatedMessages: false,
-      labelCount: 0,
-      rootLabelCount: 0,
-      terms: '',
-    };
-  // A canonical `<FormField>`'s own props (label/description/error) aren't
-  // hand-rolled evidence — but its rendered children (a child snippet can
-  // still hand-roll a label/description/error wrapper) must keep being
-  // inspected below, via the general recursion's `attributes` key skip for
-  // Component nodes. Only its own local markup evidence is suppressed here.
-  if (node['type'] === 'HtmlTag' && isRecord(node['expression'])) {
-    const html = staticStringFromExpression(node['expression'], bindings);
-    if (html !== undefined) {
-      const nested = parseSvelteFragment(html);
-      return nested === undefined
-        ? {
-            count: 0,
-            isolatedMessages: false,
-            labelCount: 0,
-            rootLabelCount: 0,
-            terms: '',
-          }
-        : qualifyingFieldLabels(nested, html, bindings);
-    }
-  }
-  const localEvidence = localMarkupEvidence(node, source, bindings);
   let count = 0;
   let labelCount = localEvidence.labelCount;
   const terms = [localEvidence.terms];
   const deferredMessageTerms: string[] = [];
-  const childEvidence: FieldEvidence[] = [];
-  for (const [key, value] of Object.entries(node)) {
-    if (node['type'] === 'Component' && key === 'attributes') continue;
-    const children = Array.isArray(value) ? value : [value];
-    for (const child of children) {
-      if (!isRecord(child)) continue;
-      childEvidence.push(qualifyingFieldLabels(child, source, bindings));
-    }
-  }
   const hasDirectLabel =
     localEvidence.labelCount > 0 || childEvidence.some((evidence) => evidence.rootLabelCount > 0);
   for (const evidence of childEvidence) {
@@ -355,7 +397,6 @@ function qualifyingFieldLabels(
     labelCount += evidence.labelCount;
     terms.push(evidence.terms);
   }
-
   let combinedTerms = terms.join(' ');
   if (labelCount === 0 && deferredMessageTerms.length > 0)
     combinedTerms = `${combinedTerms} ${deferredMessageTerms.join(' ')}`;
@@ -379,9 +420,50 @@ function qualifyingFieldLabels(
   };
 }
 
+function qualifyingFieldLabelBranches(
+  node: unknown,
+  source: string,
+  bindings: ReadonlyMap<string, readonly string[]>,
+): FieldEvidence[] {
+  if (!isRecord(node)) return [emptyFieldEvidence()];
+  // A canonical `<FormField>`'s own props (label/description/error) aren't
+  // hand-rolled evidence — but its rendered children (a child snippet can
+  // still hand-roll a label/description/error wrapper) must keep being
+  // inspected below, via the general recursion's `attributes` key skip for
+  // Component nodes. Only its own local markup evidence is suppressed here.
+  if (node['type'] === 'HtmlTag' && isRecord(node['expression'])) {
+    const evidences = staticStringValuesFromExpression(node['expression'], bindings).flatMap(
+      (html) => {
+        const nested = parseSvelteFragment(html);
+        return nested === undefined ? [] : qualifyingFieldLabelBranches(nested, html, bindings);
+      },
+    );
+    if (evidences.length > 0) return evidences;
+  }
+  const localEvidence = localMarkupEvidence(node, source, bindings);
+  let combinations: FieldEvidence[][] = [[]];
+  for (const [key, value] of Object.entries(node)) {
+    if (node['type'] === 'Component' && key === 'attributes') continue;
+    const children = Array.isArray(value) ? value : [value];
+    for (const child of children) {
+      if (!isRecord(child)) continue;
+      const branches = qualifyingFieldLabelBranches(child, source, bindings);
+      combinations = combinations.flatMap((combination) =>
+        branches.map((branch) => [...combination, branch]),
+      );
+    }
+  }
+  return combinations.map((childEvidence) => summarizeFieldEvidence(localEvidence, childEvidence));
+}
+
 export function fieldWrapperCount(source: string): number {
   const fragment = parseSvelteFragment(source);
   return fragment === undefined
     ? 0
-    : qualifyingFieldLabels(fragment, source, staticStringBindings(source)).count;
+    : Math.max(
+        0,
+        ...qualifyingFieldLabelBranches(fragment, source, staticStringBindings(source)).map(
+          (evidence) => evidence.count,
+        ),
+      );
 }

--- a/packages/components/scripts/primitive-composition-field.ts
+++ b/packages/components/scripts/primitive-composition-field.ts
@@ -82,6 +82,24 @@ function staticStringBindings(source: string): Map<string, string> {
       if (value !== undefined) bindings.set(declaration['id']['name'], value);
     }
   }
+  const walk = (node: unknown): void => {
+    if (!isRecord(node)) return;
+    if (
+      node['type'] === 'AssignmentExpression' &&
+      node['operator'] === '=' &&
+      isRecord(node['left']) &&
+      node['left']['type'] === 'Identifier' &&
+      typeof node['left']['name'] === 'string'
+    ) {
+      const value = staticStringFromExpression(node['right'], bindings);
+      if (value !== undefined) bindings.set(node['left']['name'], value);
+    }
+    for (const child of Object.values(node)) {
+      if (Array.isArray(child)) for (const item of child) walk(item);
+      else if (isRecord(child)) walk(child);
+    }
+  };
+  for (const statement of body) walk(statement);
   return bindings;
 }
 

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -95,9 +95,9 @@ allowedGridCounts.set('phone-input/phone-input.css', 2);
 allowedGridCounts.set('pricing-section/pricing-section.css', 5);
 allowedGridCounts.set('run-step-timeline/run-step-timeline.css', 2);
 allowedGridCounts.set('selectable-row/selectable-row.css', 2);
-// The selector-aware analyzer counts only the line grid: the lines container's
-// display:grid has no grid-definition property and is not a hand-rolled layout.
-allowedGridCounts.set('source-diff-viewer/source-diff-viewer.css', 1);
+// The selector-aware analyzer counts the line grid's base and no-number column
+// definitions. The lines container has no grid-definition property.
+allowedGridCounts.set('source-diff-viewer/source-diff-viewer.css', 2);
 allowedGridCounts.set('stacked-list-item/stacked-list-item.css', 6);
 allowedGridCounts.set('statistic-group/statistic-group.css', 10);
 allowedGridCounts.set('statistic/statistic.css', 2);

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -455,7 +455,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
               matched = true;
               break;
             }
-          } else if (discriminantValue === undefined)
+          } else if (discriminantValue === undefined || caseValue === undefined)
             starts.push({ index, state: new Map(testState) });
         } else if (!matched) starts.push({ index, state: new Map(testState) });
       }

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -286,6 +286,7 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
   if (!isRecord(statement)) return false;
   if (
     statement['type'] === 'BreakStatement' ||
+    statement['type'] === 'ContinueStatement' ||
     statement['type'] === 'ReturnStatement' ||
     statement['type'] === 'ThrowStatement'
   )
@@ -373,6 +374,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     label: string | undefined;
     states: Map<string, unknown[]>[] | undefined;
   }> = [];
+  const continueTargets: Array<{ states: Map<string, unknown[]>[] }> = [];
   const resolveDeclaration = (name: string, kind: string, initializer: unknown): void => {
     if (initializer === undefined || initializer === null) {
       // `var name;` preserves a prior value, while an uninitialized `let`
@@ -404,6 +406,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   ): void => {
     if (!isRecord(node)) return;
     let pushedAliasBlock = false;
+    let blockBindingBase: Map<string, unknown[]> | undefined;
     let currentShadowed = shadowed;
     let currentInsideFunction = insideFunction;
     if (node['type'] === 'BreakStatement') {
@@ -417,12 +420,37 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       target?.states?.push(cloneBindings());
       return;
     }
+    if (node['type'] === 'ContinueStatement') {
+      continueTargets.at(-1)?.states.push(cloneBindings());
+      return;
+    }
     if (node['type'] === 'LabeledStatement') {
       const label =
         isRecord(node['label']) && typeof node['label']['name'] === 'string'
           ? node['label']['name']
           : undefined;
       if (isRecord(node['body'])) walk(node['body'], currentShadowed, currentInsideFunction, label);
+      return;
+    }
+    if (node['type'] === 'TryStatement') {
+      const base = cloneBindings();
+      const alternatives: Map<string, unknown[]>[] = [];
+      if (isRecord(node['block'])) {
+        walk(node['block'], currentShadowed, currentInsideFunction);
+        alternatives.push(cloneBindings());
+      }
+      bindings.clear();
+      for (const [name, values] of base) bindings.set(name, [...values]);
+      if (isRecord(node['handler'])) {
+        walk(node['handler'], currentShadowed, currentInsideFunction);
+        alternatives.push(cloneBindings());
+      }
+      bindings.clear();
+      for (const [name, values] of alternatives[0] ?? base) bindings.set(name, [...values]);
+      for (const alternative of alternatives.slice(1))
+        mergeBindingStates(cloneBindings(), alternative);
+      if (isRecord(node['finalizer']))
+        walk(node['finalizer'], currentShadowed, currentInsideFunction);
       return;
     }
     if (node['type'] === 'SwitchStatement') {
@@ -589,7 +617,13 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         ? new Map([...callbackFrame].map(([name, values]) => [name, [...values]] as const))
         : undefined;
       const branchCallbackFrames: Map<string, unknown[]>[] = [];
-      const branches = [node['consequent'], node['alternate']].map((branch) => {
+      const branchCandidates =
+        staticTruthiness(node['test'], base) === true
+          ? [node['consequent']]
+          : staticTruthiness(node['test'], base) === false
+            ? [node['alternate']]
+            : [node['consequent'], node['alternate']];
+      const branches = branchCandidates.map((branch) => {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
         if (callbackFrame) {
@@ -753,8 +787,11 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         bindings.clear();
         for (const [name, values] of beforeBody) bindings.set(name, [...values]);
         const interruptedStates: Map<string, unknown[]>[] = [];
+        const continuedStates: Map<string, unknown[]>[] = [];
         breakTargets.push({ label: controlLabel, states: interruptedStates });
+        continueTargets.push({ states: continuedStates });
         walk(node['body'], loopShadowed, currentInsideFunction);
+        continueTargets.pop();
         breakTargets.pop();
         if (
           node['type'] === 'ForStatement' &&
@@ -763,6 +800,10 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         )
           walk(node['update'], loopShadowed, currentInsideFunction);
         let afterBody = cloneBindings();
+        for (const continuedState of continuedStates) {
+          mergeBindingStates(afterBody, continuedState);
+          afterBody = cloneBindings();
+        }
         for (const interruptedState of interruptedStates) {
           mergeBindingStates(afterBody, interruptedState);
           afterBody = cloneBindings();
@@ -800,6 +841,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
       localAliasFrames.push(new Map());
       pushedAliasBlock = true;
+      blockBindingBase = cloneBindings();
       const lexicalNames = new Set<string>();
       for (const statement of node['body']) {
         if (
@@ -922,7 +964,26 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         for (const item of value) walk(item, currentShadowed, currentInsideFunction);
       else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction);
     }
-    if (pushedAliasBlock) localAliasFrames.pop();
+    if (pushedAliasBlock) {
+      localAliasFrames.pop();
+      if (blockBindingBase && node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
+        const lexicalNames = new Set<string>();
+        for (const statement of node['body'])
+          if (
+            isRecord(statement) &&
+            statement['type'] === 'VariableDeclaration' &&
+            (statement['kind'] === 'let' || statement['kind'] === 'const') &&
+            Array.isArray(statement['declarations'])
+          )
+            for (const declaration of statement['declarations'])
+              if (isRecord(declaration)) declaredNamesInPattern(declaration['id'], lexicalNames);
+        for (const name of lexicalNames) {
+          const previous = blockBindingBase.get(name);
+          if (previous === undefined) bindings.delete(name);
+          else bindings.set(name, [...previous]);
+        }
+      }
+    }
     if (
       node['type'] === 'FunctionDeclaration' ||
       node['type'] === 'FunctionExpression' ||

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -164,7 +164,7 @@ function declaresNameWithinFunctionScope(node: unknown, name: string): boolean {
 function resolvedAssignmentValue(
   rawValue: unknown,
   bindings: ReadonlyMap<string, unknown[]> = new Map(),
-): { set: true; value: unknown } | { set: false } {
+): { set: true; values: unknown[] } | { set: false } {
   const value = unwrapTypeExpression(rawValue);
   if (
     isRecord(value) &&
@@ -172,11 +172,13 @@ function resolvedAssignmentValue(
       String(value['type']),
     )
   )
-    return { set: true, value };
-  if (isRecord(value) && value['type'] === 'Literal') return { set: true, value: value['value'] };
+    return { set: true, values: [value] };
+  if (isRecord(value) && value['type'] === 'Literal')
+    return { set: true, values: [value['value']] };
   if (isRecord(value) && value['type'] === 'Identifier' && typeof value['name'] === 'string') {
     const candidates = bindings.get(value['name']);
-    if (candidates?.length === 1) return { set: true, value: candidates[0] };
+    if (candidates !== undefined && candidates.length > 0)
+      return { set: true, values: [...candidates] };
   }
   return { set: false };
 }
@@ -207,8 +209,8 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         continue;
       const name = declaration['id']['name'];
       if (statement['kind'] !== 'const') mutableBindings.add(name);
-      const resolved = resolvedAssignmentValue(declaration['init'], bindings);
-      if (resolved.set) bindings.set(name, [resolved.value]);
+      const resolved = resolvedAssignmentValue(declaration['init']);
+      if (resolved.set) bindings.set(name, resolved.values);
       else bindings.delete(name);
     }
   }
@@ -232,24 +234,29 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     node: unknown,
     shadowed: ReadonlySet<string>,
     insideFunction: boolean,
-    conditional: boolean,
+    conditional = false,
   ): void => {
     if (!isRecord(node)) return;
     let currentShadowed = shadowed;
     let currentInsideFunction = insideFunction;
-    let currentConditional = conditional;
-    if (
-      [
-        'IfStatement',
-        'SwitchStatement',
-        'ForStatement',
-        'ForInStatement',
-        'ForOfStatement',
-        'WhileStatement',
-        'DoWhileStatement',
-      ].includes(String(node['type']))
-    )
-      currentConditional = true;
+    if (node['type'] === 'IfStatement') {
+      if (isRecord(node['test']))
+        walk(node['test'], currentShadowed, currentInsideFunction, conditional);
+      if (isRecord(node['consequent']))
+        walk(node['consequent'], currentShadowed, currentInsideFunction, true);
+      if (isRecord(node['alternate']))
+        walk(node['alternate'], currentShadowed, currentInsideFunction, true);
+      return;
+    }
+    if (node['type'] === 'ConditionalExpression') {
+      if (isRecord(node['test']))
+        walk(node['test'], currentShadowed, currentInsideFunction, conditional);
+      if (isRecord(node['consequent']))
+        walk(node['consequent'], currentShadowed, currentInsideFunction, true);
+      if (isRecord(node['alternate']))
+        walk(node['alternate'], currentShadowed, currentInsideFunction, true);
+      return;
+    }
     if (
       node['type'] === 'FunctionDeclaration' ||
       node['type'] === 'FunctionExpression' ||
@@ -278,23 +285,23 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     ) {
       const name = node['left']['name'];
       const resolved = resolvedAssignmentValue(node['right'], bindings);
-      if (currentInsideFunction || currentConditional) {
-        if (resolved.set) bindings.set(name, [...(bindings.get(name) ?? []), resolved.value]);
+      if (currentInsideFunction) {
+        if (resolved.set) bindings.set(name, [...(bindings.get(name) ?? []), ...resolved.values]);
+      } else if (resolved.set && conditional) {
+        bindings.set(name, [...(bindings.get(name) ?? []), ...resolved.values]);
       } else if (resolved.set) {
-        bindings.set(name, [resolved.value]);
+        bindings.set(name, resolved.values);
       } else {
         bindings.delete(name);
       }
     }
     for (const value of Object.values(node)) {
       if (Array.isArray(value))
-        for (const item of value)
-          walk(item, currentShadowed, currentInsideFunction, currentConditional);
-      else if (isRecord(value))
-        walk(value, currentShadowed, currentInsideFunction, currentConditional);
+        for (const item of value) walk(item, currentShadowed, currentInsideFunction, conditional);
+      else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction, conditional);
     }
   };
-  for (const statement of body) walk(statement, new Set(), false, false);
+  for (const statement of body) walk(statement, new Set(), false);
 
   return bindings;
 }

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -253,7 +253,12 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         );
       }
       bindings.clear();
-      for (const [name, values] of base) {
+      const names = new Set([
+        ...base.keys(),
+        ...branchValues.flatMap((branch) => [...branch.keys()]),
+      ]);
+      for (const name of names) {
+        const values = base.get(name) ?? [];
         const merged = branchValues.flatMap((branch) => branch.get(name) ?? values);
         bindings.set(name, [...new Set(merged)]);
       }
@@ -270,7 +275,9 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       });
       bindings.clear();
-      for (const [name, values] of base) {
+      const names = new Set([...base.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
+      for (const name of names) {
+        const values = base.get(name) ?? [];
         const merged = branches.flatMap((branch) => branch.get(name) ?? values);
         bindings.set(name, [...new Set(merged)]);
       }

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -196,6 +196,7 @@ function mergeValues(values: readonly unknown[]): unknown[] {
 function staticBindings(instance: unknown): Map<string, unknown[]> {
   const bindings = new Map<string, unknown[]>();
   const mutableBindings = new Set<string>();
+  const declaredBindings = new Set<string>();
   const callbackBindings = new Map<string, unknown[]>();
   if (!isRecord(instance) || !isRecord(instance['content'])) return bindings;
   const body = instance['content']['body'];
@@ -220,6 +221,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       )
         continue;
       const name = declaration['id']['name'];
+      declaredBindings.add(name);
       if (statement['kind'] !== 'const') mutableBindings.add(name);
     }
   }
@@ -240,6 +242,23 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   // ConditionalExpression's branches are both kept.
   const valuesWithCallbackState = (name: string, values: readonly unknown[]): unknown[] =>
     mergeValues([...values, ...(callbackBindings.get(name) ?? [])]);
+  const cloneBindings = (): Map<string, unknown[]> =>
+    new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+  const mergeBindingStates = (
+    base: Map<string, unknown[]>,
+    branch: Map<string, unknown[]>,
+  ): void => {
+    bindings.clear();
+    const names = new Set([...base.keys(), ...branch.keys()]);
+    for (const name of names) {
+      const values = mergeValues([...(base.get(name) ?? []), ...(branch.get(name) ?? [])]);
+      if (values.length > 0) bindings.set(name, values);
+    }
+  };
+  const breakTargets: Array<{
+    label: string | undefined;
+    states: Map<string, unknown[]>[] | undefined;
+  }> = [];
   const resolveDeclaration = (name: string, kind: string, initializer: unknown): void => {
     if (initializer === undefined) {
       // `var name;` preserves a prior value, while an uninitialized `let`
@@ -261,10 +280,50 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       else bindings.delete(name);
     }
   };
-  const walk = (node: unknown, shadowed: ReadonlySet<string>, insideFunction: boolean): void => {
+  const walk = (
+    node: unknown,
+    shadowed: ReadonlySet<string>,
+    insideFunction: boolean,
+    controlLabel?: string,
+  ): void => {
     if (!isRecord(node)) return;
     let currentShadowed = shadowed;
     let currentInsideFunction = insideFunction;
+    if (node['type'] === 'BreakStatement') {
+      const label =
+        isRecord(node['label']) && typeof node['label']['name'] === 'string'
+          ? node['label']['name']
+          : undefined;
+      const target = label
+        ? breakTargets.findLast((candidate) => candidate.label === label)
+        : breakTargets.at(-1);
+      target?.states?.push(cloneBindings());
+      return;
+    }
+    if (node['type'] === 'LabeledStatement') {
+      const label =
+        isRecord(node['label']) && typeof node['label']['name'] === 'string'
+          ? node['label']['name']
+          : undefined;
+      if (isRecord(node['body'])) walk(node['body'], currentShadowed, currentInsideFunction, label);
+      return;
+    }
+    if (node['type'] === 'SwitchStatement') {
+      const interruptedStates: Map<string, unknown[]>[] = [];
+      breakTargets.push({ label: controlLabel, states: interruptedStates });
+      for (const value of Object.values(node)) {
+        if (Array.isArray(value))
+          for (const item of value) walk(item, currentShadowed, currentInsideFunction);
+        else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction);
+      }
+      breakTargets.pop();
+      let continuingState = cloneBindings();
+      for (const interruptedState of interruptedStates) {
+        mergeBindingStates(continuingState, interruptedState);
+        continuingState = cloneBindings();
+      }
+      return;
+    }
     if (node['type'] === 'IfStatement') {
       if (isRecord(node['test'])) walk(node['test'], currentShadowed, currentInsideFunction);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
@@ -322,23 +381,21 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       )
         for (const declaration of loopBinding['declarations'])
           if (isRecord(declaration)) declaredNamesInPattern(declaration['id'], loopShadowed);
-      const cloneBindings = (): Map<string, unknown[]> =>
-        new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
-      const mergeBindingStates = (
-        base: Map<string, unknown[]>,
-        branch: Map<string, unknown[]>,
-      ): void => {
-        bindings.clear();
-        const names = new Set([...base.keys(), ...branch.keys()]);
-        for (const name of names) {
-          const values = mergeValues([...(base.get(name) ?? []), ...(branch.get(name) ?? [])]);
-          if (values.length > 0) bindings.set(name, values);
-        }
-      };
       const literalTruthiness = (expression: unknown): boolean | undefined => {
         if (!isRecord(expression)) return undefined;
         if (expression['type'] === 'Literal') return Boolean(expression['value']);
-        if (expression['type'] === 'Identifier' && expression['name'] === 'undefined') return false;
+        if (expression['type'] === 'Identifier' && expression['name'] === 'undefined') {
+          if (loopShadowed.has('undefined')) return undefined;
+          const values = bindings.get('undefined');
+          if (values !== undefined && values.length === 1) {
+            const value = values[0];
+            return isRecord(value) && value['type'] === 'Literal'
+              ? Boolean(value['value'])
+              : Boolean(value);
+          }
+          if (declaredBindings.has('undefined')) return undefined;
+          return false;
+        }
         return undefined;
       };
       const guaranteedBody = (): boolean => {
@@ -362,6 +419,21 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
           right['elements'].length === 0
         );
       };
+      const endsWithAbruptExit = (candidate: unknown): boolean => {
+        if (!isRecord(candidate)) return false;
+        if (
+          candidate['type'] === 'BreakStatement' ||
+          candidate['type'] === 'ReturnStatement' ||
+          candidate['type'] === 'ThrowStatement'
+        )
+          return true;
+        return (
+          candidate['type'] === 'BlockStatement' &&
+          Array.isArray(candidate['body']) &&
+          candidate['body'].length > 0 &&
+          endsWithAbruptExit(candidate['body'][candidate['body'].length - 1])
+        );
+      };
       const canExitAfterEnteringStableTest = (candidate: unknown, testName: string): boolean => {
         if (!isRecord(candidate)) return false;
         if (
@@ -370,7 +442,12 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
           candidate['type'] === 'ArrowFunctionExpression'
         )
           return false;
-        if (candidate['type'] === 'BreakStatement' || candidate['type'] === 'CallExpression')
+        if (
+          candidate['type'] === 'BreakStatement' ||
+          candidate['type'] === 'ReturnStatement' ||
+          candidate['type'] === 'ThrowStatement' ||
+          candidate['type'] === 'CallExpression'
+        )
           return true;
         if (
           candidate['type'] === 'AssignmentExpression' &&
@@ -419,10 +496,21 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       if (!definitelyEmptyBody() && !hasOnlyZeroEntryTerminalState && isRecord(node['body'])) {
         bindings.clear();
         for (const [name, values] of beforeBody) bindings.set(name, [...values]);
+        const interruptedStates: Map<string, unknown[]>[] = [];
+        breakTargets.push({ label: controlLabel, states: interruptedStates });
         walk(node['body'], loopShadowed, currentInsideFunction);
-        if (node['type'] === 'ForStatement' && isRecord(node['update']))
+        breakTargets.pop();
+        if (
+          node['type'] === 'ForStatement' &&
+          isRecord(node['update']) &&
+          !endsWithAbruptExit(node['body'])
+        )
           walk(node['update'], loopShadowed, currentInsideFunction);
-        const afterBody = cloneBindings();
+        let afterBody = cloneBindings();
+        for (const interruptedState of interruptedStates) {
+          mergeBindingStates(afterBody, interruptedState);
+          afterBody = cloneBindings();
+        }
         if (!guaranteedBody()) mergeBindingStates(beforeBody, afterBody);
       } else {
         bindings.clear();

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -578,6 +578,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
               return;
             if (
               candidate['type'] === 'VariableDeclaration' &&
+              (candidate['kind'] === 'let' || candidate['kind'] === 'const') &&
               Array.isArray(candidate['declarations'])
             )
               for (const declaration of candidate['declarations'])

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -146,11 +146,17 @@ function declaresNameWithinFunctionScope(node: unknown, name: string): boolean {
     node['type'] === 'ArrowFunctionExpression'
   )
     return false;
-  if (node['type'] === 'VariableDeclarator') {
-    const names = new Set<string>();
-    declaredNamesInPattern(node['id'], names);
-    if (names.has(name)) return true;
-  }
+  if (
+    node['type'] === 'VariableDeclaration' &&
+    node['kind'] === 'var' &&
+    Array.isArray(node['declarations'])
+  )
+    for (const declaration of node['declarations']) {
+      if (!isRecord(declaration)) continue;
+      const names = new Set<string>();
+      declaredNamesInPattern(declaration['id'], names);
+      if (names.has(name)) return true;
+    }
   for (const value of Object.values(node)) {
     if (Array.isArray(value)) {
       if (value.some((item) => declaresNameWithinFunctionScope(item, name))) return true;
@@ -183,15 +189,21 @@ function resolvedAssignmentValue(
   return { set: false };
 }
 
+function mergeValues(values: readonly unknown[]): unknown[] {
+  return [...new Set(values)];
+}
+
 function staticBindings(instance: unknown): Map<string, unknown[]> {
   const bindings = new Map<string, unknown[]>();
   const mutableBindings = new Set<string>();
+  const callbackBindings = new Map<string, unknown[]>();
   if (!isRecord(instance) || !isRecord(instance['content'])) return bindings;
   const body = instance['content']['body'];
   if (!Array.isArray(body)) return bindings;
 
-  // Pass 1: collect top-level `let`/`var` declarations (module-scope mutable
-  // bindings) and their initial value, in source order.
+  // Collect top-level binding names before walking the body. Values themselves
+  // are resolved by the walk so aliases observe assignments that precede their
+  // declaration in source order.
   for (const statement of body) {
     if (
       !isRecord(statement) ||
@@ -209,12 +221,8 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         continue;
       const name = declaration['id']['name'];
       if (statement['kind'] !== 'const') mutableBindings.add(name);
-      const resolved = resolvedAssignmentValue(declaration['init'], bindings);
-      if (resolved.set) bindings.set(name, resolved.values);
-      else bindings.delete(name);
     }
   }
-  if (mutableBindings.size === 0) return bindings;
 
   // Pass 2: apply every reassignment of a tracked mutable binding, including
   // writes made inside function bodies — a click handler reassigning a
@@ -230,6 +238,29 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   // initial render looked like, so it's recorded as an *additional*
   // reachable value rather than replacing the existing one — the same way a
   // ConditionalExpression's branches are both kept.
+  const valuesWithCallbackState = (name: string, values: readonly unknown[]): unknown[] =>
+    mergeValues([...values, ...(callbackBindings.get(name) ?? [])]);
+  const resolveDeclaration = (name: string, kind: string, initializer: unknown): void => {
+    if (initializer === undefined) {
+      // `var name;` preserves a prior value, while an uninitialized `let`
+      // declaration makes the binding unknown.
+      if (kind === 'var' && bindings.has(name)) return;
+      const callbackValues = callbackBindings.get(name) ?? [];
+      if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
+      else bindings.delete(name);
+      return;
+    }
+    const resolved = resolvedAssignmentValue(initializer, bindings);
+    if (resolved.set) {
+      const values = valuesWithCallbackState(name, resolved.values);
+      if (values.length > 0) bindings.set(name, values);
+      else bindings.delete(name);
+    } else {
+      const callbackValues = callbackBindings.get(name) ?? [];
+      if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
+      else bindings.delete(name);
+    }
+  };
   const walk = (node: unknown, shadowed: ReadonlySet<string>, insideFunction: boolean): void => {
     if (!isRecord(node)) return;
     let currentShadowed = shadowed;
@@ -292,6 +323,44 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       );
       if (newlyShadowed.length > 0)
         currentShadowed = new Set([...currentShadowed, ...newlyShadowed]);
+    } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
+      const lexicalNames = new Set<string>();
+      for (const statement of node['body']) {
+        if (
+          !isRecord(statement) ||
+          statement['type'] !== 'VariableDeclaration' ||
+          (statement['kind'] !== 'let' && statement['kind'] !== 'const') ||
+          !Array.isArray(statement['declarations'])
+        )
+          continue;
+        for (const declaration of statement['declarations'])
+          if (isRecord(declaration)) declaredNamesInPattern(declaration['id'], lexicalNames);
+      }
+      const newlyShadowed = [...mutableBindings].filter(
+        (name) => !currentShadowed.has(name) && lexicalNames.has(name),
+      );
+      if (newlyShadowed.length > 0)
+        currentShadowed = new Set([...currentShadowed, ...newlyShadowed]);
+    }
+    if (
+      node['type'] === 'VariableDeclaration' &&
+      !currentInsideFunction &&
+      Array.isArray(node['declarations'])
+    ) {
+      for (const declaration of node['declarations']) {
+        if (
+          !isRecord(declaration) ||
+          !isRecord(declaration['id']) ||
+          declaration['id']['type'] !== 'Identifier' ||
+          typeof declaration['id']['name'] !== 'string'
+        )
+          continue;
+        resolveDeclaration(
+          declaration['id']['name'],
+          typeof node['kind'] === 'string' ? node['kind'] : 'let',
+          declaration['init'],
+        );
+      }
     }
     if (
       node['type'] === 'AssignmentExpression' &&
@@ -305,11 +374,22 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       const name = node['left']['name'];
       const resolved = resolvedAssignmentValue(node['right'], bindings);
       if (currentInsideFunction) {
-        if (resolved.set) bindings.set(name, [...(bindings.get(name) ?? []), ...resolved.values]);
+        if (resolved.set) {
+          callbackBindings.set(
+            name,
+            mergeValues([...(callbackBindings.get(name) ?? []), ...resolved.values]),
+          );
+          bindings.set(
+            name,
+            valuesWithCallbackState(name, [...(bindings.get(name) ?? []), ...resolved.values]),
+          );
+        }
       } else if (resolved.set) {
-        bindings.set(name, resolved.values);
+        bindings.set(name, valuesWithCallbackState(name, resolved.values));
       } else {
-        bindings.delete(name);
+        const callbackValues = callbackBindings.get(name) ?? [];
+        if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
+        else bindings.delete(name);
       }
     }
     for (const value of Object.values(node)) {

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -252,8 +252,9 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         ...branchValues.flatMap((branch) => [...branch.keys()]),
       ]);
       for (const name of names) {
-        const merged = branchValues.flatMap((branch) => branch.get(name) ?? []);
-        bindings.set(name, [...new Set(merged)]);
+        const merged = [...new Set(branchValues.flatMap((branch) => branch.get(name) ?? []))];
+        if (merged.length > 0) bindings.set(name, merged);
+        else bindings.delete(name);
       }
       return;
     }
@@ -269,8 +270,9 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       bindings.clear();
       const names = new Set([...base.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
       for (const name of names) {
-        const merged = branches.flatMap((branch) => branch.get(name) ?? []);
-        bindings.set(name, [...new Set(merged)]);
+        const merged = [...new Set(branches.flatMap((branch) => branch.get(name) ?? []))];
+        if (merged.length > 0) bindings.set(name, merged);
+        else bindings.delete(name);
       }
       return;
     }

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -230,24 +230,18 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   // initial render looked like, so it's recorded as an *additional*
   // reachable value rather than replacing the existing one — the same way a
   // ConditionalExpression's branches are both kept.
-  const walk = (
-    node: unknown,
-    shadowed: ReadonlySet<string>,
-    insideFunction: boolean,
-    conditional = false,
-  ): void => {
+  const walk = (node: unknown, shadowed: ReadonlySet<string>, insideFunction: boolean): void => {
     if (!isRecord(node)) return;
     let currentShadowed = shadowed;
     let currentInsideFunction = insideFunction;
     if (node['type'] === 'IfStatement') {
-      if (isRecord(node['test']))
-        walk(node['test'], currentShadowed, currentInsideFunction, conditional);
+      if (isRecord(node['test'])) walk(node['test'], currentShadowed, currentInsideFunction);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       const branchValues: Map<string, unknown[]>[] = [];
       for (const branch of [node['consequent'], node['alternate']]) {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
-        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction, false);
+        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction);
         branchValues.push(
           new Map([...bindings].map(([name, values]) => [name, [...values]] as const)),
         );
@@ -264,13 +258,12 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       return;
     }
     if (node['type'] === 'ConditionalExpression') {
-      if (isRecord(node['test']))
-        walk(node['test'], currentShadowed, currentInsideFunction, conditional);
+      if (isRecord(node['test'])) walk(node['test'], currentShadowed, currentInsideFunction);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       const branches = [node['consequent'], node['alternate']].map((branch) => {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
-        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction, false);
+        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction);
         return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       });
       bindings.clear();
@@ -311,8 +304,6 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       const resolved = resolvedAssignmentValue(node['right'], bindings);
       if (currentInsideFunction) {
         if (resolved.set) bindings.set(name, [...(bindings.get(name) ?? []), ...resolved.values]);
-      } else if (resolved.set && conditional) {
-        bindings.set(name, [...(bindings.get(name) ?? []), ...resolved.values]);
       } else if (resolved.set) {
         bindings.set(name, resolved.values);
       } else {
@@ -321,8 +312,8 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     }
     for (const value of Object.values(node)) {
       if (Array.isArray(value))
-        for (const item of value) walk(item, currentShadowed, currentInsideFunction, conditional);
-      else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction, conditional);
+        for (const item of value) walk(item, currentShadowed, currentInsideFunction);
+      else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction);
     }
   };
   for (const statement of body) walk(statement, new Set(), false);

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -299,6 +299,13 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
     statement['type'] === 'ThrowStatement'
   )
     return true;
+  if (statement['type'] === 'IfStatement')
+    return (
+      isRecord(statement['consequent']) &&
+      unconditionallyAbruptStatement(statement['consequent']) &&
+      isRecord(statement['alternate']) &&
+      unconditionallyAbruptStatement(statement['alternate'])
+    );
   return (
     statement['type'] === 'BlockStatement' &&
     Array.isArray(statement['body']) &&

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -78,7 +78,15 @@ function staticNullish(
     return staticNullish(candidates[0], bindings);
   }
   if (expression['type'] === 'UnaryExpression' && expression['operator'] === 'void') return true;
-  return false;
+  if (
+    expression['type'] === 'ObjectExpression' ||
+    expression['type'] === 'ArrayExpression' ||
+    expression['type'] === 'FunctionExpression' ||
+    expression['type'] === 'ArrowFunctionExpression' ||
+    expression['type'] === 'ClassExpression'
+  )
+    return false;
+  return undefined;
 }
 
 function staticTruthiness(
@@ -481,6 +489,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       const starts: Array<{ index: number; state: Map<string, unknown[]> }> = [];
       let testState = new Map(base);
       let matched = false;
+      let defaultIndex: number | undefined;
       for (let index = 0; index < cases.length; index++) {
         const caseNode = cases[index];
         if (caseNode === undefined) continue;
@@ -498,12 +507,11 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
             }
           } else if (discriminantValue === undefined || caseValue === undefined)
             starts.push({ index, state: new Map(testState) });
-        } else if (!matched) starts.push({ index, state: new Map(testState) });
+        } else if (defaultIndex === undefined) defaultIndex = index;
       }
-      if (!matched && cases.some((caseNode) => !isRecord(caseNode['test']))) {
-        const index = cases.findIndex((caseNode) => !isRecord(caseNode['test']));
-        starts.push({ index, state: new Map(testState) });
-      } else if (discriminantValue === undefined)
+      if (!matched && defaultIndex !== undefined)
+        starts.push({ index: defaultIndex, state: new Map(testState) });
+      else if (discriminantValue === undefined)
         starts.push({ index: cases.length, state: new Map(testState) });
       const terminalStates: Map<string, unknown[]>[] = [];
       for (const start of starts) {
@@ -668,6 +676,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     ) {
       const loopBinding = node['type'] === 'ForStatement' ? node['init'] : node['left'];
       const loopShadowed = new Set(currentShadowed);
+      const loopLocalNames = new Set<string>();
       if (
         isRecord(loopBinding) &&
         loopBinding['type'] === 'VariableDeclaration' &&
@@ -675,15 +684,35 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         Array.isArray(loopBinding['declarations'])
       )
         for (const declaration of loopBinding['declarations'])
-          if (isRecord(declaration)) declaredNamesInPattern(declaration['id'], loopShadowed);
-      const literalTruthiness = (expression: unknown): boolean | undefined => {
-        if (!isRecord(expression)) return undefined;
-        if (expression['type'] === 'Literal') return Boolean(expression['value']);
-        if (expression['type'] === 'Identifier' && expression['name'] === 'undefined') {
-          if (loopShadowed.has('undefined')) return undefined;
-          return staticTruthiness(expression, bindings);
+          if (isRecord(declaration)) {
+            declaredNamesInPattern(declaration['id'], loopShadowed);
+            declaredNamesInPattern(declaration['id'], loopLocalNames);
+          }
+      const loopTruthinessBindings = new Map(bindings);
+      for (const name of loopLocalNames) loopTruthinessBindings.set(name, [unresolvedBinding]);
+      if (
+        isRecord(loopBinding) &&
+        loopBinding['type'] === 'VariableDeclaration' &&
+        Array.isArray(loopBinding['declarations'])
+      )
+        for (const declaration of loopBinding['declarations']) {
+          if (
+            !isRecord(declaration) ||
+            !isRecord(declaration['id']) ||
+            declaration['id']['type'] !== 'Identifier' ||
+            typeof declaration['id']['name'] !== 'string'
+          )
+            continue;
+          const name = declaration['id']['name'];
+          if (declaration['init'] === null || declaration['init'] === undefined) {
+            loopTruthinessBindings.set(name, [knownUndefinedBinding]);
+            continue;
+          }
+          const resolved = resolvedAssignmentValue(declaration['init'], loopTruthinessBindings);
+          loopTruthinessBindings.set(name, resolved.set ? resolved.values : [unresolvedBinding]);
         }
-        return undefined;
+      const literalTruthiness = (expression: unknown): boolean | undefined => {
+        return staticTruthiness(expression, loopTruthinessBindings);
       };
       const guaranteedBody = (): boolean => {
         if (node['type'] === 'ForStatement') {

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -459,6 +459,13 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       const cases = Array.isArray(node['cases']) ? node['cases'].filter(isRecord) : [];
       const base = cloneBindings();
       const staticCaseValue = (value: unknown): unknown => {
+        if (
+          value === null ||
+          typeof value === 'string' ||
+          typeof value === 'number' ||
+          typeof value === 'boolean'
+        )
+          return value;
         if (isRecord(value) && value['type'] === 'Literal') return value['value'];
         if (
           isRecord(value) &&

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -276,6 +276,22 @@ function mergeValues(values: readonly unknown[]): unknown[] {
   return [...new Set(values)];
 }
 
+function unconditionallyAbruptStatement(statement: unknown): boolean {
+  if (!isRecord(statement)) return false;
+  if (
+    statement['type'] === 'BreakStatement' ||
+    statement['type'] === 'ReturnStatement' ||
+    statement['type'] === 'ThrowStatement'
+  )
+    return true;
+  return (
+    statement['type'] === 'BlockStatement' &&
+    Array.isArray(statement['body']) &&
+    statement['body'].length > 0 &&
+    unconditionallyAbruptStatement(statement['body'][statement['body'].length - 1])
+  );
+}
+
 function staticBindings(instance: unknown): Map<string, unknown[]> {
   const bindings = new Map<string, unknown[]>();
   const mutableBindings = new Set<string>();
@@ -396,15 +412,74 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     if (node['type'] === 'SwitchStatement') {
       const interruptedStates: Map<string, unknown[]>[] = [];
       breakTargets.push({ label: controlLabel, states: interruptedStates });
-      for (const value of Object.values(node)) {
-        if (Array.isArray(value))
-          for (const item of value) walk(item, currentShadowed, currentInsideFunction);
-        else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction);
+      if (isRecord(node['discriminant']))
+        walk(node['discriminant'], currentShadowed, currentInsideFunction);
+      const cases = Array.isArray(node['cases']) ? node['cases'].filter(isRecord) : [];
+      const base = cloneBindings();
+      const staticCaseValue = (value: unknown): unknown => {
+        if (isRecord(value) && value['type'] === 'Literal') return value['value'];
+        if (
+          isRecord(value) &&
+          value['type'] === 'Identifier' &&
+          typeof value['name'] === 'string'
+        ) {
+          const candidates = bindings.get(value['name']) ?? [];
+          if (candidates.length === 1) return staticCaseValue(candidates[0]);
+        }
+        return undefined;
+      };
+      const discriminantValue = staticCaseValue(node['discriminant']);
+      const starts: Array<{ index: number; state: Map<string, unknown[]> }> = [];
+      let testState = new Map(base);
+      let matched = false;
+      for (let index = 0; index < cases.length; index++) {
+        const caseNode = cases[index];
+        if (caseNode === undefined) continue;
+        if (isRecord(caseNode['test'])) {
+          bindings.clear();
+          for (const [name, values] of testState) bindings.set(name, [...values]);
+          walk(caseNode['test'], currentShadowed, currentInsideFunction);
+          testState = cloneBindings();
+          const caseValue = staticCaseValue(caseNode['test']);
+          if (discriminantValue !== undefined && caseValue !== undefined) {
+            if (Object.is(discriminantValue, caseValue)) {
+              starts.push({ index, state: new Map(testState) });
+              matched = true;
+              break;
+            }
+          } else if (discriminantValue === undefined)
+            starts.push({ index, state: new Map(testState) });
+        } else if (!matched) starts.push({ index, state: new Map(testState) });
+      }
+      if (!matched && cases.some((caseNode) => !isRecord(caseNode['test']))) {
+        const index = cases.findIndex((caseNode) => !isRecord(caseNode['test']));
+        starts.push({ index, state: new Map(testState) });
+      } else if (discriminantValue === undefined)
+        starts.push({ index: cases.length, state: new Map(testState) });
+      const terminalStates: Map<string, unknown[]>[] = [];
+      for (const start of starts) {
+        bindings.clear();
+        for (const [name, values] of start.state) bindings.set(name, [...values]);
+        for (let index = start.index; index < cases.length; index++) {
+          const caseNode = cases[index];
+          if (caseNode === undefined) continue;
+          if (!Array.isArray(caseNode['consequent'])) continue;
+          for (const statement of caseNode['consequent']) {
+            walk(statement, currentShadowed, currentInsideFunction);
+            if (unconditionallyAbruptStatement(statement)) break;
+          }
+          if (caseNode['consequent'].some(unconditionallyAbruptStatement)) break;
+        }
+        terminalStates.push(cloneBindings());
       }
       breakTargets.pop();
-      let continuingState = cloneBindings();
+      let continuingState = terminalStates.shift() ?? base;
       for (const interruptedState of interruptedStates) {
         mergeBindingStates(continuingState, interruptedState);
+        continuingState = cloneBindings();
+      }
+      for (const terminalState of terminalStates) {
+        mergeBindingStates(continuingState, terminalState);
         continuingState = cloneBindings();
       }
       return;

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -1,6 +1,8 @@
 import { parse as parseSvelte } from 'svelte/compiler';
 
 type UnknownRecord = Record<string, unknown>;
+const unresolvedBinding = Symbol('unresolved-binding');
+const knownUndefinedBinding = Symbol('known-undefined-binding');
 
 function isRecord(value: unknown): value is UnknownRecord {
   return typeof value === 'object' && value !== null;
@@ -65,6 +67,8 @@ function staticNullish(
   bindings: ReadonlyMap<string, readonly unknown[]>,
 ): boolean | undefined {
   const expression = unwrapTypeExpression(rawExpression);
+  if (expression === unresolvedBinding) return undefined;
+  if (expression === knownUndefinedBinding) return true;
   if (!isRecord(expression)) return expression === null || expression === undefined;
   if (expression['type'] === 'Literal') return expression['value'] === null;
   if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
@@ -82,6 +86,8 @@ function staticTruthiness(
   bindings: ReadonlyMap<string, readonly unknown[]>,
 ): boolean | undefined {
   const expression = unwrapTypeExpression(rawExpression);
+  if (expression === unresolvedBinding) return undefined;
+  if (expression === knownUndefinedBinding) return false;
   if (!isRecord(expression)) return expression === undefined ? undefined : Boolean(expression);
   if (expression['type'] === 'Literal') return Boolean(expression['value']);
   if (expression['type'] === 'ObjectExpression' || expression['type'] === 'ArrayExpression')
@@ -368,12 +374,13 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     states: Map<string, unknown[]>[] | undefined;
   }> = [];
   const resolveDeclaration = (name: string, kind: string, initializer: unknown): void => {
-    if (initializer === undefined) {
+    if (initializer === undefined || initializer === null) {
       // `var name;` preserves a prior value, while an uninitialized `let`
       // declaration makes the binding unknown.
       if (kind === 'var' && bindings.has(name)) return;
       const callbackValues = callbackBindings.get(name) ?? [];
       if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
+      else if (name === 'undefined') bindings.set(name, [knownUndefinedBinding]);
       else bindings.delete(name);
       return;
     }
@@ -385,6 +392,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     } else {
       const callbackValues = callbackBindings.get(name) ?? [];
       if (callbackValues.length > 0) bindings.set(name, [...callbackValues]);
+      else if (name === 'undefined') bindings.set(name, [unresolvedBinding]);
       else bindings.delete(name);
     }
   };

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -308,6 +308,134 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       return;
     }
     if (
+      node['type'] === 'ForStatement' ||
+      node['type'] === 'ForInStatement' ||
+      node['type'] === 'ForOfStatement'
+    ) {
+      const loopBinding = node['type'] === 'ForStatement' ? node['init'] : node['left'];
+      const loopShadowed = new Set(currentShadowed);
+      if (
+        isRecord(loopBinding) &&
+        loopBinding['type'] === 'VariableDeclaration' &&
+        (loopBinding['kind'] === 'let' || loopBinding['kind'] === 'const') &&
+        Array.isArray(loopBinding['declarations'])
+      )
+        for (const declaration of loopBinding['declarations'])
+          if (isRecord(declaration)) declaredNamesInPattern(declaration['id'], loopShadowed);
+      const cloneBindings = (): Map<string, unknown[]> =>
+        new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const mergeBindingStates = (
+        base: Map<string, unknown[]>,
+        branch: Map<string, unknown[]>,
+      ): void => {
+        bindings.clear();
+        const names = new Set([...base.keys(), ...branch.keys()]);
+        for (const name of names) {
+          const values = mergeValues([...(base.get(name) ?? []), ...(branch.get(name) ?? [])]);
+          if (values.length > 0) bindings.set(name, values);
+        }
+      };
+      const literalTruthiness = (expression: unknown): boolean | undefined => {
+        if (!isRecord(expression)) return undefined;
+        if (expression['type'] === 'Literal') return Boolean(expression['value']);
+        if (expression['type'] === 'Identifier' && expression['name'] === 'undefined') return false;
+        return undefined;
+      };
+      const guaranteedBody = (): boolean => {
+        if (node['type'] === 'ForStatement') {
+          const test = node['test'];
+          return test === null || test === undefined || literalTruthiness(test) === true;
+        }
+        const right = node['right'];
+        if (!isRecord(right)) return false;
+        if (right['type'] === 'ArrayExpression' && Array.isArray(right['elements']))
+          return right['elements'].length > 0;
+        return false;
+      };
+      const definitelyEmptyBody = (): boolean => {
+        if (node['type'] === 'ForStatement') return literalTruthiness(node['test']) === false;
+        const right = node['right'];
+        return (
+          isRecord(right) &&
+          right['type'] === 'ArrayExpression' &&
+          Array.isArray(right['elements']) &&
+          right['elements'].length === 0
+        );
+      };
+      const canExitAfterEnteringStableTest = (candidate: unknown, testName: string): boolean => {
+        if (!isRecord(candidate)) return false;
+        if (
+          candidate['type'] === 'FunctionDeclaration' ||
+          candidate['type'] === 'FunctionExpression' ||
+          candidate['type'] === 'ArrowFunctionExpression'
+        )
+          return false;
+        if (candidate['type'] === 'BreakStatement' || candidate['type'] === 'CallExpression')
+          return true;
+        if (
+          candidate['type'] === 'AssignmentExpression' &&
+          isRecord(candidate['left']) &&
+          candidate['left']['type'] === 'Identifier' &&
+          candidate['left']['name'] === testName
+        )
+          return true;
+        if (
+          candidate['type'] === 'UpdateExpression' &&
+          isRecord(candidate['argument']) &&
+          candidate['argument']['type'] === 'Identifier' &&
+          candidate['argument']['name'] === testName
+        )
+          return true;
+        return Object.values(candidate).some((value) =>
+          Array.isArray(value)
+            ? value.some((item) => canExitAfterEnteringStableTest(item, testName))
+            : canExitAfterEnteringStableTest(value, testName),
+        );
+      };
+      const hasOnlyZeroEntryTerminalState =
+        node['type'] === 'ForStatement' &&
+        isRecord(node['test']) &&
+        node['test']['type'] === 'Identifier' &&
+        typeof node['test']['name'] === 'string' &&
+        !canExitAfterEnteringStableTest(node['body'], node['test']['name']) &&
+        !canExitAfterEnteringStableTest(node['update'], node['test']['name']);
+
+      if (node['type'] !== 'ForStatement' && isRecord(node['right']))
+        walk(node['right'], loopShadowed, currentInsideFunction);
+      if (isRecord(loopBinding)) {
+        if (
+          loopBinding['type'] === 'VariableDeclaration' &&
+          (loopBinding['kind'] === 'let' || loopBinding['kind'] === 'const') &&
+          Array.isArray(loopBinding['declarations'])
+        ) {
+          for (const declaration of loopBinding['declarations'])
+            if (isRecord(declaration) && isRecord(declaration['init']))
+              walk(declaration['init'], loopShadowed, currentInsideFunction);
+        } else walk(loopBinding, loopShadowed, currentInsideFunction);
+      }
+      if (isRecord(node['test'])) walk(node['test'], loopShadowed, currentInsideFunction);
+
+      const beforeBody = cloneBindings();
+      if (!definitelyEmptyBody() && !hasOnlyZeroEntryTerminalState && isRecord(node['body'])) {
+        bindings.clear();
+        for (const [name, values] of beforeBody) bindings.set(name, [...values]);
+        walk(node['body'], loopShadowed, currentInsideFunction);
+        if (node['type'] === 'ForStatement' && isRecord(node['update']))
+          walk(node['update'], loopShadowed, currentInsideFunction);
+        const afterBody = cloneBindings();
+        if (!guaranteedBody()) mergeBindingStates(beforeBody, afterBody);
+      } else {
+        bindings.clear();
+        for (const [name, values] of beforeBody) bindings.set(name, [...values]);
+      }
+      for (const name of loopShadowed) {
+        const previous = beforeBody.get(name);
+        if (previous === undefined) bindings.delete(name);
+        else bindings.set(name, [...previous]);
+      }
+      return;
+    }
+    if (
       node['type'] === 'FunctionDeclaration' ||
       node['type'] === 'FunctionExpression' ||
       node['type'] === 'ArrowFunctionExpression'

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -302,7 +302,6 @@ function unconditionallyAbruptStatement(statement: unknown): boolean {
 function staticBindings(instance: unknown): Map<string, unknown[]> {
   const bindings = new Map<string, unknown[]>();
   const mutableBindings = new Set<string>();
-  const declaredBindings = new Set<string>();
   const callbackBindings = new Map<string, unknown[]>();
   const callbackFrames: Map<string, unknown[]>[] = [];
   const localAliasFrames: Map<string, unknown[]>[] = [];
@@ -311,9 +310,9 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   const body = instance['content']['body'];
   if (!Array.isArray(body)) return bindings;
 
-  // Collect top-level binding names before walking the body. Values themselves
-  // are resolved by the walk so aliases observe assignments that precede their
-  // declaration in source order.
+  // Collect top-level mutable binding names before walking the body. Values
+  // themselves are resolved by the walk so aliases observe assignments that
+  // precede their declaration in source order.
   for (const statement of body) {
     if (
       !isRecord(statement) ||
@@ -330,7 +329,6 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       )
         continue;
       const name = declaration['id']['name'];
-      declaredBindings.add(name);
       if (statement['kind'] !== 'const') mutableBindings.add(name);
     }
   }
@@ -676,15 +674,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         if (expression['type'] === 'Literal') return Boolean(expression['value']);
         if (expression['type'] === 'Identifier' && expression['name'] === 'undefined') {
           if (loopShadowed.has('undefined')) return undefined;
-          const values = bindings.get('undefined');
-          if (values !== undefined && values.length === 1) {
-            const value = values[0];
-            return isRecord(value) && value['type'] === 'Literal'
-              ? Boolean(value['value'])
-              : Boolean(value);
-          }
-          if (declaredBindings.has('undefined')) return undefined;
-          return false;
+          return staticTruthiness(expression, bindings);
         }
         return undefined;
       };

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -163,6 +163,7 @@ function declaresNameWithinFunctionScope(node: unknown, name: string): boolean {
 
 function resolvedAssignmentValue(
   rawValue: unknown,
+  bindings: ReadonlyMap<string, unknown[]> = new Map(),
 ): { set: true; value: unknown } | { set: false } {
   const value = unwrapTypeExpression(rawValue);
   if (
@@ -173,6 +174,10 @@ function resolvedAssignmentValue(
   )
     return { set: true, value };
   if (isRecord(value) && value['type'] === 'Literal') return { set: true, value: value['value'] };
+  if (isRecord(value) && value['type'] === 'Identifier' && typeof value['name'] === 'string') {
+    const candidates = bindings.get(value['name']);
+    if (candidates?.length === 1) return { set: true, value: candidates[0] };
+  }
   return { set: false };
 }
 
@@ -202,7 +207,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         continue;
       const name = declaration['id']['name'];
       if (statement['kind'] !== 'const') mutableBindings.add(name);
-      const resolved = resolvedAssignmentValue(declaration['init']);
+      const resolved = resolvedAssignmentValue(declaration['init'], bindings);
       if (resolved.set) bindings.set(name, [resolved.value]);
       else bindings.delete(name);
     }
@@ -223,10 +228,28 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   // initial render looked like, so it's recorded as an *additional*
   // reachable value rather than replacing the existing one — the same way a
   // ConditionalExpression's branches are both kept.
-  const walk = (node: unknown, shadowed: ReadonlySet<string>, insideFunction: boolean): void => {
+  const walk = (
+    node: unknown,
+    shadowed: ReadonlySet<string>,
+    insideFunction: boolean,
+    conditional: boolean,
+  ): void => {
     if (!isRecord(node)) return;
     let currentShadowed = shadowed;
     let currentInsideFunction = insideFunction;
+    let currentConditional = conditional;
+    if (
+      [
+        'IfStatement',
+        'SwitchStatement',
+        'ForStatement',
+        'ForInStatement',
+        'ForOfStatement',
+        'WhileStatement',
+        'DoWhileStatement',
+      ].includes(String(node['type']))
+    )
+      currentConditional = true;
     if (
       node['type'] === 'FunctionDeclaration' ||
       node['type'] === 'FunctionExpression' ||
@@ -254,8 +277,8 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       !currentShadowed.has(node['left']['name'])
     ) {
       const name = node['left']['name'];
-      const resolved = resolvedAssignmentValue(node['right']);
-      if (currentInsideFunction) {
+      const resolved = resolvedAssignmentValue(node['right'], bindings);
+      if (currentInsideFunction || currentConditional) {
         if (resolved.set) bindings.set(name, [...(bindings.get(name) ?? []), resolved.value]);
       } else if (resolved.set) {
         bindings.set(name, [resolved.value]);
@@ -265,11 +288,13 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     }
     for (const value of Object.values(node)) {
       if (Array.isArray(value))
-        for (const item of value) walk(item, currentShadowed, currentInsideFunction);
-      else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction);
+        for (const item of value)
+          walk(item, currentShadowed, currentInsideFunction, currentConditional);
+      else if (isRecord(value))
+        walk(value, currentShadowed, currentInsideFunction, currentConditional);
     }
   };
-  for (const statement of body) walk(statement, new Set(), false);
+  for (const statement of body) walk(statement, new Set(), false, false);
 
   return bindings;
 }

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -298,6 +298,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   const declaredBindings = new Set<string>();
   const callbackBindings = new Map<string, unknown[]>();
   const callbackFrames: Map<string, unknown[]>[] = [];
+  const localAliasFrames: Map<string, unknown[]>[] = [];
   const synchronousFunctions = new WeakSet<object>();
   if (!isRecord(instance) || !isRecord(instance['content'])) return bindings;
   const body = instance['content']['body'];
@@ -345,6 +346,12 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     mergeValues([...values, ...(callbackBindings.get(name) ?? [])]);
   const cloneBindings = (): Map<string, unknown[]> =>
     new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+  const visibleAliasBindings = (): Map<string, unknown[]> => {
+    const visible = new Map(bindings);
+    for (const frame of localAliasFrames)
+      for (const [name, values] of frame) visible.set(name, values);
+    return visible;
+  };
   const mergeBindingStates = (
     base: Map<string, unknown[]>,
     branch: Map<string, unknown[]>,
@@ -388,6 +395,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     controlLabel?: string,
   ): void => {
     if (!isRecord(node)) return;
+    let pushedAliasBlock = false;
     let currentShadowed = shadowed;
     let currentInsideFunction = insideFunction;
     if (node['type'] === 'BreakStatement') {
@@ -485,6 +493,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       return;
     }
     if (node['type'] === 'IfStatement') {
+      const testTruthiness = staticTruthiness(node['test'], bindings);
       if (isRecord(node['test'])) walk(node['test'], currentShadowed, currentInsideFunction);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       const callbackFrame = callbackFrames.at(-1);
@@ -493,7 +502,13 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         : undefined;
       const branchCallbackFrames: Map<string, unknown[]>[] = [];
       const branchValues: Map<string, unknown[]>[] = [];
-      for (const branch of [node['consequent'], node['alternate']]) {
+      const branchesToWalk =
+        testTruthiness === true
+          ? [node['consequent']]
+          : testTruthiness === false
+            ? [node['alternate']]
+            : [node['consequent'], node['alternate']];
+      for (const branch of branchesToWalk) {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
         if (callbackFrame) {
@@ -502,6 +517,33 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
             callbackFrame.set(name, [...values]);
         }
         if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction);
+        if (isRecord(branch)) {
+          const localNames = new Set<string>();
+          const collect = (candidate: unknown): void => {
+            if (!isRecord(candidate)) return;
+            if (
+              candidate['type'] === 'FunctionDeclaration' ||
+              candidate['type'] === 'FunctionExpression' ||
+              candidate['type'] === 'ArrowFunctionExpression'
+            )
+              return;
+            if (
+              candidate['type'] === 'VariableDeclaration' &&
+              Array.isArray(candidate['declarations'])
+            )
+              for (const declaration of candidate['declarations'])
+                if (isRecord(declaration)) declaredNamesInPattern(declaration['id'], localNames);
+            for (const value of Object.values(candidate))
+              if (Array.isArray(value)) value.forEach(collect);
+              else if (isRecord(value)) collect(value);
+          };
+          collect(branch);
+          for (const name of localNames) {
+            const previous = base.get(name);
+            if (previous === undefined) bindings.delete(name);
+            else bindings.set(name, [...previous]);
+          }
+        }
         if (callbackFrame)
           branchCallbackFrames.push(
             new Map([...callbackFrame].map(([name, values]) => [name, [...values]] as const)),
@@ -736,6 +778,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     ) {
       currentInsideFunction = true;
       callbackFrames.push(new Map());
+      localAliasFrames.push(new Map());
       const localNames = new Set<string>();
       if (Array.isArray(node['params']))
         for (const parameter of node['params']) declaredNamesInPattern(parameter, localNames);
@@ -747,6 +790,8 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       if (newlyShadowed.length > 0)
         currentShadowed = new Set([...currentShadowed, ...newlyShadowed]);
     } else if (node['type'] === 'BlockStatement' && Array.isArray(node['body'])) {
+      localAliasFrames.push(new Map());
+      pushedAliasBlock = true;
       const lexicalNames = new Set<string>();
       for (const statement of node['body']) {
         if (
@@ -765,11 +810,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       if (newlyShadowed.length > 0)
         currentShadowed = new Set([...currentShadowed, ...newlyShadowed]);
     }
-    if (
-      node['type'] === 'VariableDeclaration' &&
-      !currentInsideFunction &&
-      Array.isArray(node['declarations'])
-    ) {
+    if (node['type'] === 'VariableDeclaration' && Array.isArray(node['declarations'])) {
       for (const declaration of node['declarations']) {
         if (
           !isRecord(declaration) ||
@@ -778,6 +819,17 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
           typeof declaration['id']['name'] !== 'string'
         )
           continue;
+        if (
+          currentInsideFunction &&
+          (!isRecord(declaration['init']) || declaration['init']['type'] !== 'ObjectExpression')
+        )
+          continue;
+        if (currentInsideFunction) {
+          const resolved = resolvedAssignmentValue(declaration['init'], visibleAliasBindings());
+          if (resolved.set)
+            localAliasFrames.at(-1)?.set(declaration['id']['name'], resolved.values);
+          continue;
+        }
         resolveDeclaration(
           declaration['id']['name'],
           typeof node['kind'] === 'string' ? node['kind'] : 'let',
@@ -795,7 +847,10 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       !currentShadowed.has(node['left']['name'])
     ) {
       const name = node['left']['name'];
-      const resolved = resolvedAssignmentValue(node['right'], bindings);
+      const aliasBindings = new Map(bindings);
+      for (const frame of localAliasFrames)
+        for (const [alias, values] of frame) aliasBindings.set(alias, values);
+      const resolved = resolvedAssignmentValue(node['right'], aliasBindings);
       if (currentInsideFunction) {
         if (resolved.set) {
           const currentFrame = callbackFrames.at(-1);
@@ -859,12 +914,14 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         for (const item of value) walk(item, currentShadowed, currentInsideFunction);
       else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction);
     }
+    if (pushedAliasBlock) localAliasFrames.pop();
     if (
       node['type'] === 'FunctionDeclaration' ||
       node['type'] === 'FunctionExpression' ||
       node['type'] === 'ArrowFunctionExpression'
     ) {
       const frame = callbackFrames.pop();
+      localAliasFrames.pop();
       const synchronous = synchronousFunctions.has(node);
       if (synchronous) synchronousFunctions.delete(node);
       if (frame) {

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -209,7 +209,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         continue;
       const name = declaration['id']['name'];
       if (statement['kind'] !== 'const') mutableBindings.add(name);
-      const resolved = resolvedAssignmentValue(declaration['init']);
+      const resolved = resolvedAssignmentValue(declaration['init'], bindings);
       if (resolved.set) bindings.set(name, resolved.values);
       else bindings.delete(name);
     }

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -258,8 +258,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         ...branchValues.flatMap((branch) => [...branch.keys()]),
       ]);
       for (const name of names) {
-        const values = base.get(name) ?? [];
-        const merged = branchValues.flatMap((branch) => branch.get(name) ?? values);
+        const merged = branchValues.flatMap((branch) => branch.get(name) ?? []);
         bindings.set(name, [...new Set(merged)]);
       }
       return;
@@ -277,8 +276,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       bindings.clear();
       const names = new Set([...base.keys(), ...branches.flatMap((branch) => [...branch.keys()])]);
       for (const name of names) {
-        const values = base.get(name) ?? [];
-        const merged = branches.flatMap((branch) => branch.get(name) ?? values);
+        const merged = branches.flatMap((branch) => branch.get(name) ?? []);
         bindings.set(name, [...new Set(merged)]);
       }
       return;

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -242,19 +242,38 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     if (node['type'] === 'IfStatement') {
       if (isRecord(node['test']))
         walk(node['test'], currentShadowed, currentInsideFunction, conditional);
-      if (isRecord(node['consequent']))
-        walk(node['consequent'], currentShadowed, currentInsideFunction, true);
-      if (isRecord(node['alternate']))
-        walk(node['alternate'], currentShadowed, currentInsideFunction, true);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const branchValues: Map<string, unknown[]>[] = [];
+      for (const branch of [node['consequent'], node['alternate']]) {
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction, false);
+        branchValues.push(
+          new Map([...bindings].map(([name, values]) => [name, [...values]] as const)),
+        );
+      }
+      bindings.clear();
+      for (const [name, values] of base) {
+        const merged = branchValues.flatMap((branch) => branch.get(name) ?? values);
+        bindings.set(name, [...new Set(merged)]);
+      }
       return;
     }
     if (node['type'] === 'ConditionalExpression') {
       if (isRecord(node['test']))
         walk(node['test'], currentShadowed, currentInsideFunction, conditional);
-      if (isRecord(node['consequent']))
-        walk(node['consequent'], currentShadowed, currentInsideFunction, true);
-      if (isRecord(node['alternate']))
-        walk(node['alternate'], currentShadowed, currentInsideFunction, true);
+      const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const branches = [node['consequent'], node['alternate']].map((branch) => {
+        bindings.clear();
+        for (const [name, values] of base) bindings.set(name, [...values]);
+        if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction, false);
+        return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      });
+      bindings.clear();
+      for (const [name, values] of base) {
+        const merged = branches.flatMap((branch) => branch.get(name) ?? values);
+        bindings.set(name, [...new Set(merged)]);
+      }
       return;
     }
     if (

--- a/packages/components/scripts/primitive-composition-style-object.ts
+++ b/packages/components/scripts/primitive-composition-style-object.ts
@@ -60,6 +60,73 @@ function mergeDeclarations(
   return new Map([...base, ...additions]);
 }
 
+function staticNullish(
+  rawExpression: unknown,
+  bindings: ReadonlyMap<string, readonly unknown[]>,
+): boolean | undefined {
+  const expression = unwrapTypeExpression(rawExpression);
+  if (!isRecord(expression)) return expression === null || expression === undefined;
+  if (expression['type'] === 'Literal') return expression['value'] === null;
+  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
+    if (expression['name'] === 'undefined' && !bindings.has('undefined')) return true;
+    const candidates = bindings.get(expression['name']);
+    if (candidates === undefined || candidates.length !== 1) return undefined;
+    return staticNullish(candidates[0], bindings);
+  }
+  if (expression['type'] === 'UnaryExpression' && expression['operator'] === 'void') return true;
+  return false;
+}
+
+function staticTruthiness(
+  rawExpression: unknown,
+  bindings: ReadonlyMap<string, readonly unknown[]>,
+): boolean | undefined {
+  const expression = unwrapTypeExpression(rawExpression);
+  if (!isRecord(expression)) return expression === undefined ? undefined : Boolean(expression);
+  if (expression['type'] === 'Literal') return Boolean(expression['value']);
+  if (expression['type'] === 'ObjectExpression' || expression['type'] === 'ArrayExpression')
+    return true;
+  if (
+    expression['type'] === 'FunctionExpression' ||
+    expression['type'] === 'ArrowFunctionExpression' ||
+    expression['type'] === 'ClassExpression'
+  )
+    return true;
+  if (expression['type'] === 'Identifier' && typeof expression['name'] === 'string') {
+    if (expression['name'] === 'undefined' && !bindings.has('undefined')) return false;
+    const candidates = bindings.get(expression['name']);
+    if (candidates === undefined || candidates.length !== 1) return undefined;
+    return staticTruthiness(candidates[0], bindings);
+  }
+  if (expression['type'] === 'UnaryExpression' && expression['operator'] === 'void') return false;
+  if (expression['type'] === 'UnaryExpression' && expression['operator'] === '!') {
+    const value = staticTruthiness(expression['argument'], bindings);
+    return value === undefined ? undefined : !value;
+  }
+  if (expression['type'] === 'LogicalExpression') {
+    const left = expression['left'];
+    const leftTruthiness = staticTruthiness(left, bindings);
+    const operator = expression['operator'];
+    if (operator === '&&') {
+      if (leftTruthiness === false) return false;
+      return leftTruthiness === true ? staticTruthiness(expression['right'], bindings) : undefined;
+    }
+    if (operator === '||') {
+      if (leftTruthiness === true) return true;
+      return leftTruthiness === false ? staticTruthiness(expression['right'], bindings) : undefined;
+    }
+    if (operator === '??') {
+      const leftNullish = staticNullish(left, bindings);
+      return leftNullish === true
+        ? staticTruthiness(expression['right'], bindings)
+        : leftNullish === false
+          ? leftTruthiness
+          : undefined;
+    }
+  }
+  return undefined;
+}
+
 function collectObjectDeclarationBranches(
   rawExpression: unknown,
   bindings: ReadonlyMap<string, readonly unknown[]>,
@@ -79,6 +146,22 @@ function collectObjectDeclarationBranches(
     expression['type'] === 'ConditionalExpression' ||
     expression['type'] === 'LogicalExpression'
   ) {
+    if (expression['type'] === 'LogicalExpression') {
+      const left = expression['left'];
+      const leftTruthiness = staticTruthiness(left, bindings);
+      const operator = expression['operator'];
+      const leftNullish = staticNullish(left, bindings);
+      const rightOnly =
+        (operator === '&&' && leftTruthiness === true) ||
+        (operator === '||' && leftTruthiness === false) ||
+        (operator === '??' && leftNullish === true);
+      const leftOnly =
+        (operator === '&&' && leftTruthiness === false) ||
+        (operator === '||' && leftTruthiness === true) ||
+        (operator === '??' && leftNullish === false);
+      if (rightOnly) return collectObjectDeclarationBranches(expression['right'], bindings);
+      if (leftOnly) return collectObjectDeclarationBranches(left, bindings);
+    }
     return [
       ...collectObjectDeclarationBranches(expression['consequent'] ?? expression['left'], bindings),
       ...collectObjectDeclarationBranches(expression['alternate'] ?? expression['right'], bindings),
@@ -198,6 +281,8 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
   const mutableBindings = new Set<string>();
   const declaredBindings = new Set<string>();
   const callbackBindings = new Map<string, unknown[]>();
+  const callbackFrames: Map<string, unknown[]>[] = [];
+  const synchronousFunctions = new WeakSet<object>();
   if (!isRecord(instance) || !isRecord(instance['content'])) return bindings;
   const body = instance['content']['body'];
   if (!Array.isArray(body)) return bindings;
@@ -327,11 +412,25 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
     if (node['type'] === 'IfStatement') {
       if (isRecord(node['test'])) walk(node['test'], currentShadowed, currentInsideFunction);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const callbackFrame = callbackFrames.at(-1);
+      const baseCallbackFrame = callbackFrame
+        ? new Map([...callbackFrame].map(([name, values]) => [name, [...values]] as const))
+        : undefined;
+      const branchCallbackFrames: Map<string, unknown[]>[] = [];
       const branchValues: Map<string, unknown[]>[] = [];
       for (const branch of [node['consequent'], node['alternate']]) {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
+        if (callbackFrame) {
+          callbackFrame.clear();
+          for (const [name, values] of baseCallbackFrame ?? [])
+            callbackFrame.set(name, [...values]);
+        }
         if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction);
+        if (callbackFrame)
+          branchCallbackFrames.push(
+            new Map([...callbackFrame].map(([name, values]) => [name, [...values]] as const)),
+          );
         branchValues.push(
           new Map([...bindings].map(([name, values]) => [name, [...values]] as const)),
         );
@@ -346,15 +445,38 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         if (merged.length > 0) bindings.set(name, merged);
         else bindings.delete(name);
       }
+      if (callbackFrame) {
+        callbackFrame.clear();
+        for (const name of new Set(branchCallbackFrames.flatMap((branch) => [...branch.keys()]))) {
+          const values = mergeValues(
+            branchCallbackFrames.flatMap((branch) => branch.get(name) ?? []),
+          );
+          if (values.length > 0) callbackFrame.set(name, values);
+        }
+      }
       return;
     }
     if (node['type'] === 'ConditionalExpression') {
       if (isRecord(node['test'])) walk(node['test'], currentShadowed, currentInsideFunction);
       const base = new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
+      const callbackFrame = callbackFrames.at(-1);
+      const baseCallbackFrame = callbackFrame
+        ? new Map([...callbackFrame].map(([name, values]) => [name, [...values]] as const))
+        : undefined;
+      const branchCallbackFrames: Map<string, unknown[]>[] = [];
       const branches = [node['consequent'], node['alternate']].map((branch) => {
         bindings.clear();
         for (const [name, values] of base) bindings.set(name, [...values]);
+        if (callbackFrame) {
+          callbackFrame.clear();
+          for (const [name, values] of baseCallbackFrame ?? [])
+            callbackFrame.set(name, [...values]);
+        }
         if (isRecord(branch)) walk(branch, currentShadowed, currentInsideFunction);
+        if (callbackFrame)
+          branchCallbackFrames.push(
+            new Map([...callbackFrame].map(([name, values]) => [name, [...values]] as const)),
+          );
         return new Map([...bindings].map(([name, values]) => [name, [...values]] as const));
       });
       bindings.clear();
@@ -363,6 +485,15 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         const merged = [...new Set(branches.flatMap((branch) => branch.get(name) ?? []))];
         if (merged.length > 0) bindings.set(name, merged);
         else bindings.delete(name);
+      }
+      if (callbackFrame) {
+        callbackFrame.clear();
+        for (const name of new Set(branchCallbackFrames.flatMap((branch) => [...branch.keys()]))) {
+          const values = mergeValues(
+            branchCallbackFrames.flatMap((branch) => branch.get(name) ?? []),
+          );
+          if (values.length > 0) callbackFrame.set(name, values);
+        }
       }
       return;
     }
@@ -529,6 +660,7 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       node['type'] === 'ArrowFunctionExpression'
     ) {
       currentInsideFunction = true;
+      callbackFrames.push(new Map());
       const localNames = new Set<string>();
       if (Array.isArray(node['params']))
         for (const parameter of node['params']) declaredNamesInPattern(parameter, localNames);
@@ -591,14 +723,45 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
       const resolved = resolvedAssignmentValue(node['right'], bindings);
       if (currentInsideFunction) {
         if (resolved.set) {
-          callbackBindings.set(
-            name,
-            mergeValues([...(callbackBindings.get(name) ?? []), ...resolved.values]),
-          );
-          bindings.set(
-            name,
-            valuesWithCallbackState(name, [...(bindings.get(name) ?? []), ...resolved.values]),
-          );
+          const currentFrame = callbackFrames.at(-1);
+          const previousCallbackValues = currentFrame?.get(name) ?? [];
+          const allCallbackValues = callbackBindings.get(name) ?? [];
+          const currentValues = bindings.get(name) ?? [];
+          const isStyleObjectValue = (value: unknown): boolean => {
+            if (!isRecord(value)) return false;
+            if (value['type'] === 'ObjectExpression') return true;
+            if (value['type'] === 'ConditionalExpression')
+              return [value['consequent'], value['alternate']].some(
+                (branch) => isRecord(branch) && branch['type'] === 'ObjectExpression',
+              );
+            return (
+              value['type'] === 'LogicalExpression' &&
+              isRecord(value['right']) &&
+              value['right']['type'] === 'ObjectExpression'
+            );
+          };
+          if (
+            [...currentValues, ...allCallbackValues, ...resolved.values].some(isStyleObjectValue)
+          ) {
+            const priorCallbackSet = new Set(previousCallbackValues);
+            currentFrame?.set(name, mergeValues(resolved.values));
+            bindings.set(
+              name,
+              mergeValues([
+                ...currentValues.filter((value) => !priorCallbackSet.has(value)),
+                ...resolved.values,
+              ]),
+            );
+          } else {
+            currentFrame?.set(name, mergeValues([...previousCallbackValues, ...resolved.values]));
+            bindings.set(
+              name,
+              mergeValues([
+                ...currentValues.filter((value) => !new Set(previousCallbackValues).has(value)),
+                ...resolved.values,
+              ]),
+            );
+          }
         }
       } else if (resolved.set) {
         bindings.set(name, valuesWithCallbackState(name, resolved.values));
@@ -608,10 +771,40 @@ function staticBindings(instance: unknown): Map<string, unknown[]> {
         else bindings.delete(name);
       }
     }
+    const synchronousCallee =
+      node['type'] === 'CallExpression' &&
+      isRecord(node['callee']) &&
+      (node['callee']['type'] === 'FunctionExpression' ||
+        node['callee']['type'] === 'ArrowFunctionExpression')
+        ? node['callee']
+        : undefined;
+    if (synchronousCallee) synchronousFunctions.add(synchronousCallee);
     for (const value of Object.values(node)) {
       if (Array.isArray(value))
         for (const item of value) walk(item, currentShadowed, currentInsideFunction);
       else if (isRecord(value)) walk(value, currentShadowed, currentInsideFunction);
+    }
+    if (
+      node['type'] === 'FunctionDeclaration' ||
+      node['type'] === 'FunctionExpression' ||
+      node['type'] === 'ArrowFunctionExpression'
+    ) {
+      const frame = callbackFrames.pop();
+      const synchronous = synchronousFunctions.has(node);
+      if (synchronous) synchronousFunctions.delete(node);
+      if (frame) {
+        if (synchronous && callbackFrames.length > 0) {
+          const parentFrame = callbackFrames.at(-1)!;
+          for (const [name, values] of frame)
+            parentFrame.set(name, mergeValues([...(parentFrame.get(name) ?? []), ...values]));
+        } else if (!synchronous) {
+          for (const [name, values] of frame)
+            callbackBindings.set(
+              name,
+              mergeValues([...(callbackBindings.get(name) ?? []), ...values]),
+            );
+        }
+      }
     }
   };
   for (const statement of body) walk(statement, new Set(), false);


### PR DESCRIPTION
Closes #1051

## Summary
- cover the residual #1051 analyzer cases and every exact-review edge case with focused regressions
- invalidate hidden proof after nested dynamic spreads and preserve dynamic attributes used by shared floating targets
- model raw-control branches, abrupt returns, switches, zero-entry and guaranteed-entry loops, IIFEs, compound writes, and var redeclarations as distinct reachable states
- preserve labeled and conditional break and continue states without applying unreachable loop updates or switch fallthrough
- recognize if/else statements whose two branches both exit before traversing unreachable raw, style, or field-loop state
- resolve field and style aliases in source order while retaining callback-derived future states across later synchronous writes
- inspect every reachable raw HTML candidate and prune static ternary arms with JavaScript literal truthiness
- preserve function, block, loop, destructuring, catch-parameter, template-binding, and inline-handler scope boundaries for mutable field, style, and polymorphic tag analysis
- retain and compare every repeated attribute constraint across selector construction, merging, negation, overlap, and shared-target matching
- normalize mixed-sensitivity and non-equality attribute implication across selector operators
- model direct-parent selector constraints without treating distinct IDs on descendant ancestor chains as disjoint
- preserve opaque pseudo arguments, handle functional pseudo names case-insensitively, and compare exact integer positional pseudos soundly
- distinguish empty, definitely nonempty, and unknown each-block collection reachability without leaking body bindings into fallbacks
- evaluate do-while tests on ordinary and continue paths while preserving break exits and excluding static-truthy post-loop fallthrough
- update the Source Diff Viewer migration baseline for the now-visible no-number positional grid definition
- exact head ff8e32e9d27e45b12197d3bd579b7d0c29df4c58 is based on current main cf18ed74fd31ebc90b2a06fa36a7c2588b529e92

## Verification
- bun test packages/components/scripts/check-primitive-composition.test.ts — 248 pass, 0 fail, 515 expect
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder exports:check
- bun run --filter=@lostgradient/cinder lint:invariants
- bun run --filter=@lostgradient/cinder lint — 0 warnings, 0 errors
- bun run typecheck — all workspace tasks successful
- bun run build — all 5 tasks successful
- bunx prettier --check on all touched files
- git diff --check
- pre-commit and pre-push checks
- two independent cumulative follow-up reviews — approved