### PR TITLE
fix(speed-dial): hide closed floating surface

### DIFF
--- a/.changeset/quiet-speed-dials.md
+++ b/.changeset/quiet-speed-dials.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Hide the closed SpeedDial floating-surface chrome while preserving action exit motion.

--- a/packages/components/src/components/speed-dial/speed-dial.css
+++ b/packages/components/src/components/speed-dial/speed-dial.css
@@ -36,6 +36,7 @@
     background: transparent;
     border-color: transparent;
     box-shadow: none;
+    overflow-y: hidden;
   }
 
   .cinder-speed-dial__actions[data-cinder-direction='up'] {

--- a/packages/components/src/components/speed-dial/speed-dial.css
+++ b/packages/components/src/components/speed-dial/speed-dial.css
@@ -26,6 +26,18 @@
     overflow-y: auto;
   }
 
+  /*
+   * Keep the action surface mounted while its children play their exit
+   * transition, but remove the shared floating-surface chrome from the
+   * settled closed state. The surface remains inert and aria-hidden in the
+   * component markup, so this is purely a visual reset.
+   */
+  .cinder-speed-dial__actions:not([data-cinder-open]) {
+    background: transparent;
+    border-color: transparent;
+    box-shadow: none;
+  }
+
   .cinder-speed-dial__actions[data-cinder-direction='up'] {
     flex-direction: column-reverse;
   }

--- a/packages/components/src/components/speed-dial/speed-dial.css
+++ b/packages/components/src/components/speed-dial/speed-dial.css
@@ -29,8 +29,8 @@
   /*
    * Keep the action surface mounted while its children play their exit
    * transition, but remove the shared floating-surface chrome from the
-   * settled closed state. The surface remains inert and aria-hidden in the
-   * component markup, so this is purely a visual reset.
+   * settled closed state. The surface remains inert in the component markup,
+   * so this is purely a visual reset.
    */
   .cinder-speed-dial__actions:not([data-cinder-open]) {
     background: transparent;

--- a/packages/components/src/components/speed-dial/speed-dial.css
+++ b/packages/components/src/components/speed-dial/speed-dial.css
@@ -28,8 +28,8 @@
 
   /*
    * Keep the action surface mounted while its children play their exit
-   * transition, but remove the shared floating-surface chrome from the
-   * settled closed state. The surface remains inert in the component markup,
+   * transition, but remove the shared floating-surface chrome whenever the
+   * surface is closed. The surface remains inert in the component markup,
    * so this is purely a visual reset.
    */
   .cinder-speed-dial__actions:not([data-cinder-open]) {

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -66,7 +66,7 @@ describe('SpeedDial', () => {
     );
     expect(speedDialStyles).toMatch(/\.cinder-speed-dial-action\s*\{[^}]*opacity:\s*0;/s);
     expect(speedDialStyles).toMatch(
-      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\) \.cinder-speed-dial-action\s*\{[^}]*pointer-events:\s*none;/s,
+      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)\s+\.cinder-speed-dial-action\s*\{[^}]*pointer-events:\s*none;/s,
     );
   });
 

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -45,9 +45,6 @@ describe('SpeedDial', () => {
     expect(container.querySelector('.cinder-speed-dial__actions')).toBe(toolbar);
     expect(toolbar.hasAttribute('data-cinder-open')).toBe(false);
     expect(toolbar.hasAttribute('inert')).toBe(true);
-    expect(speedDialStyles).toMatch(
-      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)\s*\{[^}]*background:\s*transparent;[^}]*border-color:\s*transparent;[^}]*box-shadow:\s*none;/s,
-    );
   });
 
   test('open and reduced-motion styles preserve the same closed resting reset', () => {

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -55,6 +55,7 @@ describe('SpeedDial', () => {
     expect(closedActionsRule).toMatch(/background\s*:\s*transparent\s*;/);
     expect(closedActionsRule).toMatch(/border-color\s*:\s*transparent\s*;/);
     expect(closedActionsRule).toMatch(/box-shadow\s*:\s*none\s*;/);
+    expect(closedActionsRule).toMatch(/overflow-y\s*:\s*hidden\s*;/);
 
     const openActionsRule = speedDialStyles.match(
       /\.cinder-speed-dial__actions\[data-cinder-open\]\s*\{([^}]*)\}/s,

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -45,7 +45,6 @@ describe('SpeedDial', () => {
     expect(container.querySelector('.cinder-speed-dial__actions')).toBe(toolbar);
     expect(toolbar.hasAttribute('data-cinder-open')).toBe(false);
     expect(toolbar.hasAttribute('inert')).toBe(true);
-    expect(toolbar.getAttribute('aria-hidden')).toBe('true');
     expect(speedDialStyles).toMatch(
       /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)\s*\{[^}]*background:\s*transparent;[^}]*border-color:\s*transparent;[^}]*box-shadow:\s*none;/s,
     );
@@ -79,7 +78,6 @@ describe('SpeedDial', () => {
     expect(screen.getByRole('toolbar', { name: 'Actions', hidden: true })).toBe(toolbar);
     expect(toolbar.hasAttribute('data-cinder-open')).toBe(false);
     expect(toolbar.hasAttribute('inert')).toBe(true);
-    expect(toolbar.getAttribute('aria-hidden')).toBe('true');
   });
 
   test('empty aria-label falls back to the default accessible name', () => {

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -9,6 +9,7 @@ setupHappyDom();
 const { cleanup, fireEvent, render, screen, waitFor } = await import('@testing-library/svelte');
 const { default: SpeedDialFixture } = await import('./speed-dial.fixture.svelte');
 const speedDialSource = readFileSync(new URL('./speed-dial.svelte', import.meta.url), 'utf8');
+const speedDialStyles = readFileSync(new URL('./speed-dial.css', import.meta.url), 'utf8');
 
 afterEach(() => {
   cleanup();
@@ -35,6 +36,50 @@ describe('SpeedDial', () => {
     expect(container.querySelector('.cinder-speed-dial')?.hasAttribute('data-cinder-open')).toBe(
       false,
     );
+  });
+
+  test('closed toolbar keeps its exit surface mounted but has no visible floating chrome', () => {
+    const { container } = render(SpeedDialFixture);
+    const toolbar = screen.getByRole('toolbar', { name: 'Actions', hidden: true });
+
+    expect(container.querySelector('.cinder-speed-dial__actions')).toBe(toolbar);
+    expect(toolbar.hasAttribute('data-cinder-open')).toBe(false);
+    expect(toolbar.hasAttribute('inert')).toBe(true);
+    expect(toolbar.getAttribute('aria-hidden')).toBe('true');
+    expect(speedDialStyles).toMatch(
+      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)\s*\{[^}]*background:\s*transparent;[^}]*border-color:\s*transparent;[^}]*box-shadow:\s*none;/s,
+    );
+  });
+
+  test('open and reduced-motion styles preserve the same closed resting reset', () => {
+    expect(speedDialStyles).toMatch(
+      /\.cinder-speed-dial__actions\[data-cinder-open\]\s*\{[^}]*pointer-events:\s*auto;/s,
+    );
+    expect(speedDialStyles).toMatch(
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[^}]*\.cinder-speed-dial-action\s*\{[^}]*transition:\s*none;/s,
+    );
+    expect(speedDialStyles).toMatch(
+      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)[\s\S]*?\.cinder-speed-dial-action\s*\{[^}]*opacity:\s*0;/s,
+    );
+  });
+
+  test('open and post-close settled states keep the surface mounted and unavailable when closed', async () => {
+    render(SpeedDialFixture);
+    const trigger = screen.getByRole('button', { name: 'Quick actions' });
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    const toolbar = screen.getByRole('toolbar', { name: 'Actions' });
+    expect(toolbar.hasAttribute('data-cinder-open')).toBe(true);
+    expect(toolbar.hasAttribute('inert')).toBe(false);
+    expect(toolbar.hasAttribute('aria-hidden')).toBe(false);
+
+    await fireEvent.click(trigger);
+    await flushQueuedFocus();
+    expect(screen.getByRole('toolbar', { name: 'Actions', hidden: true })).toBe(toolbar);
+    expect(toolbar.hasAttribute('data-cinder-open')).toBe(false);
+    expect(toolbar.hasAttribute('inert')).toBe(true);
+    expect(toolbar.getAttribute('aria-hidden')).toBe('true');
   });
 
   test('empty aria-label falls back to the default accessible name', () => {

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -38,7 +38,7 @@ describe('SpeedDial', () => {
     );
   });
 
-  test('closed toolbar keeps its exit surface mounted but has no visible floating chrome', () => {
+  test('closed toolbar keeps its exit surface mounted and inert', () => {
     const { container } = render(SpeedDialFixture);
     const toolbar = screen.getByRole('toolbar', { name: 'Actions', hidden: true });
 
@@ -52,15 +52,15 @@ describe('SpeedDial', () => {
       /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)\s*\{([^}]*)\}/s,
     )?.[1];
     expect(closedActionsRule).toBeDefined();
-    expect(closedActionsRule).toContain('background: transparent;');
-    expect(closedActionsRule).toContain('border-color: transparent;');
-    expect(closedActionsRule).toContain('box-shadow: none;');
+    expect(closedActionsRule).toMatch(/background\s*:\s*transparent\s*;/);
+    expect(closedActionsRule).toMatch(/border-color\s*:\s*transparent\s*;/);
+    expect(closedActionsRule).toMatch(/box-shadow\s*:\s*none\s*;/);
 
     const openActionsRule = speedDialStyles.match(
       /\.cinder-speed-dial__actions\[data-cinder-open\]\s*\{([^}]*)\}/s,
     )?.[1];
     expect(openActionsRule).toBeDefined();
-    expect(openActionsRule).toContain('pointer-events: auto;');
+    expect(openActionsRule).toMatch(/pointer-events\s*:\s*auto\s*;/);
     expect(speedDialStyles).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.cinder-speed-dial-action\s*\{[^}]*transition:\s*none;/s,
     );

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -48,6 +48,14 @@ describe('SpeedDial', () => {
   });
 
   test('open and reduced-motion styles preserve the same closed resting reset', () => {
+    const closedActionsRule = speedDialStyles.match(
+      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)\s*\{([^}]*)\}/s,
+    )?.[1];
+    expect(closedActionsRule).toBeDefined();
+    expect(closedActionsRule).toContain('background: transparent;');
+    expect(closedActionsRule).toContain('border-color: transparent;');
+    expect(closedActionsRule).toContain('box-shadow: none;');
+
     const openActionsRule = speedDialStyles.match(
       /\.cinder-speed-dial__actions\[data-cinder-open\]\s*\{([^}]*)\}/s,
     )?.[1];
@@ -71,7 +79,7 @@ describe('SpeedDial', () => {
     const toolbar = screen.getByRole('toolbar', { name: 'Actions' });
     expect(toolbar.hasAttribute('data-cinder-open')).toBe(true);
     expect(toolbar.hasAttribute('inert')).toBe(false);
-    expect(toolbar.hasAttribute('aria-hidden')).toBe(false);
+    await waitFor(() => expect(toolbar.hasAttribute('aria-hidden')).toBe(false));
 
     await fireEvent.click(trigger);
     await flushQueuedFocus();

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -57,8 +57,9 @@ describe('SpeedDial', () => {
     expect(speedDialStyles).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{[^}]*\.cinder-speed-dial-action\s*\{[^}]*transition:\s*none;/s,
     );
+    expect(speedDialStyles).toMatch(/\.cinder-speed-dial-action\s*\{[^}]*opacity:\s*0;/s);
     expect(speedDialStyles).toMatch(
-      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\)[\s\S]*?\.cinder-speed-dial-action\s*\{[^}]*opacity:\s*0;/s,
+      /\.cinder-speed-dial__actions:not\(\[data-cinder-open\]\) \.cinder-speed-dial-action\s*\{[^}]*pointer-events:\s*none;/s,
     );
   });
 

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -48,9 +48,11 @@ describe('SpeedDial', () => {
   });
 
   test('open and reduced-motion styles preserve the same closed resting reset', () => {
-    expect(speedDialStyles).toMatch(
-      /\.cinder-speed-dial__actions\[data-cinder-open\]\s*\{[^}]*pointer-events:\s*auto;/s,
-    );
+    const openActionsRule = speedDialStyles.match(
+      /\.cinder-speed-dial__actions\[data-cinder-open\]\s*\{([^}]*)\}/s,
+    )?.[1];
+    expect(openActionsRule).toBeDefined();
+    expect(openActionsRule).toContain('pointer-events: auto;');
     expect(speedDialStyles).toMatch(
       /@media \(prefers-reduced-motion: reduce\)\s*\{[^}]*\.cinder-speed-dial-action\s*\{[^}]*transition:\s*none;/s,
     );

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -62,7 +62,7 @@ describe('SpeedDial', () => {
     expect(openActionsRule).toBeDefined();
     expect(openActionsRule).toContain('pointer-events: auto;');
     expect(speedDialStyles).toMatch(
-      /@media \(prefers-reduced-motion: reduce\)\s*\{[^}]*\.cinder-speed-dial-action\s*\{[^}]*transition:\s*none;/s,
+      /@media \(prefers-reduced-motion: reduce\)\s*\{[\s\S]*?\.cinder-speed-dial-action\s*\{[^}]*transition:\s*none;/s,
     );
     expect(speedDialStyles).toMatch(/\.cinder-speed-dial-action\s*\{[^}]*opacity:\s*0;/s);
     expect(speedDialStyles).toMatch(

--- a/packages/testing/tests/floating-surface-containment.playwright.ts
+++ b/packages/testing/tests/floating-surface-containment.playwright.ts
@@ -24,6 +24,7 @@ test.describe('floating surfaces escape component containment', () => {
     await expect(actions).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
     await expect(actions).toHaveCSS('border-top-color', 'rgba(0, 0, 0, 0)');
     await expect(actions).toHaveCSS('box-shadow', 'none');
+    await expect(actions).toHaveCSS('overflow-y', 'hidden');
     await expect(actions).toHaveCSS('opacity', '1');
     await expect(actions).toHaveCSS('pointer-events', 'none');
     await expect(action).toHaveCSS('opacity', '0');

--- a/packages/testing/tests/floating-surface-containment.playwright.ts
+++ b/packages/testing/tests/floating-surface-containment.playwright.ts
@@ -16,6 +16,20 @@ async function clipComponent(page: import('@playwright/test').Page, selector: st
 }
 
 test.describe('floating surfaces escape component containment', () => {
+  test('SpeedDial closed surface has no floating chrome', async ({ page }) => {
+    await page.goto('/page/speed-dial?snapshot=1', { waitUntil: 'load' });
+    const actions = page.locator('.cinder-speed-dial__actions').first();
+    const action = actions.locator('.cinder-speed-dial-action').first();
+
+    await expect(actions).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+    await expect(actions).toHaveCSS('border-top-color', 'rgba(0, 0, 0, 0)');
+    await expect(actions).toHaveCSS('box-shadow', 'none');
+    await expect(actions).toHaveCSS('opacity', '1');
+    await expect(actions).toHaveCSS('pointer-events', 'none');
+    await expect(action).toHaveCSS('opacity', '0');
+    await expect(action).toHaveCSS('pointer-events', 'none');
+  });
+
   test('SpeedDial actions portal outside a clipping ancestor', async ({ page }) => {
     await page.goto('/page/speed-dial?snapshot=1', { waitUntil: 'load' });
     const clippingBounds = await clipComponent(page, '.cinder-speed-dial');


### PR DESCRIPTION
Closes #1069

## Summary
- hide shared floating-surface chrome and overflow scrollbar for a closed SpeedDial while keeping the action surface mounted for exit transitions
- cover closed, open, post-close, and reduced-motion resting states
- preserve the real browser regression for the closed floating surface
- keep CSS-source contracts independent of property order and formatting
- exact head 719589ea991b4cb4ad85e7f65c62533836d2fc02 is based on main 3b3685f63ca518a6006a5212c78c837b2e4ba91f

## Verification
- bun run --filter=@lostgradient/cinder test -- src/components/speed-dial/speed-dial.test.ts — 38 pass, 0 fail, 113 assertions
- focused Playwright SpeedDial closed-surface regression — 1 pass
- bun run --filter=@lostgradient/cinder styles:source-css:check
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder build
- bun run --filter=@lostgradient/cinder typecheck — 0 errors
- bunx prettier --check on all changed files
- git diff --check
- pre-push checks
- independent review approved