### PR TITLE
fix(NavigationBar): preserve sequential mobile Tab order

### DIFF
--- a/.changeset/bright-navigation-items.md
+++ b/.changeset/bright-navigation-items.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix NavigationBar mobile Tab focus bridging to preserve the before-brand destination while positioning is pending and to ignore enabled items removed from the sequential tab order.

--- a/packages/components/src/components/navigation-bar/navigation-bar-focus.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar-focus.ts
@@ -4,7 +4,7 @@ import { closestAcrossShadow, getShadowHost } from '../portal/portal.utilities.s
 const focusCandidateSelector =
   'button:not([disabled]), a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), [contenteditable="true"], [tabindex]';
 
-function getSequentialFocusTargets(root: ParentNode | null): HTMLElement[] {
+export function getSequentialFocusTargets(root: ParentNode | null): HTMLElement[] {
   if (!root) return [];
   return Array.from(root.querySelectorAll<HTMLElement>(focusCandidateSelector)).filter(
     (candidate) =>

--- a/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
+++ b/packages/components/src/components/navigation-bar/navigation-bar.a11y.md
@@ -28,10 +28,10 @@ The consumer is responsible for:
 
 ## Keyboard Interactions
 
-| Key    | Behavior                                                                                                         |
-| ------ | ---------------------------------------------------------------------------------------------------------------- |
-| Tab    | Moves focus through items and actions in DOM order.                                                              |
-| Escape | Closes the mobile menu when open. Scoped to the `<nav>` element—Escape pressed outside the navbar has no effect. |
+| Key    | Behavior                                                                                                                       |
+| ------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| Tab    | Moves focus through sequentially focusable items and actions in DOM order; enabled controls with `tabindex="-1"` are excluded. |
+| Escape | Closes the mobile menu when open. Scoped to the `<nav>` element—Escape pressed outside the navbar has no effect.               |
 
 ### Scoped Escape behavior
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -87,8 +87,8 @@
   // Stores the toggle element for focus return after Escape-close.
   let navigationBarElement: HTMLElement | null = null;
   let toggleElement: HTMLElement | null = null;
-  let pendingTabFocus = false;
-  let pendingTabFocusTarget: HTMLElement | null = null;
+  let pendingTabFocus = $state(false);
+  let pendingTabFocusTarget = $state<HTMLElement | null>(null);
   let itemsRegionElement: HTMLDivElement | null = null;
   let sourceSubtreeUnavailable = $state(false);
   const itemsPortalScope = createPortalAttachment({
@@ -359,9 +359,13 @@
     if (!anchoredItems.positionReady) return false;
 
     const enabledItems = getSequentialNavigationItems();
-    if (enabledItems.length === 0) return false;
+    const logicalEnabledItems = getNavigationItems().filter(isEnabledNavigationItem);
+    if (enabledItems.length === 0 && logicalEnabledItems.length === 0) return false;
 
-    if (event.shiftKey && navigationItem === enabledItems[0]) {
+    if (
+      event.shiftKey &&
+      (navigationItem === enabledItems[0] || navigationItem === logicalEnabledItems[0])
+    ) {
       const previousTarget = getFocusTargetBeforeItems();
       if (!previousTarget) return false;
       event.preventDefault();
@@ -369,7 +373,10 @@
       return true;
     }
 
-    if (!event.shiftKey && navigationItem === enabledItems.at(-1)) {
+    if (
+      !event.shiftKey &&
+      (navigationItem === enabledItems.at(-1) || navigationItem === logicalEnabledItems.at(-1))
+    ) {
       const nextTarget = getFocusTargetAfterItems();
       if (!nextTarget) return false;
       event.preventDefault();

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -365,12 +365,21 @@
     const enabledItems = getSequentialNavigationItems();
     const logicalEnabledItems = getNavigationItems().filter(isEnabledNavigationItem);
     const isSequentialTarget = sequentialItems.includes(navigationItem);
+    const hasSequentialTargetBefore = sequentialItems.some(
+      (target) =>
+        Boolean(target.compareDocumentPosition(navigationItem) & Node.DOCUMENT_POSITION_FOLLOWING),
+    );
+    const hasSequentialTargetAfter = sequentialItems.some(
+      (target) =>
+        Boolean(navigationItem.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_FOLLOWING),
+    );
     if (enabledItems.length === 0 && logicalEnabledItems.length === 0) return false;
 
     if (
       event.shiftKey &&
       (navigationItem === sequentialItems[0] ||
         (!isSequentialTarget &&
+          !hasSequentialTargetBefore &&
           (navigationItem === enabledItems[0] || navigationItem === logicalEnabledItems[0])))
     ) {
       const previousTarget = getFocusTargetBeforeItems();
@@ -384,6 +393,7 @@
       !event.shiftKey &&
       (navigationItem === sequentialItems.at(-1) ||
         (!isSequentialTarget &&
+          !hasSequentialTargetAfter &&
           (navigationItem === enabledItems.at(-1) ||
             navigationItem === logicalEnabledItems.at(-1))))
     ) {

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -43,6 +43,7 @@
     findFocusTargetAfterNavigationItems,
     findFocusTargetBeforeNavigationItems,
     getNavigationBarBrandFocusTargets,
+    getSequentialFocusTargets,
   } from './navigation-bar-focus.ts';
 
   const COLLAPSIBLE_MAX_WIDTH_REM = 47.99;
@@ -87,6 +88,7 @@
   let navigationBarElement: HTMLElement | null = null;
   let toggleElement: HTMLElement | null = null;
   let pendingTabFocus = false;
+  let pendingTabFocusTarget: HTMLElement | null = null;
   let itemsRegionElement: HTMLDivElement | null = null;
   let sourceSubtreeUnavailable = $state(false);
   const itemsPortalScope = createPortalAttachment({
@@ -112,11 +114,15 @@
   );
 
   $effect(() => {
-    if (!mobileMenuOpen || !isMobileLayout) pendingTabFocus = false;
+    if (!mobileMenuOpen || !isMobileLayout) {
+      pendingTabFocus = false;
+      pendingTabFocusTarget = null;
+    }
     if (!pendingTabFocus || !anchoredItems.positionReady) return;
     pendingTabFocus = false;
-    const firstItem = getNavigationItems().find(isEnabledNavigationItem);
-    firstItem?.focus();
+    const pendingTarget = pendingTabFocusTarget;
+    pendingTabFocusTarget = null;
+    queueMicrotask(() => (pendingTarget ?? getToggleTabTarget())?.focus());
   });
 
   $effect(() => {
@@ -210,28 +216,37 @@
     if (event.key !== 'Tab' || event.shiftKey || !isMobileLayout || !mobileMenuOpen) return;
     if (!anchoredItems.positionReady) {
       pendingTabFocus = true;
+      pendingTabFocusTarget =
+        menuTogglePlacement === 'before-brand'
+          ? (getNavigationBarBrandFocusTargets(navigationBarElement)[0] ?? null)
+          : null;
       event.preventDefault();
       return;
     }
-    const brandTarget =
-      menuTogglePlacement === 'before-brand'
-        ? getNavigationBarBrandFocusTargets(navigationBarElement)[0]
-        : null;
-    if (brandTarget) {
-      event.preventDefault();
-      brandTarget.focus();
-      return;
-    }
-    const firstItem = getNavigationItems().find(isEnabledNavigationItem);
-    if (!firstItem) return;
+    const target = getToggleTabTarget();
+    if (!target) return;
     event.preventDefault();
-    firstItem.focus();
+    target.focus();
   }
 
   function getNavigationItems(): HTMLElement[] {
     if (!itemsRegionElement) return [];
 
     return Array.from(itemsRegionElement.querySelectorAll<HTMLElement>(navigationItemSelector));
+  }
+
+  function getSequentialNavigationItems(): HTMLElement[] {
+    return getSequentialFocusTargets(itemsRegionElement).filter(
+      (item) => item.matches(navigationItemSelector) && isEnabledNavigationItem(item),
+    );
+  }
+
+  function getToggleTabTarget(): HTMLElement | null {
+    const brandTarget =
+      menuTogglePlacement === 'before-brand'
+        ? getNavigationBarBrandFocusTargets(navigationBarElement)[0]
+        : null;
+    return brandTarget ?? getSequentialNavigationItems()[0] ?? null;
   }
 
   function bridgeBrandTabToPortaledPanel(event: KeyboardEvent): boolean {
@@ -250,7 +265,7 @@
     const brandTargets = getNavigationBarBrandFocusTargets(navigationBarElement);
     if (event.target !== brandTargets.at(-1)) return false;
 
-    const firstItem = getNavigationItems().find(isEnabledNavigationItem);
+    const firstItem = getSequentialNavigationItems()[0];
     if (!firstItem) return false;
 
     event.preventDefault();
@@ -343,7 +358,7 @@
   function bridgePortaledPanelTab(event: KeyboardEvent, navigationItem: HTMLElement): boolean {
     if (!anchoredItems.positionReady) return false;
 
-    const enabledItems = getNavigationItems().filter(isEnabledNavigationItem);
+    const enabledItems = getSequentialNavigationItems();
     if (enabledItems.length === 0) return false;
 
     if (event.shiftKey && navigationItem === enabledItems[0]) {

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -365,13 +365,11 @@
     const enabledItems = getSequentialNavigationItems();
     const logicalEnabledItems = getNavigationItems().filter(isEnabledNavigationItem);
     const isSequentialTarget = sequentialItems.includes(navigationItem);
-    const hasSequentialTargetBefore = sequentialItems.some(
-      (target) =>
-        Boolean(target.compareDocumentPosition(navigationItem) & Node.DOCUMENT_POSITION_FOLLOWING),
+    const hasSequentialTargetBefore = sequentialItems.some((target) =>
+      Boolean(target.compareDocumentPosition(navigationItem) & Node.DOCUMENT_POSITION_FOLLOWING),
     );
-    const hasSequentialTargetAfter = sequentialItems.some(
-      (target) =>
-        Boolean(navigationItem.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_FOLLOWING),
+    const hasSequentialTargetAfter = sequentialItems.some((target) =>
+      Boolean(navigationItem.compareDocumentPosition(target) & Node.DOCUMENT_POSITION_FOLLOWING),
     );
     if (enabledItems.length === 0 && logicalEnabledItems.length === 0) return false;
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -361,13 +361,17 @@
   function bridgePortaledPanelTab(event: KeyboardEvent, navigationItem: HTMLElement): boolean {
     if (!anchoredItems.positionReady) return false;
 
+    const sequentialItems = getSequentialFocusTargets(itemsRegionElement);
     const enabledItems = getSequentialNavigationItems();
     const logicalEnabledItems = getNavigationItems().filter(isEnabledNavigationItem);
+    const isSequentialTarget = sequentialItems.includes(navigationItem);
     if (enabledItems.length === 0 && logicalEnabledItems.length === 0) return false;
 
     if (
       event.shiftKey &&
-      (navigationItem === enabledItems[0] || navigationItem === logicalEnabledItems[0])
+      (navigationItem === sequentialItems[0] ||
+        (!isSequentialTarget &&
+          (navigationItem === enabledItems[0] || navigationItem === logicalEnabledItems[0])))
     ) {
       const previousTarget = getFocusTargetBeforeItems();
       if (!previousTarget) return false;
@@ -378,7 +382,10 @@
 
     if (
       !event.shiftKey &&
-      (navigationItem === enabledItems.at(-1) || navigationItem === logicalEnabledItems.at(-1))
+      (navigationItem === sequentialItems.at(-1) ||
+        (!isSequentialTarget &&
+          (navigationItem === enabledItems.at(-1) ||
+            navigationItem === logicalEnabledItems.at(-1))))
     ) {
       const nextTarget = getFocusTargetAfterItems();
       if (!nextTarget) return false;
@@ -445,9 +452,16 @@
     }
 
     const navigationItem = getEventNavigationItem(event);
-    if (!navigationItem || navigationItem !== event.target) return;
+    if (
+      event.key === 'Tab' &&
+      event.target instanceof HTMLElement &&
+      itemsRegionElement?.contains(event.target) &&
+      bridgePortaledPanelTab(event, event.target)
+    ) {
+      return;
+    }
 
-    if (event.key === 'Tab' && bridgePortaledPanelTab(event, navigationItem)) return;
+    if (!navigationItem || navigationItem !== event.target) return;
 
     if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
       event.preventDefault();

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -122,7 +122,10 @@
     pendingTabFocus = false;
     const pendingTarget = pendingTabFocusTarget;
     pendingTabFocusTarget = null;
-    queueMicrotask(() => (pendingTarget ?? getToggleTabTarget())?.focus());
+    queueMicrotask(() => {
+      const target = pendingTarget ?? getToggleTabTarget() ?? getFocusTargetAfterItems();
+      target?.focus();
+    });
   });
 
   $effect(() => {

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -251,6 +251,18 @@ function negativeFinalNavigationSnippet() {
   }));
 }
 
+function inlineControlBeforeNegativeNavigationSnippet() {
+  return createRawSnippet(() => ({
+    render: () => `
+      <div>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="enabled">Enabled</button>
+        <button type="button" id="inline-control">Inline control</button>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="skipped" tabindex="-1">Skipped</button>
+      </div>
+    `,
+  }));
+}
+
 function allExcludedNavigationSnippet() {
   return createRawSnippet(() => ({
     render: () => `
@@ -1028,6 +1040,33 @@ describe('NavigationBar', () => {
       expect(document.activeElement).toBe(skippedItem);
       await fireEvent.keyDown(skippedItem, { key: 'Tab' });
       expect(document.activeElement).toBe(accountAction);
+    });
+  });
+
+  test('forward Tab from the final sequential inline control reaches actions', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        items: inlineControlBeforeNegativeNavigationSnippet(),
+        menuToggle: toggleSnippet(),
+        actions: actionButtonSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+      const itemsRegion = await waitForMobilePanelPosition(container);
+      const toggle = container.querySelector('#toggle-btn') as HTMLButtonElement;
+      const enabledItem = itemsRegion.querySelector('[data-key="enabled"]') as HTMLButtonElement;
+      const inlineControl = itemsRegion.querySelector('#inline-control') as HTMLButtonElement;
+      const skippedItem = itemsRegion.querySelector('[data-key="skipped"]') as HTMLButtonElement;
+      const accountAction = container.querySelector('#nav-action') as HTMLButtonElement;
+
+      toggle.focus();
+      await fireEvent.keyDown(toggle, { key: 'Tab' });
+      expect(document.activeElement).toBe(enabledItem);
+
+      inlineControl.focus();
+      await fireEvent.keyDown(inlineControl, { key: 'Tab' });
+      expect(document.activeElement).toBe(accountAction);
+      expect(document.activeElement).not.toBe(skippedItem);
     });
   });
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -977,6 +977,49 @@ describe('NavigationBar', () => {
     });
   });
 
+  test('reverse Tab bridges from an arrow-focused leading item with tabindex=-1', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        items: negativeFirstNavigationSnippet(),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+      const itemsRegion = await waitForMobilePanelPosition(container);
+      const toggle = container.querySelector('#toggle-btn') as HTMLButtonElement;
+      const skippedItem = itemsRegion.querySelector('[data-key="skipped"]') as HTMLButtonElement;
+      const enabledItem = itemsRegion.querySelector('[data-key="enabled"]') as HTMLButtonElement;
+
+      enabledItem.focus();
+      await fireEvent.keyDown(enabledItem, { key: 'ArrowLeft' });
+      expect(document.activeElement).toBe(skippedItem);
+      await fireEvent.keyDown(skippedItem, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(toggle);
+    });
+  });
+
+  test('forward Tab bridges from an arrow-focused trailing item with tabindex=-1', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        items: negativeFinalNavigationSnippet(),
+        menuToggle: toggleSnippet(),
+        actions: actionButtonSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+      const itemsRegion = await waitForMobilePanelPosition(container);
+      const skippedItem = itemsRegion.querySelector('[data-key="skipped"]') as HTMLButtonElement;
+      const enabledItem = itemsRegion.querySelector('[data-key="enabled"]') as HTMLButtonElement;
+      const accountAction = container.querySelector('#nav-action') as HTMLButtonElement;
+
+      enabledItem.focus();
+      await fireEvent.keyDown(enabledItem, { key: 'ArrowRight' });
+      expect(document.activeElement).toBe(skippedItem);
+      await fireEvent.keyDown(skippedItem, { key: 'Tab' });
+      expect(document.activeElement).toBe(accountAction);
+    });
+  });
+
   test('toggle Tab skips disabled navigation items', async () => {
     await withResizeObserver(async () => {
       const { container } = render(NavigationBar, {

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -229,6 +229,28 @@ function disabledFirstNavigationSnippet() {
   }));
 }
 
+function negativeFirstNavigationSnippet() {
+  return createRawSnippet(() => ({
+    render: () => `
+      <div>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="skipped" tabindex="-1">Skipped</button>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="enabled">Enabled</button>
+      </div>
+    `,
+  }));
+}
+
+function negativeFinalNavigationSnippet() {
+  return createRawSnippet(() => ({
+    render: () => `
+      <div>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="enabled">Enabled</button>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item data-key="skipped" tabindex="-1">Skipped</button>
+      </div>
+    `,
+  }));
+}
+
 function keyboardNavigationSnippet(clicks: Record<string, number>) {
   return createRawSnippet(() => ({
     render: () => `
@@ -294,6 +316,7 @@ describe('NavigationBar', () => {
   test('guards responsive portal focus and effective disabled targets', () => {
     expect(navigationBarSource).toContain("item.matches(':disabled')");
     expect(navigationBarSource).toContain('pendingTabFocus');
+    expect(navigationBarSource).toContain('pendingTabFocusTarget');
     expect(navigationBarSource).toContain(
       "isMobileLayout && mobileMenuOpen ? 'cinder-_floating-surface' : undefined",
     );
@@ -917,10 +940,65 @@ describe('NavigationBar', () => {
     });
   });
 
+  test('last sequential navigation item tabs to actions when a final enabled item has tabindex=-1', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        items: negativeFinalNavigationSnippet(),
+        menuToggle: toggleSnippet(),
+        actions: actionButtonSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+      const itemsRegion = await waitForMobilePanelPosition(container);
+      const enabledItem = itemsRegion.querySelector('[data-key="enabled"]') as HTMLButtonElement;
+      const accountAction = container.querySelector('#nav-action') as HTMLButtonElement;
+
+      enabledItem.focus();
+      await fireEvent.keyDown(enabledItem, { key: 'Tab' });
+      expect(document.activeElement).toBe(accountAction);
+    });
+  });
+
+  test('reverse Tab uses the first sequential navigation item when an enabled item has tabindex=-1', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        items: negativeFirstNavigationSnippet(),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+      const itemsRegion = await waitForMobilePanelPosition(container);
+      const toggle = container.querySelector('#toggle-btn') as HTMLButtonElement;
+      const enabledItem = itemsRegion.querySelector('[data-key="enabled"]') as HTMLButtonElement;
+
+      enabledItem.focus();
+      await fireEvent.keyDown(enabledItem, { key: 'Tab', shiftKey: true });
+      expect(document.activeElement).toBe(toggle);
+    });
+  });
+
   test('toggle Tab skips disabled navigation items', async () => {
     await withResizeObserver(async () => {
       const { container } = render(NavigationBar, {
         items: disabledFirstNavigationSnippet(),
+        menuToggle: toggleSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+      const itemsRegion = await waitForMobilePanelPosition(container);
+      const toggle = container.querySelector('#toggle-btn') as HTMLButtonElement;
+      const enabledItem = itemsRegion.querySelector('[data-key="enabled"]');
+
+      toggle.focus();
+      await fireEvent.keyDown(toggle, { key: 'Tab' });
+      expect(document.activeElement).toBe(enabledItem);
+    });
+  });
+
+  test('toggle Tab skips enabled navigation items removed from sequential tab order', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        items: negativeFirstNavigationSnippet(),
         menuToggle: toggleSnippet(),
       });
 

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -251,6 +251,17 @@ function negativeFinalNavigationSnippet() {
   }));
 }
 
+function allExcludedNavigationSnippet() {
+  return createRawSnippet(() => ({
+    render: () => `
+      <div>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item aria-disabled="true">Disabled</button>
+        <button type="button" class="cinder-navigation-item" data-cinder-navigation-item tabindex="-1">Excluded</button>
+      </div>
+    `,
+  }));
+}
+
 function keyboardNavigationSnippet(clicks: Record<string, number>) {
   return createRawSnippet(() => ({
     render: () => `
@@ -1016,6 +1027,26 @@ describe('NavigationBar', () => {
       await fireEvent.keyDown(enabledItem, { key: 'ArrowRight' });
       expect(document.activeElement).toBe(skippedItem);
       await fireEvent.keyDown(skippedItem, { key: 'Tab' });
+      expect(document.activeElement).toBe(accountAction);
+    });
+  });
+
+  test('pending toggle Tab advances to actions when no navigation item is sequentially focusable', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        items: allExcludedNavigationSnippet(),
+        menuToggle: toggleSnippet(),
+        actions: actionButtonSnippet(),
+      });
+
+      await openCollapsedMobileMenu(container);
+      const toggle = container.querySelector('#toggle-btn') as HTMLButtonElement;
+      const accountAction = container.querySelector('#nav-action') as HTMLButtonElement;
+
+      toggle.focus();
+      await fireEvent.keyDown(toggle, { key: 'Tab' });
+      await waitForMobilePanelPosition(container);
+      await tick();
       expect(document.activeElement).toBe(accountAction);
     });
   });

--- a/packages/components/src/components/navigation-bar/navigation-bar.test.ts
+++ b/packages/components/src/components/navigation-bar/navigation-bar.test.ts
@@ -1146,6 +1146,27 @@ describe('NavigationBar', () => {
     });
   });
 
+  test('pending toggle Tab preserves a focusable brand before the portaled items', async () => {
+    await withResizeObserver(async () => {
+      const { container } = render(NavigationBar, {
+        brand: brandLinkSnippet(),
+        items: keyboardNavigationSnippet({}),
+        menuToggle: toggleSnippet(),
+        menuTogglePlacement: 'before-brand',
+      });
+
+      await openCollapsedMobileMenu(container);
+      const toggle = container.querySelector('#toggle-btn') as HTMLButtonElement;
+      const brandLink = container.querySelector('#brand-link');
+
+      toggle.focus();
+      await fireEvent.keyDown(toggle, { key: 'Tab' });
+      await waitForMobilePanelPosition(container);
+      await tick();
+      expect(document.activeElement).toBe(brandLink);
+    });
+  });
+
   test('brand Tab enters the portaled items after a before-brand toggle', async () => {
     await withResizeObserver(async () => {
       const { container } = render(NavigationBar, {

--- a/packages/testing/tests/chat-harness.playwright.ts
+++ b/packages/testing/tests/chat-harness.playwright.ts
@@ -410,8 +410,20 @@ test.describe('chat harness — scroll, unread, jump', () => {
 
       const timeline = harness.locator('.chat-timeline');
       await harness.locator('[data-testid="scroll-top"]').click();
-      const anchor = timeline.getByText('Tell me about alpha.').first();
+      const anchor = timeline
+        .locator('.chat-message')
+        .filter({ hasText: 'Tell me about alpha.' })
+        .first();
       await expect(anchor).toBeVisible();
+      await expect
+        .poll(async () => {
+          const [anchorBox, timelineBox] = await Promise.all([
+            anchor.boundingBox(),
+            timeline.boundingBox(),
+          ]);
+          return anchorBox !== null && timelineBox !== null;
+        })
+        .toBe(true);
       const before = await anchor.boundingBox();
       const beforeTimeline = await timeline.boundingBox();
       expect(before).not.toBeNull();
@@ -635,8 +647,20 @@ test.describe('chat harness — scroll, unread, jump', () => {
 
       const timeline = harness.locator('.chat-timeline');
       await harness.locator('[data-testid="scroll-top"]').click();
-      const anchor = timeline.getByText('Tell me about alpha.').first();
+      const anchor = timeline
+        .locator('.chat-message')
+        .filter({ hasText: 'Tell me about alpha.' })
+        .first();
       await expect(anchor).toBeVisible();
+      await expect
+        .poll(async () => {
+          const [anchorBox, timelineBox] = await Promise.all([
+            anchor.boundingBox(),
+            timeline.boundingBox(),
+          ]);
+          return anchorBox !== null && timelineBox !== null;
+        })
+        .toBe(true);
       const before = await anchor.boundingBox();
       const beforeTimeline = await timeline.boundingBox();
       expect(before).not.toBeNull();


### PR DESCRIPTION
Closes #1070

- preserve the before-brand toggle destination while mobile panel positioning is pending
- use the existing sequential focus model for navigation-item Tab boundaries
- add regression coverage and document the keyboard behavior

Validation:
- bun run --filter=@lostgradient/cinder test -- src/components/navigation-bar/navigation-bar.test.ts
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder lint
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder exports:check