### PR TITLE
Fail closed on unparsed container queries

### DIFF
--- a/.changeset/fail-closed-container-queries.md
+++ b/.changeset/fail-closed-container-queries.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fail closed when text-direction container queries contain syntax the evaluator cannot fully parse.

--- a/packages/components/src/_internal/text-direction-container.ts
+++ b/packages/components/src/_internal/text-direction-container.ts
@@ -75,6 +75,8 @@ export function evaluateLogicalContainerCondition(
   const trimmed = conditionText.trim();
   if (trimmed.startsWith('(') && trimmed.endsWith(')'))
     return evaluateLogicalContainerCondition(trimmed.slice(1, -1), width, remSize, inlineSize);
+  if (/^not\b/i.test(trimmed))
+    return !evaluateLogicalContainerCondition(trimmed.slice(3), width, remSize, inlineSize);
   return evaluateContainerSizeConstraints(trimmed, width, remSize, inlineSize);
 }
 

--- a/packages/components/src/_internal/text-direction-container.ts
+++ b/packages/components/src/_internal/text-direction-container.ts
@@ -101,7 +101,7 @@ const containerSizeTermPattern =
 const featureFirstRangePattern =
   /^(?:width|inline-size)\s*(?:>=|>|<=|<)\s*(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/i;
 const valueFirstRangePattern =
-  /^(?:(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)\s*(?:<=|<|>=|>)\s*(?:width|inline-size))(?:\s*(?:<=|<|>=|>)\s*(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem))?$/i;
+  /^(?:(?:(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)\s*(?:<=|<)\s*(?:width|inline-size))(?:\s*(?:<=|<)\s*(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem))?|(?:(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)\s*(?:>=|>)\s*(?:width|inline-size))(?:\s*(?:>=|>)\s*(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem))?)$/i;
 
 /**
  * Returns true only when every token in a size condition belongs to the
@@ -115,21 +115,25 @@ export function isFullyParsedContainerCondition(conditionText: string): boolean 
 }
 
 function parseContainerCondition(conditionText: string): boolean {
-  const trimmed = unwrapRedundantParentheses(conditionText);
+  const original = conditionText.trim();
+  const trimmed = unwrapRedundantParentheses(original);
+  const wasGrouped = trimmed !== original;
   const orParts = splitTopLevel(trimmed, 'or');
-  if (orParts.length > 1) return orParts.every(parseContainerCondition);
   const andParts = splitTopLevel(trimmed, 'and');
+  if (orParts.length > 1 && andParts.length > 1) return false;
+  if (orParts.length > 1) return orParts.every(parseContainerCondition);
   if (andParts.length > 1) return andParts.every(parseContainerCondition);
   const notPrefix = /^not\s+/i.exec(trimmed);
   if (notPrefix) {
     const operand = trimmed.slice(notPrefix[0].length).trim();
     const unwrappedOperand = unwrapRedundantParentheses(operand);
-    return unwrappedOperand !== operand && parseContainerCondition(unwrappedOperand);
+    return unwrappedOperand !== operand && parseContainerCondition(operand);
   }
   return (
-    containerSizeTermPattern.test(trimmed) ||
-    featureFirstRangePattern.test(trimmed) ||
-    valueFirstRangePattern.test(trimmed)
+    wasGrouped &&
+    (containerSizeTermPattern.test(trimmed) ||
+      featureFirstRangePattern.test(trimmed) ||
+      valueFirstRangePattern.test(trimmed))
   );
 }
 

--- a/packages/components/src/_internal/text-direction-container.ts
+++ b/packages/components/src/_internal/text-direction-container.ts
@@ -61,6 +61,7 @@ export function evaluateLogicalContainerCondition(
   remSize: number,
   inlineSize: number,
 ): boolean {
+  if (!isFullyParsedContainerCondition(conditionText)) return false;
   const orParts = splitTopLevel(conditionText, 'or');
   if (orParts.length > 1)
     return orParts.some((part) =>
@@ -75,6 +76,62 @@ export function evaluateLogicalContainerCondition(
   if (trimmed.startsWith('(') && trimmed.endsWith(')'))
     return evaluateLogicalContainerCondition(trimmed.slice(1, -1), width, remSize, inlineSize);
   return evaluateContainerSizeConstraints(trimmed, width, remSize, inlineSize);
+}
+
+const containerSizeTermPattern =
+  /^(?:(?:min|max)-(?:width|inline-size)|(?:width|inline-size))\s*:\s*(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/i;
+const featureFirstRangePattern =
+  /^(?:width|inline-size)\s*(?:>=|>|<=|<)\s*(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)$/i;
+const valueFirstRangePattern =
+  /^(?:(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem)\s*(?:<=|<|>=|>)\s*(?:width|inline-size))(?:\s*(?:<=|<|>=|>)\s*(?:\d+(?:\.\d+)?|\.\d+)(?:px|rem))?$/i;
+
+/**
+ * Returns true only when every token in a size condition belongs to the
+ * deliberately small grammar evaluated below. Unknown CSS syntax must not
+ * silently inherit the evaluator's historical "active" default.
+ */
+export function isFullyParsedContainerCondition(conditionText: string): boolean {
+  const trimmed = conditionText.trim();
+  if (!trimmed || !hasBalancedParentheses(trimmed)) return false;
+  return parseContainerCondition(trimmed);
+}
+
+function parseContainerCondition(conditionText: string): boolean {
+  let trimmed = conditionText.trim();
+  while (isWrappedByParentheses(trimmed)) trimmed = trimmed.slice(1, -1).trim();
+  const orParts = splitTopLevel(trimmed, 'or');
+  if (orParts.length > 1) return orParts.every(parseContainerCondition);
+  const andParts = splitTopLevel(trimmed, 'and');
+  if (andParts.length > 1) return andParts.every(parseContainerCondition);
+  if (/^not\b/i.test(trimmed)) return parseContainerCondition(trimmed.slice(3));
+  return (
+    containerSizeTermPattern.test(trimmed) ||
+    featureFirstRangePattern.test(trimmed) ||
+    valueFirstRangePattern.test(trimmed)
+  );
+}
+
+function hasBalancedParentheses(conditionText: string): boolean {
+  let depth = 0;
+  for (const character of conditionText) {
+    if (character === '(') depth += 1;
+    if (character === ')') {
+      depth -= 1;
+      if (depth < 0) return false;
+    }
+  }
+  return depth === 0;
+}
+
+function isWrappedByParentheses(conditionText: string): boolean {
+  if (!conditionText.startsWith('(') || !conditionText.endsWith(')')) return false;
+  let depth = 0;
+  for (let index = 0; index < conditionText.length; index += 1) {
+    if (conditionText[index] === '(') depth += 1;
+    if (conditionText[index] === ')') depth -= 1;
+    if (depth === 0 && index < conditionText.length - 1) return false;
+  }
+  return depth === 0;
 }
 
 // True when the condition references a width/inline-size comparison whose

--- a/packages/components/src/_internal/text-direction-container.ts
+++ b/packages/components/src/_internal/text-direction-container.ts
@@ -62,21 +62,41 @@ export function evaluateLogicalContainerCondition(
   inlineSize: number,
 ): boolean {
   if (!isFullyParsedContainerCondition(conditionText)) return false;
+  return evaluateParsedLogicalContainerCondition(conditionText, width, remSize, inlineSize);
+}
+
+function evaluateParsedLogicalContainerCondition(
+  conditionText: string,
+  width: number,
+  remSize: number,
+  inlineSize: number,
+): boolean {
   const orParts = splitTopLevel(conditionText, 'or');
   if (orParts.length > 1)
     return orParts.some((part) =>
-      evaluateLogicalContainerCondition(part, width, remSize, inlineSize),
+      evaluateParsedLogicalContainerCondition(part, width, remSize, inlineSize),
     );
   const andParts = splitTopLevel(conditionText, 'and');
   if (andParts.length > 1)
     return andParts.every((part) =>
-      evaluateLogicalContainerCondition(part, width, remSize, inlineSize),
+      evaluateParsedLogicalContainerCondition(part, width, remSize, inlineSize),
     );
   const trimmed = conditionText.trim();
   if (trimmed.startsWith('(') && trimmed.endsWith(')'))
-    return evaluateLogicalContainerCondition(trimmed.slice(1, -1), width, remSize, inlineSize);
-  if (/^not\b/i.test(trimmed))
-    return !evaluateLogicalContainerCondition(trimmed.slice(3), width, remSize, inlineSize);
+    return evaluateParsedLogicalContainerCondition(
+      trimmed.slice(1, -1),
+      width,
+      remSize,
+      inlineSize,
+    );
+  const notPrefix = /^not\s+/i.exec(trimmed);
+  if (notPrefix)
+    return !evaluateParsedLogicalContainerCondition(
+      trimmed.slice(notPrefix[0].length),
+      width,
+      remSize,
+      inlineSize,
+    );
   return evaluateContainerSizeConstraints(trimmed, width, remSize, inlineSize);
 }
 
@@ -105,7 +125,11 @@ function parseContainerCondition(conditionText: string): boolean {
   if (orParts.length > 1) return orParts.every(parseContainerCondition);
   const andParts = splitTopLevel(trimmed, 'and');
   if (andParts.length > 1) return andParts.every(parseContainerCondition);
-  if (/^not\b/i.test(trimmed)) return parseContainerCondition(trimmed.slice(3));
+  const notPrefix = /^not\s+/i.exec(trimmed);
+  if (notPrefix) {
+    const operand = trimmed.slice(notPrefix[0].length).trim();
+    return isWrappedByParentheses(operand) && parseContainerCondition(operand);
+  }
   return (
     containerSizeTermPattern.test(trimmed) ||
     featureFirstRangePattern.test(trimmed) ||

--- a/packages/components/src/_internal/text-direction-container.ts
+++ b/packages/components/src/_internal/text-direction-container.ts
@@ -82,13 +82,9 @@ function evaluateParsedLogicalContainerCondition(
       evaluateParsedLogicalContainerCondition(part, width, remSize, inlineSize),
     );
   const trimmed = conditionText.trim();
-  if (trimmed.startsWith('(') && trimmed.endsWith(')'))
-    return evaluateParsedLogicalContainerCondition(
-      trimmed.slice(1, -1),
-      width,
-      remSize,
-      inlineSize,
-    );
+  const unwrapped = unwrapRedundantParentheses(trimmed);
+  if (unwrapped !== trimmed)
+    return evaluateParsedLogicalContainerCondition(unwrapped, width, remSize, inlineSize);
   const notPrefix = /^not\s+/i.exec(trimmed);
   if (notPrefix)
     return !evaluateParsedLogicalContainerCondition(
@@ -119,8 +115,7 @@ export function isFullyParsedContainerCondition(conditionText: string): boolean 
 }
 
 function parseContainerCondition(conditionText: string): boolean {
-  let trimmed = conditionText.trim();
-  while (isWrappedByParentheses(trimmed)) trimmed = trimmed.slice(1, -1).trim();
+  const trimmed = unwrapRedundantParentheses(conditionText);
   const orParts = splitTopLevel(trimmed, 'or');
   if (orParts.length > 1) return orParts.every(parseContainerCondition);
   const andParts = splitTopLevel(trimmed, 'and');
@@ -128,7 +123,8 @@ function parseContainerCondition(conditionText: string): boolean {
   const notPrefix = /^not\s+/i.exec(trimmed);
   if (notPrefix) {
     const operand = trimmed.slice(notPrefix[0].length).trim();
-    return isWrappedByParentheses(operand) && parseContainerCondition(operand);
+    const unwrappedOperand = unwrapRedundantParentheses(operand);
+    return unwrappedOperand !== operand && parseContainerCondition(unwrappedOperand);
   }
   return (
     containerSizeTermPattern.test(trimmed) ||
@@ -149,15 +145,33 @@ function hasBalancedParentheses(conditionText: string): boolean {
   return depth === 0;
 }
 
-function isWrappedByParentheses(conditionText: string): boolean {
-  if (!conditionText.startsWith('(') || !conditionText.endsWith(')')) return false;
+function unwrapRedundantParentheses(conditionText: string): string {
+  const trimmed = conditionText.trim();
+  if (!trimmed.startsWith('(') || !trimmed.endsWith(')')) return trimmed;
+  const matchingClose = new Map<number, number>();
+  const openPositions: number[] = [];
   let depth = 0;
-  for (let index = 0; index < conditionText.length; index += 1) {
-    if (conditionText[index] === '(') depth += 1;
-    if (conditionText[index] === ')') depth -= 1;
-    if (depth === 0 && index < conditionText.length - 1) return false;
+  for (let index = 0; index < trimmed.length; index += 1) {
+    if (trimmed[index] === '(') {
+      openPositions.push(index);
+      depth += 1;
+    } else if (trimmed[index] === ')') {
+      const open = openPositions.pop();
+      if (open === undefined) return trimmed;
+      matchingClose.set(open, index);
+      depth -= 1;
+    }
   }
-  return depth === 0;
+  if (depth !== 0) return trimmed;
+  let start = 0;
+  let end = trimmed.length - 1;
+  while (start < end && matchingClose.get(start) === end) {
+    start += 1;
+    end -= 1;
+    while (/\s/.test(trimmed[start] ?? '')) start += 1;
+    while (/\s/.test(trimmed[end] ?? '')) end -= 1;
+  }
+  return start === 0 ? trimmed : trimmed.slice(start, end + 1).trim();
 }
 
 // True when the condition references a width/inline-size comparison whose

--- a/packages/components/src/_internal/text-direction-container.ts
+++ b/packages/components/src/_internal/text-direction-container.ts
@@ -114,17 +114,24 @@ export function isFullyParsedContainerCondition(conditionText: string): boolean 
   return parseContainerCondition(trimmed);
 }
 
-function parseContainerCondition(conditionText: string): boolean {
+function parseContainerCondition(conditionText: string, isTopLevelCondition = true): boolean {
   const original = conditionText.trim();
   const trimmed = unwrapRedundantParentheses(original);
   const wasGrouped = trimmed !== original;
   const orParts = splitTopLevel(trimmed, 'or');
   const andParts = splitTopLevel(trimmed, 'and');
   if (orParts.length > 1 && andParts.length > 1) return false;
-  if (orParts.length > 1) return orParts.every(parseContainerCondition);
-  if (andParts.length > 1) return andParts.every(parseContainerCondition);
+  if (orParts.length > 1) return orParts.every((part) => parseContainerCondition(part, false));
+  if (andParts.length > 1) return andParts.every((part) => parseContainerCondition(part, false));
   const notPrefix = /^not\s+/i.exec(trimmed);
   if (notPrefix) {
+    // `not <term>` only qualifies as an `and`/`or` operand when the whole
+    // negation is itself grouped in its own parentheses — e.g.
+    // `(not (...)) and (...)`. CSS's `<media-and>`/`<media-or>` require every
+    // operand to be `<media-in-parens>`, and a bare `<media-not>` doesn't
+    // satisfy that; only a standalone top-level `not` may skip the extra
+    // grouping.
+    if (!isTopLevelCondition && !wasGrouped) return false;
     const operand = trimmed.slice(notPrefix[0].length).trim();
     const unwrappedOperand = unwrapRedundantParentheses(operand);
     return unwrappedOperand !== operand && parseContainerCondition(operand);

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -163,6 +163,27 @@ function isConditionalRuleActive(
   return true;
 }
 
+// `CSSContainerRule.conditionText` serializes the container name ahead of
+// the query for a named rule — e.g. `@container sidebar (min-width: 20rem)`
+// reads back as `"sidebar (min-width: 20rem)"`, not just the query. The
+// grammar this module validates only understands the query itself, so the
+// name prefix must be removed before parsing: prefer the standard
+// `containerQuery` accessor (already name-free), falling back to stripping
+// the known container name token when that accessor is unavailable.
+function resolveContainerQueryText(
+  conditionText: string,
+  rule: CSSRule,
+  containerName: unknown,
+): string {
+  const containerQuery = Reflect.get(rule, 'containerQuery');
+  if (typeof containerQuery === 'string' && containerQuery) return containerQuery;
+  if (typeof containerName !== 'string' || !containerName) return conditionText;
+  if (!conditionText.startsWith(containerName)) return conditionText;
+  const rest = conditionText.slice(containerName.length);
+  if (!/^\s/.test(rest)) return conditionText;
+  return rest.trimStart();
+}
+
 function isContainerQueryActive(
   conditionText: string,
   element: HTMLElement,
@@ -170,11 +191,11 @@ function isContainerQueryActive(
   getParentElement: ParentElementResolver,
 ): boolean {
   if (typeof getComputedStyle !== 'function') return false;
-  const styleQuery = parseStyleQuery(conditionText);
+  const containerName = Reflect.get(rule, 'containerName');
+  const queryText = resolveContainerQueryText(conditionText, rule, containerName);
+  const styleQuery = parseStyleQuery(queryText);
   if (styleQuery) {
-    const remainder = (
-      conditionText.slice(0, styleQuery.index) + conditionText.slice(styleQuery.end)
-    )
+    const remainder = (queryText.slice(0, styleQuery.index) + queryText.slice(styleQuery.end))
       .replace(/^\s*(?:and|or|not)\b/i, '')
       .replace(/^\(|\)$/g, '')
       .trim();
@@ -184,7 +205,6 @@ function isContainerQueryActive(
     // style() term, which would wrongly treat an inactive compound rule as
     // an active styling hint.
     if (remainder) return false;
-    const containerName = Reflect.get(rule, 'containerName');
     let ancestor = getParentElement(element);
     while (ancestor) {
       if (typeof containerName === 'string' && containerName) {
@@ -202,16 +222,15 @@ function isContainerQueryActive(
       const value =
         getComputedStyle(ancestor).getPropertyValue(styleQuery.name).trim() ||
         ancestor.style.getPropertyValue(styleQuery.name).trim();
-      return /^\s*not\b/i.test(conditionText)
+      return /^\s*not\b/i.test(queryText)
         ? value !== styleQuery.value.trim()
         : value === styleQuery.value.trim();
     }
     return false;
   }
-  const containerName = Reflect.get(rule, 'containerName');
   const queriesPhysicalWidth =
-    /(?:^|[\s(])(?:width|min-width|max-width)\s*[:<>=]/i.test(conditionText) ||
-    /[\d.]+(?:px|rem)\s*(?:<=|<|>=|>)\s*width\b/i.test(conditionText);
+    /(?:^|[\s(])(?:width|min-width|max-width)\s*[:<>=]/i.test(queryText) ||
+    /[\d.]+(?:px|rem)\s*(?:<=|<|>=|>)\s*width\b/i.test(queryText);
   let container = getParentElement(element);
   while (container) {
     const computedStyle = getComputedStyle(container);
@@ -270,7 +289,7 @@ function isContainerQueryActive(
     computedContainerStyle.getPropertyValue('writing-mode') ||
     container.style.writingMode ||
     container.style.getPropertyValue('writing-mode');
-  const usesInlineSize = /(?:inline-size|min-inline-size|max-inline-size)/i.test(conditionText);
+  const usesInlineSize = /(?:inline-size|min-inline-size|max-inline-size)/i.test(queryText);
   const isVerticalWritingMode = /^(?:vertical|sideways)-/i.test(writingMode);
   const verticalInlineAxis = usesInlineSize && isVerticalWritingMode;
   // `offsetWidth`/`offsetHeight` report the border-box size from layout,
@@ -346,8 +365,8 @@ function isContainerQueryActive(
   // — fail closed instead of silently defaulting to "matches" (an inactive
   // rule at the current size would otherwise be treated as an active
   // styling hint).
-  if (hasUnsupportedContainerSizeQuery(conditionText)) return false;
-  return evaluateLogicalContainerCondition(conditionText, width, remSize, inlineSize);
+  if (hasUnsupportedContainerSizeQuery(queryText)) return false;
+  return evaluateLogicalContainerCondition(queryText, width, remSize, inlineSize);
 }
 
 export function isContainerRule(rule: CSSRule): boolean {

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -170,13 +170,22 @@ function isConditionalRuleActive(
 // name prefix must be removed before parsing: prefer the standard
 // `containerQuery` accessor (already name-free), falling back to stripping
 // the known container name token when that accessor is unavailable.
+//
+// A name-only rule — `@container sidebar {}` — is valid CSS (verified
+// against real browser behavior: Chromium parses it into a CSSContainerRule
+// and matches it whenever a same-named queryable container exists) and its
+// `containerQuery` legitimately reads back as `''`, not "unsupported".
+// Checking `typeof containerQuery === 'string'` (not truthiness) trusts
+// that empty string instead of falling through to the name-stripping
+// fallback, which would otherwise hand the bare container name to the
+// query grammar below as if it were a condition.
 function resolveContainerQueryText(
   conditionText: string,
   rule: CSSRule,
   containerName: unknown,
 ): string {
   const containerQuery = Reflect.get(rule, 'containerQuery');
-  if (typeof containerQuery === 'string' && containerQuery) return containerQuery;
+  if (typeof containerQuery === 'string') return containerQuery;
   if (typeof containerName !== 'string' || !containerName) return conditionText;
   if (!conditionText.startsWith(containerName)) return conditionText;
   const rest = conditionText.slice(containerName.length);
@@ -193,6 +202,16 @@ function isContainerQueryActive(
   if (typeof getComputedStyle !== 'function') return false;
   const containerName = Reflect.get(rule, 'containerName');
   const queryText = resolveContainerQueryText(conditionText, rule, containerName);
+  // A container rule with no condition at all — a name-only rule, or (in
+  // legacy environments lacking `containerQuery`) a conditionText that was
+  // nothing but the name — has nothing here to evaluate. Real browsers
+  // treat a name-only rule as trivially matching once a same-named
+  // queryable container exists, but honoring that would mean treating
+  // container *existence alone*, with no actual condition, as an
+  // activation signal. This module deliberately requires a parsed
+  // condition before treating a rule as active; fail closed instead,
+  // same as every other unparsed or unsupported condition below.
+  if (!queryText.trim()) return false;
   const styleQuery = parseStyleQuery(queryText);
   if (styleQuery) {
     const remainder = (queryText.slice(0, styleQuery.index) + queryText.slice(styleQuery.end))

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -536,6 +536,36 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('fails closed for a malformed negated container query before applying direction', () => {
+    const container = document.createElement('section');
+    container.style.setProperty('container-type', 'inline-size');
+    Object.defineProperty(container, 'offsetWidth', { value: 400, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'malformed-negated-container-ltr';
+    container.appendChild(element);
+    document.body.appendChild(container);
+    const nestedRule = createStyleRule({
+      selectorText: '.malformed-negated-container-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText:
+        '@container not min-width: 20px { .malformed-negated-container-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: 'not min-width: 20px',
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('rtl');
+    } finally {
+      container.remove();
+    }
+  });
+
   test('uses an active style container query direction rule', () => {
     const wrapper = document.createElement('section');
     wrapper.style.setProperty('--example', 'true');

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -115,6 +115,10 @@ describe('resolveTextDirection', () => {
       ['foo(width >= 20px)', false],
       ['(min-width: 20px) and (unknown-feature: 1px)', false],
       ['(min-width: 1.2.3px)', false],
+      ['min-width: 20px', false],
+      ['min-width: 20px and max-width: 40px', false],
+      ['(min-width: 20px) and (max-width: 40px) or (width: 100px)', false],
+      ['(20px < width > 40px)', false],
     ];
     for (const [condition, expected] of cases) {
       expect(isFullyParsedContainerCondition(condition), condition).toBe(expected);
@@ -130,6 +134,16 @@ describe('resolveTextDirection', () => {
     expect(evaluateLogicalContainerCondition('not (min-width: 20px)', 30, 16, 30)).toBe(false);
     expect(evaluateLogicalContainerCondition('not min-width: 20px', 10, 16, 10)).toBe(false);
     expect(evaluateLogicalContainerCondition('not(width >= 20px)', 10, 16, 10)).toBe(false);
+    expect(evaluateLogicalContainerCondition('min-width: 20px', 30, 16, 30)).toBe(false);
+    expect(
+      evaluateLogicalContainerCondition(
+        '(min-width: 20px) and (max-width: 40px) or (width: 100px)',
+        30,
+        16,
+        30,
+      ),
+    ).toBe(false);
+    expect(evaluateLogicalContainerCondition('(20px < width > 40px)', 50, 16, 50)).toBe(false);
   });
 
   test('only treats unknown CSS rules with container at-rule text as container rules', () => {

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -108,6 +108,8 @@ describe('resolveTextDirection', () => {
       ['(min-width: 20px) or (max-width: 40rem)', true],
       ['not (min-width: 20px)', true],
       ['not ((min-width: 20px) or (max-width: 40rem))', true],
+      ['not min-width: 20px', false],
+      ['not(width >= 20px)', false],
       ['(min-width: 20px) unexpected', false],
       ['(width >= 20px) xor (width <= 40px)', false],
       ['foo(width >= 20px)', false],
@@ -126,6 +128,8 @@ describe('resolveTextDirection', () => {
     expect(evaluateLogicalContainerCondition(condition, 15, 16, 15)).toBe(true);
     expect(evaluateLogicalContainerCondition('not (min-width: 20px)', 10, 16, 10)).toBe(true);
     expect(evaluateLogicalContainerCondition('not (min-width: 20px)', 30, 16, 30)).toBe(false);
+    expect(evaluateLogicalContainerCondition('not min-width: 20px', 10, 16, 10)).toBe(false);
+    expect(evaluateLogicalContainerCondition('not(width >= 20px)', 10, 16, 10)).toBe(false);
   });
 
   test('only treats unknown CSS rules with container at-rule text as container rules', () => {

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -2,7 +2,10 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
-import { isFullyParsedContainerCondition } from './text-direction-container.ts';
+import {
+  evaluateLogicalContainerCondition,
+  isFullyParsedContainerCondition,
+} from './text-direction-container.ts';
 import {
   elementDirectionStyleOverride,
   isContainerRule,
@@ -104,6 +107,7 @@ describe('resolveTextDirection', () => {
       ['(min-width: 20px) and (max-width: 40rem)', true],
       ['(min-width: 20px) or (max-width: 40rem)', true],
       ['not (min-width: 20px)', true],
+      ['not ((min-width: 20px) or (max-width: 40rem))', true],
       ['(min-width: 20px) unexpected', false],
       ['(width >= 20px) xor (width <= 40px)', false],
       ['foo(width >= 20px)', false],
@@ -113,6 +117,15 @@ describe('resolveTextDirection', () => {
     for (const [condition, expected] of cases) {
       expect(isFullyParsedContainerCondition(condition), condition).toBe(expected);
     }
+  });
+
+  test('evaluates grouped NOT over OR without treating it as an implicit conjunction', () => {
+    const condition = 'not ((min-width: 20px) or (max-width: 10px))';
+    expect(evaluateLogicalContainerCondition(condition, 5, 16, 5)).toBe(false);
+    expect(evaluateLogicalContainerCondition(condition, 30, 16, 30)).toBe(false);
+    expect(evaluateLogicalContainerCondition(condition, 15, 16, 15)).toBe(true);
+    expect(evaluateLogicalContainerCondition('not (min-width: 20px)', 10, 16, 10)).toBe(true);
+    expect(evaluateLogicalContainerCondition('not (min-width: 20px)', 30, 16, 30)).toBe(false);
   });
 
   test('only treats unknown CSS rules with container at-rule text as container rules', () => {

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 
 import { setupHappyDom } from '../test/happy-dom.ts';
+import { isFullyParsedContainerCondition } from './text-direction-container.ts';
 import {
   elementDirectionStyleOverride,
   isContainerRule,
@@ -93,6 +94,27 @@ function createStyleSheetWithThrowingRules(): CSSStyleSheet {
 }
 
 describe('resolveTextDirection', () => {
+  test('fails closed when a container condition contains unparsed syntax', () => {
+    const cases: [string, boolean][] = [
+      ['(min-width: 20px)', true],
+      ['(max-inline-size: 40rem)', true],
+      ['(width: 20px)', true],
+      ['(inline-size >= 20rem)', true],
+      ['(20rem <= width <= 40rem)', true],
+      ['(min-width: 20px) and (max-width: 40rem)', true],
+      ['(min-width: 20px) or (max-width: 40rem)', true],
+      ['not (min-width: 20px)', true],
+      ['(min-width: 20px) unexpected', false],
+      ['(width >= 20px) xor (width <= 40px)', false],
+      ['foo(width >= 20px)', false],
+      ['(min-width: 20px) and (unknown-feature: 1px)', false],
+      ['(min-width: 1.2.3px)', false],
+    ];
+    for (const [condition, expected] of cases) {
+      expect(isFullyParsedContainerCondition(condition), condition).toBe(expected);
+    }
+  });
+
   test('only treats unknown CSS rules with container at-rule text as container rules', () => {
     const unknownRule = { cssText: '@unknown (min-width: 1px) {}', type: 0 } as unknown as CSSRule;
     const containerRule = {

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -119,6 +119,9 @@ describe('resolveTextDirection', () => {
       ['min-width: 20px and max-width: 40px', false],
       ['(min-width: 20px) and (max-width: 40px) or (width: 100px)', false],
       ['(20px < width > 40px)', false],
+      ['not (min-width: 20px) and (max-width: 40rem)', false],
+      ['not (min-width: 20px) or (max-width: 40rem)', false],
+      ['(not (min-width: 20px)) and (max-width: 40rem)', true],
     ];
     for (const [condition, expected] of cases) {
       expect(isFullyParsedContainerCondition(condition), condition).toBe(expected);
@@ -144,6 +147,21 @@ describe('resolveTextDirection', () => {
       ),
     ).toBe(false);
     expect(evaluateLogicalContainerCondition('(20px < width > 40px)', 50, 16, 50)).toBe(false);
+  });
+
+  test('fails closed on an ungrouped NOT combined with AND/OR', () => {
+    // `not (min-width: 20px) and (max-width: 40px)` is not valid CSS grammar
+    // — `<media-and>` requires each operand to be `<media-in-parens>`, and a
+    // bare `<media-not>` doesn't qualify without its own wrapping parens.
+    // Without the fix this evaluated as `NOT(width >= 20px) AND (width <=
+    // 40px)`, wrongly activating below 20px instead of failing closed.
+    const ungrouped = 'not (min-width: 20px) and (max-width: 40px)';
+    expect(evaluateLogicalContainerCondition(ungrouped, 10, 16, 10)).toBe(false);
+    expect(evaluateLogicalContainerCondition(ungrouped, 30, 16, 30)).toBe(false);
+    // The grouped equivalent remains valid and evaluates normally.
+    const grouped = '(not (min-width: 20px)) and (max-width: 40px)';
+    expect(evaluateLogicalContainerCondition(grouped, 10, 16, 10)).toBe(true);
+    expect(evaluateLogicalContainerCondition(grouped, 30, 16, 30)).toBe(false);
   });
 
   test('only treats unknown CSS rules with container at-rule text as container rules', () => {
@@ -1071,6 +1089,78 @@ describe('resolveTextDirection', () => {
       cssText: '@container sidebar style(--theme: dark) { .named-style-ltr { direction: ltr; } }',
       type: 0,
       conditionText: 'style(--theme: dark)',
+      containerName: 'sidebar',
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      namedContainer.remove();
+    }
+  });
+
+  test('strips a real CSSContainerRule.conditionText container-name prefix for named size queries', () => {
+    // A real `CSSContainerRule.conditionText` for a named rule serializes the
+    // container name ahead of the query — `@container sidebar (min-width:
+    // 20rem)` reads back as `"sidebar (min-width: 20rem)"`, not just the
+    // query. The size-query grammar only understands the query itself, so
+    // without stripping the name this must not silently fail closed.
+    const container = document.createElement('section');
+    container.style.setProperty('container-type', 'inline-size');
+    container.style.setProperty('container-name', 'sidebar');
+    Object.defineProperty(container, 'offsetWidth', { value: 400, configurable: true });
+    const wrapper = document.createElement('div');
+    wrapper.style.setProperty('container-type', 'inline-size');
+    Object.defineProperty(wrapper, 'offsetWidth', { value: 100, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'real-named-container-ltr';
+    wrapper.appendChild(element);
+    container.appendChild(wrapper);
+    document.body.appendChild(container);
+    const nestedRule = createStyleRule({
+      selectorText: '.real-named-container-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText:
+        '@container sidebar (min-width: 20rem) { .real-named-container-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: 'sidebar (min-width: 20rem)',
+      containerName: 'sidebar',
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      container.remove();
+    }
+  });
+
+  test('strips a real CSSContainerRule.conditionText container-name prefix for named style queries', () => {
+    const namedContainer = document.createElement('section');
+    namedContainer.style.setProperty('container-name', 'sidebar');
+    namedContainer.style.setProperty('--theme', 'dark');
+    const nearerContainer = document.createElement('div');
+    nearerContainer.style.setProperty('--theme', 'light');
+    const element = document.createElement('div');
+    element.className = 'real-named-style-ltr';
+    nearerContainer.appendChild(element);
+    namedContainer.appendChild(nearerContainer);
+    document.body.appendChild(namedContainer);
+    const nestedRule = createStyleRule({ selectorText: '.real-named-style-ltr', direction: 'ltr' });
+    const outerRule = {
+      cssText:
+        '@container sidebar style(--theme: dark) { .real-named-style-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: 'sidebar style(--theme: dark)',
       containerName: 'sidebar',
       cssRules: [nestedRule],
     } as unknown as CSSRule;

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -1175,6 +1175,45 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('fails closed for a name-only container rule with an empty containerQuery', () => {
+    // `@container sidebar {}` — a name with no condition — is valid CSS:
+    // verified against real Chromium, it parses into a CSSContainerRule
+    // whose `containerQuery` reads back as `''` (not undefined) and which
+    // matches whenever a same-named queryable container exists. This
+    // module doesn't reproduce that container-existence check on its own,
+    // so it must fail closed instead of treating the bare container name
+    // as if it were parseable query syntax.
+    const container = document.createElement('section');
+    container.style.setProperty('container-type', 'inline-size');
+    container.style.setProperty('container-name', 'sidebar');
+    Object.defineProperty(container, 'offsetWidth', { value: 400, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'name-only-container-ltr';
+    container.appendChild(element);
+    document.body.appendChild(container);
+    const nestedRule = createStyleRule({
+      selectorText: '.name-only-container-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText: '@container sidebar { .name-only-container-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: 'sidebar',
+      containerName: 'sidebar',
+      containerQuery: '',
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('rtl');
+    } finally {
+      container.remove();
+    }
+  });
+
   test('uses composed shadow ancestry for named style containers', () => {
     const host = document.createElement('div');
     host.style.setProperty('container-name', 'sidebar');


### PR DESCRIPTION
Closes #1060

## Summary
- require container query conditions to be fully parsed before evaluation
- evaluate grouped unary `not` conditions recursively
- cover supported, malformed, partially parsed, and negated condition forms

## Validation
- focused text-direction and MegaMenu tests: 103 pass, 0 fail
- `bun run --filter=@lostgradient/cinder typecheck`
- targeted Oxlint and formatting checks
- `git diff --check`