### PR TITLE
Fix MegaMenu focus in shadow roots

### DIFF
--- a/.changeset/fix-mega-menu-shadow-focus.md
+++ b/.changeset/fix-mega-menu-shadow-focus.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Resolve MegaMenu keyboard focus targets from the component root so shadow-root navigation and focus restoration work correctly.

--- a/packages/components/src/components/mega-menu/mega-menu-content.svelte
+++ b/packages/components/src/components/mega-menu/mega-menu-content.svelte
@@ -12,6 +12,8 @@
     triggerId: (itemId: string) => string;
     submenuTriggerId: (itemId: string, submenuId: string) => string;
     submenuPanelId: (itemId: string, submenuId: string) => string;
+    elementById: <T extends HTMLElement = HTMLElement>(id: string) => T | null;
+    focusElementById: (id: string) => void;
     closeMenu: (restoreFocus?: boolean) => void;
   }
 
@@ -23,6 +25,8 @@
     triggerId,
     submenuTriggerId,
     submenuPanelId,
+    elementById,
+    focusElementById,
     closeMenu,
   }: Props = $props();
 
@@ -42,13 +46,13 @@
     const target = item.submenu[bounded];
     if (!target) return;
     openSubmenuId = target.id;
-    document.getElementById(submenuTriggerId(item.id, target.id))?.focus();
+    focusElementById(submenuTriggerId(item.id, target.id));
   }
 
   async function focusSubmenuPanel(submenuId: string) {
     if (typeof document === 'undefined') return;
     await tick();
-    const panel = document.getElementById(submenuPanelId(item.id, submenuId));
+    const panel = elementById(submenuPanelId(item.id, submenuId));
     if (!(panel instanceof HTMLElement)) return;
     const firstFocusable = panel.querySelector<HTMLElement>('a[href], button:not([disabled])');
     (firstFocusable ?? panel).focus();
@@ -94,7 +98,7 @@
     }
     if (event.key === horizontalKeys.return) {
       event.preventDefault();
-      document.getElementById(triggerId(item.id))?.focus();
+      focusElementById(triggerId(item.id));
       return;
     }
 
@@ -138,7 +142,7 @@
     if (event.key === submenuHorizontalKeys().return && openSubmenu) {
       event.preventDefault();
       event.stopPropagation();
-      document.getElementById(submenuTriggerId(item.id, openSubmenu.id))?.focus();
+      focusElementById(submenuTriggerId(item.id, openSubmenu.id));
       return;
     }
     if (event.key === 'Escape') {

--- a/packages/components/src/components/mega-menu/mega-menu.svelte
+++ b/packages/components/src/components/mega-menu/mega-menu.svelte
@@ -173,6 +173,26 @@
     return `cinder-mega-menu-${instanceId}-submenu-panel-${normalizedItem}-${normalizedSubmenu}-${stableHash(`${itemId}:${submenuId}`)}`;
   }
 
+  type MenuRoot = Pick<Document, 'activeElement' | 'getElementById'>;
+
+  function menuRoot(): MenuRoot | null {
+    const root = navElement?.getRootNode();
+    if (!root || !('activeElement' in root) || !('getElementById' in root)) return null;
+    return root as MenuRoot;
+  }
+
+  function elementById<T extends HTMLElement = HTMLElement>(id: string): T | null {
+    return menuRoot()?.getElementById(id) as T | null;
+  }
+
+  function focusElementById(id: string) {
+    elementById(id)?.focus();
+  }
+
+  function activeElement(): Element | null {
+    return menuRoot()?.activeElement ?? null;
+  }
+
   function updateIndicator() {
     if (!indicatorVisible || !navElement || !openItemId) {
       indicatorStyle = '';
@@ -205,14 +225,14 @@
       restoreFocus &&
       currentItemId !== null &&
       typeof document !== 'undefined' &&
-      navElement?.contains(document.activeElement);
+      navElement?.contains(activeElement());
 
     openItemId = null;
     previousOpenIndex = null;
 
     if (shouldRestoreFocus && currentItemId) {
       void tick().then(() => {
-        document.getElementById(triggerId(currentItemId))?.focus();
+        focusElementById(triggerId(currentItemId));
       });
     }
   }
@@ -221,7 +241,7 @@
     const bounded = ((index % items.length) + items.length) % items.length;
     const target = items[bounded];
     if (!target || typeof document === 'undefined') return;
-    document.getElementById(triggerId(target.id))?.focus();
+    focusElementById(triggerId(target.id));
   }
 
   function onTriggerClick(index: number) {
@@ -252,7 +272,7 @@
   async function focusPanelContent(itemId: string) {
     if (typeof document === 'undefined') return;
     await tick();
-    const panel = document.getElementById(contentId(itemId));
+    const panel = elementById(contentId(itemId));
     if (!(panel instanceof HTMLElement)) return;
     const firstFocusable = panel.querySelector<HTMLElement>(
       'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])',
@@ -438,6 +458,8 @@
           {triggerId}
           {submenuTriggerId}
           {submenuPanelId}
+          {elementById}
+          {focusElementById}
           {closeMenu}
         />
       {/key}

--- a/packages/components/src/components/mega-menu/mega-menu.svelte
+++ b/packages/components/src/components/mega-menu/mega-menu.svelte
@@ -173,16 +173,26 @@
     return `cinder-mega-menu-${instanceId}-submenu-panel-${normalizedItem}-${normalizedSubmenu}-${stableHash(`${itemId}:${submenuId}`)}`;
   }
 
-  type MenuRoot = Pick<Document, 'activeElement' | 'getElementById'>;
+  type MenuRoot = Pick<Document, 'activeElement'> & Pick<ParentNode, 'querySelector'>;
 
   function menuRoot(): MenuRoot | null {
     const root = navElement?.getRootNode();
-    if (!root || !('activeElement' in root) || !('getElementById' in root)) return null;
+    if (!root || !('activeElement' in root) || !('querySelector' in root)) return null;
     return root as MenuRoot;
   }
 
+  function escapeIdForSelector(id: string): string {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') return CSS.escape(id);
+    return id
+      .replaceAll('\\', '\\\\')
+      .replaceAll('"', '\\"')
+      .replaceAll('\n', '\\a ')
+      .replaceAll('\r', '\\d ')
+      .replaceAll('\f', '\\c ');
+  }
+
   function elementById<T extends HTMLElement = HTMLElement>(id: string): T | null {
-    return menuRoot()?.getElementById(id) as T | null;
+    return menuRoot()?.querySelector<T>(`[id="${escapeIdForSelector(id)}"]`) ?? null;
   }
 
   function focusElementById(id: string) {

--- a/packages/components/src/components/mega-menu/mega-menu.test.ts
+++ b/packages/components/src/components/mega-menu/mega-menu.test.ts
@@ -66,7 +66,7 @@ const items = [
 ];
 
 describe('MegaMenu', () => {
-  function getTriggerByLabel(container: HTMLElement, label: string): HTMLButtonElement {
+  function getTriggerByLabel(container: ParentNode, label: string): HTMLButtonElement {
     const triggers = Array.from(
       container.querySelectorAll<HTMLButtonElement>('.cinder-mega-menu__trigger'),
     );
@@ -192,6 +192,54 @@ describe('MegaMenu', () => {
     first.focus();
     await fireEvent.keyDown(first, { key: 'ArrowRight' });
     expect(document.activeElement).toBe(second);
+  });
+
+  test('shadow-root keyboard navigation resolves focus targets inside the component root', async () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    document.body.append(host);
+    const view = render(MegaMenu, { target: shadow, props: { items } });
+
+    try {
+      const products = getTriggerByLabel(shadow, 'Products');
+      const resources = getTriggerByLabel(shadow, 'Resources');
+      products.focus();
+      await fireEvent.keyDown(products, { key: 'ArrowRight' });
+      expect(shadow.activeElement).toBe(resources);
+
+      products.focus();
+      await fireEvent.keyDown(products, { key: 'ArrowDown' });
+      const uiKit = shadow.querySelector<HTMLAnchorElement>('a[href="/ui"]');
+      expect(shadow.activeElement).toBe(uiKit);
+
+      const frontend = Array.from(
+        shadow.querySelectorAll<HTMLButtonElement>('.cinder-mega-menu__submenu-trigger'),
+      ).find((trigger) => trigger.textContent?.trim() === 'Frontend');
+      const backend = Array.from(
+        shadow.querySelectorAll<HTMLButtonElement>('.cinder-mega-menu__submenu-trigger'),
+      ).find((trigger) => trigger.textContent?.trim() === 'Backend');
+      if (!frontend || !backend) throw new Error('Missing nested submenu triggers.');
+
+      frontend.focus();
+      await fireEvent.keyDown(frontend, { key: 'ArrowDown' });
+      expect(shadow.activeElement).toBe(backend);
+
+      await fireEvent.keyDown(backend, { key: 'ArrowRight' });
+      const apis = shadow.querySelector<HTMLAnchorElement>('a[href="/apis"]');
+      expect(shadow.activeElement).toBe(apis);
+
+      if (!apis) throw new Error('Missing nested submenu link.');
+      await fireEvent.keyDown(apis, { key: 'ArrowLeft' });
+      expect(shadow.activeElement).toBe(backend);
+
+      await fireEvent.keyDown(backend, { key: 'Escape' });
+      await Promise.resolve();
+      expect(shadow.querySelector('.cinder-mega-menu__content')).toBeNull();
+      expect(shadow.activeElement).toBe(products);
+    } finally {
+      view.unmount();
+      host.remove();
+    }
   });
 
   test('arrow keys enter, traverse, and leave a nested submenu', async () => {

--- a/packages/components/src/components/mega-menu/mega-menu.test.ts
+++ b/packages/components/src/components/mega-menu/mega-menu.test.ts
@@ -210,6 +210,7 @@ describe('MegaMenu', () => {
       products.focus();
       await fireEvent.keyDown(products, { key: 'ArrowDown' });
       const uiKit = shadow.querySelector<HTMLAnchorElement>('a[href="/ui"]');
+      if (!uiKit) throw new Error('Missing panel link.');
       expect(shadow.activeElement).toBe(uiKit);
 
       const frontend = Array.from(
@@ -226,9 +227,9 @@ describe('MegaMenu', () => {
 
       await fireEvent.keyDown(backend, { key: 'ArrowRight' });
       const apis = shadow.querySelector<HTMLAnchorElement>('a[href="/apis"]');
+      if (!apis) throw new Error('Missing nested submenu link.');
       expect(shadow.activeElement).toBe(apis);
 
-      if (!apis) throw new Error('Missing nested submenu link.');
       await fireEvent.keyDown(apis, { key: 'ArrowLeft' });
       expect(shadow.activeElement).toBe(backend);
 

--- a/packages/testing/tests/mega-menu.playwright.ts
+++ b/packages/testing/tests/mega-menu.playwright.ts
@@ -65,6 +65,44 @@ test('nested submenu keyboard navigation enters, traverses, and exits', async ({
   await expect(page.locator('.cinder-mega-menu__content')).toHaveCount(0);
 });
 
+test('nested submenu keyboard navigation stays scoped inside a shadow root', async ({
+  componentPage,
+}) => {
+  const page = await componentPage.open({
+    entry: megaMenuEntry,
+    theme: 'light',
+    viewport: desktop,
+  });
+
+  await page.locator('.cinder-mega-menu').evaluate((menu) => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    document.body.append(host);
+    shadow.append(menu);
+  });
+
+  const products = page.getByRole('button', { name: 'Products' });
+  await products.focus();
+  await products.press('ArrowDown');
+  await expect(page.getByRole('link', { name: 'Components' })).toBeFocused();
+
+  await page.getByRole('link', { name: 'Components' }).press('Tab');
+  await page.getByRole('link', { name: 'Design tokens' }).press('Tab');
+  const frontend = page.getByRole('button', { name: 'Frontend' });
+  await expect(frontend).toBeFocused();
+  await frontend.press('ArrowDown');
+  const backend = page.getByRole('button', { name: 'Backend' });
+  await expect(backend).toBeFocused();
+  await backend.press('ArrowRight');
+  const apis = page.getByRole('link', { name: 'APIs' });
+  await expect(apis).toBeFocused();
+  await apis.press('ArrowLeft');
+  await expect(backend).toBeFocused();
+  await backend.press('Escape');
+  await expect(products).toBeFocused();
+  await expect(page.locator('.cinder-mega-menu__content')).toHaveCount(0);
+});
+
 test('mobile submenu layout preserves lateral navigation without overflowing', async ({
   componentPage,
 }) => {


### PR DESCRIPTION
Closes #1061

## Summary
- resolve MegaMenu focus targets from the component root instead of `document`
- use the root-scoped active element for Escape focus restoration
- cover trigger, panel, nested submenu, return, and restore-focus behavior inside a shadow root
- include a patch changeset

## Validation
- focused text-direction and MegaMenu tests: 102 pass, 0 fail
- MegaMenu Playwright: 3 passed
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder lint:invariants`
- targeted Prettier check
- `git diff --check`