### PR TITLE
fix: compose autocomplete from Input

### DIFF
--- a/.changeset/composed-autocomplete-input.md
+++ b/.changeset/composed-autocomplete-input.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Compose Autocomplete's editable control from the Input primitive.

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -5,7 +5,6 @@
 export const allowedRawControlCounts = new Map<string, number>([
   ['_radio/radio.svelte', 1],
   ['approval-card/approval-card-actions.svelte', 2],
-  ['autocomplete/autocomplete.svelte', 1],
   ['checkbox/checkbox.svelte', 1],
   ['combobox/combobox.svelte', 1],
   ['command-palette/command-palette.svelte', 1],

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -148,7 +148,6 @@ allowedFloatingCounts.set('styles/components/experimental/popover.css', 4);
 export const allowedFieldWrapperCounts = new Map<string, number>(
   [
     '_radio/radio.svelte',
-    'autocomplete/autocomplete.svelte',
     'checkbox/checkbox.svelte',
     'combobox/combobox.svelte',
     'date-picker/date-picker.svelte',

--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -5,30 +5,6 @@
     gap: var(--cinder-space-2);
   }
 
-  .cinder-autocomplete__label {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--cinder-space-1);
-    color: var(--cinder-text);
-    font-size: var(--cinder-text-sm);
-    font-weight: var(--cinder-font-medium);
-  }
-
-  .cinder-autocomplete__description,
-  .cinder-autocomplete__error {
-    margin: 0;
-    font-size: var(--cinder-text-sm);
-    line-height: var(--cinder-leading-normal);
-  }
-
-  .cinder-autocomplete__description {
-    color: var(--cinder-text-muted);
-  }
-
-  .cinder-autocomplete__error {
-    color: var(--cinder-danger);
-  }
-
   .cinder-autocomplete__panel {
     padding: var(--cinder-space-1);
   }

--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -1,4 +1,5 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../input/input.css';
 @layer cinder.components {
   .cinder-autocomplete {
     display: grid;

--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -14,30 +14,6 @@
     font-weight: var(--cinder-font-medium);
   }
 
-  .cinder-autocomplete__input {
-    width: 100%;
-    min-height: 2.5rem;
-    padding: 0.625rem 0.75rem;
-    border: 1px solid var(--cinder-border);
-    border-radius: var(--cinder-radius-md);
-    background: var(--cinder-surface-raised);
-    color: var(--cinder-text);
-    font: inherit;
-  }
-
-  .cinder-autocomplete__input:focus-visible {
-    outline: var(--cinder-ring-width) solid transparent;
-    box-shadow: var(--_cinder-focus-ring-shadow);
-  }
-
-  @media (forced-colors: active) {
-    .cinder-autocomplete__input:focus-visible {
-      outline: var(--cinder-ring-width) solid ButtonText;
-      outline-offset: 3px;
-      box-shadow: none;
-    }
-  }
-
   .cinder-autocomplete__description,
   .cinder-autocomplete__error {
     margin: 0;

--- a/packages/components/src/components/autocomplete/autocomplete.svelte
+++ b/packages/components/src/components/autocomplete/autocomplete.svelte
@@ -26,6 +26,7 @@
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import Input from '../input/input.svelte';
   import Popover from '../popover/popover.svelte';
   import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
 
@@ -350,6 +351,13 @@
     oninput?.(target.value);
   }
 
+  function attachInput(node: HTMLInputElement): () => void {
+    inputElement = node;
+    return () => {
+      if (inputElement === node) inputElement = null;
+    };
+  }
+
   function handleFocus(): void {
     autocompleteDismissed = false;
     inputFocused = true;
@@ -444,14 +452,14 @@
     </label>
   {/if}
 
-  <input
-    bind:this={inputElement}
+  <Input
     {...rest}
     id={resolvedId}
     type="text"
     class="cinder-autocomplete__input"
-    {value}
+    bind:value
     {placeholder}
+    inputAttachment={attachInput}
     disabled={field.disabled}
     required={field.required}
     {readonly}

--- a/packages/components/src/components/autocomplete/autocomplete.svelte
+++ b/packages/components/src/components/autocomplete/autocomplete.svelte
@@ -21,6 +21,7 @@
 
 <script lang="ts">
   import type { AutocompleteProps, AutocompleteSuggestion } from './autocomplete.types.ts';
+  import type { InputProps } from '../input/input.types.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import { resolveFieldControl } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
@@ -74,13 +75,12 @@
   const listboxId = $derived(`${resolvedId}-listbox`);
   const resolvedMinQueryLength = $derived(toNonNegativeInteger(minQueryLength, 1));
   const resolvedMaxVisibleSuggestions = $derived(toNonNegativeInteger(maxVisibleSuggestions, 50));
-
-  $effect(() => {
-    if (context && id && context.controlId !== id) {
-      devWarn(
-        `[cinder/Autocomplete] id mismatch: Autocomplete id="${id}" but wrapping FormField expects controlId="${context.controlId}". Set the same id on both.`,
-      );
-    }
+  const inputFieldProperties = $derived.by(() => {
+    const properties: Partial<Pick<InputProps, 'label' | 'description' | 'error'>> = {};
+    if (label !== undefined) properties.label = label;
+    if (description !== undefined) properties.description = description;
+    if (error !== undefined) properties.error = error;
+    return properties;
   });
 
   let inputElement = $state<HTMLInputElement | null>(null);
@@ -439,25 +439,12 @@
   data-disabled={field.disabled ? '' : undefined}
   data-invalid={field.ariaInvalid === 'true' ? '' : undefined}
 >
-  {#if label}
-    <label
-      for={resolvedId}
-      class="cinder-autocomplete__label"
-      data-disabled={field.disabled || undefined}
-    >
-      {label}
-      {#if field.required}
-        <span class="cinder-_required-marker" aria-hidden="true">*</span>
-      {/if}
-    </label>
-  {/if}
-
   <Input
     {...rest}
     id={resolvedId}
     type="text"
-    class="cinder-autocomplete__input"
     bind:value
+    {...inputFieldProperties}
     {placeholder}
     inputAttachment={attachInput}
     disabled={field.disabled}
@@ -470,8 +457,8 @@
     aria-haspopup="listbox"
     aria-controls={open ? listboxId : undefined}
     aria-activedescendant={activeDescendant}
-    aria-invalid={field.ariaInvalid}
-    aria-describedby={field.describedBy}
+    aria-invalid={consumerInvalid}
+    aria-describedby={consumerDescribedBy}
     oninput={handleInput}
     onfocus={handleFocus}
     onblur={handleBlur}
@@ -483,14 +470,6 @@
       composing = false;
     }}
   />
-
-  {#if description}
-    <p id={field.ownDescriptionId} class="cinder-autocomplete__description">{description}</p>
-  {/if}
-
-  {#if error}
-    <p id={field.ownErrorId} class="cinder-autocomplete__error" aria-live="polite">{error}</p>
-  {/if}
 
   <!-- Persistent status announcer (loading / no-results), outside the portaled
        popover so screen readers reliably hear it. -->

--- a/packages/components/src/components/autocomplete/autocomplete.svelte
+++ b/packages/components/src/components/autocomplete/autocomplete.svelte
@@ -20,14 +20,13 @@
 </script>
 
 <script lang="ts">
+  import Input, { type InputProps } from '@lostgradient/cinder/input';
   import type { AutocompleteProps, AutocompleteSuggestion } from './autocomplete.types.ts';
-  import type { InputProps } from '../input/input.types.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import { resolveFieldControl } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { pushEscapeHandler } from '../../_internal/overlay.ts';
   import { classNames } from '../../utilities/class-names.ts';
-  import Input from '../input/input.svelte';
   import Popover from '../popover/popover.svelte';
   import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
 

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -68,6 +68,18 @@ describe('Autocomplete — rendering and ARIA', () => {
     expect(css).toContain("@import '../input/input.css';");
   });
 
+  test('imports the composed Input API through its public subpath', async () => {
+    const [componentSource, typesSource] = await Promise.all([
+      Bun.file(new URL('./autocomplete.svelte', import.meta.url)).text(),
+      Bun.file(new URL('./autocomplete.types.ts', import.meta.url)).text(),
+    ]);
+
+    expect(componentSource).toContain("from '@lostgradient/cinder/input';");
+    expect(typesSource).toContain("from '@lostgradient/cinder/input';");
+    expect(componentSource).not.toContain("from '../input/");
+    expect(typesSource).not.toContain("from '../input/");
+  });
+
   test('renders a combobox input with autocomplete=list semantics', () => {
     const { container } = render(Autocomplete, {
       props: {

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -75,6 +75,37 @@ describe('Autocomplete — rendering and ARIA', () => {
     expect(input.classList.contains('cinder-input')).toBe(true);
   });
 
+  test('delegates label, description, and error wiring to Input', () => {
+    const { container } = render(Autocomplete, {
+      props: {
+        id: 'owned-field',
+        label: 'Search records',
+        description: 'Type at least one character',
+        error: 'Choose a valid record',
+        suggestionSource: () => [],
+      },
+    });
+
+    const input = getInput(container);
+    const describedBy = input.getAttribute('aria-describedby')?.split(/\s+/) ?? [];
+
+    expect(container.querySelector('.cinder-input-field__label')?.getAttribute('for')).toBe(
+      'owned-field',
+    );
+    expect(container.querySelector('.cinder-input-field__description')?.textContent).toBe(
+      'Type at least one character',
+    );
+    expect(container.querySelector('.cinder-input-field__error')?.textContent).toBe(
+      'Choose a valid record',
+    );
+    expect(container.querySelector('.cinder-autocomplete__label')).toBeNull();
+    expect(container.querySelector('.cinder-autocomplete__description')).toBeNull();
+    expect(container.querySelector('.cinder-autocomplete__error')).toBeNull();
+    expect(describedBy).toContain('owned-field-description');
+    expect(describedBy).toContain('owned-field-error');
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+
   test('forwards consumer native class and style while keeping the Input primitive class', () => {
     const { container } = render(Autocomplete, {
       props: {
@@ -690,12 +721,12 @@ describe('Autocomplete — FormField context', () => {
     });
 
     const input = getInput(container);
-    // resolveFieldControl composes both the control-level and context-level error ids;
+    // Input composes both the control-level and context-level error ids;
     // the deduplication pass removes the context description that also appears in
-    // context.describedBy, so the final order is: description, control-error, field-error.
+    // context.describedBy, so the final order is: description, input-error, field-error.
     const describedBy = input.getAttribute('aria-describedby') ?? '';
     expect(describedBy).toContain('fruit-search-description');
-    expect(describedBy).toContain('fruit-search-control-error');
+    expect(describedBy).toContain('fruit-search-input-error');
     // The FormField's own (field-level) error id must also be composed in — assert it
     // explicitly so a future regression that drops it can't pass silently.
     expect(describedBy).toContain('fruit-search-error');

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -6,6 +6,12 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
+// Source-package tests do not resolve the package's self-reference through Bun's
+// export map. Keep the component on its public subpath while mapping that entry
+// to the source implementation for this focused test process.
+const inputModule = await import('../input/index.ts');
+mock.module('@lostgradient/cinder/input', () => inputModule);
+
 const { render, fireEvent, waitFor, cleanup } = await import('@testing-library/svelte');
 const { default: Autocomplete } = await import('./autocomplete.svelte');
 const { default: FormFieldAutocompleteFixture } =

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -57,6 +57,11 @@ afterEach(() => {
 });
 
 describe('Autocomplete — rendering and ARIA', () => {
+  test('sidecar imports the composed Input styles', async () => {
+    const css = await Bun.file(new URL('./autocomplete.css', import.meta.url)).text();
+    expect(css).toContain("@import '../input/input.css';");
+  });
+
   test('renders a combobox input with autocomplete=list semantics', () => {
     const { container } = render(Autocomplete, {
       props: {
@@ -167,21 +172,25 @@ describe('Autocomplete — rendering and ARIA', () => {
     expect(input.form).toBe(form);
     expect(input.name).toBe('query');
     expect(input.value).toBe('');
-    const serialized = new FormData();
-    serialized.set(input.name, input.value);
-    expect(serialized.get('query')).toBe('');
+    // happy-dom does not collect the nested Input control through
+    // `new FormData(form)`, so take a fresh snapshot from the exact native
+    // properties that browsers serialize for each assertion.
+    const serializeInput = () => {
+      const snapshot = new FormData();
+      snapshot.set(input.name, input.value);
+      return snapshot;
+    };
+    expect(serializeInput().get('query')).toBe('');
 
     await fireEvent.input(input, { target: { value: 'changed' } });
     expect(input.value).toBe('changed');
-    serialized.set(input.name, input.value);
-    expect(serialized.get('query')).toBe('changed');
+    expect(serializeInput().get('query')).toBe('changed');
 
     form.reset();
     await waitFor(() => {
       expect(input.value).toBe('');
     });
-    serialized.set(input.name, input.value);
-    expect(serialized.get('query')).toBe('');
+    expect(serializeInput().get('query')).toBe('');
   });
 });
 

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -102,6 +102,56 @@ describe('Autocomplete — rendering and ARIA', () => {
 
     expect(getInput(container).getAttribute('autocomplete')).toBe('street-address');
   });
+
+  test('forwards native name, autofocus, and readonly semantics', () => {
+    const { container } = render(Autocomplete, {
+      props: {
+        id: 'native-search',
+        name: 'query',
+        autofocus: true,
+        readonly: true,
+        suggestionSource: () => [],
+      },
+    });
+
+    const input = getInput(container);
+    expect(input.getAttribute('name')).toBe('query');
+    expect(input.hasAttribute('autofocus')).toBe(true);
+    expect(input.readOnly).toBe(true);
+  });
+
+  test('participates in form serialization and restores the native value on reset', async () => {
+    const form = document.createElement('form');
+    document.body.append(form);
+    const rendered = render(Autocomplete, {
+      target: form,
+      props: {
+        id: 'form-search',
+        name: 'query',
+        suggestionSource: () => [],
+      },
+    });
+
+    const input = getInput(rendered.container);
+    expect(input.form).toBe(form);
+    expect(input.name).toBe('query');
+    expect(input.value).toBe('');
+    const serialized = new FormData();
+    serialized.set(input.name, input.value);
+    expect(serialized.get('query')).toBe('');
+
+    await fireEvent.input(input, { target: { value: 'changed' } });
+    expect(input.value).toBe('changed');
+    serialized.set(input.name, input.value);
+    expect(serialized.get('query')).toBe('changed');
+
+    form.reset();
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+    serialized.set(input.name, input.value);
+    expect(serialized.get('query')).toBe('');
+  });
 });
 
 describe('Autocomplete — suggestions and free-form input', () => {

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -72,6 +72,23 @@ describe('Autocomplete — rendering and ARIA', () => {
     expect(input.getAttribute('aria-haspopup')).toBe('listbox');
     expect(input.getAttribute('aria-expanded')).toBe('false');
     expect(input.getAttribute('autocomplete')).toBe('off');
+    expect(input.classList.contains('cinder-input')).toBe(true);
+  });
+
+  test('forwards consumer native class and style while keeping the Input primitive class', () => {
+    const { container } = render(Autocomplete, {
+      props: {
+        id: 'styled-search',
+        class: 'custom-autocomplete',
+        style: 'accent-color: rebeccapurple',
+        suggestionSource: () => [],
+      },
+    });
+
+    const input = getInput(container);
+    expect(container.firstElementChild?.classList.contains('custom-autocomplete')).toBe(true);
+    expect(input.classList.contains('cinder-input')).toBe(true);
+    expect(input.getAttribute('style')).toContain('accent-color: rebeccapurple');
   });
 
   test('consumer autocomplete attribute wins over the default off value', () => {

--- a/packages/components/src/components/autocomplete/autocomplete.types.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.types.ts
@@ -1,4 +1,4 @@
-import type { InputProps } from '../input/input.types.ts';
+import type { InputProps } from '@lostgradient/cinder/input';
 
 export type AutocompleteSuggestion = {
   /** Text committed into the input when this suggestion is completed. */

--- a/packages/components/src/components/autocomplete/autocomplete.types.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.types.ts
@@ -1,4 +1,4 @@
-import type { HTMLInputAttributes } from 'svelte/elements';
+import type { InputProps } from '../input/input.types.ts';
 
 export type AutocompleteSuggestion = {
   /** Text committed into the input when this suggestion is completed. */
@@ -56,9 +56,23 @@ export type AutocompleteSchemaProps = {
 };
 
 export type AutocompleteProps = Omit<
-  HTMLInputAttributes,
+  InputProps,
+  | 'id'
   | 'type'
   | 'value'
+  | 'onValueChangeRequest'
+  | 'onValueChange'
+  | 'label'
+  | 'hideLabel'
+  | 'description'
+  | 'error'
+  | 'inputAttachment'
+  | 'leading'
+  | 'leadingInteractive'
+  | 'trailing'
+  | 'trailingInteractive'
+  | 'placeholder'
+  | 'class'
   | 'oninput'
   | 'onchange'
   | 'onkeydown'


### PR DESCRIPTION
Closes #1089

## Summary
- replace the Autocomplete raw native input with the Cinder Input primitive through its public component subpath
- preserve filtering, focus anchoring, ARIA, native input events, and form serialization/reset behavior
- forward native class, style, autocomplete, name, autofocus, and readonly semantics through Input
- include the composed Input CSS in the Autocomplete style sidecar
- remove duplicated input-frame CSS and the Autocomplete primitive-composition migration entries
- include the required patch changeset
- exact head 477f9b5262738f3a41d71456f51816fd7d1fa73d is based on main 9e45bc5007ca93190bbd068d5ef8e454e1113767

## Verification
- bun run --filter=@lostgradient/cinder test -- ./src/components/autocomplete/autocomplete.test.ts — 35 pass, 0 fail, 157 assertions
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder lint:invariants
- bun run typecheck
- bunx prettier --check on changed Autocomplete source and tests
- git diff --check
- pre-commit and pre-push checks
- independent review approved