### PR TITLE
fix: compose SearchField from Input

### DIFF
--- a/.changeset/search-field-input-composition.md
+++ b/.changeset/search-field-input-composition.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Compose SearchField with the shared Input control while preserving its search and clear behavior.

--- a/.changeset/search-field-input-composition.md
+++ b/.changeset/search-field-input-composition.md
@@ -2,4 +2,4 @@
 '@lostgradient/cinder': patch
 ---
 
-Compose SearchField with the shared Input control while preserving its search and clear behavior.
+Compose SearchField with the shared Input control while preserving its search, clear behavior, and interactive hit targets.

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -16,7 +16,6 @@ export const allowedRawControlCounts = new Map<string, number>([
   ['json-editor/json-editor.svelte', 1],
   ['multi-select/multi-select.svelte', 2],
   ['pin-input/pin-input.svelte', 1],
-  ['search-field/search-field.svelte', 1],
   ['select/select.svelte', 2],
   ['selection-popover/selection-popover.svelte', 1],
   ['table-row/table-row.svelte', 3],

--- a/packages/components/src/components/input/input.svelte
+++ b/packages/components/src/components/input/input.svelte
@@ -188,7 +188,10 @@
     >
       {#if leading}
         <span
-          class="cinder-input-group__leading cinder-_truncate"
+          class={classNames(
+            'cinder-input-group__leading',
+            !leadingInteractive && 'cinder-_truncate',
+          )}
           aria-hidden={leadingInteractive ? undefined : 'true'}>{@render leading()}</span
         >
       {/if}
@@ -197,7 +200,10 @@
 
       {#if trailing}
         <span
-          class="cinder-input-group__trailing cinder-_truncate"
+          class={classNames(
+            'cinder-input-group__trailing',
+            !trailingInteractive && 'cinder-_truncate',
+          )}
           aria-hidden={trailingInteractive ? undefined : 'true'}>{@render trailing()}</span
         >
       {:else if rendersNativeDateIcon}

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -584,6 +584,8 @@ describe('Input group (leading/trailing addons)', () => {
     const trailingSpan = container.querySelector('.cinder-input-group__trailing');
     expect(leadingSpan?.getAttribute('aria-hidden')).toBe('true');
     expect(trailingSpan?.getAttribute('aria-hidden')).toBe('true');
+    expect(leadingSpan?.classList.contains('cinder-_truncate')).toBe(true);
+    expect(trailingSpan?.classList.contains('cinder-_truncate')).toBe(true);
   });
 
   test('leadingInteractive=true omits aria-hidden on leading container', () => {
@@ -597,6 +599,7 @@ describe('Input group (leading/trailing addons)', () => {
     });
     const leadingSpan = container.querySelector('.cinder-input-group__leading');
     expect(leadingSpan?.hasAttribute('aria-hidden')).toBe(false);
+    expect(leadingSpan?.classList.contains('cinder-_truncate')).toBe(false);
   });
 
   test('trailingInteractive=true omits aria-hidden on trailing container', () => {
@@ -610,6 +613,7 @@ describe('Input group (leading/trailing addons)', () => {
     });
     const trailingSpan = container.querySelector('.cinder-input-group__trailing');
     expect(trailingSpan?.hasAttribute('aria-hidden')).toBe(false);
+    expect(trailingSpan?.classList.contains('cinder-_truncate')).toBe(false);
   });
 
   test('groupClassName applies to the grouped control frame', () => {

--- a/packages/components/src/components/search-field/search-field.a11y.md
+++ b/packages/components/src/components/search-field/search-field.a11y.md
@@ -31,9 +31,9 @@ If you want the shortcut announced to assistive technology, put it in the `FormF
 
 That way AT users hear the shortcut as part of the field's description on focus, and sighted users get the visual hint—neither audience hears it twice.
 
-## Error styling on the wrapper
+## Error styling on the Input group
 
-The wrapper carries `data-invalid` (mirrored from the input's `aria-invalid`) so the entire composite field—border, ring, focus state—reads as invalid. The `aria-invalid` attribute on the inner `<input>` is the source of truth for assistive technology; the `data-invalid` on the wrapper exists only to drive CSS for the surrounding chrome.
+The shared `Input` group carries `data-invalid` (mirrored from the input's `aria-invalid`) so the entire composite field—border, ring, focus state—reads as invalid. The `aria-invalid` attribute on the inner `<input>` is the source of truth for assistive technology; the group's `data-invalid` exists only to drive CSS for the surrounding chrome.
 
 ## Form-field integration
 

--- a/packages/components/src/components/search-field/search-field.css
+++ b/packages/components/src/components/search-field/search-field.css
@@ -1,4 +1,5 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../input/input.css';
 @layer cinder.components {
   /* ========================================
  * SEARCH FIELD

--- a/packages/components/src/components/search-field/search-field.css
+++ b/packages/components/src/components/search-field/search-field.css
@@ -5,52 +5,7 @@
  * ======================================== */
 
   .cinder-search-field {
-    display: inline-flex;
-    align-items: center;
     inline-size: 100%;
-    min-height: 2.25rem;
-    padding-inline: var(--cinder-space-2);
-    gap: var(--cinder-space-1-5);
-    background: var(--cinder-surface-raised);
-    border: 1px solid var(--cinder-border);
-    border-radius: var(--cinder-radius-md);
-    color: var(--cinder-text);
-    transition:
-      border-color var(--cinder-duration-fast) var(--cinder-ease-standard),
-      box-shadow var(--cinder-duration-fast) var(--cinder-ease-standard);
-  }
-
-  @media (hover: hover) {
-    .cinder-search-field:hover:not([data-disabled]) {
-      border-color: var(--cinder-border-strong);
-    }
-  }
-
-  .cinder-search-field:focus-within {
-    outline: var(--cinder-ring-width) solid transparent;
-    box-shadow:
-      0 0 0 var(--cinder-ring-offset) var(--cinder-ring-offset-color),
-      0 0 0 calc(var(--cinder-ring-offset) + var(--cinder-ring-width))
-        var(--_cinder-search-field-ring, var(--cinder-ring-color));
-  }
-
-  @media (forced-colors: active) {
-    .cinder-search-field:focus-within {
-      outline: var(--cinder-ring-width) solid Highlight;
-      outline-offset: 1px;
-    }
-  }
-
-  .cinder-search-field[data-invalid] {
-    --_cinder-search-field-ring: var(--cinder-danger);
-    border-color: var(--cinder-danger);
-  }
-
-  .cinder-search-field[data-disabled] {
-    background: var(--cinder-surface-inset);
-    border-color: var(--cinder-border-muted);
-    color: var(--cinder-text-disabled);
-    cursor: not-allowed;
   }
 
   /* ----------------------------------------
@@ -61,7 +16,6 @@
     display: inline-flex;
     align-items: center;
     flex: 0 0 auto;
-    color: var(--cinder-text-muted);
   }
 
   .cinder-search-field__icon {
@@ -69,46 +23,9 @@
     block-size: 1rem;
   }
 
-  /* ----------------------------------------
- * Input element
- * ---------------------------------------- */
-
-  .cinder-search-field__input {
-    flex: 1 1 auto;
-    min-inline-size: 0;
-    appearance: none;
-    border: none;
-    background: transparent;
-    padding-block: var(--cinder-space-1-5);
-    padding-inline: 0;
-    font-size: var(--cinder-text-sm);
-    font-family: inherit;
-    line-height: var(--cinder-leading-normal);
-    color: inherit;
-  }
-
-  .cinder-search-field__input:focus-visible {
-    /* cinder-focus-ring-owner: parent — the .cinder-search-field wrapper paints
-       the ring for the whole field; the bare input suppresses its own. */
-    outline: none;
-    box-shadow: none;
-  }
-
-  .cinder-search-field__input::placeholder {
-    color: var(--cinder-text-subtle);
-  }
-
-  .cinder-search-field__input:disabled {
-    cursor: not-allowed;
-  }
-
-  .cinder-search-field__input:disabled::placeholder {
-    color: var(--cinder-text-disabled);
-  }
-
   /* Suppress the WebKit native clear button — we render our own. */
-  .cinder-search-field__input::-webkit-search-cancel-button,
-  .cinder-search-field__input::-webkit-search-decoration {
+  .cinder-search-field .cinder-input::-webkit-search-cancel-button,
+  .cinder-search-field .cinder-input::-webkit-search-decoration {
     display: none;
   }
 

--- a/packages/components/src/components/search-field/search-field.svelte
+++ b/packages/components/src/components/search-field/search-field.svelte
@@ -85,11 +85,12 @@
         element.value = resetTarget;
       });
     };
+    const form = element.form;
     element.addEventListener('search', handler);
-    element.form?.addEventListener('reset', resetHandler);
+    form?.addEventListener('reset', resetHandler);
     return () => {
       element.removeEventListener('search', handler);
-      element.form?.removeEventListener('reset', resetHandler);
+      form?.removeEventListener('reset', resetHandler);
       if (inputElement === element) inputElement = null;
     };
   };

--- a/packages/components/src/components/search-field/search-field.svelte
+++ b/packages/components/src/components/search-field/search-field.svelte
@@ -24,7 +24,7 @@
   import type { SearchFieldProps } from './search-field.types.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
-  import Input from '../input/input.svelte';
+  import Input from '@lostgradient/cinder/input';
 
   let {
     id,

--- a/packages/components/src/components/search-field/search-field.svelte
+++ b/packages/components/src/components/search-field/search-field.svelte
@@ -22,9 +22,9 @@
   import X from 'lucide-svelte/icons/x';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import type { SearchFieldProps } from './search-field.types.ts';
-  import { ariaInvalid, composeDescribedBy } from '../../_internal/field-control.ts';
   import { getFormFieldContext } from '../../_internal/form-field-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
+  import Input from '../input/input.svelte';
 
   let {
     id,
@@ -33,7 +33,6 @@
     shortcut,
     disabled,
     readonly,
-    name,
     class: customClassName,
     oninput,
     onsearch,
@@ -43,7 +42,8 @@
   }: SearchFieldProps = $props();
 
   const context = getFormFieldContext();
-  const resolvedId = $derived(id ?? context?.controlId);
+  const generatedId = $props.id();
+  const resolvedId = $derived(id ?? context?.controlId ?? generatedId);
 
   let inputElement = $state<HTMLInputElement | null>(null);
   const resetTarget = untrack(() => value);
@@ -51,13 +51,8 @@
   const currentValue = $derived(value);
   const hasValue = $derived(currentValue.length > 0);
 
-  const describedBy = $derived(
-    composeDescribedBy(context?.descriptionId, context?.errorId, rest['aria-describedby']),
-  );
   const consumerAriaInvalid = $derived(rest['aria-invalid']);
-  const resolvedAriaInvalid = $derived(
-    context?.invalid ?? consumerAriaInvalid ?? ariaInvalid(false),
-  );
+  const resolvedAriaInvalid = $derived(context?.invalid ?? consumerAriaInvalid ?? undefined);
   const isInvalid = $derived(resolvedAriaInvalid === 'true' || resolvedAriaInvalid === true);
   const resolvedRequired = $derived(rest.required ?? context?.required ?? false);
   const resolvedDisabled = $derived(disabled ?? context?.disabled ?? false);
@@ -73,19 +68,30 @@
 
   function handleInput(event: Event) {
     const target = event.currentTarget as HTMLInputElement;
-    const next = target.value;
-    value = next;
-    oninput?.(next);
+    oninput?.(target.value);
   }
 
   function handleKeyDown(event: KeyboardEvent) {
     consumerKeyDown?.(event as KeyboardEvent & { currentTarget: EventTarget & HTMLInputElement });
   }
 
-  const searchEventListener: Attachment<HTMLInputElement> = (element) => {
+  const inputAttachment: Attachment<HTMLInputElement> = (element) => {
+    inputElement = element;
     const handler = () => onsearch?.(element.value);
+    const resetHandler = (event: Event) => {
+      queueMicrotask(() => {
+        if (event.defaultPrevented) return;
+        value = resetTarget;
+        element.value = resetTarget;
+      });
+    };
     element.addEventListener('search', handler);
-    return () => element.removeEventListener('search', handler);
+    element.form?.addEventListener('reset', resetHandler);
+    return () => {
+      element.removeEventListener('search', handler);
+      element.form?.removeEventListener('reset', resetHandler);
+      if (inputElement === element) inputElement = null;
+    };
   };
 
   function handleClear() {
@@ -98,52 +104,15 @@
     oninput?.('');
     onClear?.();
   }
-
-  $effect(() => {
-    const form = inputElement?.form;
-    if (!form) return;
-
-    const handleReset = (event: Event) => {
-      queueMicrotask(() => {
-        if (event.defaultPrevented) return;
-        value = resetTarget;
-        if (inputElement) inputElement.value = resetTarget;
-      });
-    };
-
-    form.addEventListener('reset', handleReset);
-    return () => form.removeEventListener('reset', handleReset);
-  });
 </script>
 
-<div
-  class={classNames('cinder-search-field', customClassName)}
-  data-disabled={resolvedDisabled ? '' : undefined}
-  data-invalid={isInvalid ? '' : undefined}
->
+{#snippet leadingIcon()}
   <span class="cinder-search-field__leading" aria-hidden="true">
     <Search class="cinder-search-field__icon" aria-hidden="true" />
   </span>
+{/snippet}
 
-  <input
-    bind:this={inputElement}
-    {...rest}
-    id={resolvedId}
-    {name}
-    type="search"
-    class="cinder-search-field__input"
-    value={currentValue}
-    {placeholder}
-    {readonly}
-    disabled={resolvedDisabled}
-    required={resolvedRequired}
-    aria-invalid={resolvedAriaInvalid}
-    aria-describedby={describedBy}
-    oninput={handleInput}
-    onkeydown={handleKeyDown}
-    {@attach searchEventListener}
-  />
-
+{#snippet trailingContent()}
   <button
     type="button"
     class="cinder-search-field__clear"
@@ -159,4 +128,29 @@
   {#if shortcut}
     <kbd class="cinder-search-field__shortcut" aria-hidden="true">{shortcut}</kbd>
   {/if}
+{/snippet}
+
+<div
+  class={classNames('cinder-search-field', customClassName)}
+  data-disabled={resolvedDisabled ? '' : undefined}
+  data-invalid={isInvalid ? '' : undefined}
+>
+  <Input
+    {...rest}
+    id={resolvedId}
+    bind:value
+    {placeholder}
+    {readonly}
+    type="search"
+    class="cinder-search-field__input"
+    disabled={resolvedDisabled}
+    required={resolvedRequired}
+    aria-invalid={resolvedAriaInvalid}
+    oninput={handleInput}
+    onkeydown={handleKeyDown}
+    {inputAttachment}
+    leading={leadingIcon}
+    trailing={trailingContent}
+    trailingInteractive
+  />
 </div>

--- a/packages/components/src/components/search-field/search-field.test.ts
+++ b/packages/components/src/components/search-field/search-field.test.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 import { afterEach, describe, expect, mock, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import type { SearchFieldProps } from './search-field.types.ts';
@@ -19,6 +20,11 @@ const { default: FormFieldSearchFieldFixture } =
   await import('../../test/fixtures/form-field-search-field-fixture.svelte');
 
 describe('SearchField rendering', () => {
+  test('sidecar imports the composed Input styles', () => {
+    const styles = readFileSync(new URL('./search-field.css', import.meta.url), 'utf8');
+    expect(styles).toContain("@import '../input/input.css';");
+  });
+
   test('type surface excludes inherited defaultValue', () => {
     const excludesInheritedDefaultValue: 'defaultValue' extends keyof SearchFieldProps
       ? false

--- a/packages/components/src/components/search-field/search-field.test.ts
+++ b/packages/components/src/components/search-field/search-field.test.ts
@@ -129,6 +129,9 @@ describe('SearchField clear button', () => {
     });
     const clear = container.querySelector('.cinder-search-field__clear') as HTMLButtonElement;
     expect(clear.hasAttribute('hidden')).toBe(false);
+    expect(
+      clear.closest('.cinder-input-group__trailing')?.classList.contains('cinder-_truncate'),
+    ).toBe(false);
   });
 
   test('clear button has aria-label="Clear search"', () => {

--- a/packages/components/src/components/search-field/search-field.test.ts
+++ b/packages/components/src/components/search-field/search-field.test.ts
@@ -7,6 +7,12 @@ import type { SearchFieldProps } from './search-field.types.ts';
 
 setupHappyDom();
 
+// Source-package tests do not resolve the package's self-reference through Bun's
+// export map. Keep the component on its public subpath while mapping that entry
+// to the source implementation for this focused test process.
+const { default: Input } = await import('../input/index.ts');
+mock.module('@lostgradient/cinder/input', () => ({ default: Input }));
+
 const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
 
 // Unmount renders between tests; shared document.body otherwise leaks activeElement/nodes.
@@ -102,9 +108,8 @@ describe('SearchField rendering', () => {
     const { container } = render(SearchField, {
       props: { id: 'search', style: 'letter-spacing: 0.05em;' },
     });
-    expect(container.querySelector('#search')?.getAttribute('style')).toBe(
-      'letter-spacing: 0.05em;',
-    );
+    const input = container.querySelector('#search') as HTMLInputElement;
+    expect(input.style.letterSpacing).toBe('0.05em');
   });
 });
 

--- a/packages/components/src/components/search-field/search-field.test.ts
+++ b/packages/components/src/components/search-field/search-field.test.ts
@@ -34,6 +34,13 @@ describe('SearchField rendering', () => {
     expect(input.getAttribute('type')).toBe('search');
   });
 
+  test('composes the shared Input control and grouped adornments', () => {
+    const { container } = render(SearchField, { props: { id: 'search', value: 'cinder' } });
+    expect(container.querySelector('.cinder-input-field')).not.toBeNull();
+    expect(container.querySelector('.cinder-input-group')).not.toBeNull();
+    expect(container.querySelector('#search')?.classList.contains('cinder-input')).toBe(true);
+  });
+
   test('forwards accessible input attributes while preserving the search role', () => {
     const { getByRole } = render(SearchField, {
       props: {
@@ -83,6 +90,15 @@ describe('SearchField rendering', () => {
     });
     const root = container.querySelector('.cinder-search-field');
     expect(root?.classList.contains('my-search')).toBe(true);
+  });
+
+  test('forwards native style props to the shared input control', () => {
+    const { container } = render(SearchField, {
+      props: { id: 'search', style: 'letter-spacing: 0.05em;' },
+    });
+    expect(container.querySelector('#search')?.getAttribute('style')).toBe(
+      'letter-spacing: 0.05em;',
+    );
   });
 });
 


### PR DESCRIPTION
Closes #1091

## Summary
- compose the SearchField native control from the Cinder Input primitive through its public component subpath
- preserve search and clear events, keyboard handlers, focus restoration, ARIA, FormField context, form reset, and grouped adornments
- keep interactive addon wrappers free of truncation so the clear button retains its full hit target
- keep the SearchField root class while forwarding native style props to Input
- remove duplicate control CSS and the SearchField raw-control migration entry
- update the accessibility record and include the required patch changeset
- exact head 1e61913ed9ae7737ae3d49a3eb164bfbae8c179e is based on main 462b85b8cad5859bbcd97c86428fc10d839aa255

## Verification
- bun run --filter=@lostgradient/cinder test -- src/components/input/input.test.ts src/components/search-field/search-field.test.ts — 98 pass, 0 fail, 181 assertions
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder exports:check
- bun run --filter=@lostgradient/cinder check:primitive-composition
- bun run --filter=@lostgradient/cinder build
- bun run --filter=@lostgradient/cinder typecheck
- bunx prettier --check on changed files
- git diff --check
- pre-commit and pre-push checks
- independent review approved