### PR TITLE
docs: record Table, DataTable, and DataGrid boundaries

### DIFF
--- a/.changeset/tabular-family-boundaries.md
+++ b/.changeset/tabular-family-boundaries.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Document the boundaries between the Table, DataTable, and DataGrid component families.

--- a/docs/decisions/tabular-families.md
+++ b/docs/decisions/tabular-families.md
@@ -1,0 +1,38 @@
+# Tabular component boundaries
+
+Decision: preserve `Table`, `DataTable`, and `DataGrid` as separate public
+families. They overlap in presentation, but their semantic and interaction
+contracts are intentionally different; consolidation would make the simplest
+use cases pay for the most complex behavior.
+
+## Responsibilities
+
+- **Table** owns native HTML table semantics and composition. Use it when
+  consumers need custom cell, row, header, spanning, or nested markup while
+  retaining `<table>`, `<thead>`, `<tbody>`, and scoped header semantics. It
+  does not own data fetching, virtualization, or grid-style cell focus.
+- **DataTable** owns the data-driven convenience contract over native table
+  markup. Use it when columns and rows are runtime data and callers want
+  generated captions, scope attributes, sorting, optional row selection, and
+  fixed-height row virtualization for large append-only datasets. Avoid it when
+  cells require bespoke composition or interactive grid behavior.
+- **DataGrid** owns interactive ARIA `grid` behavior. Use it for row/cell
+  focus, keyboard navigation, range selection, stable row identity, column
+  sizing/pinning, and optional row/column virtualization. It is not a native
+  table and should not replace semantic tables for read-only tabular content.
+
+Virtualization belongs to DataTable only for its fixed-height append-only mode
+and to DataGrid for interactive row/column windows. Selection in DataTable is
+row-checkbox selection that preserves native table semantics; DataGrid owns
+cell/range selection and grid keyboard interaction. Interactive editing,
+resize handles, and drag-to-reorder remain explicit future capabilities rather
+than reasons to blur these boundaries.
+
+## Alternatives and review boundary
+
+Choose the nearest simpler alternative first: use Table for bespoke semantic
+markup, DataTable for data-shaped native tables, and DataGrid only when grid
+interaction or virtualization requires it. Do not add overlapping features to
+one family to avoid choosing another; a proposal that changes these
+responsibilities must update this decision and the affected accessibility and
+interaction tests first.

--- a/docs/decisions/tabular-families.md
+++ b/docs/decisions/tabular-families.md
@@ -13,9 +13,10 @@ use cases pay for the most complex behavior.
   does not own data fetching, virtualization, or grid-style cell focus.
 - **DataTable** owns the data-driven convenience contract over native table
   markup. Use it when columns and rows are runtime data and callers want
-  generated captions, scope attributes, sorting, optional row selection, and
-  fixed-height row virtualization for large append-only datasets. Avoid it when
-  cells require bespoke composition or interactive grid behavior.
+  generated captions, scope attributes, sortable headers with consumer-owned
+  row reordering, optional row selection, and fixed-height row virtualization
+  for large append-only datasets. Avoid it when cells require bespoke
+  composition or interactive grid behavior.
 - **DataGrid** owns interactive ARIA `grid` behavior. Use it for row/cell
   focus, keyboard navigation, range selection, stable row identity, column
   sizing/pinning, and optional row/column virtualization. It is not a native
@@ -32,7 +33,7 @@ than reasons to blur these boundaries.
 
 Choose the nearest simpler alternative first: use Table for bespoke semantic
 markup, DataTable for data-shaped native tables, and DataGrid only when grid
-interaction or virtualization requires it. Do not add overlapping features to
-one family to avoid choosing another; a proposal that changes these
+interaction or grid-specific virtualization requires it. Do not add overlapping
+features to one family to avoid choosing another; a proposal that changes these
 responsibilities must update this decision and the affected accessibility and
 interaction tests first.

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -1639,6 +1639,7 @@
       ],
       "related": [
         "table",
+        "data-grid",
         "table-header",
         "table-body",
         "table-row",
@@ -5240,7 +5241,15 @@
           "reason": "Listing key-value attributes of one entity — use description-list instead."
         }
       ],
-      "related": ["table-header", "table-body", "table-row", "table-cell", "table-header-cell"],
+      "related": [
+        "data-table",
+        "data-grid",
+        "table-header",
+        "table-body",
+        "table-row",
+        "table-cell",
+        "table-header-cell"
+      ],
       "hasConstraints": false,
       "hasExamples": true,
       "artifacts": {

--- a/packages/components/src/components/data-grid/README.md
+++ b/packages/components/src/components/data-grid/README.md
@@ -4,7 +4,8 @@ ARIA data grid foundation for spreadsheet-like datasets with stable row identity
 
 See the [tabular family boundaries](../../../../../docs/decisions/tabular-families.md).
 DataGrid is the interactive-grid alternative to the native Table and DataTable
-families; choose DataTable when native table semantics are the requirement.
+families; choose Table for bespoke native markup or DataTable for data-shaped
+native tables.
 
 ## Usage
 

--- a/packages/components/src/components/data-grid/README.md
+++ b/packages/components/src/components/data-grid/README.md
@@ -2,6 +2,10 @@
 
 ARIA data grid foundation for spreadsheet-like datasets with stable row identity, explicit column widths, keyboard navigation, row selection, cell/range selection, and pinned-column metadata.
 
+See the [tabular family boundaries](../../../../docs/decisions/tabular-families.md).
+DataGrid is the interactive-grid alternative to the native Table and DataTable
+families; choose DataTable when native table semantics are the requirement.
+
 ## Usage
 
 ```svelte

--- a/packages/components/src/components/data-grid/README.md
+++ b/packages/components/src/components/data-grid/README.md
@@ -2,7 +2,7 @@
 
 ARIA data grid foundation for spreadsheet-like datasets with stable row identity, explicit column widths, keyboard navigation, row selection, cell/range selection, and pinned-column metadata.
 
-See the [tabular family boundaries](../../../../docs/decisions/tabular-families.md).
+See the [tabular family boundaries](../../../../../docs/decisions/tabular-families.md).
 DataGrid is the interactive-grid alternative to the native Table and DataTable
 families; choose DataTable when native table semantics are the requirement.
 

--- a/packages/components/src/components/data-grid/README.md
+++ b/packages/components/src/components/data-grid/README.md
@@ -2,7 +2,7 @@
 
 ARIA data grid foundation for spreadsheet-like datasets with stable row identity, explicit column widths, keyboard navigation, row selection, cell/range selection, and pinned-column metadata.
 
-See the [tabular family boundaries](../../../../../docs/decisions/tabular-families.md).
+See the [tabular family boundaries](https://github.com/stevekinney/cinder/blob/main/docs/decisions/tabular-families.md).
 DataGrid is the interactive-grid alternative to the native Table and DataTable
 families; choose Table for bespoke native markup or DataTable for data-shaped
 native tables.

--- a/packages/components/src/components/data-table/README.md
+++ b/packages/components/src/components/data-table/README.md
@@ -2,7 +2,7 @@
 
 Data-driven accessible table that renders rows and columns into a real `<table>` with `<caption>`, scoped column and row headers, optional sortable columns, and a horizontal-scroll responsive container.
 
-See the [tabular family boundaries](../../../../docs/decisions/tabular-families.md).
+See the [tabular family boundaries](../../../../../docs/decisions/tabular-families.md).
 DataTable is the native-table convenience layer; use Table for bespoke cell
 composition and DataGrid when cell focus, range selection, or grid semantics
 are required.

--- a/packages/components/src/components/data-table/README.md
+++ b/packages/components/src/components/data-table/README.md
@@ -2,7 +2,7 @@
 
 Data-driven accessible table that renders rows and columns into a real `<table>` with `<caption>`, scoped column and row headers, optional sortable columns, and a horizontal-scroll responsive container.
 
-See the [tabular family boundaries](../../../../../docs/decisions/tabular-families.md).
+See the [tabular family boundaries](https://github.com/stevekinney/cinder/blob/main/docs/decisions/tabular-families.md).
 DataTable is the native-table convenience layer; use Table for bespoke cell
 composition and DataGrid when cell focus, range selection, or grid semantics
 are required.

--- a/packages/components/src/components/data-table/README.md
+++ b/packages/components/src/components/data-table/README.md
@@ -2,6 +2,11 @@
 
 Data-driven accessible table that renders rows and columns into a real `<table>` with `<caption>`, scoped column and row headers, optional sortable columns, and a horizontal-scroll responsive container.
 
+See the [tabular family boundaries](../../../../docs/decisions/tabular-families.md).
+DataTable is the native-table convenience layer; use Table for bespoke cell
+composition and DataGrid when cell focus, range selection, or grid semantics
+are required.
+
 ## Usage
 
 ```svelte

--- a/packages/components/src/components/data-table/data-table.svelte
+++ b/packages/components/src/components/data-table/data-table.svelte
@@ -10,7 +10,7 @@
    * @useWhen You want correct scope=col / scope=row semantics and aria-sort wiring without writing Table.Header / Table.Body manually.
    * @avoidWhen You need custom cell rendering, interactive cells, nested components, or column spanning — use the compositional Table family directly.
    * @avoidWhen You need fully custom cell or row composition — use Table directly.
-   * @related table, table-header, table-body, table-row, table-cell, table-header-cell
+   * @related table, data-grid, table-header, table-body, table-row, table-cell, table-header-cell
    */
   export type {
     DataTableColumn,

--- a/packages/components/src/components/table/README.md
+++ b/packages/components/src/components/table/README.md
@@ -2,6 +2,11 @@
 
 Full data table with header, body, and optional footer for structured tabular content.
 
+See the [tabular family boundaries](../../../../docs/decisions/tabular-families.md)
+for when to choose Table versus DataTable or DataGrid. Table is the nearest
+choice when you need custom native-table markup; use DataTable for runtime
+columns/rows and DataGrid for interactive grid semantics.
+
 ## Usage
 
 `Table` is a compound component. Import the parent and compose its leaves via

--- a/packages/components/src/components/table/README.md
+++ b/packages/components/src/components/table/README.md
@@ -2,7 +2,7 @@
 
 Full data table with header, body, and optional footer for structured tabular content.
 
-See the [tabular family boundaries](../../../../../docs/decisions/tabular-families.md)
+See the [tabular family boundaries](https://github.com/stevekinney/cinder/blob/main/docs/decisions/tabular-families.md)
 for when to choose Table versus DataTable or DataGrid. Table is the nearest
 choice when you need custom native-table markup; use DataTable for runtime
 columns/rows and DataGrid for interactive grid semantics.

--- a/packages/components/src/components/table/README.md
+++ b/packages/components/src/components/table/README.md
@@ -2,7 +2,7 @@
 
 Full data table with header, body, and optional footer for structured tabular content.
 
-See the [tabular family boundaries](../../../../docs/decisions/tabular-families.md)
+See the [tabular family boundaries](../../../../../docs/decisions/tabular-families.md)
 for when to choose Table versus DataTable or DataGrid. Table is the nearest
 choice when you need custom native-table markup; use DataTable for runtime
 columns/rows and DataGrid for interactive grid semantics.

--- a/packages/components/src/components/table/table.svelte
+++ b/packages/components/src/components/table/table.svelte
@@ -10,7 +10,7 @@
    * @useWhen Coordinating column sort state across header cells via the sort prop.
    * @avoidWhen Rendering a responsive card grid — use grid-list instead.
    * @avoidWhen Listing key-value attributes of one entity — use description-list instead.
-   * @related table-header, table-body, table-row, table-cell, table-header-cell
+   * @related data-table, data-grid, table-header, table-body, table-row, table-cell, table-header-cell
    */
   export type {
     SortDirection,


### PR DESCRIPTION
Closes #1104

## Summary
- record the preserve decision and explicit responsibilities for Table, DataTable, and DataGrid
- link each family documentation entry to the decision and nearest alternatives
- update generated component metadata and include a patch changeset

## Validation
- TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/components/src/components/table packages/components/src/components/data-table packages/components/src/components/data-grid
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder exports:check
- bun run --filter=@lostgradient/cinder typecheck
- bunx prettier --check <changed files>

Please request the repository-configured review bots.