### PR TITLE
CommandMenu: remove duplicated floating-surface declarations

### DIFF
--- a/.changeset/command-menu-floating-surface.md
+++ b/.changeset/command-menu-floating-surface.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Remove duplicated CommandMenu floating-surface chrome declarations so shared overlay styling owns the panel surface.

--- a/packages/components/src/components/command-menu/command-menu.css
+++ b/packages/components/src/components/command-menu/command-menu.css
@@ -9,22 +9,14 @@
  * ======================================== */
 
   .cinder-command-menu {
-    position: fixed;
-    z-index: var(--cinder-z-popover);
-    box-sizing: border-box;
+    /* CommandMenu keeps a smaller caret menu viewport and flush item padding;
+     * shared panel chrome comes from cinder-_floating-surface. */
     min-inline-size: min(20rem, calc(100vw - var(--cinder-space-4)));
     max-inline-size: min(28rem, calc(100vw - var(--cinder-space-4)));
     max-block-size: min(20rem, calc(100vh - var(--cinder-space-4)));
-    margin: 0;
     padding: var(--cinder-space-2) 0;
     overflow-y: auto;
-    overscroll-behavior: contain;
     list-style: none;
-    border: 1px solid var(--cinder-border);
-    border-radius: var(--cinder-radius-md);
-    background: var(--cinder-surface-raised);
-    color: var(--cinder-text);
-    box-shadow: var(--cinder-shadow-lg, 0 10px 15px rgb(0 0 0 / 0.15));
   }
 
   .cinder-command-menu__listbox {

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -1,5 +1,7 @@
 /// <reference lib="dom" />
 import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { parse } from 'postcss';
+import selectorParser from 'postcss-selector-parser';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 
@@ -45,14 +47,30 @@ function queryListbox() {
 }
 
 function commandMenuRootDeclarationsFromCss(css: string) {
-  const declarationBlocks = Array.from(
-    css.matchAll(/\.cinder-command-menu\s*\{(?<body>[^}]*)\}/g),
-    (match) => match.groups?.['body'],
-  ).filter((body): body is string => body !== undefined);
+  const declarations: string[] = [];
 
-  expect(declarationBlocks.length).toBeGreaterThan(0);
+  parse(css).walkRules((rule) => {
+    let targetsCommandMenuRoot = false;
+    selectorParser((selectors) => {
+      selectors.each((selector) => {
+        const lastCombinatorIndex = selector.nodes.findLastIndex(
+          (node) => node.type === 'combinator',
+        );
+        targetsCommandMenuRoot ||= selector.nodes
+          .slice(lastCombinatorIndex + 1)
+          .some((node) => node.type === 'class' && node.value === 'cinder-command-menu');
+      });
+    }).processSync(rule.selector);
 
-  return declarationBlocks.join('\n');
+    if (!targetsCommandMenuRoot) return;
+    rule.each((node) => {
+      if (node.type === 'decl') declarations.push(`${node.prop}: ${node.value}`);
+    });
+  });
+
+  expect(declarations.length).toBeGreaterThan(0);
+
+  return declarations.join('\n');
 }
 
 async function commandMenuRootDeclarations() {
@@ -82,10 +100,14 @@ describe('CommandMenu', () => {
   test('the CSS declaration guard inspects every root selector block', () => {
     const declarations = commandMenuRootDeclarationsFromCss(`
       .cinder-command-menu { padding: 0; }
-      .cinder-command-menu { position: fixed; }
+      .cinder-command-menu[data-cinder-position-ready='false'] { position: fixed; }
+      .cinder-command-menu.cinder-_floating-surface { box-shadow: none; }
+      .cinder-command-menu .cinder-command-menu__empty { color: red; }
     `);
 
     expect(declarations).toContain('position: fixed');
+    expect(declarations).toContain('box-shadow: none');
+    expect(declarations).not.toContain('color: red');
   });
 
   test('composes shared floating-surface chrome instead of redeclaring it', async () => {

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -44,14 +44,21 @@ function queryListbox() {
   return document.body.querySelector<HTMLUListElement>('[role="listbox"]');
 }
 
+function commandMenuRootDeclarationsFromCss(css: string) {
+  const declarationBlocks = Array.from(
+    css.matchAll(/\.cinder-command-menu\s*\{(?<body>[^}]*)\}/g),
+    (match) => match.groups?.['body'],
+  ).filter((body): body is string => body !== undefined);
+
+  expect(declarationBlocks.length).toBeGreaterThan(0);
+
+  return declarationBlocks.join('\n');
+}
+
 async function commandMenuRootDeclarations() {
   const css = await Bun.file(new URL('./command-menu.css', import.meta.url)).text();
-  const match = css.match(/\.cinder-command-menu\s*\{(?<body>[^}]*)\}/);
-  const body = match?.groups?.['body'];
 
-  expect(body).toBeDefined();
-
-  return body!;
+  return commandMenuRootDeclarationsFromCss(css);
 }
 
 async function settleCommandMenu() {
@@ -72,6 +79,15 @@ afterEach(() => {
 });
 
 describe('CommandMenu', () => {
+  test('the CSS declaration guard inspects every root selector block', () => {
+    const declarations = commandMenuRootDeclarationsFromCss(`
+      .cinder-command-menu { padding: 0; }
+      .cinder-command-menu { position: fixed; }
+    `);
+
+    expect(declarations).toContain('position: fixed');
+  });
+
   test('composes shared floating-surface chrome instead of redeclaring it', async () => {
     const rootDeclarations = await commandMenuRootDeclarations();
 

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -44,6 +44,16 @@ function queryListbox() {
   return document.body.querySelector<HTMLUListElement>('[role="listbox"]');
 }
 
+async function commandMenuRootDeclarations() {
+  const css = await Bun.file(new URL('./command-menu.css', import.meta.url)).text();
+  const match = css.match(/\.cinder-command-menu\s*\{(?<body>[^}]*)\}/);
+  const body = match?.groups?.['body'];
+
+  expect(body).toBeDefined();
+
+  return body!;
+}
+
 async function settleCommandMenu() {
   await Promise.resolve();
   await tick();
@@ -62,6 +72,24 @@ afterEach(() => {
 });
 
 describe('CommandMenu', () => {
+  test('composes shared floating-surface chrome instead of redeclaring it', async () => {
+    const rootDeclarations = await commandMenuRootDeclarations();
+
+    for (const property of [
+      'position',
+      'z-index',
+      'box-sizing',
+      'margin',
+      'border',
+      'border-radius',
+      'background',
+      'color',
+      'box-shadow',
+    ]) {
+      expect(rootDeclarations).not.toContain(`${property}:`);
+    }
+  });
+
   test('renders a portaled listbox while open', async () => {
     render(CommandMenuFixture);
     await waitFor(() => expect(queryMenu()).not.toBeNull());

--- a/packages/components/src/components/command-menu/command-menu.test.ts
+++ b/packages/components/src/components/command-menu/command-menu.test.ts
@@ -46,8 +46,8 @@ function queryListbox() {
   return document.body.querySelector<HTMLUListElement>('[role="listbox"]');
 }
 
-function commandMenuRootDeclarationsFromCss(css: string) {
-  const declarations: string[] = [];
+function commandMenuRootDeclarationPropertiesFromCss(css: string) {
+  const declarationProperties: string[] = [];
 
   parse(css).walkRules((rule) => {
     let targetsCommandMenuRoot = false;
@@ -64,19 +64,19 @@ function commandMenuRootDeclarationsFromCss(css: string) {
 
     if (!targetsCommandMenuRoot) return;
     rule.each((node) => {
-      if (node.type === 'decl') declarations.push(`${node.prop}: ${node.value}`);
+      if (node.type === 'decl') declarationProperties.push(node.prop.toLowerCase());
     });
   });
 
-  expect(declarations.length).toBeGreaterThan(0);
+  expect(declarationProperties.length).toBeGreaterThan(0);
 
-  return declarations.join('\n');
+  return declarationProperties;
 }
 
-async function commandMenuRootDeclarations() {
+async function commandMenuRootDeclarationProperties() {
   const css = await Bun.file(new URL('./command-menu.css', import.meta.url)).text();
 
-  return commandMenuRootDeclarationsFromCss(css);
+  return commandMenuRootDeclarationPropertiesFromCss(css);
 }
 
 async function settleCommandMenu() {
@@ -98,20 +98,20 @@ afterEach(() => {
 
 describe('CommandMenu', () => {
   test('the CSS declaration guard inspects every root selector block', () => {
-    const declarations = commandMenuRootDeclarationsFromCss(`
+    const declarationProperties = commandMenuRootDeclarationPropertiesFromCss(`
       .cinder-command-menu { padding: 0; }
       .cinder-command-menu[data-cinder-position-ready='false'] { position: fixed; }
       .cinder-command-menu.cinder-_floating-surface { box-shadow: none; }
       .cinder-command-menu .cinder-command-menu__empty { color: red; }
     `);
 
-    expect(declarations).toContain('position: fixed');
-    expect(declarations).toContain('box-shadow: none');
-    expect(declarations).not.toContain('color: red');
+    expect(declarationProperties).toContain('position');
+    expect(declarationProperties).toContain('box-shadow');
+    expect(declarationProperties).not.toContain('color');
   });
 
   test('composes shared floating-surface chrome instead of redeclaring it', async () => {
-    const rootDeclarations = await commandMenuRootDeclarations();
+    const rootDeclarationProperties = await commandMenuRootDeclarationProperties();
 
     for (const property of [
       'position',
@@ -124,7 +124,7 @@ describe('CommandMenu', () => {
       'color',
       'box-shadow',
     ]) {
-      expect(rootDeclarations).not.toContain(`${property}:`);
+      expect(rootDeclarationProperties).not.toContain(property);
     }
   });
 


### PR DESCRIPTION
## Summary

- Remove shared positioning, stacking, box, border, background, and shadow declarations from CommandMenu CSS.
- Keep CommandMenu-specific viewport, padding, overflow, and empty-state rules.
- Add a regression guard that inspects every CommandMenu root selector block.

Closes #1099

## Validation

- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/components/src/components/command-menu`
- `bun run --filter=@lostgradient/cinder lint:invariants`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bunx prettier --check packages/components/src/components/command-menu/command-menu.css packages/components/src/components/command-menu/command-menu.test.ts`

## Scope

CommandMenu surface CSS only. CommandPalette behavior is unchanged.
