### PR TITLE
docs: record editor/chat accepted duplication boundaries

### DIFF
--- a/.changeset/editor-chat-surface-boundaries.md
+++ b/.changeset/editor-chat-surface-boundaries.md
@@ -1,0 +1,7 @@
+---
+'@lostgradient/chat': patch
+'@lostgradient/cinder': patch
+'@lostgradient/editor': patch
+---
+
+Document the distinct ownership boundaries for editor, Cinder, and Chat message surfaces.

--- a/.changeset/editor-chat-surface-boundaries.md
+++ b/.changeset/editor-chat-surface-boundaries.md
@@ -4,4 +4,4 @@
 '@lostgradient/editor': patch
 ---
 
-Document the distinct ownership boundaries for editor, Cinder, and Chat message surfaces.
+Document the distinct ownership boundaries for editor and Cinder diff viewers plus Cinder and Chat message surfaces.

--- a/docs/decisions/editor-chat-cinder-surfaces.md
+++ b/docs/decisions/editor-chat-cinder-surfaces.md
@@ -25,10 +25,11 @@ package boundary or force editor dependencies into Cinder core.
   timestamp chrome plus an arbitrary body snippet usable by any Cinder
   consumer. Avoid it when the Chat package's conversation state, transport,
   streaming, or tool-call context is required.
-- Chat's message renderer owns Chat-specific conversation state, streaming and
-  tool-call presentation, transport metadata, and package-level composition. It
-  may compose Cinder primitives, but Cinder must not depend on Chat. Avoid it
-  for a generic standalone message.
+- Chat `ChatMessage` owns Chat-specific message rendering: adapter-provided
+  metadata, streaming state, and tool-call presentation. The `Chat` container
+  and `ChatAdapter` own conversation state and transport. `ChatMessage` may
+  compose Cinder primitives, but Cinder must not depend on Chat. Avoid it for a
+  generic standalone message.
 
 These are domain adapters, not duplicate sources of truth. New shared visual
 primitives should be added to Cinder only when they have a domain-neutral API;

--- a/docs/decisions/editor-chat-cinder-surfaces.md
+++ b/docs/decisions/editor-chat-cinder-surfaces.md
@@ -1,0 +1,36 @@
+# Editor, diff, message, and chat surface boundaries
+
+Decision: retain both near-neighbour pairs as accepted duplication. The
+dependency direction remains editor/chat → Cinder; Cinder does not import either
+downstream package.
+
+## Diff viewers
+
+- Editor `diff-viewer` owns review-editor presentation and editor-runtime
+  integration: ProseMirror/Milkdown context, commentary, editable review
+  workflows, and editor-specific actions. Avoid it for a standalone unified
+  diff in a Cinder application.
+- Cinder `source-diff-viewer` owns a dependency-light read-only source diff. It
+  parses unified-diff text, renders syntax-oriented additions/deletions, and
+  remains usable without the editor package. Avoid it for editable review or
+  commentary workflows.
+
+The visual overlap is intentional; their parsers, dependency owners, and
+interaction contracts differ. Sharing either implementation would reverse the
+package boundary or force editor dependencies into Cinder core.
+
+## Message renderers
+
+- Cinder `Message` owns the core chat message surface: role/content layout,
+  markdown-safe rendering hooks, status states, and action affordances usable by
+  any Cinder consumer. Avoid it when the Chat package's conversation state and
+  transport context are required.
+- Chat's message renderer owns Chat-specific conversation state, streaming and
+  tool-call presentation, transport metadata, and package-level composition. It
+  may compose Cinder primitives, but Cinder must not depend on Chat. Avoid it
+  for a generic standalone message.
+
+These are domain adapters, not duplicate sources of truth. New shared visual
+primitives should be added to Cinder only when they have a domain-neutral API;
+editor or Chat behavior remains in its owning package. Any future consolidation
+must preserve the one-way dependency and add focused import/runtime coverage.

--- a/docs/decisions/editor-chat-cinder-surfaces.md
+++ b/docs/decisions/editor-chat-cinder-surfaces.md
@@ -6,14 +6,14 @@ downstream package.
 
 ## Diff viewers
 
-- Editor `diff-viewer` owns review-editor presentation and editor-runtime
-  integration: ProseMirror/Milkdown context, commentary, editable review
-  workflows, and editor-specific actions. Avoid it for a standalone unified
-  diff in a Cinder application.
+- Editor `diff-viewer` owns the Markdown review surface in the editor package:
+  normalization, front-matter handling, hunked and word-level changes, view
+  modes, and revert actions. Avoid it for a standalone unified diff in a
+  Cinder application.
 - Cinder `source-diff-viewer` owns a dependency-light read-only source diff. It
-  parses unified-diff text, renders syntax-oriented additions/deletions, and
-  remains usable without the editor package. Avoid it for editable review or
-  commentary workflows.
+  parses unified-diff text, renders structured file/hunk rows with additions
+  and removals, and remains usable without the editor package. Avoid it for
+  Markdown review workflows that need normalization or revert actions.
 
 The visual overlap is intentional; their parsers, dependency owners, and
 interaction contracts differ. Sharing either implementation would reverse the
@@ -21,10 +21,10 @@ package boundary or force editor dependencies into Cinder core.
 
 ## Message renderers
 
-- Cinder `Message` owns the core chat message surface: role/content layout,
-  markdown-safe rendering hooks, status states, and action affordances usable by
-  any Cinder consumer. Avoid it when the Chat package's conversation state and
-  transport context are required.
+- Cinder `Message` owns the domain-neutral message shell: role/name and
+  timestamp chrome plus an arbitrary body snippet usable by any Cinder
+  consumer. Avoid it when the Chat package's conversation state, transport,
+  streaming, or tool-call context is required.
 - Chat's message renderer owns Chat-specific conversation state, streaming and
   tool-call presentation, transport metadata, and package-level composition. It
   may compose Cinder primitives, but Cinder must not depend on Chat. Avoid it

--- a/docs/decisions/package-boundaries.md
+++ b/docs/decisions/package-boundaries.md
@@ -5,6 +5,10 @@
 
 ## Summary
 
+The accepted boundaries for the Editor diff viewer versus Cinder's source diff
+viewer, and Cinder Message versus Chat's renderer, are recorded in the
+[surface boundary decision](./editor-chat-cinder-surfaces.md).
+
 `@lostgradient/chat` proved the sibling-package pattern. The same treatment is owed to the
 markdown/editing family. The recommendation is **two new published packages plus a lazy-import
 pass** — not eight. Everything else that looks like a candidate fails the bar.

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -1,7 +1,8 @@
 # @lostgradient/chat
 
-The Chat message renderer owns conversation, streaming, transport, and tool-call
-presentation. See the [editor/chat/Cinder surface boundary](../../docs/decisions/editor-chat-cinder-surfaces.md)
+`ChatMessage` owns streaming, adapter-provided message metadata, and tool-call
+presentation; `Chat` and `ChatAdapter` own conversation state and transport. See
+the [editor/chat/Cinder surface boundary](../../docs/decisions/editor-chat-cinder-surfaces.md)
 for the intentional distinction from Cinder's domain-neutral `Message`.
 
 `@lostgradient/chat` is Cinder's Svelte 5 conversation surface, packaged separately so applications that do not render Chat do not install or bundle its conversation-model dependencies.

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -2,7 +2,7 @@
 
 `ChatMessage` owns streaming, adapter-provided message metadata, and tool-call
 presentation; `Chat` and `ChatAdapter` own conversation state and transport. See
-the [editor/chat/Cinder surface boundary](../../docs/decisions/editor-chat-cinder-surfaces.md)
+the [editor/chat/Cinder surface boundary](https://github.com/stevekinney/cinder/blob/main/docs/decisions/editor-chat-cinder-surfaces.md)
 for the intentional distinction from Cinder's domain-neutral `Message`.
 
 `@lostgradient/chat` is Cinder's Svelte 5 conversation surface, packaged separately so applications that do not render Chat do not install or bundle its conversation-model dependencies.

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -1,5 +1,9 @@
 # @lostgradient/chat
 
+The Chat message renderer owns conversation, streaming, transport, and tool-call
+presentation. See the [editor/chat/Cinder surface boundary](../../docs/decisions/editor-chat-cinder-surfaces.md)
+for the intentional distinction from Cinder's domain-neutral `Message`.
+
 `@lostgradient/chat` is Cinder's Svelte 5 conversation surface, packaged separately so applications that do not render Chat do not install or bundle its conversation-model dependencies.
 
 ## Install

--- a/packages/components/src/components/message/README.md
+++ b/packages/components/src/components/message/README.md
@@ -3,7 +3,7 @@
 Chat-style bubble that renders a role label, optional timestamp, and arbitrary body content for transcript or run-stream views.
 
 See the [editor/chat/Cinder surface boundary](../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
-This is the domain-neutral Cinder message surface; use Chat's renderer when
+This is the domain-neutral Cinder message surface; use Chat's `ChatMessage` when
 conversation, streaming, or tool-call state is required.
 
 ## Usage

--- a/packages/components/src/components/message/README.md
+++ b/packages/components/src/components/message/README.md
@@ -2,7 +2,7 @@
 
 Chat-style bubble that renders a role label, optional timestamp, and arbitrary body content for transcript or run-stream views.
 
-See the [editor/chat/Cinder surface boundary](../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+See the [editor/chat/Cinder surface boundary](https://github.com/stevekinney/cinder/blob/main/docs/decisions/editor-chat-cinder-surfaces.md).
 This is the domain-neutral Cinder message surface; use Chat's `ChatMessage` when
 conversation, streaming, or tool-call state is required.
 

--- a/packages/components/src/components/message/README.md
+++ b/packages/components/src/components/message/README.md
@@ -2,6 +2,10 @@
 
 Chat-style bubble that renders a role label, optional timestamp, and arbitrary body content for transcript or run-stream views.
 
+See the [editor/chat/Cinder surface boundary](../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+This is the domain-neutral Cinder message surface; use Chat's renderer when
+conversation, streaming, or tool-call state is required.
+
 ## Usage
 
 ```svelte

--- a/packages/components/src/components/message/README.md
+++ b/packages/components/src/components/message/README.md
@@ -2,7 +2,7 @@
 
 Chat-style bubble that renders a role label, optional timestamp, and arbitrary body content for transcript or run-stream views.
 
-See the [editor/chat/Cinder surface boundary](../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+See the [editor/chat/Cinder surface boundary](../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
 This is the domain-neutral Cinder message surface; use Chat's renderer when
 conversation, streaming, or tool-call state is required.
 

--- a/packages/components/src/components/source-diff-viewer/README.md
+++ b/packages/components/src/components/source-diff-viewer/README.md
@@ -2,7 +2,7 @@
 
 Lightweight unified-patch viewer for source-code and operational diffs with file headers, hunk headers, line state styling, and bounded rendering.
 
-See the [editor/Cinder surface boundary](../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+See the [editor/Cinder surface boundary](../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
 SourceDiffViewer owns dependency-light source patches; use the editor DiffViewer
 for Markdown review and editor-runtime workflows.
 

--- a/packages/components/src/components/source-diff-viewer/README.md
+++ b/packages/components/src/components/source-diff-viewer/README.md
@@ -2,7 +2,7 @@
 
 Lightweight unified-patch viewer for source-code and operational diffs with file headers, hunk headers, line state styling, and bounded rendering.
 
-See the [editor/Cinder surface boundary](../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+See the [editor/Cinder surface boundary](https://github.com/stevekinney/cinder/blob/main/docs/decisions/editor-chat-cinder-surfaces.md).
 `SourceDiffViewer` owns dependency-light source patches; use the editor `DiffViewer`
 for Markdown review and editor-runtime workflows.
 

--- a/packages/components/src/components/source-diff-viewer/README.md
+++ b/packages/components/src/components/source-diff-viewer/README.md
@@ -3,7 +3,7 @@
 Lightweight unified-patch viewer for source-code and operational diffs with file headers, hunk headers, line state styling, and bounded rendering.
 
 See the [editor/Cinder surface boundary](../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
-SourceDiffViewer owns dependency-light source patches; use the editor DiffViewer
+`SourceDiffViewer` owns dependency-light source patches; use the editor `DiffViewer`
 for Markdown review and editor-runtime workflows.
 
 ## Usage

--- a/packages/components/src/components/source-diff-viewer/README.md
+++ b/packages/components/src/components/source-diff-viewer/README.md
@@ -2,6 +2,10 @@
 
 Lightweight unified-patch viewer for source-code and operational diffs with file headers, hunk headers, line state styling, and bounded rendering.
 
+See the [editor/Cinder surface boundary](../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+SourceDiffViewer owns dependency-light source patches; use the editor DiffViewer
+for Markdown review and editor-runtime workflows.
+
 ## Usage
 
 ```svelte

--- a/packages/editor/src/lib/components/diff-viewer/README.md
+++ b/packages/editor/src/lib/components/diff-viewer/README.md
@@ -2,6 +2,10 @@
 
 Side-by-side or unified Markdown diff surface with hunk grouping, word-level inline changes, and size-based debounce gating.
 
+See the [editor/Cinder surface boundary](../../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+This editor-owned viewer is for Markdown review workflows; use Cinder's
+SourceDiffViewer for dependency-light operational source patches.
+
 ## Usage
 
 ```svelte

--- a/packages/editor/src/lib/components/diff-viewer/README.md
+++ b/packages/editor/src/lib/components/diff-viewer/README.md
@@ -2,7 +2,7 @@
 
 Side-by-side or unified Markdown diff surface with hunk grouping, word-level inline changes, and size-based debounce gating.
 
-See the [editor/Cinder surface boundary](../../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
+See the [editor/Cinder surface boundary](https://github.com/stevekinney/cinder/blob/main/docs/decisions/editor-chat-cinder-surfaces.md).
 This editor-owned `DiffViewer` is for Markdown review workflows; use Cinder's
 `SourceDiffViewer` for dependency-light operational source patches.
 

--- a/packages/editor/src/lib/components/diff-viewer/README.md
+++ b/packages/editor/src/lib/components/diff-viewer/README.md
@@ -3,8 +3,8 @@
 Side-by-side or unified Markdown diff surface with hunk grouping, word-level inline changes, and size-based debounce gating.
 
 See the [editor/Cinder surface boundary](../../../../../../docs/decisions/editor-chat-cinder-surfaces.md).
-This editor-owned viewer is for Markdown review workflows; use Cinder's
-SourceDiffViewer for dependency-light operational source patches.
+This editor-owned `DiffViewer` is for Markdown review workflows; use Cinder's
+`SourceDiffViewer` for dependency-light operational source patches.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Record the accepted duplication boundary for Editor DiffViewer vs Cinder SourceDiffViewer.
- Record the domain ownership boundary for Cinder Message vs ChatMessage.
- Link package READMEs and package-boundary decision docs to the durable decision.

## Verification
- `bun run --filter=@lostgradient/editor typecheck`
- `bun run --filter=@lostgradient/chat typecheck`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run lint`
- Focused diff/message tests (all passing)
- `bun run format:check` *(reports two pre-existing warnings in untouched files)*

Closes #1106