### PR TITLE
refactor: share row-item styling across list primitives

### DIFF
--- a/.changeset/shared-row-item-boundary.md
+++ b/.changeset/shared-row-item-boundary.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Share row and option-item geometry and state styling across list primitives.

--- a/packages/components/src/components/_internal/row-item.md
+++ b/packages/components/src/components/_internal/row-item.md
@@ -1,0 +1,12 @@
+# Shared row-item boundary
+
+`cinder-_row-item` owns the common flex-row geometry, minimum inline size, active/selected state fill, keyboard-cursor ring, disabled state, and forced-colors fallback for option-like rows.
+
+## Composition map
+
+- `dropdown-item`, `command-item`, and `navigation-item` compose the boundary directly. `side-navigation-item` composes it transitively through `navigation-item`.
+- `selectable-row` is excluded because its root grid preserves full-row hover while its primary action and trailing controls remain independent siblings; applying a flex row would break wrap alignment.
+- `stacked-list-item` is excluded because its leading/body/trailing grid changes columns and areas at a container breakpoint.
+- `grid-list-item` is excluded because it is a card cell with stretched-link hover and image geometry, not an option row.
+- `choice-grid-item` is excluded because its centered, fixed-height answer tile and feedback states intentionally override row alignment and state colors.
+- `tree-item` is excluded because its row is nested inside a hierarchical item and owns disclosure, selection, drag, rename, and drop-target state styling.

--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -25,7 +25,7 @@
   /*
    * The active/keyboard-highlighted row treatment is owned by the shared
    * `.cinder-_option-row[data-cinder-active]` rules in
-   * `styles/components/_floating-surface.css`: a `--cinder-surface-hover`
+   * `styles/components/_row-item.css`: a `--cinder-surface-hover`
    * background plus an inset `--cinder-ring-color` ring (and a forced-colors
    * `outline: Highlight` fallback). A component-local override here previously
    * pinned the background to `--cinder-surface-raised` — identical to the

--- a/packages/components/src/components/autocomplete/autocomplete.css
+++ b/packages/components/src/components/autocomplete/autocomplete.css
@@ -25,7 +25,7 @@
   /*
    * The active/keyboard-highlighted row treatment is owned by the shared
    * `.cinder-_option-row[data-cinder-active]` rules in
-   * `styles/components/_row-item.css`: a `--cinder-surface-hover`
+   * `styles/components/_row-item.css`: a `--cinder-surface-raised-hover`
    * background plus an inset `--cinder-ring-color` ring (and a forced-colors
    * `outline: Highlight` fallback). A component-local override here previously
    * pinned the background to `--cinder-surface-raised` — identical to the

--- a/packages/components/src/components/autocomplete/autocomplete.test.ts
+++ b/packages/components/src/components/autocomplete/autocomplete.test.ts
@@ -476,7 +476,7 @@ describe('Autocomplete — keyboard completion', () => {
       (option) => option.getAttribute('data-cinder-active') !== null,
     );
     expect(activeOption).toBeDefined();
-    // The shared `_floating-surface.css` rules key off this class, so carrying
+    // The shared `_row-item.css` rules key off this class, so carrying
     // it is what gives the active row its background + keyboard-cursor ring.
     expect(activeOption?.classList.contains('cinder-_option-row')).toBe(true);
 
@@ -496,7 +496,7 @@ describe('Autocomplete — keyboard completion', () => {
     // must inset a `--cinder-ring-color` ring (the system focus-ring token,
     // tuned to clear 3:1 against near-white surfaces).
     const sharedCss = await Bun.file(
-      new URL('../../styles/components/_floating-surface.css', import.meta.url),
+      new URL('../../styles/components/_row-item.css', import.meta.url),
     ).text();
     const sharedCssWithoutComments = sharedCss.replace(/\/\*[\s\S]*?\*\//g, '');
     expect(sharedCssWithoutComments).toMatch(

--- a/packages/components/src/components/command-item/command-item.svelte
+++ b/packages/components/src/components/command-item/command-item.svelte
@@ -111,7 +111,7 @@
   {@attach registerWithPalette}
   id={itemId ?? undefined}
   role="option"
-  class={classNames('cinder-command-item', className)}
+  class={classNames('cinder-_row-item', 'cinder-command-item', className)}
   aria-selected={isActive}
   aria-disabled={disabled || undefined}
   aria-label={normalizedAccessibleLabel}

--- a/packages/components/src/components/dropdown-item/dropdown-item.svelte
+++ b/packages/components/src/components/dropdown-item/dropdown-item.svelte
@@ -50,6 +50,7 @@
   const sharedClass = $derived(
     classNames(
       'cinder-_option-row',
+      'cinder-_row-item',
       'cinder-dropdown-item',
       inset && 'cinder-dropdown-item--inset',
       customClassName,

--- a/packages/components/src/components/navigation-item/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item/navigation-item.svelte
@@ -48,7 +48,9 @@
 
   const isLink = $derived(href !== undefined);
 
-  const resolvedClass = $derived(classNames('cinder-navigation-item', customClassName));
+  const resolvedClass = $derived(
+    classNames('cinder-_row-item', 'cinder-navigation-item', customClassName),
+  );
   // Disabled forces tabindex=-1; otherwise the consumer's value (or undefined) is kept.
   const resolvedTabindex = $derived(disabled ? -1 : tabindex);
   const ariaCurrent = $derived(active ? current : undefined);

--- a/packages/components/src/styles/components.css
+++ b/packages/components/src/styles/components.css
@@ -7,6 +7,7 @@
 @import './components/_control-item.css';
 @import './components/_field-label.css';
 @import './components/_floating-surface.css';
+@import './components/_row-item.css';
 @import './components/_input-frame.css';
 @import '../components/_internal/person-byline.css';
 

--- a/packages/components/src/styles/components/_floating-surface.css
+++ b/packages/components/src/styles/components/_floating-surface.css
@@ -24,33 +24,10 @@
     pointer-events: none;
   }
 
-  /*
-   * The keyboard cursor (`data-cinder-active`) gets a geometric ring on top of
-   * the background tint. The `--cinder-surface-raised-hover` fill is intentionally a
-   * subtle ~1.1:1 step against the panel's `--cinder-surface-raised` — fine for
-   * pointer hover, but on its own it fails WCAG 1.4.11 (3:1 non-text contrast)
-   * for the *sole* keyboard-position indicator. `--cinder-ring-color` is the
-   * system focus-ring token (light arm clamped to L 0.58 specifically to clear
-   * 3:1 against near-white surfaces), so an inset ring makes the active row
-   * unambiguous in both themes. An inset `box-shadow` (not `outline`) is used so
-   * the ring follows the row's `border-radius`. Scoped to `data-cinder-active`
-   * only: `aria-selected` is the committed choice and must stay visually
-   * distinct from the transient keyboard cursor.
-   */
   @media (forced-colors: active) {
     .cinder-_floating-surface {
       border-color: CanvasText;
       box-shadow: none;
     }
-
-    /*
-     * Forced-colors strips `box-shadow`, so the keyboard cursor falls back to a
-     * system `Highlight` outline. A selected-but-not-active row is reset to no
-     * outline so the committed choice does not masquerade as the keyboard
-     * cursor. The `:not([data-cinder-active])` guard is load-bearing: a row that
-     * is BOTH selected and the cursor must keep its `Highlight` outline (equal
-     * specificity means a bare `[aria-selected='true']` reset would win on
-     * source order and erase the only forced-colors position indicator).
-     */
   }
 }

--- a/packages/components/src/styles/components/_floating-surface.css
+++ b/packages/components/src/styles/components/_floating-surface.css
@@ -24,19 +24,6 @@
     pointer-events: none;
   }
 
-  .cinder-_option-row {
-    display: flex;
-    align-items: center;
-    gap: var(--cinder-space-2);
-    border-radius: var(--cinder-radius-sm);
-    color: var(--cinder-text);
-  }
-
-  .cinder-_option-row[data-cinder-active],
-  .cinder-_option-row[aria-selected='true'] {
-    background: var(--cinder-surface-raised-hover);
-  }
-
   /*
    * The keyboard cursor (`data-cinder-active`) gets a geometric ring on top of
    * the background tint. The `--cinder-surface-raised-hover` fill is intentionally a
@@ -50,16 +37,6 @@
    * only: `aria-selected` is the committed choice and must stay visually
    * distinct from the transient keyboard cursor.
    */
-  .cinder-_option-row[data-cinder-active] {
-    box-shadow: inset 0 0 0 1px var(--cinder-ring-color);
-  }
-
-  .cinder-_option-row[aria-disabled='true'],
-  .cinder-_option-row[data-cinder-disabled] {
-    color: var(--cinder-text-disabled);
-    cursor: not-allowed;
-  }
-
   @media (forced-colors: active) {
     .cinder-_floating-surface {
       border-color: CanvasText;
@@ -75,14 +52,5 @@
      * specificity means a bare `[aria-selected='true']` reset would win on
      * source order and erase the only forced-colors position indicator).
      */
-    .cinder-_option-row[data-cinder-active] {
-      box-shadow: none;
-      outline: 1px solid Highlight;
-      outline-offset: -1px;
-    }
-
-    .cinder-_option-row[aria-selected='true']:not([data-cinder-active]) {
-      outline: none;
-    }
   }
 }

--- a/packages/components/src/styles/components/_row-item.css
+++ b/packages/components/src/styles/components/_row-item.css
@@ -1,0 +1,45 @@
+@layer cinder.components {
+  /* Shared geometry and transient row state for option-like items. */
+  .cinder-_row-item,
+  .cinder-_option-row {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-2);
+    min-inline-size: 0;
+    border-radius: var(--cinder-radius-sm);
+  }
+
+  .cinder-_row-item[data-cinder-active],
+  .cinder-_row-item[aria-selected='true'],
+  .cinder-_option-row[data-cinder-active],
+  .cinder-_option-row[aria-selected='true'] {
+    background: var(--cinder-surface-raised-hover);
+  }
+
+  .cinder-_row-item[data-cinder-active],
+  .cinder-_option-row[data-cinder-active] {
+    box-shadow: inset 0 0 0 1px var(--cinder-ring-color);
+  }
+
+  .cinder-_row-item[aria-disabled='true'],
+  .cinder-_row-item[data-cinder-disabled],
+  .cinder-_option-row[aria-disabled='true'],
+  .cinder-_option-row[data-cinder-disabled] {
+    color: var(--cinder-text-disabled);
+    cursor: not-allowed;
+  }
+
+  @media (forced-colors: active) {
+    .cinder-_row-item[data-cinder-active],
+    .cinder-_option-row[data-cinder-active] {
+      box-shadow: none;
+      outline: 1px solid Highlight;
+      outline-offset: -1px;
+    }
+
+    .cinder-_row-item[aria-selected='true']:not([data-cinder-active]),
+    .cinder-_option-row[aria-selected='true']:not([data-cinder-active]) {
+      outline: none;
+    }
+  }
+}

--- a/packages/components/src/styles/components/_row-item.css
+++ b/packages/components/src/styles/components/_row-item.css
@@ -9,6 +9,12 @@
     border-radius: var(--cinder-radius-sm);
   }
 
+  /*
+   * The keyboard cursor gets an inset ring on top of the subtle active fill so
+   * its boundary meets non-text contrast requirements without changing layout.
+   * Keep this separate from aria-selected: selection is the committed value,
+   * while data-cinder-active is the transient cursor.
+   */
   .cinder-_row-item[data-cinder-active],
   .cinder-_row-item[aria-selected='true'],
   .cinder-_option-row[data-cinder-active],
@@ -37,6 +43,8 @@
       outline-offset: -1px;
     }
 
+    /* Match the active selector's specificity so this reset cannot erase the
+     * forced-colors cursor outline through source order alone. */
     .cinder-_row-item[aria-selected='true']:not([data-cinder-active]),
     .cinder-_option-row[aria-selected='true']:not([data-cinder-active]) {
       outline: none;

--- a/packages/components/src/styles/components/row-item.test.ts
+++ b/packages/components/src/styles/components/row-item.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const componentsRoot = resolve(import.meta.dir, '../../components');
+
+describe('shared row-item boundary', () => {
+  test('is composed by the option-like families only', () => {
+    const shared = readFileSync(resolve(import.meta.dir, '_row-item.css'), 'utf8');
+    expect(shared).toContain('.cinder-_row-item');
+    for (const family of ['dropdown-item', 'command-item', 'navigation-item']) {
+      expect(readFileSync(resolve(componentsRoot, family, `${family}.svelte`), 'utf8')).toContain(
+        'cinder-_row-item',
+      );
+    }
+    for (const family of [
+      'selectable-row',
+      'stacked-list-item',
+      'grid-list-item',
+      'choice-grid-item',
+      'tree-item',
+    ]) {
+      expect(
+        readFileSync(resolve(componentsRoot, family, `${family}.svelte`), 'utf8'),
+      ).not.toContain('cinder-_row-item');
+    }
+  });
+});

--- a/packages/components/src/styles/components/row-item.test.ts
+++ b/packages/components/src/styles/components/row-item.test.ts
@@ -7,7 +7,10 @@ const componentsRoot = resolve(import.meta.dir, '../../components');
 describe('shared row-item boundary', () => {
   test('is composed by the option-like families only', () => {
     const shared = readFileSync(resolve(import.meta.dir, '_row-item.css'), 'utf8');
+    const floatingSurface = readFileSync(resolve(import.meta.dir, '_floating-surface.css'), 'utf8');
     expect(shared).toContain('.cinder-_row-item');
+    expect(shared).toContain('.cinder-_option-row');
+    expect(floatingSurface).not.toContain('.cinder-_option-row');
     for (const family of ['dropdown-item', 'command-item', 'navigation-item']) {
       expect(readFileSync(resolve(componentsRoot, family, `${family}.svelte`), 'utf8')).toContain(
         'cinder-_row-item',

--- a/packages/components/src/styles/components/row-item.test.ts
+++ b/packages/components/src/styles/components/row-item.test.ts
@@ -7,7 +7,10 @@ const componentsRoot = resolve(import.meta.dir, '../../components');
 describe('shared row-item boundary', () => {
   test('is composed by the option-like families only', () => {
     const shared = readFileSync(resolve(import.meta.dir, '_row-item.css'), 'utf8');
-    const floatingSurface = readFileSync(resolve(import.meta.dir, '_floating-surface.css'), 'utf8');
+    const floatingSurface = readFileSync(
+      resolve(import.meta.dir, '_floating-surface.css'),
+      'utf8',
+    ).replace(/\/\*[\s\S]*?\*\//g, '');
     expect(shared).toContain('.cinder-_row-item');
     expect(shared).toContain('.cinder-_option-row');
     expect(floatingSurface).not.toContain('.cinder-_option-row');

--- a/packages/components/src/styles/index.css
+++ b/packages/components/src/styles/index.css
@@ -34,6 +34,7 @@
 @import './components/_dismiss-button.css';
 @import './components/_field-label.css';
 @import './components/_floating-surface.css';
+@import './components/_row-item.css';
 @import './components/_control-item.css';
 @import './components/_input-frame.css';
 @import './components/_status-surface.css';


### PR DESCRIPTION
## Summary
- introduce a private shared row-item style boundary for option-like rows
- compose DropdownItem, CommandItem, NavigationItem, and transitively SideNavigationItem
- document semantic exclusions and add ownership regression coverage

## Verification
- focused row/item tests (118 passing)
- components:check
- exports:check
- typecheck
- lint

Closes #1102