### PR TITLE
docs: record dialog preset boundary

### DIFF
--- a/.changeset/dialog-preset-boundary.md
+++ b/.changeset/dialog-preset-boundary.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Document the distinct Modal, ConfirmDialog, and AlertDialog preset boundaries.

--- a/docs/decisions/dialog-presets.md
+++ b/docs/decisions/dialog-presets.md
@@ -16,9 +16,10 @@ Modal primitive, not duplicate shells.
 - **AlertDialog** is the nearest alternative for system-initiated urgent
   acknowledgement. It uses `role="alertdialog"`, requires a concise
   description, disables Escape/backdrop/close-X dismissal, and can close only
-  through an explicit acknowledgement action. Use Modal with `role="alertdialog"`
-  only when richer body composition is required and the same restrictions are
-  supplied.
+  through an explicit action: acknowledgement, or the preset's explicit cancel
+  alternative when `cancelLabel` is supplied. Use Modal with
+  `role="alertdialog"` only when richer body composition is required and the
+  same dismissal restrictions are supplied.
 
 All three preserve native dialog focus trapping, keyboard behavior, dismissal
 events, and ARIA naming/description contracts. Do not fold the presets into

--- a/docs/decisions/dialog-presets.md
+++ b/docs/decisions/dialog-presets.md
@@ -1,5 +1,8 @@
 # Dialog preset boundary
 
+**Status:** Accepted 2026-08-04.
+**Date:** 2026-08-04
+
 Decision: preserve `Modal`, `ConfirmDialog`, and `AlertDialog` as separate
 public entries. The latter two are intentionally opinionated presets over the
 Modal primitive, not duplicate shells.

--- a/docs/decisions/dialog-presets.md
+++ b/docs/decisions/dialog-presets.md
@@ -1,0 +1,28 @@
+# Dialog preset boundary
+
+Decision: preserve `Modal`, `ConfirmDialog`, and `AlertDialog` as separate
+public entries. The latter two are intentionally opinionated presets over the
+Modal primitive, not duplicate shells.
+
+- **Modal** is the nearest alternative when content is rich, has more than two
+  actions, or needs custom focus and dismissal policy. It owns the generic
+  modal lifecycle: focus capture/restore, native dialog top-layer semantics,
+  body scroll lock, optional Escape/backdrop dismissal, and close button.
+- **ConfirmDialog** is the nearest alternative for a user-initiated binary
+  decision. It acknowledges the user's action with explicit confirm/cancel
+  buttons, defaults focus to cancel, and routes Escape, backdrop, and close-X
+  to `onCancel`. It must remain safely dismissible because the user initiated
+  the interruption.
+- **AlertDialog** is the nearest alternative for system-initiated urgent
+  acknowledgement. It uses `role="alertdialog"`, requires a concise
+  description, disables Escape/backdrop/close-X dismissal, and can close only
+  through an explicit acknowledgement action. Use Modal with `role="alertdialog"`
+  only when richer body composition is required and the same restrictions are
+  supplied.
+
+All three preserve native dialog focus trapping, keyboard behavior, dismissal
+events, and ARIA naming/description contracts. Do not fold the presets into
+Modal variants: doing so would turn acknowledgement policy into a collection
+of booleans and make it easier to accidentally weaken the urgent blocking
+contract. New dialog APIs must choose one of these boundaries and retain the
+existing keyboard, focus, dismissal, and ARIA tests.

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -250,7 +250,7 @@
       "tags": ["overlay", "dialog"],
       "useWhen": [
         "Requiring acknowledgement of a blocking warning before the user can continue.",
-        "Presenting a destructive or high-risk message that needs an explicit OK action."
+        "A system-initiated or out-of-band condition requires explicit acknowledgement before continuing."
       ],
       "avoidWhen": [
         {
@@ -1392,7 +1392,7 @@
           "reason": "Announcing a non-blocking result — use toast-region or banner."
         }
       ],
-      "related": ["modal", "drawer", "sheet"],
+      "related": ["modal", "alert-dialog", "drawer", "sheet"],
       "hasConstraints": false,
       "hasExamples": true,
       "artifacts": {

--- a/packages/components/src/components/alert-dialog/README.md
+++ b/packages/components/src/components/alert-dialog/README.md
@@ -2,6 +2,9 @@
 
 Sticky blocking acknowledgement dialog that cannot be dismissed by Escape or backdrop click. The user must click an explicit action button to proceed.
 
+See the [dialog preset boundary](../../../../docs/decisions/dialog-presets.md)
+for the preserved role, acknowledgement, and dismissal contract.
+
 ## Dialog model
 
 AlertDialog is one of three dialog-level components:

--- a/packages/components/src/components/alert-dialog/README.md
+++ b/packages/components/src/components/alert-dialog/README.md
@@ -2,7 +2,7 @@
 
 Sticky blocking acknowledgement dialog that cannot be dismissed by Escape or backdrop click. The user must click an explicit action button to proceed.
 
-See the [dialog preset boundary](../../../../docs/decisions/dialog-presets.md)
+See the [dialog preset boundary](../../../../../docs/decisions/dialog-presets.md)
 for the preserved role, acknowledgement, and dismissal contract.
 
 ## Dialog model

--- a/packages/components/src/components/alert-dialog/README.md
+++ b/packages/components/src/components/alert-dialog/README.md
@@ -2,7 +2,7 @@
 
 Sticky blocking acknowledgement dialog that cannot be dismissed by Escape or backdrop click. The user must click an explicit action button to proceed.
 
-See the [dialog preset boundary](../../../../../docs/decisions/dialog-presets.md)
+See the [dialog preset boundary](https://github.com/stevekinney/cinder/blob/main/docs/decisions/dialog-presets.md)
 for the preserved role, acknowledgement, and dismissal contract.
 
 ## Dialog model

--- a/packages/components/src/components/alert-dialog/alert-dialog.svelte
+++ b/packages/components/src/components/alert-dialog/alert-dialog.svelte
@@ -7,7 +7,7 @@
    * @tag overlay
    * @tag dialog
    * @useWhen Requiring acknowledgement of a blocking warning before the user can continue.
-   * @useWhen Presenting a destructive or high-risk message that needs an explicit OK action.
+   * @useWhen A system-initiated or out-of-band condition requires explicit acknowledgement before continuing.
    * @avoidWhen Asking a reversible yes/no question — use confirm-dialog.
    * @avoidWhen Collecting rich form input — compose modal instead.
    * @related modal, confirm-dialog, drawer

--- a/packages/components/src/components/confirm-dialog/README.md
+++ b/packages/components/src/components/confirm-dialog/README.md
@@ -2,7 +2,7 @@
 
 Pre-wired modal dialog for user-initiated binary decisions: "proceed" or "cancel". Focus defaults to the cancel button — the industry-standard guard against accidental destructive confirms.
 
-See the [dialog preset boundary](../../../../../docs/decisions/dialog-presets.md)
+See the [dialog preset boundary](https://github.com/stevekinney/cinder/blob/main/docs/decisions/dialog-presets.md)
 for the preserved role, acknowledgement, and dismissal contract.
 
 ## Dialog model

--- a/packages/components/src/components/confirm-dialog/README.md
+++ b/packages/components/src/components/confirm-dialog/README.md
@@ -2,6 +2,9 @@
 
 Pre-wired modal dialog for user-initiated binary decisions: "proceed" or "cancel". Focus defaults to the cancel button — the industry-standard guard against accidental destructive confirms.
 
+See the [dialog preset boundary](../../../../docs/decisions/dialog-presets.md)
+for the preserved role, acknowledgement, and dismissal contract.
+
 ## Dialog model
 
 ConfirmDialog is one of three dialog-level components:

--- a/packages/components/src/components/confirm-dialog/README.md
+++ b/packages/components/src/components/confirm-dialog/README.md
@@ -2,7 +2,7 @@
 
 Pre-wired modal dialog for user-initiated binary decisions: "proceed" or "cancel". Focus defaults to the cancel button — the industry-standard guard against accidental destructive confirms.
 
-See the [dialog preset boundary](../../../../docs/decisions/dialog-presets.md)
+See the [dialog preset boundary](../../../../../docs/decisions/dialog-presets.md)
 for the preserved role, acknowledgement, and dismissal contract.
 
 ## Dialog model
@@ -16,7 +16,7 @@ ConfirmDialog is one of three dialog-level components:
 The key distinction between ConfirmDialog and AlertDialog is _who initiates_ the interruption:
 
 - ConfirmDialog is for user-initiated actions that need a safety gate ("You clicked Delete — are you sure?"). Escape is a safe exit; cancel is the default focus.
-- AlertDialog is for system-initiated or out-of-band urgency ("Your session expired", "This action affects others"). Escape is blocked; acknowledgement is mandatory.
+- AlertDialog is for system-initiated or out-of-band urgency ("Your session expired", "A background process failed"). Escape is blocked; acknowledgement is mandatory.
 
 ## Choosing this component
 

--- a/packages/components/src/components/confirm-dialog/confirm-dialog.svelte
+++ b/packages/components/src/components/confirm-dialog/confirm-dialog.svelte
@@ -10,7 +10,7 @@
    * @useWhen Asking the user to confirm a discrete decision with two clear outcomes.
    * @avoidWhen Collecting structured input or multiple fields — compose a modal with form controls instead.
    * @avoidWhen Announcing a non-blocking result — use toast-region or banner.
-   * @related modal, drawer, sheet
+   * @related modal, alert-dialog, drawer, sheet
    */
   export type { ConfirmDialogProps } from './confirm-dialog.types.ts';
 </script>

--- a/packages/components/src/components/modal/README.md
+++ b/packages/components/src/components/modal/README.md
@@ -2,7 +2,7 @@
 
 Generic modal shell for rich content, forms, and structured workflows. Use the more specialised components when the content fits their narrower contract.
 
-See the [dialog preset boundary](../../../../../docs/decisions/dialog-presets.md)
+See the [dialog preset boundary](https://github.com/stevekinney/cinder/blob/main/docs/decisions/dialog-presets.md)
 for the durable distinction from ConfirmDialog and AlertDialog.
 
 ## Choosing this component

--- a/packages/components/src/components/modal/README.md
+++ b/packages/components/src/components/modal/README.md
@@ -2,6 +2,9 @@
 
 Generic modal shell for rich content, forms, and structured workflows. Use the more specialised components when the content fits their narrower contract.
 
+See the [dialog preset boundary](../../../../docs/decisions/dialog-presets.md)
+for the durable distinction from ConfirmDialog and AlertDialog.
+
 ## Choosing this component
 
 - Presenting rich or structured content (forms, multi-step wizards, detail views) inside a blocking overlay.

--- a/packages/components/src/components/modal/README.md
+++ b/packages/components/src/components/modal/README.md
@@ -2,7 +2,7 @@
 
 Generic modal shell for rich content, forms, and structured workflows. Use the more specialised components when the content fits their narrower contract.
 
-See the [dialog preset boundary](../../../../docs/decisions/dialog-presets.md)
+See the [dialog preset boundary](../../../../../docs/decisions/dialog-presets.md)
 for the durable distinction from ConfirmDialog and AlertDialog.
 
 ## Choosing this component


### PR DESCRIPTION
## Summary
- preserve Modal, ConfirmDialog, and AlertDialog as distinct public presets
- record role, dismissal, acknowledgement, and nearest-alternative contracts
- align component metadata and add a patch changeset

## Verification
- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/components/src/components/modal packages/components/src/components/alert-dialog packages/components/src/components/confirm-dialog`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run --filter=@lostgradient/cinder typecheck`

Closes #1105