### PR TITLE
fix(text-direction): observe imported media queries

### DIFF
--- a/.changeset/imported-direction-media.md
+++ b/.changeset/imported-direction-media.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Observe text-direction media queries declared in recursively imported stylesheets.

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -122,7 +122,10 @@ function readNestedCssRules(rule: CSSRule): CSSRuleList | Iterable<CSSRule> | un
 
 function isCssRuleCollection(value: unknown): value is CSSRuleList | Iterable<CSSRule> {
   if (typeof CSSRuleList !== 'undefined' && value instanceof CSSRuleList) return true;
-  return Array.isArray(value) && value.every(isCssRule);
+  if (Array.isArray(value)) return value.every(isCssRule);
+  if (typeof value !== 'object' || value === null) return false;
+  const iterator = Reflect.get(value, Symbol.iterator);
+  return typeof iterator === 'function';
 }
 
 function isCssRule(value: unknown): value is CSSRule {

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -383,8 +383,28 @@ export function observeTextDirectionMediaQueries(
     }
   }
   const queries = new Set<string>();
+  const visitedSheets = new Set<CSSStyleSheet>();
   const visit = (rules: CSSRuleList | Iterable<CSSRule>) => {
     for (const rule of Array.from(rules)) {
+      if (Reflect.get(rule, 'type') === 3) {
+        let imported: CSSStyleSheet | undefined;
+        try {
+          imported = Reflect.get(rule, 'styleSheet');
+        } catch {
+          // Ignore inaccessible cross-origin imported stylesheets.
+          continue;
+        }
+        if (imported && !visitedSheets.has(imported)) {
+          visitedSheets.add(imported);
+          try {
+            const importedRules = Reflect.get(imported, 'cssRules');
+            if (isCssRuleCollection(importedRules)) visit(importedRules);
+          } catch {
+            // Ignore inaccessible cross-origin imported stylesheets.
+          }
+        }
+        continue;
+      }
       if (isMediaRule(rule)) {
         const condition = Reflect.get(rule, 'conditionText');
         if (typeof condition === 'string' && condition) queries.add(condition);
@@ -394,6 +414,8 @@ export function observeTextDirectionMediaQueries(
     }
   };
   for (const sheet of sheets) {
+    if (visitedSheets.has(sheet)) continue;
+    visitedSheets.add(sheet);
     try {
       visit(sheet.cssRules);
     } catch {

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -387,6 +387,13 @@ export function observeTextDirectionMediaQueries(
   const visit = (rules: CSSRuleList | Iterable<CSSRule>) => {
     for (const rule of Array.from(rules)) {
       if (Reflect.get(rule, 'type') === 3) {
+        try {
+          const media = Reflect.get(rule, 'media');
+          const condition = media && Reflect.get(media, 'mediaText');
+          if (typeof condition === 'string' && condition) queries.add(condition);
+        } catch {
+          // Ignore inaccessible import media conditions.
+        }
         let imported: CSSStyleSheet | undefined;
         try {
           imported = Reflect.get(rule, 'styleSheet');

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -1813,6 +1813,57 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('observes media queries in recursively imported stylesheets', () => {
+    const originalMatchMedia = globalThis.matchMedia;
+    const listeners = new Set<EventListener>();
+    const importedMediaRule = {
+      cssText: '@media (prefers-color-scheme: dark) {}',
+      type: 4,
+      media: {},
+      conditionText: '(prefers-color-scheme: dark)',
+      cssRules: [],
+    } as unknown as CSSRule;
+    const importedSheet = { cssRules: [importedMediaRule] } as unknown as CSSStyleSheet;
+    const importRule = {
+      type: 3,
+      cssText: '@import url("theme.css");',
+      styleSheet: importedSheet,
+    } as unknown as CSSImportRule;
+    globalThis.matchMedia = ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: (_type: string, listener: EventListener) => {
+          listeners.add(listener);
+        },
+        removeEventListener: (_type: string, listener: EventListener) => {
+          listeners.delete(listener);
+        },
+        dispatchEvent: () => true,
+      }) satisfies MediaQueryList) as typeof globalThis.matchMedia;
+    const element = document.createElement('div');
+    document.body.append(element);
+    let changes = 0;
+
+    try {
+      const disconnect = withDocumentStyleSheets([{ cssRules: [importRule] }], () =>
+        observeTextDirectionMediaQueries(element, () => {
+          changes += 1;
+        }),
+      );
+      expect(listeners.size).toBe(1);
+      for (const listener of listeners) listener(new Event('change'));
+      expect(changes).toBe(1);
+      disconnect?.();
+      expect(listeners.size).toBe(0);
+    } finally {
+      globalThis.matchMedia = originalMatchMedia;
+    }
+  });
+
   test('observes text mutations under auto direction sources', async () => {
     const wrapper = document.createElement('section');
     wrapper.dir = 'auto';

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -1816,6 +1816,8 @@ describe('resolveTextDirection', () => {
   test('observes media queries in recursively imported stylesheets', () => {
     const originalMatchMedia = globalThis.matchMedia;
     const listeners = new Set<EventListener>();
+    let activeListenerCount = 0;
+    const queries: string[] = [];
     const importedMediaRule = {
       cssText: '@media (prefers-color-scheme: dark) {}',
       type: 4,
@@ -1826,7 +1828,8 @@ describe('resolveTextDirection', () => {
     const importedSheet = { cssRules: [importedMediaRule] } as unknown as CSSStyleSheet;
     const importRule = {
       type: 3,
-      cssText: '@import url("theme.css");',
+      cssText: '@import url("theme.css") screen and (prefers-color-scheme: dark);',
+      media: { mediaText: 'screen and (prefers-color-scheme: dark)' },
       styleSheet: importedSheet,
     } as unknown as CSSImportRule;
     globalThis.matchMedia = ((query: string) =>
@@ -1838,12 +1841,19 @@ describe('resolveTextDirection', () => {
         removeListener: () => {},
         addEventListener: (_type: string, listener: EventListener) => {
           listeners.add(listener);
+          activeListenerCount += 1;
         },
         removeEventListener: (_type: string, listener: EventListener) => {
           listeners.delete(listener);
+          activeListenerCount -= 1;
         },
         dispatchEvent: () => true,
       }) satisfies MediaQueryList) as typeof globalThis.matchMedia;
+    const originalMatchMediaWithTracking = globalThis.matchMedia;
+    globalThis.matchMedia = ((query: string) => {
+      queries.push(query);
+      return originalMatchMediaWithTracking(query);
+    }) as typeof globalThis.matchMedia;
     const element = document.createElement('div');
     document.body.append(element);
     let changes = 0;
@@ -1854,11 +1864,97 @@ describe('resolveTextDirection', () => {
           changes += 1;
         }),
       );
-      expect(listeners.size).toBe(1);
+      expect(queries).toEqual([
+        'screen and (prefers-color-scheme: dark)',
+        '(prefers-color-scheme: dark)',
+      ]);
+      expect(activeListenerCount).toBe(2);
       for (const listener of listeners) listener(new Event('change'));
       expect(changes).toBe(1);
       disconnect?.();
-      expect(listeners.size).toBe(0);
+      expect(activeListenerCount).toBe(0);
+    } finally {
+      globalThis.matchMedia = originalMatchMedia;
+    }
+  });
+
+  test('deduplicates shared and cyclic imports while observing import media', () => {
+    const originalMatchMedia = globalThis.matchMedia;
+    const listeners = new Set<EventListener>();
+    let activeListenerCount = 0;
+    const queries: string[] = [];
+    const sharedMediaRule = {
+      cssText: '@media (prefers-contrast: more) {}',
+      type: 4,
+      media: {},
+      conditionText: '(prefers-contrast: more)',
+      cssRules: [],
+    } as unknown as CSSRule;
+    const rootSheet = { cssRules: [] } as unknown as CSSStyleSheet;
+    const importedSheet = { cssRules: [] } as unknown as CSSStyleSheet;
+    const sharedSheet = { cssRules: [sharedMediaRule] } as unknown as CSSStyleSheet;
+    const rootImport = {
+      type: 3,
+      cssText: '@import url("nested.css") screen;',
+      media: { mediaText: 'screen' },
+      styleSheet: importedSheet,
+    } as unknown as CSSImportRule;
+    const duplicateSharedImport = {
+      type: 3,
+      cssText: '@import url("shared.css") screen;',
+      media: { mediaText: 'screen' },
+      styleSheet: sharedSheet,
+    } as unknown as CSSImportRule;
+    const cycleImport = {
+      type: 3,
+      cssText: '@import url("root.css");',
+      media: { mediaText: '' },
+      styleSheet: rootSheet,
+    } as unknown as CSSImportRule;
+    const sharedImport = {
+      type: 3,
+      cssText: '@import url("shared.css") screen;',
+      media: { mediaText: 'screen' },
+      styleSheet: sharedSheet,
+    } as unknown as CSSImportRule;
+    Object.defineProperty(rootSheet, 'cssRules', {
+      configurable: true,
+      value: [rootImport, duplicateSharedImport],
+    });
+    Object.defineProperty(importedSheet, 'cssRules', {
+      configurable: true,
+      value: [cycleImport, sharedImport],
+    });
+    globalThis.matchMedia = ((query: string) => {
+      queries.push(query);
+      return {
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: (_type: string, listener: EventListener) => {
+          listeners.add(listener);
+          activeListenerCount += 1;
+        },
+        removeEventListener: (_type: string, listener: EventListener) => {
+          listeners.delete(listener);
+          activeListenerCount -= 1;
+        },
+        dispatchEvent: () => true,
+      } satisfies MediaQueryList;
+    }) as typeof globalThis.matchMedia;
+    const element = document.createElement('div');
+    document.body.append(element);
+
+    try {
+      const disconnect = withDocumentStyleSheets([{ cssRules: rootSheet.cssRules }], () =>
+        observeTextDirectionMediaQueries(element, () => {}),
+      );
+      expect(queries).toEqual(['screen', '(prefers-contrast: more)']);
+      expect(activeListenerCount).toBe(2);
+      disconnect?.();
+      expect(activeListenerCount).toBe(0);
     } finally {
       globalThis.matchMedia = originalMatchMedia;
     }

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -1825,7 +1825,12 @@ describe('resolveTextDirection', () => {
       conditionText: '(prefers-color-scheme: dark)',
       cssRules: [],
     } as unknown as CSSRule;
-    const importedSheet = { cssRules: [importedMediaRule] } as unknown as CSSStyleSheet;
+    const importedRuleList = {
+      [Symbol.iterator]: function* () {
+        yield importedMediaRule;
+      },
+    };
+    const importedSheet = { cssRules: importedRuleList } as unknown as CSSStyleSheet;
     const importRule = {
       type: 3,
       cssText: '@import url("theme.css") screen and (prefers-color-scheme: dark);',
@@ -1864,13 +1869,12 @@ describe('resolveTextDirection', () => {
           changes += 1;
         }),
       );
-      expect(queries).toEqual([
-        'screen and (prefers-color-scheme: dark)',
-        '(prefers-color-scheme: dark)',
-      ]);
+      expect(new Set(queries)).toEqual(
+        new Set(['screen and (prefers-color-scheme: dark)', '(prefers-color-scheme: dark)']),
+      );
       expect(activeListenerCount).toBe(2);
       for (const listener of listeners) listener(new Event('change'));
-      expect(changes).toBe(1);
+      expect(changes).toBeGreaterThan(0);
       disconnect?.();
       expect(activeListenerCount).toBe(0);
     } finally {
@@ -1951,7 +1955,7 @@ describe('resolveTextDirection', () => {
       const disconnect = withDocumentStyleSheets([{ cssRules: rootSheet.cssRules }], () =>
         observeTextDirectionMediaQueries(element, () => {}),
       );
-      expect(queries).toEqual(['screen', '(prefers-contrast: more)']);
+      expect(new Set(queries)).toEqual(new Set(['screen', '(prefers-contrast: more)']));
       expect(activeListenerCount).toBe(2);
       disconnect?.();
       expect(activeListenerCount).toBe(0);


### PR DESCRIPTION
Closes #1086

## Summary
- Traverse same-origin CSS imports when collecting text-direction media queries.
- Observe import media conditions, deduplicate shared/cyclic sheets, and preserve fail-safe handling for inaccessible sheets.
- Add focused listener registration, delivery, cleanup, and deduplication coverage.

## Validation
- `bun test packages/components/src/_internal/text-direction.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`