### PR TITLE
docs(command-palette): retain native dialog contract

### DIFF
--- a/.changeset/command-palette-native-dialog.md
+++ b/.changeset/command-palette-native-dialog.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Document CommandPalette's intentional native modal dialog boundary.

--- a/docs/decisions/command-palette-native-dialog.md
+++ b/docs/decisions/command-palette-native-dialog.md
@@ -1,0 +1,36 @@
+# CommandPalette native dialog contract
+
+Decision: retain CommandPalette's native modal `<dialog>` rather than composing
+the panel from `cinder-_floating-surface`.
+
+## Why
+
+CommandPalette is a modal command surface, not a non-modal anchored popover. The
+native `showModal()` path supplies top-layer placement, a modal backdrop, and
+browser focus containment. Its existing lifecycle also routes Escape, backdrop
+dismissal, focus restoration, and the combobox/listbox virtual-focus contract
+through one component. Replacing it with the floating-surface primitive would
+require rebuilding those guarantees and could weaken modal isolation or keyboard
+accessibility.
+
+The nearest alternative is `Combobox` for a non-modal single-value picker. Use
+`Popover` or `cinder-_floating-surface` for contextual, non-modal surfaces.
+
+## Contract and consequences
+
+- CommandPalette renders a native `<dialog>` and calls `showModal()` while open.
+- The dialog remains in the browser top layer with `aria-modal="true"`; its
+  native focus trap is part of the public accessibility contract.
+- Escape is owned by the shared escape stack and closes the palette once; the
+  native `cancel` event is prevented so dismissal is single-sourced.
+- Clicking the dialog backdrop closes it; clicks inside the panel do not.
+- Focus remains on the combobox input while `aria-activedescendant` moves across
+  listbox options, and closing restores the captured or supplied trigger focus.
+
+## Alternatives rejected
+
+Using `Popover` or a bare floating surface would preserve positioning but not
+the native modal top layer, backdrop, focus trap, or modal semantics without a
+new bespoke modal implementation. Migrating is therefore out of scope unless a
+separate contract decision explicitly replaces those guarantees and adds
+browser and assistive-technology verification.

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -34,6 +34,12 @@ export const allowedRawControlCounts = new Map<string, number>([
 // their primitive migration is completed.
 export const allowedRawControlSignatures = new Map<string, readonly string[]>([
   [
+    'command-palette/command-palette.svelte',
+    [
+      'input|aria-activedescendant|aria-autocomplete=list|aria-controls|aria-expanded=true|autocomplete=off|autocorrect=off|class=cinder-command-palette__input|id|oninput|onkeydown|placeholder|role=combobox|spellcheck=false|this|type=text|value',
+    ],
+  ],
+  [
     'approval-card/approval-card-actions.svelte',
     [
       'textarea|class=cinder-approval-card__textarea cinder-approval-card__textarea--reason|id|rows=2|value',

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -7,6 +7,9 @@ export const allowedRawControlCounts = new Map<string, number>([
   ['approval-card/approval-card-actions.svelte', 2],
   ['checkbox/checkbox.svelte', 1],
   ['combobox/combobox.svelte', 1],
+  // CommandPalette intentionally retains one native text input inside a modal
+  // <dialog>; see docs/decisions/command-palette-native-dialog.md. This exception
+  // is bounded to the editable combobox control, not the dialog surface.
   ['command-palette/command-palette.svelte', 1],
   ['date-picker/date-picker.svelte', 2],
   ['faceted-filter-bar/faceted-filter-bar.svelte', 1],

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -133,6 +133,9 @@ export const allowedFloatingCounts = new Map<string, number>(
     'waveform/waveform.css',
   ].map((filePath) => [filePath, 1] as const),
 );
+// CommandPalette is intentionally absent from this floating-surface migration:
+// its panel remains a native modal <dialog>, not a positioned non-modal surface.
+// See docs/decisions/command-palette-native-dialog.md for the bounded exception.
 allowedFloatingCounts.set('dropdown/dropdown.css', 6);
 allowedFloatingCounts.set('menu-bar/menu-bar.css', 2);
 allowedFloatingCounts.set('styles/components/experimental/popover.css', 4);

--- a/packages/components/src/components/command-palette/README.md
+++ b/packages/components/src/components/command-palette/README.md
@@ -4,7 +4,7 @@ Modal search overlay for keyboard-first commands, destinations, and record jumpe
 
 CommandPalette intentionally uses a native modal `<dialog>` for top-layer,
 backdrop, focus-trap, and `aria-modal` semantics. See the
-[native dialog contract](../../../../../docs/decisions/command-palette-native-dialog.md).
+[native dialog contract](https://github.com/stevekinney/cinder/blob/main/docs/decisions/command-palette-native-dialog.md).
 For a non-modal single-value picker, use [Combobox](../combobox/README.md).
 
 ## Usage

--- a/packages/components/src/components/command-palette/README.md
+++ b/packages/components/src/components/command-palette/README.md
@@ -4,7 +4,7 @@ Modal search overlay for keyboard-first commands, destinations, and record jumpe
 
 CommandPalette intentionally uses a native modal `<dialog>` for top-layer,
 backdrop, focus-trap, and `aria-modal` semantics. See the
-[native dialog contract](../../../../docs/decisions/command-palette-native-dialog.md).
+[native dialog contract](../../../../../docs/decisions/command-palette-native-dialog.md).
 For a non-modal single-value picker, use [Combobox](../combobox/README.md).
 
 ## Usage

--- a/packages/components/src/components/command-palette/README.md
+++ b/packages/components/src/components/command-palette/README.md
@@ -2,6 +2,11 @@
 
 Modal search overlay for keyboard-first commands, destinations, and record jumpers.
 
+CommandPalette intentionally uses a native modal `<dialog>` for top-layer,
+backdrop, focus-trap, and `aria-modal` semantics. See the
+[native dialog contract](../../../../docs/decisions/command-palette-native-dialog.md).
+For a non-modal single-value picker, use [Combobox](../combobox/README.md).
+
 ## Usage
 
 ```svelte


### PR DESCRIPTION
## Summary

- record the accepted native modal `<dialog>` contract for CommandPalette
- document modal/top-layer, focus, Escape, backdrop, and combobox/listbox accessibility boundaries
- bound the primitive-composition tracker exception and link the nearest non-modal alternative

## Verification

- `bun test packages/components/src/components/command-palette/command-palette.test.ts --conditions browser --conditions svelte --parallel=1` (46/46)
- `bun test packages/components/scripts/check-primitive-composition.test.ts --conditions browser --conditions svelte --parallel=1` (248/248)
- `bun run --filter=@lostgradient/cinder lint:invariants`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run --filter=@lostgradient/cinder check:no-static-style-attributes`

Closes #1100
Parent: #919