### PR TITLE
refactor(logo-cloud): compose shared Grid

### DIFF
--- a/.changeset/logo-cloud-grid-composition.md
+++ b/.changeset/logo-cloud-grid-composition.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Compose LogoCloud layout with Grid while preserving its responsive column behavior.

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -55,7 +55,6 @@ export const allowedGridCounts = new Map<string, number>(
     'grid-list/grid-list.css',
     'grid/grid.css',
     'hero-section/hero-section.css',
-    'logo-cloud/logo-cloud.css',
     'newsletter-section/newsletter-section.css',
     'phone-input/phone-input.css',
     'pricing-section/pricing-section.css',
@@ -83,7 +82,6 @@ allowedGridCounts.set('footer/footer.css', 2);
 allowedGridCounts.set('form-section/form-section.css', 7);
 allowedGridCounts.set('grid/grid.css', 2);
 allowedGridCounts.set('kanban-board/kanban-board.css', 5);
-allowedGridCounts.set('logo-cloud/logo-cloud.css', 11);
 // The nested submenu's master/detail column split adds one tracked match
 // alongside the top-level section grid and the existing trigger/panel split.
 allowedGridCounts.set('mega-menu/mega-menu.css', 3);

--- a/packages/components/src/components/logo-cloud/README.md
+++ b/packages/components/src/components/logo-cloud/README.md
@@ -39,8 +39,7 @@ Renders a responsive cloud of customer or partner logos with optional links.
 
 <!-- generated:variables:start -->
 
-This component does not declare any local CSS variables.
-
+- `--cinder-grid-columns`
 <!-- generated:variables:end -->
 
 ## Subcomponents

--- a/packages/components/src/components/logo-cloud/logo-cloud.css
+++ b/packages/components/src/components/logo-cloud/logo-cloud.css
@@ -1,4 +1,5 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../grid/grid.css';
 @layer cinder.components {
   .cinder-logo-cloud {
     container-type: inline-size;
@@ -29,26 +30,8 @@
     list-style: none;
     margin: 0;
     padding: 0;
-    display: grid;
-    gap: var(--cinder-space-5);
+    --cinder-grid-columns: repeat(2, minmax(0, 1fr));
     align-items: center;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .cinder-logo-cloud[data-cinder-columns='3'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .cinder-logo-cloud[data-cinder-columns='4'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-
-  .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .cinder-logo-cloud__item {
@@ -83,23 +66,23 @@
 
   @container cinder-logo-cloud (min-width: 48rem) {
     .cinder-logo-cloud[data-cinder-columns='3'] .cinder-logo-cloud__list {
-      grid-template-columns: repeat(3, minmax(0, 1fr));
+      --cinder-grid-columns: repeat(3, minmax(0, 1fr));
     }
 
     .cinder-logo-cloud[data-cinder-columns='4'] .cinder-logo-cloud__list,
     .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list,
     .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {
-      grid-template-columns: repeat(4, minmax(0, 1fr));
+      --cinder-grid-columns: repeat(4, minmax(0, 1fr));
     }
   }
 
   @container cinder-logo-cloud (min-width: 64rem) {
     .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list {
-      grid-template-columns: repeat(5, minmax(0, 1fr));
+      --cinder-grid-columns: repeat(5, minmax(0, 1fr));
     }
 
     .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {
-      grid-template-columns: repeat(6, minmax(0, 1fr));
+      --cinder-grid-columns: repeat(6, minmax(0, 1fr));
     }
   }
 }

--- a/packages/components/src/components/logo-cloud/logo-cloud.svelte
+++ b/packages/components/src/components/logo-cloud/logo-cloud.svelte
@@ -18,6 +18,7 @@
 
 <script lang="ts">
   import Container from '../container/container.svelte';
+  import Grid from '@lostgradient/cinder/grid';
   import { classNames } from '../../utilities/class-names.ts';
 
   import type { LogoCloudProps } from './logo-cloud.types.ts';
@@ -53,7 +54,7 @@
         </header>
       {/if}
 
-      <ul class="cinder-logo-cloud__list">
+      <Grid as="ul" gap="var(--cinder-space-5)" class="cinder-logo-cloud__list">
         {#each logos as logo, index (`${logo.name}-${index}`)}
           <li class="cinder-logo-cloud__item">
             {#if logo.href}
@@ -70,7 +71,7 @@
             {/if}
           </li>
         {/each}
-      </ul>
+      </Grid>
     </div>
   </Container>
 </svelte:element>

--- a/packages/components/src/components/logo-cloud/logo-cloud.test.ts
+++ b/packages/components/src/components/logo-cloud/logo-cloud.test.ts
@@ -23,15 +23,10 @@ const logos = [
   { name: 'Orbit', src: '/orbit.svg' },
 ];
 
-const responsiveColumns = [
-  { columns: 3, narrow: 2, medium: 3, wide: 3 },
-  { columns: 4, narrow: 2, medium: 4, wide: 4 },
-  { columns: 5, narrow: 2, medium: 4, wide: 5 },
-  { columns: 6, narrow: 2, medium: 4, wide: 6 },
-] as const;
+const acceptedColumns = [3, 4, 5, 6] as const;
 
 describe('LogoCloud', () => {
-  test('maps every columns value to its accepted responsive grid contract', () => {
+  test('composes the shared Grid and its stylesheet', () => {
     const stylesheet = readFileSync(new URL('./logo-cloud.css', import.meta.url), 'utf8');
     const component = readFileSync(new URL('./logo-cloud.svelte', import.meta.url), 'utf8');
     expect(stylesheet).toContain("@import '../grid/grid.css';");
@@ -39,27 +34,10 @@ describe('LogoCloud', () => {
     expect(component).toContain('as="ul"');
     expect(component).toContain('gap="var(--cinder-space-5)"');
     expect(component).not.toContain('columns={2}');
-    expect(stylesheet).toContain('--cinder-grid-columns: repeat(2, minmax(0, 1fr));');
-
-    for (const { columns, narrow, medium, wide } of responsiveColumns) {
-      expect(narrow).toBe(2);
-      if (medium === 4) {
-        expect(stylesheet).toContain(
-          ".cinder-logo-cloud[data-cinder-columns='4'] .cinder-logo-cloud__list,\n    .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list,\n    .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {\n      --cinder-grid-columns: repeat(4, minmax(0, 1fr));",
-        );
-      } else {
-        expect(stylesheet).toContain(
-          `.cinder-logo-cloud[data-cinder-columns='${columns}'] .cinder-logo-cloud__list {\n      --cinder-grid-columns: repeat(${medium}, minmax(0, 1fr));`,
-        );
-      }
-      expect(stylesheet).toContain(`--cinder-grid-columns: repeat(${wide}, minmax(0, 1fr));`);
-    }
-    expect(stylesheet).toContain('@container cinder-logo-cloud (min-width: 48rem)');
-    expect(stylesheet).toContain('@container cinder-logo-cloud (min-width: 64rem)');
   });
 
   test('renders every accepted columns prop through the shared Grid', () => {
-    for (const { columns } of responsiveColumns) {
+    for (const columns of acceptedColumns) {
       const props = { logos, columns };
       const { container, unmount } = render(LogoCloud, { props });
       const root = container.querySelector('.cinder-logo-cloud');

--- a/packages/components/src/components/logo-cloud/logo-cloud.test.ts
+++ b/packages/components/src/components/logo-cloud/logo-cloud.test.ts
@@ -23,22 +23,55 @@ const logos = [
   { name: 'Orbit', src: '/orbit.svg' },
 ];
 
+const responsiveColumns = [
+  { columns: 3, narrow: 2, medium: 3, wide: 3 },
+  { columns: 4, narrow: 2, medium: 4, wide: 4 },
+  { columns: 5, narrow: 2, medium: 4, wide: 5 },
+  { columns: 6, narrow: 2, medium: 4, wide: 6 },
+] as const;
+
 describe('LogoCloud', () => {
-  test('maps each columns value to its matching grid track count', () => {
+  test('maps every columns value to its accepted responsive grid contract', () => {
     const stylesheet = readFileSync(new URL('./logo-cloud.css', import.meta.url), 'utf8');
+    const component = readFileSync(new URL('./logo-cloud.svelte', import.meta.url), 'utf8');
+    expect(stylesheet).toContain("@import '../grid/grid.css';");
+    expect(component).toContain('<Grid');
+    expect(component).toContain('as="ul"');
+    expect(component).toContain('gap="var(--cinder-space-5)"');
+    expect(component).not.toContain('columns={2}');
+    expect(stylesheet).toContain('--cinder-grid-columns: repeat(2, minmax(0, 1fr));');
+
+    for (const { columns, narrow, medium, wide } of responsiveColumns) {
+      expect(narrow).toBe(2);
+      if (medium === 4) {
+        expect(stylesheet).toContain(
+          ".cinder-logo-cloud[data-cinder-columns='4'] .cinder-logo-cloud__list,\n    .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list,\n    .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {\n      --cinder-grid-columns: repeat(4, minmax(0, 1fr));",
+        );
+      } else {
+        expect(stylesheet).toContain(
+          `.cinder-logo-cloud[data-cinder-columns='${columns}'] .cinder-logo-cloud__list {\n      --cinder-grid-columns: repeat(${medium}, minmax(0, 1fr));`,
+        );
+      }
+      expect(stylesheet).toContain(`--cinder-grid-columns: repeat(${wide}, minmax(0, 1fr));`);
+    }
     expect(stylesheet).toContain('@container cinder-logo-cloud (min-width: 48rem)');
-    expect(stylesheet).toContain(
-      ".cinder-logo-cloud[data-cinder-columns='3'] .cinder-logo-cloud__list {\n      grid-template-columns: repeat(3, minmax(0, 1fr));",
-    );
-    expect(stylesheet).toContain(
-      ".cinder-logo-cloud[data-cinder-columns='4'] .cinder-logo-cloud__list,\n    .cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list,\n    .cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {\n      grid-template-columns: repeat(4, minmax(0, 1fr));",
-    );
-    expect(stylesheet).toContain(
-      ".cinder-logo-cloud[data-cinder-columns='5'] .cinder-logo-cloud__list {\n      grid-template-columns: repeat(5, minmax(0, 1fr));",
-    );
-    expect(stylesheet).toContain(
-      ".cinder-logo-cloud[data-cinder-columns='6'] .cinder-logo-cloud__list {\n      grid-template-columns: repeat(6, minmax(0, 1fr));",
-    );
+    expect(stylesheet).toContain('@container cinder-logo-cloud (min-width: 64rem)');
+  });
+
+  test('renders every accepted columns prop through the shared Grid', () => {
+    for (const { columns } of responsiveColumns) {
+      const props = { logos, columns };
+      const { container, unmount } = render(LogoCloud, { props });
+      const root = container.querySelector('.cinder-logo-cloud');
+      expect(root?.getAttribute('data-cinder-columns')).toBe(String(columns));
+      expect(root?.querySelector('ul.cinder-logo-cloud__list.cinder-grid')).not.toBeNull();
+      unmount();
+    }
+    const { container, unmount } = render(LogoCloud, { props: { logos } });
+    const root = container.querySelector('.cinder-logo-cloud');
+    expect(root?.getAttribute('data-cinder-columns')).toBe('5');
+    expect(root?.querySelector('ul.cinder-logo-cloud__list.cinder-grid')).not.toBeNull();
+    unmount();
   });
 
   test('renders logo images and optional links', () => {
@@ -67,6 +100,9 @@ describe('LogoCloud', () => {
     });
     const root = container.querySelector('.cinder-logo-cloud');
     expect(root?.getAttribute('data-cinder-columns')).toBe('6');
+    expect(root?.querySelector('.cinder-logo-cloud__list')?.classList.contains('cinder-grid')).toBe(
+      true,
+    );
     expect(root?.hasAttribute('data-cinder-grayscale')).toBe(true);
   });
 

--- a/packages/components/src/components/logo-cloud/logo-cloud.variables.json
+++ b/packages/components/src/components/logo-cloud/logo-cloud.variables.json
@@ -1,1 +1,1 @@
-[]
+["--cinder-grid-columns"]

--- a/packages/components/src/components/logo-cloud/logo-cloud.variables.ts
+++ b/packages/components/src/components/logo-cloud/logo-cloud.variables.ts
@@ -1,3 +1,3 @@
-const variables: readonly string[] = [];
+const variables: readonly string[] = ['--cinder-grid-columns'];
 
 export default variables;

--- a/packages/components/src/styles/component-variables-contract.test.ts
+++ b/packages/components/src/styles/component-variables-contract.test.ts
@@ -147,6 +147,8 @@ describe('component *.variables.json contract', () => {
   const OWNERSHIP_ALLOWLIST: Record<string, string[]> = {
     // The kanban board is the cascade scope for its columns and cards.
     'kanban-board': ['--cinder-kanban-column-', '--cinder-kanban-card-'],
+    // LogoCloud owns the cascade override surface for its composed Grid list.
+    'logo-cloud': ['--cinder-grid-'],
   };
 
   test('every variable in components variables.json is owned by the declaring component', async () => {

--- a/packages/testing/tests/components.playwright.ts
+++ b/packages/testing/tests/components.playwright.ts
@@ -145,6 +145,14 @@ test.describe('table scroll recipe', () => {
 
 const allEntries = loadManifest();
 
+const LOGO_CLOUD_RESPONSIVE_COLUMNS = [3, 4, 5, 6] as const;
+
+function gridTrackCount(element: Element): number {
+  const value = getComputedStyle(element).gridTemplateColumns.trim();
+  if (value === '' || value === 'none') return 0;
+  return value.split(/\s+/u).length;
+}
+
 test.describe('number input resting geometry', () => {
   test('desktop steppers fill the grouped control without dead spacing', async ({
     componentPage,
@@ -181,6 +189,51 @@ test.describe('number input resting geometry', () => {
     expect(
       Math.abs(decrementBox!.x + decrementBox!.width - (groupBox!.x + groupBox!.width)),
     ).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe('logo cloud responsive columns', () => {
+  test('keeps the accepted rendered column contract at 48rem and 64rem boundaries', async ({
+    componentPage,
+  }) => {
+    const entry = allEntries.find((candidate) => candidate.slug === 'logo-cloud');
+    if (!entry) throw new Error('LogoCloud is missing from the component manifest.');
+
+    const page = await componentPage.open({
+      entry,
+      theme: 'light',
+      viewport: { name: 'desktop', width: 1280, height: 900 },
+    });
+    const logoCloud = page.locator('.cinder-logo-cloud').first();
+    const logoList = logoCloud.locator('.cinder-logo-cloud__list');
+    await expect(logoCloud).toHaveCount(1);
+
+    const cases = [
+      { width: 767, expected: { 3: 2, 4: 2, 5: 2, 6: 2 } },
+      { width: 768, expected: { 3: 3, 4: 4, 5: 4, 6: 4 } },
+      { width: 1023, expected: { 3: 3, 4: 4, 5: 4, 6: 4 } },
+      { width: 1024, expected: { 3: 3, 4: 4, 5: 5, 6: 6 } },
+    ] as const;
+
+    for (const columns of LOGO_CLOUD_RESPONSIVE_COLUMNS) {
+      await logoCloud.evaluate((element, nextColumns) => {
+        element.setAttribute('data-cinder-columns', String(nextColumns));
+        if (element instanceof HTMLElement) {
+          element.style.fontSize = '16px';
+        }
+      }, columns);
+
+      for (const { width, expected } of cases) {
+        await logoCloud.evaluate((element, nextWidth) => {
+          if (element instanceof HTMLElement) {
+            element.style.inlineSize = `${nextWidth}px`;
+          }
+        }, width);
+
+        const actual = await logoList.evaluate(gridTrackCount);
+        expect(actual, `columns=${columns} at ${width}px`).toBe(expected[columns]);
+      }
+    }
   });
 });
 

--- a/packages/testing/tests/components.playwright.ts
+++ b/packages/testing/tests/components.playwright.ts
@@ -230,8 +230,19 @@ test.describe('logo cloud responsive columns', () => {
           }
         }, width);
 
-        const actual = await logoList.evaluate(gridTrackCount);
-        expect(actual, `columns=${columns} at ${width}px`).toBe(expected[columns]);
+        // A second programmatic resize of this size-contained element
+        // (container-type: inline-size) doesn't settle within the same
+        // task: getComputedStyle().width can still report the previous
+        // width immediately after element.style.inlineSize is written,
+        // which leaves the container query — and this grid's column
+        // count — reading stale. It takes ~2 rendering frames to settle
+        // (confirmed empirically), so poll instead of reading once.
+        await expect
+          .poll(() => logoList.evaluate(gridTrackCount), {
+            message: `columns=${columns} at ${width}px`,
+            timeout: 2_000,
+          })
+          .toBe(expected[columns]);
       }
     }
   });


### PR DESCRIPTION
## Summary

- compose LogoCloud's logo list with the shared `Grid` primitive
- preserve the accepted 2/3/4/5/6 responsive column contract
- remove the duplicate grid allow-list entry and refresh generated metadata

Closes #1097

## Validation

- `bun test --conditions browser --conditions svelte --parallel=1 packages/components/src/components/logo-cloud`
- `bun run --filter=@lostgradient/cinder components:generate`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder lint:invariants`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder typecheck`
- targeted Prettier check for touched files
