### PR TITLE
fix(choice-grid): compose shared Grid layout

### DIFF
--- a/.changeset/choice-grid-shared-layout.md
+++ b/.changeset/choice-grid-shared-layout.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': minor
+---
+
+Compose ChoiceGrid with the shared Grid layout primitive while preserving its selection behavior.

--- a/.changeset/choice-grid-shared-layout.md
+++ b/.changeset/choice-grid-shared-layout.md
@@ -1,5 +1,5 @@
 ---
-'@lostgradient/cinder': minor
+'@lostgradient/cinder': patch
 ---
 
 Compose ChoiceGrid with the shared Grid layout primitive while preserving its selection behavior.

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -47,7 +47,6 @@ export const allowedGridCounts = new Map<string, number>(
     'bento-grid/bento-grid.css',
     'blog-section/blog-section.css',
     'calendar/calendar.css',
-    'choice-grid/choice-grid.css',
     'data-grid/data-grid.css',
     'date-picker/date-picker.css',
     'event-stream-viewer/event-stream-viewer.css',

--- a/packages/components/src/components/choice-grid/choice-grid.css
+++ b/packages/components/src/components/choice-grid/choice-grid.css
@@ -9,6 +9,10 @@
    * ======================================== */
 
   /* Disabled grid dims every item. Individual item disabled states also apply. */
+  .cinder-choice-grid {
+    inline-size: 100%;
+  }
+
   .cinder-choice-grid[data-cinder-disabled] {
     opacity: 0.6;
     pointer-events: none;

--- a/packages/components/src/components/choice-grid/choice-grid.css
+++ b/packages/components/src/components/choice-grid/choice-grid.css
@@ -1,23 +1,12 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
 
+@import '../grid/grid.css';
 @import '../choice-grid-item/choice-grid-item.css';
 
 @layer cinder.components {
   /* ========================================
    * CHOICE GRID — parent container
    * ======================================== */
-
-  .cinder-choice-grid {
-    /* Default grid layout: responsive auto-fill. Overridden by the
-     * --cinder-choice-grid-columns inline style set from the `columns` prop. */
-    display: grid;
-    grid-template-columns: var(
-      --cinder-choice-grid-columns,
-      repeat(auto-fill, minmax(min(10rem, 100%), 1fr))
-    );
-    gap: var(--cinder-space-3);
-    inline-size: 100%;
-  }
 
   /* Disabled grid dims every item. Individual item disabled states also apply. */
   .cinder-choice-grid[data-cinder-disabled] {

--- a/packages/components/src/components/choice-grid/choice-grid.svelte
+++ b/packages/components/src/components/choice-grid/choice-grid.svelte
@@ -29,6 +29,7 @@
   import { createSingleSelection, createMultiSelection } from '../../_internal/collection.ts';
   import { handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
+  import Grid from '../grid/grid.svelte';
 
   let {
     value = $bindable(null),
@@ -246,27 +247,22 @@
     }
   });
 
-  // Grid template columns CSS.
-  const gridTemplateColumns = $derived(
-    columns === 'responsive'
-      ? `repeat(auto-fill, minmax(min(${minColumnWidth}, 100%), 1fr))`
-      : `repeat(${columns}, 1fr)`,
-  );
-
   // ARIA role: radiogroup for single-select, group for multi-select.
   const role = $derived(multiple ? 'group' : 'radiogroup');
 </script>
 
-<div
+<Grid
   {...rest}
-  {role}
+  minItemWidth={columns === 'responsive' ? minColumnWidth : undefined}
+  columns={columns === 'responsive' ? undefined : columns}
+  gap="var(--cinder-space-3)"
   class={classNames('cinder-choice-grid', className)}
+  {role}
   aria-label={resolvedAriaLabel}
   aria-labelledby={resolvedAriaLabelledby}
   aria-disabled={disabled || undefined}
   data-cinder-multiple={multiple || undefined}
   data-cinder-disabled={disabled || undefined}
-  style:--cinder-choice-grid-columns={gridTemplateColumns}
 >
   {@render children()}
-</div>
+</Grid>

--- a/packages/components/src/components/choice-grid/choice-grid.svelte
+++ b/packages/components/src/components/choice-grid/choice-grid.svelte
@@ -29,7 +29,7 @@
   import { createSingleSelection, createMultiSelection } from '../../_internal/collection.ts';
   import { handleRovingKeydown } from '../../utilities/roving-tabindex.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
-  import Grid from '../grid/grid.svelte';
+  import Grid from '@lostgradient/cinder/grid';
 
   let {
     value = $bindable(null),

--- a/packages/components/src/components/choice-grid/choice-grid.svelte
+++ b/packages/components/src/components/choice-grid/choice-grid.svelte
@@ -249,12 +249,19 @@
 
   // ARIA role: radiogroup for single-select, group for multi-select.
   const role = $derived(multiple ? 'group' : 'radiogroup');
+
+  // Grid renders a configurable HTMLElement tag, while ChoiceGrid preserves
+  // the div-specific attributes from its public API. The forwarded attributes
+  // are otherwise identical at runtime.
+  const gridRest = rest as Record<string, unknown>;
+  const gridLayout = $derived(
+    columns === 'responsive' ? { minItemWidth: minColumnWidth } : { columns },
+  );
 </script>
 
 <Grid
-  {...rest}
-  minItemWidth={columns === 'responsive' ? minColumnWidth : undefined}
-  columns={columns === 'responsive' ? undefined : columns}
+  {...gridRest}
+  {...gridLayout}
   gap="var(--cinder-space-3)"
   class={classNames('cinder-choice-grid', className)}
   {role}

--- a/packages/components/src/components/choice-grid/choice-grid.test.ts
+++ b/packages/components/src/components/choice-grid/choice-grid.test.ts
@@ -403,7 +403,7 @@ describe('ChoiceGrid feedback states', () => {
 
 describe('ChoiceGrid column layout', () => {
   test('composes the shared Grid root', async () => {
-    const { container } = render(Wrapper, { ariaLabel: 'Choices', items: [items[0]] });
+    const { container } = render(Wrapper, { ariaLabel: 'Choices', items: [items[0]!] });
 
     expect(container.querySelector('.cinder-choice-grid.cinder-grid')).not.toBeNull();
   });

--- a/packages/components/src/components/choice-grid/choice-grid.test.ts
+++ b/packages/components/src/components/choice-grid/choice-grid.test.ts
@@ -407,6 +407,24 @@ describe('ChoiceGrid column layout', () => {
 
     expect(container.querySelector('.cinder-choice-grid.cinder-grid')).not.toBeNull();
   });
+  test('maps fixed columns to the shared Grid layout variable', () => {
+    const { container } = render(Wrapper, {
+      ariaLabel: 'Choices',
+      columns: 3,
+      items,
+    });
+    const root = container.querySelector<HTMLElement>('.cinder-choice-grid');
+    expect(root?.style.getPropertyValue('--cinder-grid-columns')).toBe('repeat(3, 1fr)');
+  });
+
+  test('maps responsive minimum width to the shared Grid layout variable', () => {
+    const { container } = render(Wrapper, {
+      ariaLabel: 'Choices',
+      items,
+    });
+    const root = container.querySelector<HTMLElement>('.cinder-choice-grid');
+    expect(root?.style.getPropertyValue('--cinder-grid-min-item-width')).toBe('10rem');
+  });
   test('applies .cinder-choice-grid class to the root', () => {
     const { container } = render(Wrapper, {
       ariaLabel: 'Pick one',

--- a/packages/components/src/components/choice-grid/choice-grid.test.ts
+++ b/packages/components/src/components/choice-grid/choice-grid.test.ts
@@ -402,6 +402,11 @@ describe('ChoiceGrid feedback states', () => {
 // ---------------------------------------------------------------------------
 
 describe('ChoiceGrid column layout', () => {
+  test('composes the shared Grid root', async () => {
+    const { container } = render(Wrapper, { ariaLabel: 'Choices', items: [items[0]] });
+
+    expect(container.querySelector('.cinder-choice-grid.cinder-grid')).not.toBeNull();
+  });
   test('applies .cinder-choice-grid class to the root', () => {
     const { container } = render(Wrapper, {
       ariaLabel: 'Pick one',


### PR DESCRIPTION
Closes #1098

## Summary
- compose ChoiceGrid with the shared Grid primitive
- preserve ChoiceGrid selection, keyboard, and accessibility behavior
- remove duplicated grid CSS and primitive-composition allow-list entry

## Validation
- ChoiceGrid tests: 48 passing
- components:generate/check: passing
- lint:invariants: passing
- typecheck: passing
- formatting and diff checks: passing