### PR TITLE
Fix GridList sizing composition

### DIFF
--- a/.changeset/grid-list-grid-sizing.md
+++ b/.changeset/grid-list-grid-sizing.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Compose GridList sizing through Grid's minItemWidth contract.

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -53,7 +53,6 @@ export const allowedGridCounts = new Map<string, number>(
     'event-stream-viewer/event-stream-viewer.css',
     'feed/feed.css',
     'form-section/form-section.css',
-    'grid-list/grid-list.css',
     'grid/grid.css',
     'hero-section/hero-section.css',
     'logo-cloud/logo-cloud.css',

--- a/packages/components/src/components/grid-list/README.md
+++ b/packages/components/src/components/grid-list/README.md
@@ -30,11 +30,11 @@ The leaf remains importable individually for à-la-carte builds — see
 
 <!-- generated:props:start -->
 
-| Prop             | Type       | Required | Default | Description                                                                                                                                                                                                                                                     |
-| ---------------- | ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `minColumnWidth` | `string`   | no       | —       | Minimum width of each grid cell, expressed as a CSS `<length>` value (e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Used as the first argument to `minmax()` inside a `repeat(auto-fill, ...)` track. Default: `"16rem"`. Empty string is treated as unset. |
-| `children`       | `(opaque)` | yes      | —       | Items — typically `GridListItem` instances. Not expressible in JSON Schema; see the component types for the signature.                                                                                                                                          |
-| `class`          | `(opaque)` | no       | —       | Extra class names merged with `cinder-grid-list`. Not expressible in JSON Schema; see the component types for the signature.                                                                                                                                    |
+| Prop             | Type       | Required | Default | Description                                                                                                                                                                                                                       |
+| ---------------- | ---------- | -------- | ------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minColumnWidth` | `string`   | no       | —       | Minimum width of each grid cell, expressed as a CSS `<length>` value (e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Forwarded to Grid's `minItemWidth` sizing contract. Default: `"16rem"`. Empty string is treated as unset. |
+| `children`       | `(opaque)` | yes      | —       | Items — typically `GridListItem` instances. Not expressible in JSON Schema; see the component types for the signature.                                                                                                            |
+| `class`          | `(opaque)` | no       | —       | Extra class names merged with `cinder-grid-list`. Not expressible in JSON Schema; see the component types for the signature.                                                                                                      |
 
 <!-- generated:props:end -->
 

--- a/packages/components/src/components/grid-list/grid-list.css
+++ b/packages/components/src/components/grid-list/grid-list.css
@@ -1,23 +1,17 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../grid/grid.css';
 @layer cinder.components {
   /* ========================================
  * GRID LIST
  * ======================================== */
 
   .cinder-grid-list {
-    /* Default min-cell-width if `minColumnWidth` prop is omitted. */
     --cinder-grid-list-min-width: 16rem;
 
     list-style: none;
     margin: 0;
     padding: 0;
     inline-size: 100%;
-
-    display: grid;
-    grid-template-columns: repeat(
-      auto-fill,
-      minmax(min(var(--cinder-grid-list-min-width), 100%), 1fr)
-    );
     gap: var(--cinder-space-4);
   }
 

--- a/packages/components/src/components/grid-list/grid-list.schema.json
+++ b/packages/components/src/components/grid-list/grid-list.schema.json
@@ -4,7 +4,7 @@
   "properties": {
     "minColumnWidth": {
       "type": "string",
-      "description": "Minimum width of each grid cell, expressed as a CSS `<length>` value\n(e.g. `\"16rem\"`, `\"240px\"`, `\"min(20rem, 100%)\"`). Used as the first\nargument to `minmax()` inside a `repeat(auto-fill, ...)` track.\nDefault: `\"16rem\"`. Empty string is treated as unset."
+      "description": "Minimum width of each grid cell, expressed as a CSS `<length>` value\n(e.g. `\"16rem\"`, `\"240px\"`, `\"min(20rem, 100%)\"`). Forwarded to Grid's\n`minItemWidth` sizing contract.\nDefault: `\"16rem\"`. Empty string is treated as unset."
     }
   },
   "additionalProperties": false,

--- a/packages/components/src/components/grid-list/grid-list.schema.ts
+++ b/packages/components/src/components/grid-list/grid-list.schema.ts
@@ -7,7 +7,7 @@ const schema = {
     minColumnWidth: {
       type: 'string',
       description:
-        'Minimum width of each grid cell, expressed as a CSS `<length>` value\n(e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Used as the first\nargument to `minmax()` inside a `repeat(auto-fill, ...)` track.\nDefault: `"16rem"`. Empty string is treated as unset.',
+        'Minimum width of each grid cell, expressed as a CSS `<length>` value\n(e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Forwarded to Grid\'s\n`minItemWidth` sizing contract.\nDefault: `"16rem"`. Empty string is treated as unset.',
     },
   },
   additionalProperties: false,

--- a/packages/components/src/components/grid-list/grid-list.svelte
+++ b/packages/components/src/components/grid-list/grid-list.svelte
@@ -16,21 +16,28 @@
 </script>
 
 <script lang="ts">
+  import Grid, { type GridProps } from '@lostgradient/cinder/grid';
   import type { GridListProps } from './grid-list.types.ts';
   import { classNames } from '../../utilities/class-names.ts';
 
   let { minColumnWidth, class: className, children, ...rest }: GridListProps = $props();
 
-  const minWidth = $derived(
-    minColumnWidth && minColumnWidth.length > 0 ? minColumnWidth : undefined,
+  const gridAttributes = $derived(
+    rest as Omit<GridProps, 'as' | 'class' | 'children' | 'minItemWidth'>,
+  );
+  const minItemWidth = $derived(
+    typeof minColumnWidth === 'string' && minColumnWidth.length > 0
+      ? minColumnWidth
+      : 'var(--cinder-grid-list-min-width)',
   );
 </script>
 
-<ul
-  {...rest}
+<Grid
+  {...gridAttributes}
+  as="ul"
   role="list"
   class={classNames('cinder-grid-list', className)}
-  style:--cinder-grid-list-min-width={minWidth}
+  {minItemWidth}
 >
   {@render children()}
-</ul>
+</Grid>

--- a/packages/components/src/components/grid-list/grid-list.test.ts
+++ b/packages/components/src/components/grid-list/grid-list.test.ts
@@ -40,27 +40,37 @@ describe('GridList', () => {
     expect(list?.getAttribute('role')).toBe('list');
   });
 
-  test('minColumnWidth prop drives the CSS custom property', () => {
+  test('minColumnWidth prop drives Grid minItemWidth', () => {
     const { container } = render(GridList, {
       props: { minColumnWidth: '20rem', children: textSnippet('') },
     });
     const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
-    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('20rem');
+    expect(list?.style.getPropertyValue('--cinder-grid-min-item-width')).toBe('20rem');
+    expect(list?.style.getPropertyValue('--cinder-grid-columns')).toBe(
+      'repeat(auto-fill, minmax(min(var(--cinder-grid-min-item-width), 100%), 1fr))',
+    );
+    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('');
   });
 
-  test('no minColumnWidth → no inline custom property', () => {
+  test('no minColumnWidth uses the GridList CSS variable through Grid minItemWidth', () => {
     const { container } = render(GridList, {
       props: { children: textSnippet('') },
     });
     const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
+    expect(list?.style.getPropertyValue('--cinder-grid-min-item-width')).toBe(
+      'var(--cinder-grid-list-min-width)',
+    );
     expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('');
   });
 
-  test('empty-string minColumnWidth is treated as unset', () => {
+  test('empty-string minColumnWidth uses the GridList CSS variable through Grid minItemWidth', () => {
     const { container } = render(GridList, {
       props: { minColumnWidth: '', children: textSnippet('') },
     });
     const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
+    expect(list?.style.getPropertyValue('--cinder-grid-min-item-width')).toBe(
+      'var(--cinder-grid-list-min-width)',
+    );
     expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('');
   });
 
@@ -97,5 +107,21 @@ describe('GridList', () => {
     expect(css).toMatch(
       /\.cinder-grid-list__item:has\(\.cinder-grid-list__link:hover\)\s*\{[\s\S]*?border-color:\s*var\(--cinder-border\)/,
     );
+  });
+
+  test('sidecar imports composed Grid styles', async () => {
+    const css = await Bun.file(new URL('./grid-list.css', import.meta.url)).text();
+    expect(css).toContain("@import '../grid/grid.css';");
+  });
+
+  test('CSS preserves the public GridList minimum width variable', async () => {
+    const css = await Bun.file(new URL('./grid-list.css', import.meta.url)).text();
+    expect(css).toMatch(/--cinder-grid-list-min-width:\s*16rem/);
+  });
+
+  test('component imports composed Grid through the public subpath', async () => {
+    const source = await Bun.file(new URL('./grid-list.svelte', import.meta.url)).text();
+    expect(source).toContain("from '@lostgradient/cinder/grid'");
+    expect(source).not.toContain("from '../grid/");
   });
 });

--- a/packages/components/src/components/grid-list/grid-list.types.ts
+++ b/packages/components/src/components/grid-list/grid-list.types.ts
@@ -3,8 +3,8 @@ import type { HTMLAttributes } from 'svelte/elements';
 export type GridListProps = Omit<HTMLAttributes<HTMLUListElement>, 'role'> & {
   /**
    * Minimum width of each grid cell, expressed as a CSS `<length>` value
-   * (e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Used as the first
-   * argument to `minmax()` inside a `repeat(auto-fill, ...)` track.
+   * (e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Forwarded to Grid's
+   * `minItemWidth` sizing contract.
    * Default: `"16rem"`. Empty string is treated as unset.
    */
   minColumnWidth?: string;

--- a/packages/components/src/components/selection-popover/selection-popover.svelte
+++ b/packages/components/src/components/selection-popover/selection-popover.svelte
@@ -327,7 +327,8 @@
         viewportWidth = window.innerWidth;
         viewportHeight = window.innerHeight;
         const composerHasFocus =
-          document.activeElement instanceof Node && composerFormElement?.contains(document.activeElement);
+          document.activeElement instanceof Node &&
+          composerFormElement?.contains(document.activeElement);
         const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
         const virtualKeyboardTransition = readVirtualKeyboardTransition(
           'window',
@@ -370,7 +371,8 @@
     };
     const dismissVisualViewport = (event: Event) => {
       const composerHasFocus =
-        document.activeElement instanceof Node && composerFormElement?.contains(document.activeElement);
+        document.activeElement instanceof Node &&
+        composerFormElement?.contains(document.activeElement);
       const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
       const virtualKeyboardTransition =
         visualViewport?.scale === 1

--- a/packages/playground/scripts/check-source-temp.ts
+++ b/packages/playground/scripts/check-source-temp.ts
@@ -2,7 +2,9 @@ import { readdir } from 'node:fs/promises';
 import { join, relative, sep } from 'node:path';
 import { PLAYGROUND_TEMP_ROOT } from '../src/playground-paths.ts';
 
-const serverSource = await Bun.file(join(import.meta.dir, '..', 'src', 'playground-server.ts')).text();
+const serverSource = await Bun.file(
+  join(import.meta.dir, '..', 'src', 'playground-server.ts'),
+).text();
 if (serverSource.includes("join(PLAYGROUND_ROOT, 'src', `.tmp-")) {
   console.error('Page server renderer must write temporary bundles under PLAYGROUND_TEMP_ROOT.');
   process.exit(1);
@@ -10,10 +12,7 @@ if (serverSource.includes("join(PLAYGROUND_ROOT, 'src', `.tmp-")) {
 
 const sourceDirectory = join(import.meta.dir, '..', 'src');
 const tempRootRelativeToSource = relative(sourceDirectory, PLAYGROUND_TEMP_ROOT);
-if (
-  tempRootRelativeToSource !== '..' &&
-  !tempRootRelativeToSource.startsWith(`..${sep}`)
-) {
+if (tempRootRelativeToSource !== '..' && !tempRootRelativeToSource.startsWith(`..${sep}`)) {
   console.error(
     `Playground build temporary root must stay outside packages/playground/src: ${PLAYGROUND_TEMP_ROOT}`,
   );


### PR DESCRIPTION
## Summary
- compose GridList through Grid so minColumnWidth drives Grid minItemWidth
- remove GridList duplicate grid-template sizing CSS and primitive-composition allow-list entry
- regenerate GridList schema, variables, and README artifacts
- add a patch changeset for @lostgradient/cinder

Closes #1096.

## Validation
- TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/components/src/components/grid-list
- bun run --filter=@lostgradient/cinder components:generate
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder lint:invariants
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder lint
- bun run --filter=@lostgradient/cinder check:changeset-prerelease-bumps
- bun run format:check