### PR TITLE
refactor(grid-list): compose shared Grid sizing

### DIFF
--- a/.changeset/shared-grid-list-sizing.md
+++ b/.changeset/shared-grid-list-sizing.md
@@ -1,5 +1,7 @@
 ---
-'@lostgradient/cinder': patch
+'@lostgradient/cinder': minor
 ---
 
-Compose GridList with the shared Grid sizing contract.
+Compose GridList with the shared Grid sizing contract. This removes the
+`--cinder-grid-list-min-width` CSS variable; pass `minColumnWidth` to GridList
+instead.

--- a/.changeset/shared-grid-list-sizing.md
+++ b/.changeset/shared-grid-list-sizing.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Compose GridList with the shared Grid sizing contract.

--- a/packages/components/scripts/check-primitive-composition.test.ts
+++ b/packages/components/scripts/check-primitive-composition.test.ts
@@ -31,6 +31,10 @@ describe('primitive composition guard', () => {
     expect(allowedGridCounts.get('footer/footer.css')).toBe(2);
   });
 
+  test('drops grid-list from the retired grid migration allow-list', () => {
+    expect(allowedGridCounts.has('grid-list/grid-list.css')).toBe(false);
+  });
+
   test('tracks only the remaining date field-wrapper migrations', () => {
     expect(allowedFieldWrapperCounts.get('date-picker/date-picker.svelte')).toBe(2);
     expect(allowedFieldWrapperCounts.has('date-range-field/date-range-field.svelte')).toBe(false);

--- a/packages/components/scripts/primitive-composition-migrations.ts
+++ b/packages/components/scripts/primitive-composition-migrations.ts
@@ -53,7 +53,6 @@ export const allowedGridCounts = new Map<string, number>(
     'event-stream-viewer/event-stream-viewer.css',
     'feed/feed.css',
     'form-section/form-section.css',
-    'grid-list/grid-list.css',
     'grid/grid.css',
     'hero-section/hero-section.css',
     'logo-cloud/logo-cloud.css',

--- a/packages/components/src/components/grid-list/README.md
+++ b/packages/components/src/components/grid-list/README.md
@@ -42,7 +42,8 @@ The leaf remains importable individually for à-la-carte builds — see
 
 <!-- generated:variables:start -->
 
-- `--cinder-grid-list-min-width`
+This component does not declare any local CSS variables.
+
 <!-- generated:variables:end -->
 
 ## Subcomponents

--- a/packages/components/src/components/grid-list/grid-list.css
+++ b/packages/components/src/components/grid-list/grid-list.css
@@ -1,24 +1,15 @@
 @layer cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
+@import '../grid/grid.css';
 @layer cinder.components {
   /* ========================================
  * GRID LIST
  * ======================================== */
 
   .cinder-grid-list {
-    /* Default min-cell-width if `minColumnWidth` prop is omitted. */
-    --cinder-grid-list-min-width: 16rem;
-
     list-style: none;
     margin: 0;
     padding: 0;
     inline-size: 100%;
-
-    display: grid;
-    grid-template-columns: repeat(
-      auto-fill,
-      minmax(min(var(--cinder-grid-list-min-width), 100%), 1fr)
-    );
-    gap: var(--cinder-space-4);
   }
 
   /* ----------------------------------------

--- a/packages/components/src/components/grid-list/grid-list.svelte
+++ b/packages/components/src/components/grid-list/grid-list.svelte
@@ -16,21 +16,23 @@
 </script>
 
 <script lang="ts">
+  import type { GridProps } from '../grid/grid.types.ts';
   import type { GridListProps } from './grid-list.types.ts';
+  import Grid from '../grid/grid.svelte';
   import { classNames } from '../../utilities/class-names.ts';
 
   let { minColumnWidth, class: className, children, ...rest }: GridListProps = $props();
 
-  const minWidth = $derived(
-    minColumnWidth && minColumnWidth.length > 0 ? minColumnWidth : undefined,
-  );
+  const minWidth = $derived(minColumnWidth && minColumnWidth.length > 0 ? minColumnWidth : '16rem');
+  const gridRest = rest as unknown as Omit<GridProps, 'children'>;
 </script>
 
-<ul
-  {...rest}
+<Grid
+  {...gridRest}
+  as="ul"
+  minItemWidth={minWidth}
   role="list"
   class={classNames('cinder-grid-list', className)}
-  style:--cinder-grid-list-min-width={minWidth}
 >
   {@render children()}
-</ul>
+</Grid>

--- a/packages/components/src/components/grid-list/grid-list.svelte
+++ b/packages/components/src/components/grid-list/grid-list.svelte
@@ -16,15 +16,14 @@
 </script>
 
 <script lang="ts">
-  import type { GridProps } from '../grid/grid.types.ts';
+  import Grid, { type GridProps } from '@lostgradient/cinder/grid';
   import type { GridListProps } from './grid-list.types.ts';
-  import Grid from '../grid/grid.svelte';
   import { classNames } from '../../utilities/class-names.ts';
 
   let { minColumnWidth, class: className, children, ...rest }: GridListProps = $props();
 
   const minWidth = $derived(minColumnWidth && minColumnWidth.length > 0 ? minColumnWidth : '16rem');
-  const gridRest = rest as unknown as Omit<GridProps, 'children'>;
+  const gridRest = $derived(rest as unknown as Omit<GridProps, 'children'>);
 </script>
 
 <Grid

--- a/packages/components/src/components/grid-list/grid-list.test.ts
+++ b/packages/components/src/components/grid-list/grid-list.test.ts
@@ -28,6 +28,7 @@ describe('GridList', () => {
     });
     const list = container.querySelector('ul.cinder-grid-list');
     expect(list).not.toBeNull();
+    expect(list?.classList.contains('cinder-grid')).toBe(true);
     expect(list?.getAttribute('role')).toBe('list');
   });
 
@@ -45,15 +46,15 @@ describe('GridList', () => {
       props: { minColumnWidth: '20rem', children: textSnippet('') },
     });
     const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
-    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('20rem');
+    expect(list?.style.getPropertyValue('--cinder-grid-min-item-width')).toBe('20rem');
   });
 
-  test('no minColumnWidth → no inline custom property', () => {
+  test('no minColumnWidth → shared Grid default is used', () => {
     const { container } = render(GridList, {
       props: { children: textSnippet('') },
     });
     const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
-    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('');
+    expect(list?.style.getPropertyValue('--cinder-grid-min-item-width')).toBe('16rem');
   });
 
   test('empty-string minColumnWidth is treated as unset', () => {
@@ -61,7 +62,7 @@ describe('GridList', () => {
       props: { minColumnWidth: '', children: textSnippet('') },
     });
     const list = container.querySelector('ul.cinder-grid-list') as HTMLElement;
-    expect(list?.style.getPropertyValue('--cinder-grid-list-min-width')).toBe('');
+    expect(list?.style.getPropertyValue('--cinder-grid-min-item-width')).toBe('16rem');
   });
 
   test('class prop is merged', () => {
@@ -91,6 +92,8 @@ describe('GridList', () => {
 
   test('linked items lift on hover via :has()', async () => {
     const css = await Bun.file(new URL('./grid-list.css', import.meta.url)).text();
+    expect(css).toContain("@import '../grid/grid.css';");
+    expect(css).not.toContain('grid-template-columns');
     expect(css).toMatch(
       /\.cinder-grid-list__item:has\(\.cinder-grid-list__link:hover\)\s*\{[\s\S]*?box-shadow:\s*var\(--cinder-shadow-md\)/,
     );

--- a/packages/components/src/components/grid-list/grid-list.variables.json
+++ b/packages/components/src/components/grid-list/grid-list.variables.json
@@ -1,1 +1,1 @@
-["--cinder-grid-list-min-width"]
+[]

--- a/packages/components/src/components/grid-list/grid-list.variables.ts
+++ b/packages/components/src/components/grid-list/grid-list.variables.ts
@@ -1,3 +1,3 @@
-const variables: readonly string[] = ['--cinder-grid-list-min-width'];
+const variables: readonly string[] = [];
 
 export default variables;


### PR DESCRIPTION
## Summary
- compose GridList with the shared Grid sizing contract
- preserve list semantics and responsive min-column behavior
- remove duplicated grid sizing CSS and the retired migration allowance
- add an issue-local guard regression and patch changeset

## Verification
- `TZ=UTC LANG=en_US.UTF-8 bun test --conditions browser --conditions svelte --parallel=1 packages/components/src/components/grid-list` (27 pass)
- `bun test --conditions browser --conditions svelte --parallel=1 packages/components/scripts/check-primitive-composition.test.ts` (249 pass)
- `bun run --filter=@lostgradient/cinder components:generate`
- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder exports:check`
- `bun run --filter=@lostgradient/cinder lint:invariants`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder typecheck` (0 errors, established 20 warnings)
- Prettier and `git diff --check`

Closes #1096