### PR TITLE
fix(portal): resolve nearest owner across shadow roots

### DIFF
--- a/.changeset/nearest-portal-owner-shadow.md
+++ b/.changeset/nearest-portal-owner-shadow.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Resolve the nearest portal owner across shadow roots and native top-layer boundaries.

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -146,7 +146,6 @@ describe('Portal', () => {
     expect(findNearestOpenTopLayer(source)).toBeNull();
   });
 
-
   test('finds an enclosing owner marker across nested shadow hosts', () => {
     const owner = document.createElement('div');
     owner.id = 'outer-shadow-owner';
@@ -163,6 +162,24 @@ describe('Portal', () => {
     document.body.append(outerHost);
 
     expect(findNearestOpenTopLayer(source)).toBe(owner);
+  });
+
+  test('skips a self-owned trigger marker across shadow boundaries', () => {
+    const trigger = document.createElement('div');
+    trigger.id = 'shadow-self-owner';
+    trigger.className = 'cinder-popover__trigger';
+    trigger.setAttribute('data-cinder-portal-owner', trigger.id);
+    const outerHost = document.createElement('div');
+    const outerShadow = outerHost.attachShadow({ mode: 'open' });
+    const innerHost = document.createElement('div');
+    const innerShadow = innerHost.attachShadow({ mode: 'open' });
+    const source = document.createElement('button');
+    innerShadow.append(source);
+    outerShadow.append(innerHost);
+    trigger.append(outerHost);
+    document.body.append(trigger);
+
+    expect(findNearestOpenTopLayer(source)).toBeNull();
   });
 
   test('prefers a nearer native modal over an outer portal owner marker', () => {

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -146,6 +146,25 @@ describe('Portal', () => {
     expect(findNearestOpenTopLayer(source)).toBeNull();
   });
 
+
+  test('finds an enclosing owner marker across nested shadow hosts', () => {
+    const owner = document.createElement('div');
+    owner.id = 'outer-shadow-owner';
+    const outerHost = document.createElement('div');
+    const outerShadow = outerHost.attachShadow({ mode: 'open' });
+    const outerMarker = document.createElement('div');
+    outerMarker.setAttribute('data-cinder-portal-owner', owner.id);
+    const innerHost = document.createElement('div');
+    const innerShadow = innerHost.attachShadow({ mode: 'open' });
+    const source = document.createElement('button');
+    innerShadow.append(source);
+    outerMarker.append(innerHost);
+    outerShadow.append(owner, outerMarker);
+    document.body.append(outerHost);
+
+    expect(findNearestOpenTopLayer(source)).toBe(owner);
+  });
+
   test('prefers a nearer native modal over an outer portal owner marker', () => {
     const outer = document.createElement('div');
     const owner = document.createElement('div');

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -112,6 +112,54 @@ describe('Portal', () => {
     expect(findNearestOpenTopLayer(source, (element) => element === dialog)).toBe(dialog);
   });
 
+  test('resolves a portal owner marker and owner inside the same shadow root', () => {
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const owner = document.createElement('div');
+    owner.id = 'shadow-owner';
+    const marker = document.createElement('div');
+    marker.setAttribute('data-cinder-portal-owner', owner.id);
+    const source = document.createElement('button');
+    marker.append(source);
+    shadow.append(owner, marker);
+    document.body.append(host);
+
+    expect(findNearestOpenTopLayer(source)).toBe(owner);
+  });
+
+  test('falls back to the document owner when a shadow-root owner is absent', () => {
+    const documentOwner = document.createElement('div');
+    documentOwner.id = 'document-owner';
+    document.body.append(documentOwner);
+    const host = document.createElement('div');
+    const shadow = host.attachShadow({ mode: 'open' });
+    const marker = document.createElement('div');
+    marker.setAttribute('data-cinder-portal-owner', documentOwner.id);
+    const source = document.createElement('button');
+    marker.append(source);
+    shadow.append(marker);
+    document.body.append(host);
+
+    expect(findNearestOpenTopLayer(source)).toBe(documentOwner);
+
+    marker.setAttribute('data-cinder-portal-owner', 'missing-owner');
+    expect(findNearestOpenTopLayer(source)).toBeNull();
+  });
+
+  test('prefers a nearer native modal over an outer portal owner marker', () => {
+    const outer = document.createElement('div');
+    const owner = document.createElement('div');
+    owner.id = 'outer-owner';
+    outer.setAttribute('data-cinder-portal-owner', owner.id);
+    const dialog = document.createElement('dialog');
+    const source = document.createElement('button');
+    dialog.append(source);
+    outer.append(dialog, owner);
+    document.body.append(outer);
+
+    expect(findNearestOpenTopLayer(source, (element) => element === dialog)).toBe(dialog);
+  });
+
   test('observePortalSourceAvailability crosses a shadow host for hidden/inert/aria-hidden', async () => {
     // `closest('[hidden], [inert], [aria-hidden="true"]')` cannot see past a
     // shadow boundary. The computed-style walk this helper also runs does

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -99,14 +99,7 @@ export function findNearestOpenTopLayer(
   // (not-yet-existing) scope, not a genuinely enclosing owner. Continuing the search from its
   // parent finds the next marker up the tree, which — by construction — belongs to a different,
   // truly enclosing popover/top-layer instance (see the nested-popover-in-trigger follow-up).
-  const ownerLookupSource = source.closest('.cinder-popover__trigger')?.parentElement ?? source;
-  const ownerId = ownerLookupSource.closest<HTMLElement>('[data-cinder-portal-owner]')?.dataset[
-    'cinderPortalOwner'
-  ];
-  if (ownerId) {
-    const owner = document.getElementById(ownerId);
-    if (owner instanceof HTMLElement) return owner;
-  }
+  const selfTrigger = source.closest('.cinder-popover__trigger');
   let candidate: HTMLElement | null = source;
   while (candidate) {
     try {
@@ -118,6 +111,24 @@ export function findNearestOpenTopLayer(
     } catch {
       // Unsupported pseudo-classes are treated as closed.
     }
+
+    if (candidate !== selfTrigger) {
+      const ownerId = candidate.dataset['cinderPortalOwner'];
+      if (ownerId) {
+        const root = candidate.getRootNode();
+        const localOwner =
+          root instanceof ShadowRoot
+            ? Array.from(root.querySelectorAll<HTMLElement>('[id]')).find(
+                (element) => element.id === ownerId,
+              )
+            : root instanceof Document
+              ? root.getElementById(ownerId)
+              : null;
+        const owner = localOwner ?? document.getElementById(ownerId);
+        if (owner instanceof HTMLElement) return owner;
+      }
+    }
+
     const rootNode = candidate.getRootNode();
     const shadowHost: Element | null = rootNode instanceof ShadowRoot ? rootNode.host : null;
     candidate = candidate.parentElement ?? (shadowHost instanceof HTMLElement ? shadowHost : null);

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -99,7 +99,7 @@ export function findNearestOpenTopLayer(
   // (not-yet-existing) scope, not a genuinely enclosing owner. Continuing the search from its
   // parent finds the next marker up the tree, which — by construction — belongs to a different,
   // truly enclosing popover/top-layer instance (see the nested-popover-in-trigger follow-up).
-  const selfTrigger = source.closest('.cinder-popover__trigger');
+  const selfTrigger = closestAcrossShadow(source, '.cinder-popover__trigger');
   let candidate: HTMLElement | null = source;
   while (candidate) {
     try {


### PR DESCRIPTION
## Summary
- traverse native top-layer state and portal owner markers in composed ancestor order
- resolve shadow-root owners locally with document fallback
- add shadow-boundary, modal precedence, fallback, and regression coverage

Closes #1071

## Validation
- bun test packages/components/src/components/portal/portal.test.ts
- bun run --filter=@lostgradient/cinder components:check
- bun run --filter=@lostgradient/cinder exports:check
- bun run --filter=@lostgradient/cinder typecheck
- bun run --filter=@lostgradient/cinder lint
- targeted prettier check
- git diff --check