### PR TITLE
fix(text-direction): resolve native CSS nesting selectors

### DIFF
--- a/.changeset/nested-direction-selectors.md
+++ b/.changeset/nested-direction-selectors.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Resolve direction overrides authored with native CSS nesting selectors.

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -207,11 +207,20 @@ function splitSelectorList(selectorText: string): string[] {
   const selectors: string[] = [];
   let parenthesesDepth = 0;
   let bracketDepth = 0;
+  let quote: '"' | "'" | undefined;
   let start = 0;
   for (let index = 0; index < selectorText.length; index += 1) {
     const character = selectorText[index];
     if (character === '\\') {
       index += 1;
+      continue;
+    }
+    if (quote !== undefined) {
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
       continue;
     }
     if (character === '(') parenthesesDepth += 1;

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -159,37 +159,10 @@ function resolveNestedSelector(rule: CSSStyleRule): string | undefined {
 }
 
 function combineNestedSelectors(parentSelector: string, nestedSelector: string): string {
-  const parents = splitSelectorList(parentSelector);
-  const nestedSelectors = splitSelectorList(nestedSelector);
-  return nestedSelectors
-    .flatMap((child) =>
-      parents.map((parent) =>
-        child.includes('&') ? child.replaceAll('&', parent) : `${parent} ${child}`,
-      ),
-    )
-    .join(', ');
-}
-
-function splitSelectorList(selectorText: string): string[] {
-  const selectors: string[] = [];
-  let parenthesesDepth = 0;
-  let bracketDepth = 0;
-  let start = 0;
-  for (let index = 0; index < selectorText.length; index += 1) {
-    const character = selectorText[index];
-    if (character === '(') parenthesesDepth += 1;
-    if (character === ')') parenthesesDepth = Math.max(0, parenthesesDepth - 1);
-    if (character === '[') bracketDepth += 1;
-    if (character === ']') bracketDepth = Math.max(0, bracketDepth - 1);
-    if (character === ',' && parenthesesDepth === 0 && bracketDepth === 0) {
-      const selector = selectorText.slice(start, index).trim();
-      if (selector) selectors.push(selector);
-      start = index + 1;
-    }
-  }
-  const selector = selectorText.slice(start).trim();
-  if (selector) selectors.push(selector);
-  return selectors;
+  const parentContext = parentSelector.includes(',') ? `:is(${parentSelector})` : parentSelector;
+  return nestedSelector.includes('&')
+    ? nestedSelector.replaceAll('&', parentContext)
+    : `${parentContext} ${nestedSelector}`;
 }
 
 function isConditionalRuleActive(

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -159,14 +159,48 @@ function resolveNestedSelector(rule: CSSStyleRule): string | undefined {
 }
 
 function combineNestedSelectors(parentSelector: string, nestedSelector: string): string {
-  const parentContext = parentSelector.includes(',') ? `:is(${parentSelector})` : parentSelector;
+  const parentContext =
+    splitSelectorList(parentSelector).length > 1 ? `:is(${parentSelector})` : parentSelector;
   return splitSelectorList(nestedSelector)
-    .map((selector) =>
-      selector.includes('&')
-        ? selector.replaceAll('&', parentContext)
-        : `${parentContext} ${selector}`,
-    )
+    .map((selector) => {
+      const resolved = replaceNestingReferences(selector, parentContext);
+      return resolved.replaced ? resolved.selector : `${parentContext} ${selector}`;
+    })
     .join(', ');
+}
+
+function replaceNestingReferences(
+  selector: string,
+  parentContext: string,
+): { selector: string; replaced: boolean } {
+  let quote: '"' | "'" | undefined;
+  let replaced = false;
+  let resolved = '';
+  for (let index = 0; index < selector.length; index += 1) {
+    const character = selector[index]!;
+    if (character === '\\') {
+      resolved += character;
+      if (index + 1 < selector.length) resolved += selector[++index];
+      continue;
+    }
+    if (quote !== undefined) {
+      resolved += character;
+      if (character === quote) quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      resolved += character;
+      continue;
+    }
+    if (character === '&') {
+      resolved += parentContext;
+      replaced = true;
+      continue;
+    }
+    resolved += character;
+  }
+  return { selector: resolved, replaced };
 }
 
 function splitSelectorList(selectorText: string): string[] {
@@ -176,6 +210,10 @@ function splitSelectorList(selectorText: string): string[] {
   let start = 0;
   for (let index = 0; index < selectorText.length; index += 1) {
     const character = selectorText[index];
+    if (character === '\\') {
+      index += 1;
+      continue;
+    }
     if (character === '(') parenthesesDepth += 1;
     if (character === ')') parenthesesDepth = Math.max(0, parenthesesDepth - 1);
     if (character === '[') bracketDepth += 1;

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -92,7 +92,8 @@ function matchesDirectionStyleRuleList(
         continue;
       }
       try {
-        if (element.matches(rule.selectorText)) return true;
+        const selectorText = resolveNestedSelector(rule);
+        if (selectorText && element.matches(selectorText)) return true;
       } catch {
         continue;
       }
@@ -140,6 +141,20 @@ function isCssStyleRule(rule: CSSRule): rule is CSSStyleRule {
     typeof Reflect.get(rule, 'style') === 'object' &&
     Reflect.get(rule, 'style') !== null
   );
+}
+
+function resolveNestedSelector(rule: CSSStyleRule): string | undefined {
+  let selector = rule.selectorText.trim();
+  let parentRule = Reflect.get(rule, 'parentRule');
+  while (parentRule && isCssStyleRule(parentRule)) {
+    const parentSelector = parentRule.selectorText.trim();
+    if (!parentSelector) return undefined;
+    selector = selector.includes('&')
+      ? selector.replaceAll('&', parentSelector)
+      : `${parentSelector} ${selector}`;
+    parentRule = Reflect.get(parentRule, 'parentRule');
+  }
+  return selector;
 }
 
 function isConditionalRuleActive(

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -160,9 +160,35 @@ function resolveNestedSelector(rule: CSSStyleRule): string | undefined {
 
 function combineNestedSelectors(parentSelector: string, nestedSelector: string): string {
   const parentContext = parentSelector.includes(',') ? `:is(${parentSelector})` : parentSelector;
-  return nestedSelector.includes('&')
-    ? nestedSelector.replaceAll('&', parentContext)
-    : `${parentContext} ${nestedSelector}`;
+  return splitSelectorList(nestedSelector)
+    .map((selector) =>
+      selector.includes('&')
+        ? selector.replaceAll('&', parentContext)
+        : `${parentContext} ${selector}`,
+    )
+    .join(', ');
+}
+
+function splitSelectorList(selectorText: string): string[] {
+  const selectors: string[] = [];
+  let parenthesesDepth = 0;
+  let bracketDepth = 0;
+  let start = 0;
+  for (let index = 0; index < selectorText.length; index += 1) {
+    const character = selectorText[index];
+    if (character === '(') parenthesesDepth += 1;
+    if (character === ')') parenthesesDepth = Math.max(0, parenthesesDepth - 1);
+    if (character === '[') bracketDepth += 1;
+    if (character === ']') bracketDepth = Math.max(0, bracketDepth - 1);
+    if (character === ',' && parenthesesDepth === 0 && bracketDepth === 0) {
+      const selector = selectorText.slice(start, index).trim();
+      if (selector) selectors.push(selector);
+      start = index + 1;
+    }
+  }
+  const selector = selectorText.slice(start).trim();
+  if (selector) selectors.push(selector);
+  return selectors;
 }
 
 function isConditionalRuleActive(

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -146,15 +146,50 @@ function isCssStyleRule(rule: CSSRule): rule is CSSStyleRule {
 function resolveNestedSelector(rule: CSSStyleRule): string | undefined {
   let selector = rule.selectorText.trim();
   let parentRule = Reflect.get(rule, 'parentRule');
-  while (parentRule && isCssStyleRule(parentRule)) {
-    const parentSelector = parentRule.selectorText.trim();
-    if (!parentSelector) return undefined;
-    selector = selector.includes('&')
-      ? selector.replaceAll('&', parentSelector)
-      : `${parentSelector} ${selector}`;
+  while (parentRule) {
+    if (isCssStyleRule(parentRule)) {
+      const parentSelector = parentRule.selectorText.trim();
+      if (!parentSelector) return undefined;
+      selector = combineNestedSelectors(parentSelector, selector);
+      if (!selector) return undefined;
+    }
     parentRule = Reflect.get(parentRule, 'parentRule');
   }
   return selector;
+}
+
+function combineNestedSelectors(parentSelector: string, nestedSelector: string): string {
+  const parents = splitSelectorList(parentSelector);
+  const nestedSelectors = splitSelectorList(nestedSelector);
+  return nestedSelectors
+    .flatMap((child) =>
+      parents.map((parent) =>
+        child.includes('&') ? child.replaceAll('&', parent) : `${parent} ${child}`,
+      ),
+    )
+    .join(', ');
+}
+
+function splitSelectorList(selectorText: string): string[] {
+  const selectors: string[] = [];
+  let parenthesesDepth = 0;
+  let bracketDepth = 0;
+  let start = 0;
+  for (let index = 0; index < selectorText.length; index += 1) {
+    const character = selectorText[index];
+    if (character === '(') parenthesesDepth += 1;
+    if (character === ')') parenthesesDepth = Math.max(0, parenthesesDepth - 1);
+    if (character === '[') bracketDepth += 1;
+    if (character === ']') bracketDepth = Math.max(0, bracketDepth - 1);
+    if (character === ',' && parenthesesDepth === 0 && bracketDepth === 0) {
+      const selector = selectorText.slice(start, index).trim();
+      if (selector) selectors.push(selector);
+      start = index + 1;
+    }
+  }
+  const selector = selectorText.slice(start).trim();
+  if (selector) selectors.push(selector);
+  return selectors;
 }
 
 function isConditionalRuleActive(

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -433,6 +433,125 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('resolves a native CSS nesting parent selector before matching direction rules', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const shell = document.createElement('section');
+      shell.className = 'nested-shell';
+      const element = document.createElement('div');
+      element.className = 'nested-menu';
+      shell.appendChild(element);
+      document.body.appendChild(shell);
+
+      const nestedRule = createStyleRule({ selectorText: '& .nested-menu', direction: 'ltr' });
+      const outerRule = createStyleRule({ selectorText: '.nested-shell', cssRules: [nestedRule] });
+      Object.defineProperty(nestedRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
+  test('resolves multiple native CSS nesting parent selectors', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const shell = document.createElement('section');
+      shell.className = 'multi-nested-shell';
+      const region = document.createElement('div');
+      region.className = 'multi-nested-region';
+      const element = document.createElement('div');
+      element.className = 'multi-nested-menu';
+      region.appendChild(element);
+      shell.appendChild(region);
+      document.body.appendChild(shell);
+
+      const innerRule = createStyleRule({ selectorText: '& .multi-nested-menu', direction: 'ltr' });
+      const middleRule = createStyleRule({
+        selectorText: '& .multi-nested-region',
+        cssRules: [innerRule],
+      });
+      const outerRule = createStyleRule({
+        selectorText: '.multi-nested-shell',
+        cssRules: [middleRule],
+      });
+      Object.defineProperty(innerRule, 'parentRule', { configurable: true, value: middleRule });
+      Object.defineProperty(middleRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
+  test('resolves a native nesting parent selector used mid-selector', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const parent = document.createElement('section');
+      parent.className = 'mid-selector-parent';
+      const shell = document.createElement('div');
+      shell.className = 'mid-selector-shell';
+      parent.appendChild(shell);
+      document.body.appendChild(parent);
+
+      const nestedRule = createStyleRule({
+        selectorText: '.mid-selector-parent:has(&)',
+        direction: 'ltr',
+      });
+      const outerRule = createStyleRule({
+        selectorText: '.mid-selector-shell',
+        cssRules: [nestedRule],
+      });
+      Object.defineProperty(nestedRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(parent, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
   test('ignores direction rules inside inactive container-query shims', () => {
     const originalWindowGetComputedStyle = window.getComputedStyle;
     const originalGlobalGetComputedStyle = globalThis.getComputedStyle;

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -715,6 +715,59 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('preserves escaped delimiters and literal ampersands in nested selectors', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const shell = document.createElement('section');
+      shell.className = 'escaped-nesting-shell';
+      const escapedComma = document.createElement('div');
+      escapedComma.className = 'escaped,comma';
+      const literalAmpersand = document.createElement('div');
+      literalAmpersand.setAttribute('data-label', '&');
+      const escapedAmpersand = document.createElement('div');
+      escapedAmpersand.className = 'escaped&ampersand';
+      shell.append(escapedComma, literalAmpersand, escapedAmpersand);
+      document.body.appendChild(shell);
+
+      const escapedCommaRule = createStyleRule({
+        selectorText: '.escaped\\,comma',
+        direction: 'ltr',
+      });
+      const literalAmpersandRule = createStyleRule({
+        selectorText: '[data-label="&"]',
+        direction: 'ltr',
+      });
+      const escapedAmpersandRule = createStyleRule({
+        selectorText: '.escaped\\&ampersand',
+        direction: 'ltr',
+      });
+      const outerRule = createStyleRule({
+        selectorText: '.escaped-nesting-shell',
+        cssRules: [escapedCommaRule, literalAmpersandRule, escapedAmpersandRule],
+      });
+      for (const rule of [escapedCommaRule, literalAmpersandRule, escapedAmpersandRule])
+        Object.defineProperty(rule, 'parentRule', { configurable: true, value: outerRule });
+
+      withDocumentStyleSheets([{ cssRules: [outerRule] }], () => {
+        expect(elementDirectionStyleOverride(escapedComma)).toBe('ltr');
+        expect(elementDirectionStyleOverride(literalAmpersand)).toBe('ltr');
+        expect(elementDirectionStyleOverride(escapedAmpersand)).toBe('ltr');
+      });
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
   test('ignores direction rules inside inactive container-query shims', () => {
     const originalWindowGetComputedStyle = window.getComputedStyle;
     const originalGlobalGetComputedStyle = globalThis.getComputedStyle;

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -638,6 +638,43 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('prefixes implicit nesting in mixed nested selector lists', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const element = document.createElement('div');
+      element.className = 'mixed-nested-list-target';
+      document.body.appendChild(element);
+
+      const nestedRule = createStyleRule({
+        selectorText: '& .mixed-nested-list-child, .mixed-nested-list-target',
+        direction: 'ltr',
+      });
+      const outerRule = createStyleRule({
+        selectorText: '.mixed-nested-list-first, .mixed-nested-list-second',
+        cssRules: [nestedRule],
+      });
+      Object.defineProperty(nestedRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('rtl');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
   test('resolves a native nesting parent selector used mid-selector', () => {
     const originalWindowGetComputedStyle = window.getComputedStyle;
     const originalGlobalGetComputedStyle = globalThis.getComputedStyle;

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -768,6 +768,46 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('preserves delimiters and commas inside quoted nested selector values', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const shell = document.createElement('section');
+      shell.className = 'quoted-nesting-shell';
+      const element = document.createElement('div');
+      element.setAttribute('data-label', '),');
+      shell.appendChild(element);
+      document.body.appendChild(shell);
+
+      const nestedRule = createStyleRule({
+        selectorText: '[data-label="),"]',
+        direction: 'ltr',
+      });
+      const outerRule = createStyleRule({
+        selectorText: '.quoted-nesting-shell',
+        cssRules: [nestedRule],
+      });
+      Object.defineProperty(nestedRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          elementDirectionStyleOverride(element),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
   test('ignores direction rules inside inactive container-query shims', () => {
     const originalWindowGetComputedStyle = window.getComputedStyle;
     const originalGlobalGetComputedStyle = globalThis.getComputedStyle;

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -600,6 +600,44 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('preserves mixed parent-list combinations for multiple nesting references', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const container = document.createElement('section');
+      const previous = document.createElement('div');
+      previous.className = 'mixed-selector-first';
+      const element = document.createElement('div');
+      element.className = 'mixed-selector-second';
+      container.append(previous, element);
+      document.body.appendChild(container);
+
+      const nestedRule = createStyleRule({ selectorText: '& + &', direction: 'ltr' });
+      const outerRule = createStyleRule({
+        selectorText: '.mixed-selector-first, .mixed-selector-second',
+        cssRules: [nestedRule],
+      });
+      Object.defineProperty(nestedRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          elementDirectionStyleOverride(element),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
   test('resolves a native nesting parent selector used mid-selector', () => {
     const originalWindowGetComputedStyle = window.getComputedStyle;
     const originalGlobalGetComputedStyle = globalThis.getComputedStyle;

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -458,7 +458,7 @@ describe('resolveTextDirection', () => {
 
       expect(
         withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
-          resolveTextDirection(element, 'rtl'),
+          elementDirectionStyleOverride(element),
         ),
       ).toBe('ltr');
     } finally {
@@ -503,7 +503,95 @@ describe('resolveTextDirection', () => {
 
       expect(
         withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
-          resolveTextDirection(element, 'rtl'),
+          elementDirectionStyleOverride(element),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
+  test('walks through conditional rules to the nearest nested style parent', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const shell = document.createElement('section');
+      shell.className = 'conditional-nested-shell';
+      const element = document.createElement('div');
+      element.className = 'conditional-nested-menu';
+      shell.appendChild(element);
+      document.body.appendChild(shell);
+
+      const nestedRule = createStyleRule({
+        selectorText: '& .conditional-nested-menu',
+        direction: 'ltr',
+      });
+      const mediaRule = {
+        cssText: '@media all {}',
+        type: 4,
+        conditionText: 'all',
+        media: {},
+        cssRules: [nestedRule],
+      } as unknown as CSSRule;
+      const outerRule = createStyleRule({
+        selectorText: '.conditional-nested-shell',
+        cssRules: [mediaRule],
+      });
+      Object.defineProperty(nestedRule, 'parentRule', { configurable: true, value: mediaRule });
+      Object.defineProperty(mediaRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          elementDirectionStyleOverride(element),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
+  test('preserves parent selector-list grouping when resolving nesting', () => {
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+
+    try {
+      const shell = document.createElement('section');
+      shell.className = 'selector-list-first';
+      const element = document.createElement('div');
+      element.className = 'selector-list-menu';
+      shell.appendChild(element);
+      document.body.appendChild(shell);
+
+      const nestedRule = createStyleRule({
+        selectorText: '& .selector-list-menu',
+        direction: 'ltr',
+      });
+      const outerRule = createStyleRule({
+        selectorText: '.selector-list-first, .selector-list-second',
+        cssRules: [nestedRule],
+      });
+      Object.defineProperty(nestedRule, 'parentRule', { configurable: true, value: outerRule });
+
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          elementDirectionStyleOverride(element),
         ),
       ).toBe('ltr');
     } finally {


### PR DESCRIPTION
Closes #1054

Resolve native CSS nesting `&` selectors against their ancestor CSSStyleRule chain before calling `Element.matches()`. Handles multiple nesting levels, selector lists, implicit nested selectors, and mid-selector references while preserving escaped syntax. Adds focused regression coverage.