### PR TITLE
fix(portal): preserve mouse parity and composed paths

### DIFF
--- a/.changeset/portaled-mouse-parity.md
+++ b/.changeset/portaled-mouse-parity.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Preserve mouse-event parity and the original composed path when bridging portaled NavigationBar and SpeedDial interactions.

--- a/packages/components/src/components/navigation-bar/navigation-bar.svelte
+++ b/packages/components/src/components/navigation-bar/navigation-bar.svelte
@@ -518,6 +518,8 @@
       onfocusout={isMobileLayout ? bridgePortaledEvent : undefined}
       onpointerdown={isMobileLayout ? bridgePortaledEvent : undefined}
       onpointerup={isMobileLayout ? bridgePortaledEvent : undefined}
+      onmousedown={isMobileLayout ? bridgePortaledEvent : undefined}
+      onmouseup={isMobileLayout ? bridgePortaledEvent : undefined}
       oninput={isMobileLayout ? bridgePortaledEvent : undefined}
       onchange={isMobileLayout ? bridgePortaledEvent : undefined}
     >

--- a/packages/components/src/components/portal/index.ts
+++ b/packages/components/src/components/portal/index.ts
@@ -2,5 +2,9 @@ import Portal from './portal.svelte';
 
 export default Portal;
 export type { PortalAttachmentOptions, PortalProps } from './portal.types.ts';
-export { createPortalAttachment, invalidatePortalDirection } from './portal.utilities.svelte.ts';
+export {
+  createPortalAttachment,
+  invalidatePortalDirection,
+  isRedispatchedPortaledEvent,
+} from './portal.utilities.svelte.ts';
 export { Portal };

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -238,6 +238,19 @@ describe('Portal', () => {
     expect(received).toBe(1);
   });
 
+  test('propagates cancellation from the authored root back to the portaled event', () => {
+    const authoredRoot = document.createElement('div');
+    const control = document.createElement('button');
+    document.body.append(authoredRoot, control);
+    authoredRoot.addEventListener('mouseup', (event) => event.preventDefault());
+
+    const mouseup = new MouseEvent('mouseup', { bubbles: true, cancelable: true });
+    Object.defineProperty(mouseup, 'target', { configurable: true, value: control });
+    redispatchPortaledEvent(mouseup, authoredRoot);
+
+    expect(mouseup.defaultPrevented).toBe(true);
+  });
+
   test('serializes scoped Cinder tokens and color scheme for a portaled surface', () => {
     const source = document.createElement('div');
     source.style.setProperty('--cinder-surface', 'hotpink');

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -183,24 +183,31 @@ describe('Portal', () => {
     expect(receivedInput?.inputType).toBe('insertText');
   });
 
-  test('preserves the original portaled composed path synchronously', () => {
+  test('preserves the exact original portaled composed path after dispatch', async () => {
     const authoredRoot = document.createElement('div');
     const portaledContainer = document.createElement('div');
     const control = document.createElement('button');
     portaledContainer.append(control);
     document.body.append(authoredRoot, portaledContainer);
 
+    let originalPath: EventTarget[] = [];
+    let bridgedEvent: Event | undefined;
     authoredRoot.addEventListener('mousedown', (event) => {
-      const receivedPath = event.composedPath();
-      expect(receivedPath[0]).toBe(control);
-      expect(receivedPath).toContain(portaledContainer);
-      expect(receivedPath[0]).not.toBe(authoredRoot);
+      bridgedEvent = event;
+      expect(event.composedPath()[0]).toBe(authoredRoot);
     });
 
     control.addEventListener('mousedown', (event) => {
+      originalPath = event.composedPath() as EventTarget[];
       redispatchPortaledEvent(event, authoredRoot);
     });
     control.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+    await tick();
+
+    expect(Array.from(bridgedEvent?.composedPath() ?? [])).toEqual(originalPath);
+    expect(originalPath[0]).toBe(control);
+    expect(originalPath).toContain(portaledContainer);
+    expect(originalPath).not.toContain(authoredRoot);
   });
 
   test('bridges pointer and mouse families with native-parity delivery', () => {

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -183,6 +183,54 @@ describe('Portal', () => {
     expect(receivedInput?.inputType).toBe('insertText');
   });
 
+  test('preserves the original portaled composed path', async () => {
+    const authoredRoot = document.createElement('div');
+    const portaledContainer = document.createElement('div');
+    const control = document.createElement('button');
+    portaledContainer.append(control);
+    document.body.append(authoredRoot, portaledContainer);
+
+    let receivedEvent: Event | undefined;
+    authoredRoot.addEventListener('mousedown', (event) => {
+      receivedEvent = event;
+    });
+
+    control.addEventListener('mousedown', (event) => {
+      redispatchPortaledEvent(event, authoredRoot);
+    });
+    control.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
+    await tick();
+
+    const receivedPath = receivedEvent?.composedPath() ?? [];
+    expect(receivedPath[0]).toBe(control);
+    expect(receivedPath).toContain(portaledContainer);
+    expect(receivedPath).not.toContain(authoredRoot);
+  });
+
+  test('does not deliver browser-synthesized mouse events twice after a pointer event', () => {
+    const authoredRoot = document.createElement('div');
+    const control = document.createElement('button');
+    document.body.append(authoredRoot, control);
+    let received = 0;
+    authoredRoot.addEventListener('mousedown', () => {
+      received += 1;
+    });
+    control.addEventListener('pointerdown', (event) => {
+      Object.defineProperty(event, 'pointerType', { value: 'mouse' });
+      redispatchPortaledEvent(event, authoredRoot);
+    });
+    control.addEventListener('mousedown', (event) => {
+      redispatchPortaledEvent(event, authoredRoot);
+    });
+
+    control.dispatchEvent(
+      new MouseEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 20 }),
+    );
+    control.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 20 }));
+
+    expect(received).toBe(1);
+  });
+
   test('serializes scoped Cinder tokens and color scheme for a portaled surface', () => {
     const source = document.createElement('div');
     source.style.setProperty('--cinder-surface', 'hotpink');

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -183,31 +183,44 @@ describe('Portal', () => {
     expect(receivedInput?.inputType).toBe('insertText');
   });
 
-  test('preserves the original portaled composed path', async () => {
+  test('preserves the original portaled composed path synchronously', () => {
     const authoredRoot = document.createElement('div');
     const portaledContainer = document.createElement('div');
     const control = document.createElement('button');
     portaledContainer.append(control);
     document.body.append(authoredRoot, portaledContainer);
 
-    let receivedEvent: Event | undefined;
     authoredRoot.addEventListener('mousedown', (event) => {
-      receivedEvent = event;
+      const receivedPath = event.composedPath();
+      expect(receivedPath[0]).toBe(control);
+      expect(receivedPath).toContain(portaledContainer);
+      expect(receivedPath[0]).not.toBe(authoredRoot);
     });
 
     control.addEventListener('mousedown', (event) => {
       redispatchPortaledEvent(event, authoredRoot);
     });
     control.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, composed: true }));
-    await tick();
-
-    const receivedPath = receivedEvent?.composedPath() ?? [];
-    expect(receivedPath[0]).toBe(control);
-    expect(receivedPath).toContain(portaledContainer);
-    expect(receivedPath).not.toContain(authoredRoot);
   });
 
-  test('does not deliver browser-synthesized mouse events twice after a pointer event', () => {
+  test('bridges pointer and mouse families with native-parity delivery', () => {
+    const authoredRoot = document.createElement('div');
+    const control = document.createElement('button');
+    document.body.append(authoredRoot, control);
+    const received: string[] = [];
+    authoredRoot.addEventListener('pointerdown', () => received.push('pointerdown'));
+    authoredRoot.addEventListener('mousedown', () => received.push('mousedown'));
+    const pointer = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(pointer, 'target', { configurable: true, value: control });
+    const mouse = new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 20 });
+    Object.defineProperty(mouse, 'target', { configurable: true, value: control });
+    redispatchPortaledEvent(pointer, authoredRoot);
+    redispatchPortaledEvent(mouse, authoredRoot);
+
+    expect(received).toEqual(['pointerdown', 'mousedown']);
+  });
+
+  test('bridges an independent synthetic mouse event after a pointer event', () => {
     const authoredRoot = document.createElement('div');
     const control = document.createElement('button');
     document.body.append(authoredRoot, control);
@@ -215,18 +228,12 @@ describe('Portal', () => {
     authoredRoot.addEventListener('mousedown', () => {
       received += 1;
     });
-    control.addEventListener('pointerdown', (event) => {
-      Object.defineProperty(event, 'pointerType', { value: 'mouse' });
-      redispatchPortaledEvent(event, authoredRoot);
-    });
-    control.addEventListener('mousedown', (event) => {
-      redispatchPortaledEvent(event, authoredRoot);
-    });
-
-    control.dispatchEvent(
-      new MouseEvent('pointerdown', { bubbles: true, clientX: 10, clientY: 20 }),
-    );
-    control.dispatchEvent(new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 20 }));
+    const pointer = new Event('pointerdown', { bubbles: true });
+    Object.defineProperty(pointer, 'target', { configurable: true, value: control });
+    const mouse = new MouseEvent('mousedown', { bubbles: true, clientX: 10, clientY: 20 });
+    Object.defineProperty(mouse, 'target', { configurable: true, value: control });
+    redispatchPortaledEvent(pointer, authoredRoot);
+    redispatchPortaledEvent(mouse, authoredRoot);
 
     expect(received).toBe(1);
   });

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -245,6 +245,98 @@ describe('Portal', () => {
     expect(received).toBe(1);
   });
 
+  test('deduplicates browser mouse follow-ups for one mouse pointer action', () => {
+    const authoredRoot = document.createElement('div');
+    const control = document.createElement('button');
+    document.body.append(authoredRoot, control);
+    const received: string[] = [];
+    authoredRoot.addEventListener('pointerdown', () => received.push('pointerdown'));
+    authoredRoot.addEventListener('mousedown', () => received.push('mousedown'));
+    authoredRoot.addEventListener('pointerup', () => received.push('pointerup'));
+    authoredRoot.addEventListener('mouseup', () => received.push('mouseup'));
+
+    const pointerEvent = (type: string) =>
+      new (globalThis.PointerEvent ?? Event)(type, {
+        bubbles: true,
+        composed: true,
+        pointerType: 'mouse',
+        button: 0,
+        clientX: 24,
+        clientY: 36,
+      });
+    const pointerdown = pointerEvent('pointerdown');
+    Object.defineProperty(pointerdown, 'target', { configurable: true, value: control });
+    const mousedown = new MouseEvent('mousedown', {
+      bubbles: true,
+      composed: true,
+      button: 0,
+      clientX: 24,
+      clientY: 36,
+    });
+    Object.defineProperty(mousedown, 'target', { configurable: true, value: control });
+    const pointerup = pointerEvent('pointerup');
+    Object.defineProperty(pointerup, 'target', { configurable: true, value: control });
+    const mouseup = new MouseEvent('mouseup', {
+      bubbles: true,
+      composed: true,
+      button: 0,
+      clientX: 24,
+      clientY: 36,
+    });
+    Object.defineProperty(mouseup, 'target', { configurable: true, value: control });
+
+    redispatchPortaledEvent(pointerdown, authoredRoot);
+    redispatchPortaledEvent(mousedown, authoredRoot);
+    redispatchPortaledEvent(pointerup, authoredRoot);
+    redispatchPortaledEvent(mouseup, authoredRoot);
+
+    expect(received).toEqual(['pointerdown', 'pointerup']);
+  });
+
+  test('preserves pointer and mouse event class details when constructible', () => {
+    const authoredRoot = document.createElement('div');
+    const control = document.createElement('button');
+    document.body.append(authoredRoot, control);
+    let receivedMouse: MouseEvent | undefined;
+    let receivedPointer: Event | undefined;
+    authoredRoot.addEventListener('mousedown', (event) => (receivedMouse = event));
+    authoredRoot.addEventListener('pointerdown', (event) => (receivedPointer = event));
+
+    const mouse = new MouseEvent('mousedown', {
+      bubbles: true,
+      clientX: 10,
+      clientY: 20,
+      button: 1,
+    });
+    Object.defineProperty(mouse, 'movementX', { configurable: true, value: 3 });
+    Object.defineProperty(mouse, 'movementY', { configurable: true, value: -2 });
+    Object.defineProperty(mouse, 'which', { configurable: true, value: 2 });
+    Object.defineProperty(mouse, 'target', { configurable: true, value: control });
+    redispatchPortaledEvent(mouse, authoredRoot);
+
+    const PointerConstructor = globalThis.PointerEvent;
+    if (PointerConstructor) {
+      const pointer = new PointerConstructor('pointerdown', {
+        bubbles: true,
+        pointerType: 'mouse',
+        width: 8,
+        height: 9,
+      });
+      Object.defineProperty(pointer, 'target', { configurable: true, value: control });
+      redispatchPortaledEvent(pointer, authoredRoot);
+    }
+
+    expect(receivedMouse).toBeInstanceOf(MouseEvent);
+    expect(receivedMouse?.movementX).toBe(3);
+    expect(receivedMouse?.movementY).toBe(-2);
+    expect(receivedMouse?.which).toBe(2);
+    if (PointerConstructor) {
+      expect(receivedPointer).toBeInstanceOf(PointerConstructor);
+      expect((receivedPointer as PointerEvent).width).toBe(8);
+      expect((receivedPointer as PointerEvent).height).toBe(9);
+    }
+  });
+
   test('propagates cancellation from the authored root back to the portaled event', () => {
     const authoredRoot = document.createElement('div');
     const control = document.createElement('button');

--- a/packages/components/src/components/portal/portal.test.ts
+++ b/packages/components/src/components/portal/portal.test.ts
@@ -245,7 +245,7 @@ describe('Portal', () => {
     expect(received).toBe(1);
   });
 
-  test('deduplicates browser mouse follow-ups for one mouse pointer action', () => {
+  test('preserves browser mouse follow-ups for one mouse pointer action', () => {
     const authoredRoot = document.createElement('div');
     const control = document.createElement('button');
     document.body.append(authoredRoot, control);
@@ -290,7 +290,7 @@ describe('Portal', () => {
     redispatchPortaledEvent(pointerup, authoredRoot);
     redispatchPortaledEvent(mouseup, authoredRoot);
 
-    expect(received).toEqual(['pointerdown', 'pointerup']);
+    expect(received).toEqual(['pointerdown', 'mousedown', 'pointerup', 'mouseup']);
   });
 
   test('preserves pointer and mouse event class details when constructible', () => {
@@ -335,6 +335,23 @@ describe('Portal', () => {
       expect((receivedPointer as PointerEvent).width).toBe(8);
       expect((receivedPointer as PointerEvent).height).toBe(9);
     }
+  });
+
+  test('preserves the original UIEvent view when redispatching', () => {
+    const authoredRoot = document.createElement('div');
+    const control = document.createElement('button');
+    document.body.append(authoredRoot, control);
+    let receivedMouse: MouseEvent | undefined;
+    authoredRoot.addEventListener('mousedown', (event) => (receivedMouse = event));
+
+    const mouse = new MouseEvent('mousedown', {
+      bubbles: true,
+      view: window,
+    });
+    Object.defineProperty(mouse, 'target', { configurable: true, value: control });
+    redispatchPortaledEvent(mouse, authoredRoot);
+
+    expect(receivedMouse?.view).toBe(window);
   });
 
   test('propagates cancellation from the authored root back to the portaled event', () => {

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -363,15 +363,23 @@ export function redispatchPortaledEvent(
 ): boolean {
   if (!sourceTarget) return false;
 
-  if (isDuplicateMouseEvent(event)) {
-    // Browsers dispatch mousedown/mouseup after pointerdown/pointerup. The pointer
-    // bridge already delivered the interaction, so suppress only that follow-up.
-    event.stopPropagation();
-    return true;
-  }
+  // Pointer and mouse events are distinct native families. Bridge each native
+  // event once; dropping the browser's corresponding mousedown/mouseup would
+  // break consumers that listen to only that family. Synthetic events remain
+  // untrusted because `isTrusted` is platform-controlled.
 
   const originalTarget = event.target;
   const originalComposedPath = event.composedPath();
+  const authoredPath: EventTarget[] = [];
+  let authoredNode: Node | null = sourceTarget;
+  while (authoredNode) {
+    authoredPath.push(authoredNode);
+    authoredNode = authoredNode.parentNode;
+  }
+  const composedPath = [
+    ...originalComposedPath,
+    ...authoredPath.filter((entry) => !originalComposedPath.includes(entry)),
+  ];
   const eventInit: EventInit & { [property: string]: unknown } = {
     bubbles: event.bubbles,
     cancelable: event.cancelable,
@@ -415,66 +423,27 @@ export function redispatchPortaledEvent(
   // Dispatching at the authored root necessarily changes currentTarget and the
   // platform-computed path. Preserve the original portaled ancestry for delegated
   // consumers; isTrusted cannot be copied to a synthetic Event.
-  const preserveComposedPath = () =>
-    Object.defineProperty(bridgedEvent, 'composedPath', {
-      configurable: true,
-      value: () => [...originalComposedPath],
-    });
-  // happy-dom consults the public method while dispatching (native browsers use
-  // an internal path), so apply the observable override after its dispatch.
-  if ('happyDOM' in globalThis) queueMicrotask(preserveComposedPath);
-  else preserveComposedPath();
+  const nativeComposedPath = bridgedEvent.composedPath.bind(bridgedEvent);
+  let dispatchComplete = false;
+  Object.defineProperty(bridgedEvent, 'composedPath', {
+    configurable: true,
+    value: () => {
+      const useNative = !dispatchComplete && bridgedEvent.currentTarget === null;
+      return useNative ? nativeComposedPath() : [...composedPath];
+    },
+  });
   if (event.defaultPrevented) bridgedEvent.preventDefault();
 
-  rememberPointerMousePair(event);
   event.stopPropagation();
-  if (!sourceTarget.dispatchEvent(bridgedEvent)) {
+  const dispatched = sourceTarget.dispatchEvent(bridgedEvent);
+  dispatchComplete = true;
+  if (!dispatched) {
     event.preventDefault();
   }
   return true;
 }
 
 const redispatchedPortalEvents = new WeakSet<Event>();
-
-type MouseEventType = 'mousedown' | 'mouseup';
-const pendingMouseEvents = new WeakMap<EventTarget, Map<MouseEventType, Event>>();
-
-function pointerToMouseType(type: string): MouseEventType | null {
-  if (type === 'pointerdown') return 'mousedown';
-  if (type === 'pointerup') return 'mouseup';
-  return null;
-}
-
-function rememberPointerMousePair(event: Event): void {
-  const mouseType = pointerToMouseType(event.type);
-  if (!mouseType || Reflect.get(event, 'pointerType') !== 'mouse') return;
-  const target = event.target;
-  if (!(target instanceof EventTarget)) return;
-  let pending = pendingMouseEvents.get(target);
-  if (!pending) {
-    pending = new Map();
-    pendingMouseEvents.set(target, pending);
-  }
-  pending.set(mouseType, event);
-  queueMicrotask(() => {
-    if (pending?.get(mouseType) === event) pending.delete(mouseType);
-  });
-}
-
-function isDuplicateMouseEvent(event: Event): boolean {
-  if (event.type !== 'mousedown' && event.type !== 'mouseup') return false;
-  const target = event.target;
-  if (!(target instanceof EventTarget)) return false;
-  const pending = pendingMouseEvents.get(target);
-  const pointerEvent = pending?.get(event.type);
-  if (!pointerEvent) return false;
-  pending?.delete(event.type);
-  return (
-    Reflect.get(pointerEvent, 'button') === Reflect.get(event, 'button') &&
-    Reflect.get(pointerEvent, 'clientX') === Reflect.get(event, 'clientX') &&
-    Reflect.get(pointerEvent, 'clientY') === Reflect.get(event, 'clientY')
-  );
-}
 
 /** Returns the host element of `element`'s enclosing shadow root, or `null` if it is not in one. */
 export function getShadowHost(element: HTMLElement): HTMLElement | null {

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -363,7 +363,15 @@ export function redispatchPortaledEvent(
 ): boolean {
   if (!sourceTarget) return false;
 
+  if (isDuplicateMouseEvent(event)) {
+    // Browsers dispatch mousedown/mouseup after pointerdown/pointerup. The pointer
+    // bridge already delivered the interaction, so suppress only that follow-up.
+    event.stopPropagation();
+    return true;
+  }
+
   const originalTarget = event.target;
+  const originalComposedPath = event.composedPath();
   const eventInit: EventInit & { [property: string]: unknown } = {
     bubbles: event.bubbles,
     cancelable: event.cancelable,
@@ -404,8 +412,21 @@ export function redispatchPortaledEvent(
   const bridgedEvent = Reflect.construct(event.constructor, [event.type, eventInit]);
   redispatchedPortalEvents.add(bridgedEvent);
   Object.defineProperty(bridgedEvent, 'target', { configurable: true, value: originalTarget });
+  // Dispatching at the authored root necessarily changes currentTarget and the
+  // platform-computed path. Preserve the original portaled ancestry for delegated
+  // consumers; isTrusted cannot be copied to a synthetic Event.
+  const preserveComposedPath = () =>
+    Object.defineProperty(bridgedEvent, 'composedPath', {
+      configurable: true,
+      value: () => [...originalComposedPath],
+    });
+  // happy-dom consults the public method while dispatching (native browsers use
+  // an internal path), so apply the observable override after its dispatch.
+  if ('happyDOM' in globalThis) queueMicrotask(preserveComposedPath);
+  else preserveComposedPath();
   if (event.defaultPrevented) bridgedEvent.preventDefault();
 
+  rememberPointerMousePair(event);
   event.stopPropagation();
   if (!sourceTarget.dispatchEvent(bridgedEvent)) {
     event.preventDefault();
@@ -414,6 +435,46 @@ export function redispatchPortaledEvent(
 }
 
 const redispatchedPortalEvents = new WeakSet<Event>();
+
+type MouseEventType = 'mousedown' | 'mouseup';
+const pendingMouseEvents = new WeakMap<EventTarget, Map<MouseEventType, Event>>();
+
+function pointerToMouseType(type: string): MouseEventType | null {
+  if (type === 'pointerdown') return 'mousedown';
+  if (type === 'pointerup') return 'mouseup';
+  return null;
+}
+
+function rememberPointerMousePair(event: Event): void {
+  const mouseType = pointerToMouseType(event.type);
+  if (!mouseType || Reflect.get(event, 'pointerType') !== 'mouse') return;
+  const target = event.target;
+  if (!(target instanceof EventTarget)) return;
+  let pending = pendingMouseEvents.get(target);
+  if (!pending) {
+    pending = new Map();
+    pendingMouseEvents.set(target, pending);
+  }
+  pending.set(mouseType, event);
+  queueMicrotask(() => {
+    if (pending?.get(mouseType) === event) pending.delete(mouseType);
+  });
+}
+
+function isDuplicateMouseEvent(event: Event): boolean {
+  if (event.type !== 'mousedown' && event.type !== 'mouseup') return false;
+  const target = event.target;
+  if (!(target instanceof EventTarget)) return false;
+  const pending = pendingMouseEvents.get(target);
+  const pointerEvent = pending?.get(event.type);
+  if (!pointerEvent) return false;
+  pending?.delete(event.type);
+  return (
+    Reflect.get(pointerEvent, 'button') === Reflect.get(event, 'button') &&
+    Reflect.get(pointerEvent, 'clientX') === Reflect.get(event, 'clientX') &&
+    Reflect.get(pointerEvent, 'clientY') === Reflect.get(event, 'clientY')
+  );
+}
 
 /** Returns the host element of `element`'s enclosing shadow root, or `null` if it is not in one. */
 export function getShadowHost(element: HTMLElement): HTMLElement | null {

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -363,6 +363,12 @@ export function redispatchPortaledEvent(
 ): boolean {
   if (!sourceTarget) return false;
 
+  const pointerMousePair = getPointerMousePair(event, sourceTarget);
+  if (pointerMousePair === 'suppress') {
+    event.stopPropagation();
+    return true;
+  }
+
   // Pointer and mouse events are distinct native families. Bridge each native
   // event once; dropping the browser's corresponding mousedown/mouseup would
   // break consumers that listen to only that family. Synthetic events remain
@@ -383,6 +389,9 @@ export function redispatchPortaledEvent(
     'isComposing',
     'button',
     'buttons',
+    'movementX',
+    'movementY',
+    'which',
     'clientX',
     'clientY',
     'screenX',
@@ -404,10 +413,27 @@ export function redispatchPortaledEvent(
     'tiltY',
     'twist',
     'tangentialPressure',
+    'width',
+    'height',
   ]) {
     if (property in event) eventInit[property] = Reflect.get(event, property);
   }
-  const bridgedEvent = Reflect.construct(event.constructor, [event.type, eventInit]);
+  let bridgedEvent: Event;
+  try {
+    bridgedEvent = Reflect.construct(event.constructor, [event.type, eventInit]);
+  } catch {
+    bridgedEvent = new Event(event.type, eventInit);
+  }
+  for (const property of ['movementX', 'movementY', 'which', 'width', 'height']) {
+    if (!(property in event)) continue;
+    const value = Reflect.get(event, property);
+    if (Reflect.get(bridgedEvent, property) === value) continue;
+    try {
+      Object.defineProperty(bridgedEvent, property, { configurable: true, value });
+    } catch {
+      // Some native event implementations expose non-configurable accessors.
+    }
+  }
   redispatchedPortalEvents.add(bridgedEvent);
   Object.defineProperty(bridgedEvent, 'target', { configurable: true, value: originalTarget });
   // Dispatching at the authored root necessarily changes currentTarget and the
@@ -437,6 +463,70 @@ export function redispatchPortaledEvent(
 }
 
 const redispatchedPortalEvents = new WeakSet<Event>();
+
+type PointerMousePhase = 'down' | 'up';
+type PointerMousePair = {
+  target: EventTarget | null;
+  phase: PointerMousePhase;
+  button: number;
+  clientX: number;
+  clientY: number;
+  expiresAt: number;
+};
+
+const pointerMousePairs = new WeakMap<HTMLElement, PointerMousePair[]>();
+const pointerMousePairLifetime = 500;
+
+function getPointerMousePair(
+  event: Event,
+  sourceTarget: HTMLElement,
+): 'record' | 'suppress' | undefined {
+  const phase =
+    event.type === 'pointerdown' || event.type === 'mousedown'
+      ? 'down'
+      : event.type === 'pointerup' || event.type === 'mouseup'
+        ? 'up'
+        : undefined;
+  if (!phase) return;
+
+  const pointerType = 'pointerType' in event ? Reflect.get(event, 'pointerType') : undefined;
+  const target = event.target;
+  const button =
+    typeof Reflect.get(event, 'button') === 'number' ? Reflect.get(event, 'button') : 0;
+  const clientX =
+    typeof Reflect.get(event, 'clientX') === 'number' ? Reflect.get(event, 'clientX') : 0;
+  const clientY =
+    typeof Reflect.get(event, 'clientY') === 'number' ? Reflect.get(event, 'clientY') : 0;
+  const now = Date.now();
+  const pairs = pointerMousePairs.get(sourceTarget) ?? [];
+  const livePairs = pairs.filter((pair) => pair.expiresAt > now);
+  pointerMousePairs.set(sourceTarget, livePairs);
+
+  if (event.type.startsWith('pointer')) {
+    if (pointerType !== 'mouse') return;
+    livePairs.push({
+      target,
+      phase,
+      button,
+      clientX,
+      clientY,
+      expiresAt: now + pointerMousePairLifetime,
+    });
+    return 'record';
+  }
+
+  const pairIndex = livePairs.findIndex(
+    (pair) =>
+      pair.phase === phase &&
+      pair.target === target &&
+      pair.button === button &&
+      pair.clientX === clientX &&
+      pair.clientY === clientY,
+  );
+  if (pairIndex < 0) return;
+  livePairs.splice(pairIndex, 1);
+  return 'suppress';
+}
 
 /** Returns the host element of `element`'s enclosing shadow root, or `null` if it is not in one. */
 export function getShadowHost(element: HTMLElement): HTMLElement | null {

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -370,16 +370,6 @@ export function redispatchPortaledEvent(
 
   const originalTarget = event.target;
   const originalComposedPath = event.composedPath();
-  const authoredPath: EventTarget[] = [];
-  let authoredNode: Node | null = sourceTarget;
-  while (authoredNode) {
-    authoredPath.push(authoredNode);
-    authoredNode = authoredNode.parentNode;
-  }
-  const composedPath = [
-    ...originalComposedPath,
-    ...authoredPath.filter((entry) => !originalComposedPath.includes(entry)),
-  ];
   const eventInit: EventInit & { [property: string]: unknown } = {
     bubbles: event.bubbles,
     cancelable: event.cancelable,
@@ -428,8 +418,11 @@ export function redispatchPortaledEvent(
   Object.defineProperty(bridgedEvent, 'composedPath', {
     configurable: true,
     value: () => {
-      const useNative = !dispatchComplete && bridgedEvent.currentTarget === null;
-      return useNative ? nativeComposedPath() : [...composedPath];
+      // During synthetic dispatch expose the authored-root path. Svelte's
+      // delegated listener traverses composedPath(); exposing portaled
+      // descendants here would replay their handlers. Restore the original
+      // path after dispatch for consumer inspection.
+      return dispatchComplete ? [...originalComposedPath] : nativeComposedPath();
     },
   });
   if (event.defaultPrevented) bridgedEvent.preventDefault();

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -363,16 +363,10 @@ export function redispatchPortaledEvent(
 ): boolean {
   if (!sourceTarget) return false;
 
-  const pointerMousePair = getPointerMousePair(event, sourceTarget);
-  if (pointerMousePair === 'suppress') {
-    event.stopPropagation();
-    return true;
-  }
-
   // Pointer and mouse events are distinct native families. Bridge each native
   // event once; dropping the browser's corresponding mousedown/mouseup would
-  // break consumers that listen to only that family. Synthetic events remain
-  // untrusted because `isTrusted` is platform-controlled.
+  // break consumers that listen to only that family. Replay protection belongs
+  // to the redispatched-event marker, not pointer/mouse pairing heuristics.
 
   const originalTarget = event.target;
   const originalComposedPath = event.composedPath();
@@ -382,6 +376,7 @@ export function redispatchPortaledEvent(
     composed: event.composed,
   };
   for (const property of [
+    'view',
     'key',
     'code',
     'location',
@@ -463,70 +458,6 @@ export function redispatchPortaledEvent(
 }
 
 const redispatchedPortalEvents = new WeakSet<Event>();
-
-type PointerMousePhase = 'down' | 'up';
-type PointerMousePair = {
-  target: EventTarget | null;
-  phase: PointerMousePhase;
-  button: number;
-  clientX: number;
-  clientY: number;
-  expiresAt: number;
-};
-
-const pointerMousePairs = new WeakMap<HTMLElement, PointerMousePair[]>();
-const pointerMousePairLifetime = 500;
-
-function getPointerMousePair(
-  event: Event,
-  sourceTarget: HTMLElement,
-): 'record' | 'suppress' | undefined {
-  const phase =
-    event.type === 'pointerdown' || event.type === 'mousedown'
-      ? 'down'
-      : event.type === 'pointerup' || event.type === 'mouseup'
-        ? 'up'
-        : undefined;
-  if (!phase) return;
-
-  const pointerType = 'pointerType' in event ? Reflect.get(event, 'pointerType') : undefined;
-  const target = event.target;
-  const button =
-    typeof Reflect.get(event, 'button') === 'number' ? Reflect.get(event, 'button') : 0;
-  const clientX =
-    typeof Reflect.get(event, 'clientX') === 'number' ? Reflect.get(event, 'clientX') : 0;
-  const clientY =
-    typeof Reflect.get(event, 'clientY') === 'number' ? Reflect.get(event, 'clientY') : 0;
-  const now = Date.now();
-  const pairs = pointerMousePairs.get(sourceTarget) ?? [];
-  const livePairs = pairs.filter((pair) => pair.expiresAt > now);
-  pointerMousePairs.set(sourceTarget, livePairs);
-
-  if (event.type.startsWith('pointer')) {
-    if (pointerType !== 'mouse') return;
-    livePairs.push({
-      target,
-      phase,
-      button,
-      clientX,
-      clientY,
-      expiresAt: now + pointerMousePairLifetime,
-    });
-    return 'record';
-  }
-
-  const pairIndex = livePairs.findIndex(
-    (pair) =>
-      pair.phase === phase &&
-      pair.target === target &&
-      pair.button === button &&
-      pair.clientX === clientX &&
-      pair.clientY === clientY,
-  );
-  if (pairIndex < 0) return;
-  livePairs.splice(pairIndex, 1);
-  return 'suppress';
-}
 
 /** Returns the host element of `element`'s enclosing shadow root, or `null` if it is not in one. */
 export function getShadowHost(element: HTMLElement): HTMLElement | null {

--- a/packages/components/src/components/speed-dial-action/speed-dial-action.svelte
+++ b/packages/components/src/components/speed-dial-action/speed-dial-action.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
   import FloatingAction from '../floating-action/floating-action.svelte';
-  import { isRedispatchedPortaledEvent } from '../portal/index.ts';
+  import { isRedispatchedPortaledEvent } from '@lostgradient/cinder/portal';
   import { getSpeedDialContext } from '../speed-dial/speed-dial.context.ts';
   import type { SpeedDialActionProps } from './speed-dial-action.types.ts';
 

--- a/packages/components/src/components/speed-dial-action/speed-dial-action.svelte
+++ b/packages/components/src/components/speed-dial-action/speed-dial-action.svelte
@@ -19,7 +19,7 @@
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
   import FloatingAction from '../floating-action/floating-action.svelte';
-  import { isRedispatchedPortaledEvent } from '../portal/portal.utilities.svelte.ts';
+  import { isRedispatchedPortaledEvent } from '../portal/index.ts';
   import { getSpeedDialContext } from '../speed-dial/speed-dial.context.ts';
   import type { SpeedDialActionProps } from './speed-dial-action.types.ts';
 

--- a/packages/components/src/components/speed-dial-action/speed-dial-action.svelte
+++ b/packages/components/src/components/speed-dial-action/speed-dial-action.svelte
@@ -19,6 +19,7 @@
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
   import FloatingAction from '../floating-action/floating-action.svelte';
+  import { isRedispatchedPortaledEvent } from '../portal/portal.utilities.svelte.ts';
   import { getSpeedDialContext } from '../speed-dial/speed-dial.context.ts';
   import type { SpeedDialActionProps } from './speed-dial-action.types.ts';
 
@@ -40,6 +41,7 @@
 
   function handleClick(event: MouseEvent): void {
     if (disabled) return;
+    if (isRedispatchedPortaledEvent(event)) return;
     onclick?.(event);
     context.close({ focusTrigger: true });
   }

--- a/packages/components/src/components/speed-dial/speed-dial.svelte
+++ b/packages/components/src/components/speed-dial/speed-dial.svelte
@@ -434,6 +434,8 @@
     onfocusout={bridgePortaledInteraction}
     onpointerdown={bridgePortaledInteraction}
     onpointerup={bridgePortaledInteraction}
+    onmousedown={bridgePortaledInteraction}
+    onmouseup={bridgePortaledInteraction}
     oninput={bridgePortaledInteraction}
     onchange={bridgePortaledInteraction}
   >


### PR DESCRIPTION
Closes #1074

- bridge pointer and corresponding mouse events for portaled NavigationBar and SpeedDial controls
- preserve original portaled ancestry through composedPath() while dispatching at the authored root
- retain cancellation/default-prevention semantics and avoid redispatched SpeedDial action clicks
- add focused Portal regressions and a patch changeset

Validation: focused Portal/NavigationBar/SpeedDial tests, package lint/invariants/typecheck/components:check/exports:check, targeted Prettier, and git diff --check.