### PR TITLE
fix(stylelint): close z-index analyzer arity and grammar-parity gaps

### DIFF
--- a/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
@@ -3,6 +3,7 @@ import {
   classifyStaticLayer,
   cssCommentMaskCharacter,
   evaluateStaticLayerNumber,
+  evaluateStaticLayerNumberWithUnit,
   hasRuntimeDependentNumericConversion,
   hasStaticallyZeroCoefficient,
   haveCompatibleStaticDivisionTypes,
@@ -22,31 +23,11 @@ import {
 
 const fallbackFunctionPattern = /(?:var|env|attr)\(/iy;
 const invalidToggleNestedFunctionPattern = /(?:toggle|attr|calc|-webkit-calc)\(/iy;
-const bareCssNumberPattern = /^([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?)(?:[a-z%]+)?$/i;
-
-// evaluateStaticLayerNumber() rounds its result to the nearest integer, which
-// is the right behavior for classifying a layer as (near) the banned value
-// but destroys the fractional precision some checks (e.g. random()'s
-// step / 1000 endpoint-snapping tolerance) need. This parses a bare CSS
-// <number> token (optionally followed by a unit or `%`, which is stripped --
-// callers only use this to compare magnitudes that are already known to
-// share a unit) exactly; anything more complex (calc(), functions, a
-// malformed token like `1.` with a dangling decimal point) is left to the
-// caller's fallback.
-function preciseStaticNumberWithUnit(text) {
-  const trimmed = text.replaceAll(cssCommentMaskCharacter, ' ').trim();
-  const match = bareCssNumberPattern.exec(trimmed);
-  if (!match) return undefined;
-  return { value: Number(match[1]), unit: trimmed.slice(match[1].length).toLowerCase() };
-}
-
-function preciseStaticNumber(text) {
-  return preciseStaticNumberWithUnit(text)?.value;
-}
 const fallbackResolutionTooComplex = Symbol('fallback-resolution-too-complex');
 const fallbackResolutionWorkLimit = 8_000_000;
 const typedHypotParentLimit = 2_048;
 const conditionalNestingLimit = 128;
+const attrHeaderSubstitutionPeelLimit = 128;
 const uniformDivisorWitnessValues = ['1', '2', '1px', '1deg', '1s', '1hz', '1dppx'];
 const typedDivisorWitnessValues = ['1px', '1deg', '1s', '1hz', '1dppx'];
 const typedZeroWitnessValues = ['0px', '0deg', '0s', '0hz', '0dppx'];
@@ -2115,7 +2096,7 @@ function conditionalBranchValueRanges(value, group, parenthesisPairs) {
   return analysis.branchRanges;
 }
 
-function toggleBranchContainsInvalidNestedFunction(value, range) {
+function toggleBranchContainsInvalidNestedFunction(value, range, parenthesisPairs) {
   for (let index = range.start; index < range.end; index += 1) {
     if (value[index] === '"' || value[index] === "'") {
       index = quotedStringEnd(value, index);
@@ -2126,16 +2107,31 @@ function toggleBranchContainsInvalidNestedFunction(value, range) {
       index = urlTokenEnd;
       continue;
     }
-    invalidToggleNestedFunctionPattern.lastIndex = index;
-    const match = invalidToggleNestedFunctionPattern.exec(value);
     const previousCharacter = value[index - 1];
-    if (
-      match &&
+    const isFunctionBoundary =
       !isCssIdentifierCharacter(previousCharacter) &&
       previousCharacter !== '#' &&
-      previousCharacter !== '@'
-    )
-      return true;
+      previousCharacter !== '@';
+
+    invalidToggleNestedFunctionPattern.lastIndex = index;
+    if (isFunctionBoundary && invalidToggleNestedFunctionPattern.exec(value)) return true;
+
+    // A forbidden token that's only reachable through a var()/env()
+    // substitution's own fallback (rather than written directly in the
+    // branch) doesn't make the branch unconditionally invalid -- the
+    // substitution may resolve to something else entirely, e.g.
+    // `toggle(1, var(--x, calc(1)))` is still a valid, selectable branch
+    // whenever --x is set. Skip past the substitution's own parens (an
+    // attr() substitution already returned true above, since attr() is
+    // itself a forbidden token regardless of context) instead of scanning
+    // through them, same as randomItemArgumentRanges treats other
+    // functions' arguments as opaque.
+    fallbackFunctionPattern.lastIndex = index;
+    const substitutionMatch = isFunctionBoundary ? fallbackFunctionPattern.exec(value) : null;
+    if (substitutionMatch) {
+      const closeIndex = parenthesisPairs.get(index + substitutionMatch[0].length - 1);
+      if (closeIndex !== undefined && closeIndex < range.end) index = closeIndex;
+    }
   }
   return false;
 }
@@ -2156,7 +2152,7 @@ function toggleBranchValueRanges(value, group, parenthesisPairs) {
   // never applies, so it can never actually select a branch value.
   if (
     branchRanges.some((branchRange) =>
-      toggleBranchContainsInvalidNestedFunction(value, branchRange),
+      toggleBranchContainsInvalidNestedFunction(value, branchRange, parenthesisPairs),
     )
   )
     return undefined;
@@ -3410,37 +3406,30 @@ function attrHeaderTypeStart(header, identifierEnd) {
 
 // A leading var()/env()/attr() substitution can stand in for the whole
 // <attr-name> (CSS Values 5 allows arbitrary substitution functions anywhere
-// a <declaration-value> is permitted, including here). Returns the index just
-// past its matching close parenthesis, or -1 if the header doesn't start
-// with one.
-function headerLeadingSubstitutionEnd(header) {
+// a <declaration-value> is permitted, including here). Returns the index
+// just past its matching close parenthesis, and the range of its own
+// fallback argument (the text after its first top-level comma, if it has
+// one), or undefined if the header doesn't start with a substitution.
+function headerLeadingSubstitution(header) {
   fallbackFunctionPattern.lastIndex = 0;
   const match = fallbackFunctionPattern.exec(header);
-  if (!match || match.index !== 0) return -1;
+  if (!match || match.index !== 0) return undefined;
   let depth = 1;
+  let commaIndex = -1;
   for (let index = match[0].length; index < header.length; index += 1) {
     const character = header[index];
     if (character === '"' || character === "'") index = quotedStringEnd(header, index);
     else if (character === '(') depth += 1;
     else if (character === ')') {
       depth -= 1;
-      if (depth === 0) return index + 1;
-    }
+      if (depth === 0)
+        return {
+          end: index + 1,
+          fallbackRange: commaIndex === -1 ? undefined : { start: commaIndex + 1, end: index },
+        };
+    } else if (character === ',' && depth === 1 && commaIndex === -1) commaIndex = index;
   }
-  return -1;
-}
-
-// <attr-name> is `[ <ns-prefix> ]? <ident-token>` where `<ns-prefix>` is
-// itself `[ <ident-token> | '*' ]? '|'` -- so a *null* namespace (bare `|`
-// with nothing before it, e.g. `|data-layer`) is valid and must not be
-// mistaken for an invalid header. The name may also be a substitution
-// function rather than a literal identifier at all.
-function attrHeaderNameEnd(header) {
-  const leadingSubstitutionEnd = headerLeadingSubstitutionEnd(header);
-  if (leadingSubstitutionEnd !== -1) return leadingSubstitutionEnd;
-  const nameStart = header[0] === '|' ? 1 : 0;
-  const identifierEnd = cssIdentifierTokenEnd(header, nameStart);
-  return identifierEnd > nameStart ? identifierEnd : -1;
+  return undefined;
 }
 
 function attrTypeSyntaxFromHeader(header, nameEnd) {
@@ -3452,12 +3441,57 @@ function attrTypeSyntaxFromHeader(header, nameEnd) {
   return typeMatch && validAttrTypeSyntax(typeMatch[1]) ? attrType : undefined;
 }
 
+// <attr-name> is `[ <ns-prefix> ]? <ident-token>` where `<ns-prefix>` is
+// itself `[ <ident-token> | '*' ]? '|'` -- so a *null* namespace (bare `|`
+// with nothing before it, e.g. `|data-layer`) is valid and must not be
+// mistaken for an invalid header. The name may also be a substitution
+// function rather than a literal identifier at all, and per CSS Values 5's
+// grammar the substitution's own fallback argument can supply the
+// <attr-type> clause too, not just the name -- e.g.
+// `attr(var(--header, data-scale number), 0)` is only reachable through
+// var(--header)'s own fallback, never literally written after it in the
+// outer header. Peel through a chain of such substitutions iteratively
+// (not recursively, so pathologically deep nesting can't overflow the
+// stack, matching this file's other explicit nesting limits) looking for
+// the first one whose own text resolves a usable <attr-type>. Once at
+// least one substitution has consumed the whole header with no usable type
+// found anywhere in the chain, the header is still a syntactically valid
+// substitution-only name -- just with no derivable numeric witnesses --
+// whereas a header that was never a substitution at all and isn't a valid
+// identifier either is genuinely invalid. Returns the validated attrType
+// string (possibly '', meaning "no type"), or undefined if the header is
+// invalid.
+function attrHeaderType(header) {
+  let current = header;
+  let consumedByOnlySubstitution = false;
+  for (let depth = 0; depth < attrHeaderSubstitutionPeelLimit; depth += 1) {
+    const leadingSubstitution = headerLeadingSubstitution(current);
+    if (leadingSubstitution === undefined) {
+      const nameStart = current[0] === '|' ? 1 : 0;
+      const identifierEnd = cssIdentifierTokenEnd(current, nameStart);
+      if (identifierEnd === nameStart) return consumedByOnlySubstitution ? '' : undefined;
+      return attrTypeSyntaxFromHeader(current, identifierEnd);
+    }
+    if (leadingSubstitution.end !== current.length)
+      return attrTypeSyntaxFromHeader(current, leadingSubstitution.end);
+    if (leadingSubstitution.fallbackRange === undefined) return '';
+    consumedByOnlySubstitution = true;
+    // Mirror substitutionHeader()'s normalization: the fallback range is
+    // the raw text after the comma, whitespace and all (e.g. the leading
+    // space in `var(--header, data-scale number)`'s fallback), which
+    // cssIdentifierTokenEnd() and headerLeadingSubstitution() don't skip on
+    // their own.
+    current = current
+      .slice(leadingSubstitution.fallbackRange.start, leadingSubstitution.fallbackRange.end)
+      .replaceAll(cssCommentMaskCharacter, ' ')
+      .trim();
+  }
+  return '';
+}
+
 function validSubstitutionHeader(frame, value) {
   const header = substitutionHeader(frame, value);
-  if (frame.functionName === 'attr') {
-    const nameEnd = attrHeaderNameEnd(header);
-    return nameEnd !== -1 && attrTypeSyntaxFromHeader(header, nameEnd) !== undefined;
-  }
+  if (frame.functionName === 'attr') return attrHeaderType(header) !== undefined;
   const identifierEnd = cssIdentifierTokenEnd(header, 0);
   if (identifierEnd === 0) return false;
   if (frame.functionName === 'var')
@@ -3549,9 +3583,8 @@ function substitutionDefinedPathWitnessGroups(frame, value) {
   }
   if (frame.functionName !== 'attr') return undefined;
   const header = substitutionHeader(frame, value);
-  const nameEnd = attrHeaderNameEnd(header);
-  if (nameEnd === -1) return undefined;
-  const attrType = header.slice(attrHeaderTypeStart(header, nameEnd)).trim();
+  const attrType = attrHeaderType(header);
+  if (attrType === undefined) return undefined;
   return attrDefinedPathWitnessGroups(attrType);
 }
 
@@ -4870,9 +4903,12 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
   // evaluateStaticLayerNumber() rounds to the nearest integer, which is too
   // coarse to prove the step is actually positive (a small positive step
   // like 0.4 can round to a stepValue of 0) or to compute the spec's
-  // step / 1000 endpoint-snapping tolerance precisely. Re-parse the plain
-  // numeric step token at full precision instead.
-  const preciseStepValue = preciseStaticNumber(stepExpression);
+  // step / 1000 endpoint-snapping tolerance precisely. Re-evaluate the step
+  // at full precision instead -- evaluateStaticLayerNumberWithUnit() handles
+  // wrapped static math (e.g. `calc(9999)`), not just a bare numeric token,
+  // so a resolvable-but-not-bare-number step is no longer treated as
+  // unprovably positive.
+  const preciseStepValue = evaluateStaticLayerNumberWithUnit(stepExpression)?.value;
   // A step that's negative, zero, or close enough to zero that the step
   // count would be unusably large is *ignored* -- the function behaves as
   // if only A and B were given (the full continuous [A, B] range), not
@@ -4881,14 +4917,19 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
   // positive one), use that same conservative continuous treatment.
   if (preciseStepValue === undefined || preciseStepValue <= 0) return continuousRangeResult();
 
-  // preciseStaticNumberWithUnit() strips a unit rather than converting it,
-  // so the precise magnitudes below are only trustworthy when min, max, and
-  // step all share the literal same unit (or are all bare numbers) --
-  // otherwise fall back to the already-converted (but integer-rounded)
-  // values, e.g. `random(0px, 264.556875cm, 9999px)`.
-  const preciseMinimum = preciseStaticNumberWithUnit(minimumExpression);
-  const preciseMaximum = preciseStaticNumberWithUnit(maximumExpression);
-  const preciseStep = preciseStaticNumberWithUnit(stepExpression);
+  // evaluateStaticLayerNumberWithUnit() converts every canonical absolute
+  // unit to its canonical same-dimension magnitude while parsing (the same
+  // conversion evaluateStaticLayerNumber() relies on), so min, max, and step
+  // written in different but convertible units (e.g. `264.556875cm` next to
+  // `9989.02px`) are directly comparable at full precision here -- unlike
+  // evaluateStaticLayerNumber(), this doesn't also round the result, which
+  // the step / 1000 endpoint-snapping tolerance below needs. A nonzero
+  // relative length (em, vh, ...), or a unit mismatch that isn't just a
+  // convertible-unit difference, still isn't safely comparable and falls
+  // back to the already-converted (but integer-rounded) values below.
+  const preciseMinimum = evaluateStaticLayerNumberWithUnit(minimumExpression);
+  const preciseMaximum = evaluateStaticLayerNumberWithUnit(maximumExpression);
+  const preciseStep = evaluateStaticLayerNumberWithUnit(stepExpression);
   const preciseValuesShareAUnit =
     preciseMinimum !== undefined &&
     preciseMaximum !== undefined &&

--- a/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
@@ -4863,28 +4863,28 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
     return { continuous: true, values: [minimumExpression, maximumExpression] };
   };
   if (stepValue === undefined) return continuousRangeResult();
+  // CSS Values 5 (random-argument-ranges): an infinite step resolves to A
+  // outright (distinct from the nonpositive-step case below).
+  if (!Number.isFinite(stepValue)) return { continuous: false, values: [minimumExpression] };
 
   // evaluateStaticLayerNumber() rounds to the nearest integer, which is too
-  // coarse both to prove a step is truly <= 0 (CSS Values 5 folds it to the
-  // written A) and to compute the spec's step / 1000 endpoint-snapping
-  // tolerance precisely. Re-parse the plain numeric tokens (when each is
-  // one) at full precision instead.
+  // coarse to prove the step is actually positive (a small positive step
+  // like 0.4 can round to a stepValue of 0) or to compute the spec's
+  // step / 1000 endpoint-snapping tolerance precisely. Re-parse the plain
+  // numeric step token at full precision instead.
   const preciseStepValue = preciseStaticNumber(stepExpression);
-  if (preciseStepValue === undefined && stepValue <= 0) {
-    // We can't prove the step is exactly <= 0 -- it's a complex expression,
-    // or integer rounding may have collapsed a small positive step (e.g.
-    // 0.4) to a rounded stepValue of 0. Folding to a single point is only
-    // sound when it's provably correct, so fall back to treating the full
-    // [A, B] range as reachable instead of risking a false negative.
-    return continuousRangeResult();
-  }
-  // A step that's provably <= 0 folds the whole range to its start (CSS
-  // Values 5, https://www.w3.org/TR/css-values-5/#random): the written A,
-  // not the full [A, B] interval. This holds regardless of the random key,
-  // since the result is a single deterministic value either way.
-  if (preciseStepValue !== undefined && preciseStepValue <= 0)
-    return { continuous: false, values: [minimumExpression] };
-  if (!Number.isFinite(stepValue)) return { continuous: false, values: [minimumExpression] };
+  // A step that's negative, zero, or close enough to zero that the step
+  // count would be unusably large is *ignored* -- the function behaves as
+  // if only A and B were given (the full continuous [A, B] range), not
+  // folded to a single point. Whenever the step isn't provably positive (a
+  // complex expression, or a rounded value that might be masking a small
+  // positive one), use that same conservative continuous treatment.
+  if (preciseStepValue === undefined || preciseStepValue <= 0) return continuousRangeResult();
+  // A fixed key of exactly 0 always selects step index 0 (the written
+  // minimum), regardless of how many step slots the range divides into --
+  // short-circuit before the step-count cap below, which exists to bound
+  // enumerating every slot, not to bound this single, already-known one.
+  if (fixedBaseValue === 0) return { continuous: false, values: [minimumExpression] };
 
   // preciseStaticNumberWithUnit() strips a unit rather than converting it,
   // so the precise magnitudes below are only trustworthy when min, max, and

--- a/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
@@ -33,10 +33,15 @@ const bareCssNumberPattern = /^([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?)(?:[a
 // share a unit) exactly; anything more complex (calc(), functions, a
 // malformed token like `1.` with a dangling decimal point) is left to the
 // caller's fallback.
-function preciseStaticNumber(text) {
+function preciseStaticNumberWithUnit(text) {
   const trimmed = text.replaceAll(cssCommentMaskCharacter, ' ').trim();
   const match = bareCssNumberPattern.exec(trimmed);
-  return match ? Number(match[1]) : undefined;
+  if (!match) return undefined;
+  return { value: Number(match[1]), unit: trimmed.slice(match[1].length).toLowerCase() };
+}
+
+function preciseStaticNumber(text) {
+  return preciseStaticNumberWithUnit(text)?.value;
 }
 const fallbackResolutionTooComplex = Symbol('fallback-resolution-too-complex');
 const fallbackResolutionWorkLimit = 8_000_000;
@@ -3469,10 +3474,13 @@ function attrDefinedPathWitnessGroups(attrType) {
   if (attrType === '%') return [['0%', '1%']];
   if (cssIdentifierTokenEnd(attrType, 0) === attrType.length) {
     const unit = attrType.toLowerCase();
-    // attr()'s legacy `<attr-name> <type-or-unit>?` syntax also accepts the
-    // bare keywords `number`/`integer` for a dimensionless numeric read --
-    // unlike the other legacy keywords, they carry no unit suffix.
-    if (unit === 'number' || unit === 'integer') return [['0', '1']];
+    // attr()'s legacy grammar is `type(<syntax>) | raw-string | number |
+    // <attr-unit>` (CSS Values 5), where <attr-unit> is any <custom-ident>
+    // treated as a unit name. Only the literal `number` keyword is a
+    // dimensionless numeric read; `integer` isn't a recognized keyword at
+    // all here, so it's just an (unrecognized) unit name like any other,
+    // and derives no witnesses.
+    if (unit === 'number') return [['0', '1']];
     return attrLegacyNumericUnits.has(unit) ? [[`0${unit}`, `1${unit}`]] : undefined;
   }
   const typeMatch = /^type\(([^()]+)\)$/i.exec(attrType);
@@ -4880,17 +4888,46 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
     return { continuous: false, values: [minimumExpression] };
   if (!Number.isFinite(stepValue)) return { continuous: false, values: [minimumExpression] };
 
-  const effectiveStepValue = preciseStepValue ?? stepValue;
-  const preciseMinimumValue = preciseStaticNumber(minimumExpression) ?? minimumValue;
-  const preciseMaximumValue = preciseStaticNumber(maximumExpression) ?? maximumValue;
-  const stepCount = Math.floor((preciseMaximumValue - preciseMinimumValue) / effectiveStepValue);
+  // preciseStaticNumberWithUnit() strips a unit rather than converting it,
+  // so the precise magnitudes below are only trustworthy when min, max, and
+  // step all share the literal same unit (or are all bare numbers) --
+  // otherwise fall back to the already-converted (but integer-rounded)
+  // values, e.g. `random(0px, 264.556875cm, 9999px)`.
+  const preciseMinimum = preciseStaticNumberWithUnit(minimumExpression);
+  const preciseMaximum = preciseStaticNumberWithUnit(maximumExpression);
+  const preciseStep = preciseStaticNumberWithUnit(stepExpression);
+  const preciseValuesShareAUnit =
+    preciseMinimum !== undefined &&
+    preciseMaximum !== undefined &&
+    preciseStep !== undefined &&
+    preciseMinimum.unit === preciseMaximum.unit &&
+    preciseMinimum.unit === preciseStep.unit;
+  const effectiveStepValue = preciseValuesShareAUnit ? preciseStep.value : stepValue;
+  const preciseMinimumValue = preciseValuesShareAUnit ? preciseMinimum.value : minimumValue;
+  const preciseMaximumValue = preciseValuesShareAUnit ? preciseMaximum.value : maximumValue;
+  const naturalStepCount = Math.floor(
+    (preciseMaximumValue - preciseMinimumValue) / effectiveStepValue,
+  );
+  if (!Number.isSafeInteger(naturalStepCount) || naturalStepCount > 128)
+    return fallbackResolutionTooComplex;
+  // CSS Values 5's random-evaluation algorithm: epsilon is step / 1000; N is
+  // the largest integer with min + N * step <= max (naturalStepCount above),
+  // *unless* N's value isn't within epsilon of max but N + 1's would be, in
+  // which case N is extended by one. The step index at N then snaps to the
+  // written maximum (rather than the plain arithmetic) whenever it's within
+  // epsilon of it.
+  const epsilon = Math.abs(effectiveStepValue) / 1000;
+  const valueAtStep = (stepIndex) => preciseMinimumValue + effectiveStepValue * stepIndex;
+  const naturalStepIsWithinEpsilon =
+    Math.abs(preciseMaximumValue - valueAtStep(naturalStepCount)) <= epsilon;
+  const nextStepIsWithinEpsilon =
+    Math.abs(preciseMaximumValue - valueAtStep(naturalStepCount + 1)) <= epsilon;
+  const stepCount =
+    !naturalStepIsWithinEpsilon && nextStepIsWithinEpsilon
+      ? naturalStepCount + 1
+      : naturalStepCount;
   if (!Number.isSafeInteger(stepCount) || stepCount > 128) return fallbackResolutionTooComplex;
-  // CSS Values 5's stepped random() snaps the last step to the written
-  // maximum, not `minimum + step * stepCount`, whenever that computed value
-  // is within `step / 1000` of the maximum.
-  const lastStepSnapsToMaximum =
-    Math.abs(preciseMaximumValue - (preciseMinimumValue + effectiveStepValue * stepCount)) <=
-    Math.abs(effectiveStepValue) / 1000;
+  const lastStepSnapsToMaximum = Math.abs(preciseMaximumValue - valueAtStep(stepCount)) <= epsilon;
   const stepExpressionAt = (stepIndex) => {
     if (stepIndex === 0) return minimumExpression;
     if (stepIndex === stepCount && lastStepSnapsToMaximum) return maximumExpression;

--- a/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
@@ -4880,11 +4880,6 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
   // complex expression, or a rounded value that might be masking a small
   // positive one), use that same conservative continuous treatment.
   if (preciseStepValue === undefined || preciseStepValue <= 0) return continuousRangeResult();
-  // A fixed key of exactly 0 always selects step index 0 (the written
-  // minimum), regardless of how many step slots the range divides into --
-  // short-circuit before the step-count cap below, which exists to bound
-  // enumerating every slot, not to bound this single, already-known one.
-  if (fixedBaseValue === 0) return { continuous: false, values: [minimumExpression] };
 
   // preciseStaticNumberWithUnit() strips a unit rather than converting it,
   // so the precise magnitudes below are only trustworthy when min, max, and
@@ -4906,8 +4901,7 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
   const naturalStepCount = Math.floor(
     (preciseMaximumValue - preciseMinimumValue) / effectiveStepValue,
   );
-  if (!Number.isSafeInteger(naturalStepCount) || naturalStepCount > 128)
-    return fallbackResolutionTooComplex;
+  if (!Number.isSafeInteger(naturalStepCount)) return fallbackResolutionTooComplex;
   // CSS Values 5's random-evaluation algorithm: epsilon is step / 1000; N is
   // the largest integer with min + N * step <= max (naturalStepCount above),
   // *unless* N's value isn't within epsilon of max but N + 1's would be, in
@@ -4924,19 +4918,24 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
     !naturalStepIsWithinEpsilon && nextStepIsWithinEpsilon
       ? naturalStepCount + 1
       : naturalStepCount;
-  if (!Number.isSafeInteger(stepCount) || stepCount > 128) return fallbackResolutionTooComplex;
+  if (!Number.isSafeInteger(stepCount)) return fallbackResolutionTooComplex;
   const lastStepSnapsToMaximum = Math.abs(preciseMaximumValue - valueAtStep(stepCount)) <= epsilon;
   const stepExpressionAt = (stepIndex) => {
     if (stepIndex === 0) return minimumExpression;
     if (stepIndex === stepCount && lastStepSnapsToMaximum) return maximumExpression;
     return `calc((${minimumExpression}) + (${stepExpression}) * ${stepIndex})`;
   };
+  // A fixed key resolves to exactly one step index regardless of how many
+  // slots the range divides into -- computing (and stringifying) that one
+  // value is O(1), so it isn't subject to the enumeration cap below, which
+  // exists only to bound building an array of every slot.
   if (fixedBaseValue !== undefined) {
     const stepIndex = Math.floor(fixedBaseValue * (stepCount + 1));
     const expression = stepExpressionAt(stepIndex);
     if (!consumeResolutionWork(budget, expression.length)) return fallbackResolutionTooComplex;
     return { continuous: false, values: [expression] };
   }
+  if (stepCount > 128) return fallbackResolutionTooComplex;
   const values = [];
   for (let stepIndex = 0; stepIndex <= stepCount; stepIndex += 1) {
     const expression = stepExpressionAt(stepIndex);

--- a/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
@@ -22,17 +22,21 @@ import {
 
 const fallbackFunctionPattern = /(?:var|env|attr)\(/iy;
 const invalidToggleNestedFunctionPattern = /(?:toggle|attr|calc|-webkit-calc)\(/iy;
-const bareCssNumberPattern = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
+const bareCssNumberPattern = /^([+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?)(?:[a-z%]+)?$/i;
 
 // evaluateStaticLayerNumber() rounds its result to the nearest integer, which
 // is the right behavior for classifying a layer as (near) the banned value
 // but destroys the fractional precision some checks (e.g. random()'s
 // step / 1000 endpoint-snapping tolerance) need. This parses a bare CSS
-// <number> token exactly; anything more complex (calc(), units, functions)
-// is left to the caller's fallback.
+// <number> token (optionally followed by a unit or `%`, which is stripped --
+// callers only use this to compare magnitudes that are already known to
+// share a unit) exactly; anything more complex (calc(), functions, a
+// malformed token like `1.` with a dangling decimal point) is left to the
+// caller's fallback.
 function preciseStaticNumber(text) {
   const trimmed = text.replaceAll(cssCommentMaskCharacter, ' ').trim();
-  return bareCssNumberPattern.test(trimmed) ? Number(trimmed) : undefined;
+  const match = bareCssNumberPattern.exec(trimmed);
+  return match ? Number(match[1]) : undefined;
 }
 const fallbackResolutionTooComplex = Symbol('fallback-resolution-too-complex');
 const fallbackResolutionWorkLimit = 8_000_000;
@@ -1839,7 +1843,7 @@ function firstValidRuntimeFunctionStaticValidity(
     );
     return (
       group !== undefined &&
-      randomItemGroupOutputOptions(frame, value, group, parenthesisPairs) !== undefined
+      randomItemGroupOutputOptions(value, group, parenthesisPairs) !== undefined
     );
   }
   if (functionName !== 'random') return undefined;
@@ -4433,6 +4437,20 @@ function unresolvedRuntimeRangeCandidates(
       functionParent.functionName,
       parenthesisPairs,
     );
+    // calc-mix()'s current CSS Values 5 weighted-item grammar accepts any
+    // number of comma-separated items, unlike the older fixed-arity
+    // progress-interpolation shape the rest of this function's calc-mix
+    // handling assumes. Precisely modeling the weighted average's runtime
+    // range is a separate, larger undertaking; fail closed instead of
+    // silently treating an unresolved item as unreachable.
+    if (
+      functionParent.functionName === 'calc-mix' &&
+      parsedArguments !== undefined &&
+      parsedArguments.argumentRanges.some((argumentRange) =>
+        calcMixArgumentUsesExplicitWeight(value, argumentRange),
+      )
+    )
+      return failClosedRuntimeCandidate(candidate);
     if (
       !unresolvedRuntimeFunctionHasValidArity(
         functionParent.functionName,
@@ -4723,26 +4741,7 @@ function randomItemArgumentRanges(value, group, parenthesisPairs) {
   return argumentRanges;
 }
 
-// A var()/env()/attr() substitution occupying a random-item() value slot is a
-// potentially multi-token, comma-containing stream, not a guaranteed single
-// argument: its fallback may itself contain a raw top-level comma, and if the
-// referenced custom property/attribute is defined at all, its value is
-// entirely unknown. Either way, substituting it can inject additional
-// top-level items into random-item()'s argument list, shifting every index
-// after it. A *direct* child here means the substitution sits at the
-// argument's own nesting depth (its immediate enclosing parenthesis is the
-// random-item() call itself) -- anything nested one level deeper is already
-// captured by whatever function owns that inner parenthesis instead.
-function randomItemArgumentHasDirectSubstitutionChild(frame, group, argumentRange) {
-  return frame.children.some(
-    (child) =>
-      child.parenthesisParent === group &&
-      child.start >= argumentRange.start &&
-      child.start < argumentRange.end,
-  );
-}
-
-function randomItemGroupOutputOptions(frame, value, group, parenthesisPairs) {
+function randomItemGroupOutputOptions(value, group, parenthesisPairs) {
   const argumentRanges = randomItemArgumentRanges(value, group, parenthesisPairs);
   if (
     argumentRanges === undefined ||
@@ -4758,18 +4757,6 @@ function randomItemGroupOutputOptions(frame, value, group, parenthesisPairs) {
   });
   const fixedBaseValue = fixedRandomBaseValueForRange(value, argumentRanges[0]);
   if (fixedBaseValue !== undefined) {
-    // The fixed key deterministically selects `values[floor(base * N)]`, but
-    // N (and therefore which written slot ends up at that index) is only
-    // provably stable when no value slot can silently change the item count.
-    // Precisely modeling every injected-arity outcome is intractable here, so
-    // fail closed through the existing too-complex path instead of trusting
-    // an index that a comma-injecting substitution could invalidate.
-    if (
-      valueRanges.some((argumentRange) =>
-        randomItemArgumentHasDirectSubstitutionChild(frame, group, argumentRange),
-      )
-    )
-      return fallbackResolutionTooComplex;
     const selectedIndex = Math.min(Math.floor(fixedBaseValue * values.length), values.length - 1);
     return {
       continuous: false,
@@ -4782,7 +4769,7 @@ function randomItemGroupOutputOptions(frame, value, group, parenthesisPairs) {
 
 function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs) {
   if (group.functionName === 'random-item')
-    return randomItemGroupOutputOptions(frame, value, group, parenthesisPairs);
+    return randomItemGroupOutputOptions(value, group, parenthesisPairs);
   const functionRange = { start: group.functionStart, end: group.end };
   const parsedArguments = fallbackIndependentStaticArguments(
     frame,
@@ -4858,7 +4845,7 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
   const maximumExpression =
     maximumValue === minimumValue ? minimumExpression : writtenMaximumExpression;
   if (maximumValue === minimumValue) return { continuous: false, values: [minimumExpression] };
-  if (stepValue === undefined) {
+  const continuousRangeResult = () => {
     if (fixedBaseValue === 0) return { continuous: false, values: [minimumExpression] };
     if (fixedBaseValue !== undefined)
       return {
@@ -4868,27 +4855,42 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
         ],
       };
     return { continuous: true, values: [minimumExpression, maximumExpression] };
+  };
+  if (stepValue === undefined) return continuousRangeResult();
+
+  // evaluateStaticLayerNumber() rounds to the nearest integer, which is too
+  // coarse both to prove a step is truly <= 0 (CSS Values 5 folds it to the
+  // written A) and to compute the spec's step / 1000 endpoint-snapping
+  // tolerance precisely. Re-parse the plain numeric tokens (when each is
+  // one) at full precision instead.
+  const preciseStepValue = preciseStaticNumber(stepExpression);
+  if (preciseStepValue === undefined && stepValue <= 0) {
+    // We can't prove the step is exactly <= 0 -- it's a complex expression,
+    // or integer rounding may have collapsed a small positive step (e.g.
+    // 0.4) to a rounded stepValue of 0. Folding to a single point is only
+    // sound when it's provably correct, so fall back to treating the full
+    // [A, B] range as reachable instead of risking a false negative.
+    return continuousRangeResult();
   }
-  // A zero or negative step folds the whole range to its start (CSS Values 5,
-  // https://www.w3.org/TR/css-values-5/#random): the written A, not the full
-  // [A, B] interval. This holds regardless of the random key, since the
-  // result is a single deterministic value either way.
-  if (stepValue <= 0) return { continuous: false, values: [minimumExpression] };
+  // A step that's provably <= 0 folds the whole range to its start (CSS
+  // Values 5, https://www.w3.org/TR/css-values-5/#random): the written A,
+  // not the full [A, B] interval. This holds regardless of the random key,
+  // since the result is a single deterministic value either way.
+  if (preciseStepValue !== undefined && preciseStepValue <= 0)
+    return { continuous: false, values: [minimumExpression] };
   if (!Number.isFinite(stepValue)) return { continuous: false, values: [minimumExpression] };
 
-  const stepCount = Math.floor((maximumValue - minimumValue) / stepValue);
+  const effectiveStepValue = preciseStepValue ?? stepValue;
+  const preciseMinimumValue = preciseStaticNumber(minimumExpression) ?? minimumValue;
+  const preciseMaximumValue = preciseStaticNumber(maximumExpression) ?? maximumValue;
+  const stepCount = Math.floor((preciseMaximumValue - preciseMinimumValue) / effectiveStepValue);
   if (!Number.isSafeInteger(stepCount) || stepCount > 128) return fallbackResolutionTooComplex;
   // CSS Values 5's stepped random() snaps the last step to the written
   // maximum, not `minimum + step * stepCount`, whenever that computed value
-  // is within `step / 1000` of the maximum -- evaluateStaticLayerNumber()
-  // rounds to the nearest integer, which is too coarse to prove that, so
-  // re-parse the plain numeric tokens (when each is one) at full precision.
-  const preciseMinimum = preciseStaticNumber(minimumExpression) ?? minimumValue;
-  const preciseStep = preciseStaticNumber(stepExpression) ?? stepValue;
-  const preciseMaximum = preciseStaticNumber(maximumExpression) ?? maximumValue;
+  // is within `step / 1000` of the maximum.
   const lastStepSnapsToMaximum =
-    Math.abs(preciseMaximum - (preciseMinimum + preciseStep * stepCount)) <=
-    Math.abs(preciseStep) / 1000;
+    Math.abs(preciseMaximumValue - (preciseMinimumValue + effectiveStepValue * stepCount)) <=
+    Math.abs(effectiveStepValue) / 1000;
   const stepExpressionAt = (stepIndex) => {
     if (stepIndex === 0) return minimumExpression;
     if (stepIndex === stepCount && lastStepSnapsToMaximum) return maximumExpression;
@@ -5802,6 +5804,17 @@ function runtimeFunctionStaticArgumentsAreValid(
   );
 }
 
+// A best-effort check for whether a calc-mix() argument uses the current
+// CSS Values 5 weighted-item grammar (`<calc-sum> <percentage>?`) -- i.e.
+// trails its value with a space-separated percentage weight -- as opposed
+// to the older three-argument progress-interpolation shape.
+function calcMixArgumentUsesExplicitWeight(value, argumentRange) {
+  const text = value
+    .slice(argumentRange.start, argumentRange.end)
+    .replaceAll(cssCommentMaskCharacter, ' ');
+  return /\s[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?%$/i.test(text.trimEnd());
+}
+
 function childIsInsideProvablyInvalidCalcMix(child, frame, value, range, parenthesisPairs) {
   let parent = child.parenthesisParent;
   while (
@@ -5818,8 +5831,15 @@ function childIsInsideProvablyInvalidCalcMix(child, frame, value, range, parenth
         'calc-mix',
         parenthesisPairs,
       );
+      if (parsedArguments === undefined) return true;
+      // The weighted-item grammar accepts any number of comma-separated
+      // items, so the fixed three-argument arity check below only applies
+      // to calls that don't use it (the older progress-interpolation shape).
+      const usesWeightedItemGrammar = parsedArguments.argumentRanges.some((argumentRange) =>
+        calcMixArgumentUsesExplicitWeight(value, argumentRange),
+      );
       if (
-        parsedArguments === undefined ||
+        !usesWeightedItemGrammar &&
         !unresolvedRuntimeFunctionHasValidArity('calc-mix', parsedArguments.argumentCount)
       )
         return true;

--- a/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
@@ -4454,9 +4454,7 @@ function unresolvedRuntimeRangeCandidates(
     if (
       functionParent.functionName === 'calc-mix' &&
       parsedArguments !== undefined &&
-      parsedArguments.argumentRanges.some((argumentRange) =>
-        calcMixArgumentUsesExplicitWeight(value, argumentRange),
-      )
+      calcMixCallUsesWeightedItemGrammar(value, parsedArguments)
     )
       return failClosedRuntimeCandidate(candidate);
     if (
@@ -5841,15 +5839,28 @@ function runtimeFunctionStaticArgumentsAreValid(
   );
 }
 
-// A best-effort check for whether a calc-mix() argument uses the current
-// CSS Values 5 weighted-item grammar (`<calc-sum> <percentage>?`) -- i.e.
-// trails its value with a space-separated percentage weight -- as opposed
-// to the older three-argument progress-interpolation shape.
+// A best-effort check for whether a calc-mix() argument trails its value
+// with an explicit space-separated percentage weight (CSS Values 5's
+// current `<calc-sum> <percentage>?` weighted-item grammar).
 function calcMixArgumentUsesExplicitWeight(value, argumentRange) {
   const text = value
     .slice(argumentRange.start, argumentRange.end)
     .replaceAll(cssCommentMaskCharacter, ' ');
   return /\s[+-]?(?:\d+(?:\.\d+)?|\.\d+)(?:e[+-]?\d+)?%$/i.test(text.trimEnd());
+}
+
+// A per-item weight is optional on every item, so a valid weighted call can
+// have none at all -- only exactly three unweighted items is genuinely
+// ambiguous with the older three-argument progress-interpolation shape
+// (mirrors the same rule the static evaluator in z-index-value-analysis.mjs
+// uses to dispatch between the two grammars).
+function calcMixCallUsesWeightedItemGrammar(value, parsedArguments) {
+  return (
+    parsedArguments.argumentCount !== 3 ||
+    parsedArguments.argumentRanges.some((argumentRange) =>
+      calcMixArgumentUsesExplicitWeight(value, argumentRange),
+    )
+  );
 }
 
 function childIsInsideProvablyInvalidCalcMix(child, frame, value, range, parenthesisPairs) {
@@ -5872,11 +5883,8 @@ function childIsInsideProvablyInvalidCalcMix(child, frame, value, range, parenth
       // The weighted-item grammar accepts any number of comma-separated
       // items, so the fixed three-argument arity check below only applies
       // to calls that don't use it (the older progress-interpolation shape).
-      const usesWeightedItemGrammar = parsedArguments.argumentRanges.some((argumentRange) =>
-        calcMixArgumentUsesExplicitWeight(value, argumentRange),
-      );
       if (
-        !usesWeightedItemGrammar &&
+        !calcMixCallUsesWeightedItemGrammar(value, parsedArguments) &&
         !unresolvedRuntimeFunctionHasValidArity('calc-mix', parsedArguments.argumentCount)
       )
         return true;

--- a/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-fallback-analysis.mjs
@@ -21,6 +21,19 @@ import {
 } from './z-index-value-analysis.mjs';
 
 const fallbackFunctionPattern = /(?:var|env|attr)\(/iy;
+const invalidToggleNestedFunctionPattern = /(?:toggle|attr|calc|-webkit-calc)\(/iy;
+const bareCssNumberPattern = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:e[+-]?\d+)?$/i;
+
+// evaluateStaticLayerNumber() rounds its result to the nearest integer, which
+// is the right behavior for classifying a layer as (near) the banned value
+// but destroys the fractional precision some checks (e.g. random()'s
+// step / 1000 endpoint-snapping tolerance) need. This parses a bare CSS
+// <number> token exactly; anything more complex (calc(), units, functions)
+// is left to the caller's fallback.
+function preciseStaticNumber(text) {
+  const trimmed = text.replaceAll(cssCommentMaskCharacter, ' ').trim();
+  return bareCssNumberPattern.test(trimmed) ? Number(trimmed) : undefined;
+}
 const fallbackResolutionTooComplex = Symbol('fallback-resolution-too-complex');
 const fallbackResolutionWorkLimit = 8_000_000;
 const typedHypotParentLimit = 2_048;
@@ -214,6 +227,17 @@ function trimCssTriviaRange(value, start, end) {
   while (start < end && isCssWhitespaceOrComment(value[start])) start += 1;
   while (end > start && isCssWhitespaceOrComment(value[end - 1])) end -= 1;
   return { start, end };
+}
+
+// CSS Values 5's arbitrary substitution functions allow a fallback (or, for
+// first-valid(), an option) to be wrapped in a `{ ... }` guaranteed-invalid
+// wrapper so it can hold otherwise-invalid top-level tokens. When the whole
+// range is exactly that wrapper, unwrap it so the analyzer sees the actual
+// value instead of the literal braces.
+function unwrapBracedFallbackRange(value, range) {
+  return value[range.start] === '{' && value[range.end - 1] === '}'
+    ? trimCssTriviaRange(value, range.start + 1, range.end - 1)
+    : range;
 }
 
 function consumeResolutionWork(budget, amount) {
@@ -1815,7 +1839,7 @@ function firstValidRuntimeFunctionStaticValidity(
     );
     return (
       group !== undefined &&
-      randomItemGroupOutputOptions(value, group, parenthesisPairs) !== undefined
+      randomItemGroupOutputOptions(frame, value, group, parenthesisPairs) !== undefined
     );
   }
   if (functionName !== 'random') return undefined;
@@ -1955,7 +1979,10 @@ function firstValidBranchValueRanges(value, group, parenthesisPairs) {
   const branchRanges = [];
   let branchStart = group.openIndex + 1;
   const appendBranch = (branchEnd) => {
-    const branchRange = trimCssTriviaRange(value, branchStart, branchEnd);
+    const branchRange = unwrapBracedFallbackRange(
+      value,
+      trimCssTriviaRange(value, branchStart, branchEnd),
+    );
     if (branchRange.start === branchRange.end) return false;
     branchRanges.push(branchRange);
     return true;
@@ -2079,15 +2106,52 @@ function conditionalBranchValueRanges(value, group, parenthesisPairs) {
   return analysis.branchRanges;
 }
 
+function toggleBranchContainsInvalidNestedFunction(value, range) {
+  for (let index = range.start; index < range.end; index += 1) {
+    if (value[index] === '"' || value[index] === "'") {
+      index = quotedStringEnd(value, index);
+      continue;
+    }
+    const urlTokenEnd = unquotedUrlTokenEnd(value, index);
+    if (urlTokenEnd !== undefined) {
+      index = urlTokenEnd;
+      continue;
+    }
+    invalidToggleNestedFunctionPattern.lastIndex = index;
+    const match = invalidToggleNestedFunctionPattern.exec(value);
+    const previousCharacter = value[index - 1];
+    if (
+      match &&
+      !isCssIdentifierCharacter(previousCharacter) &&
+      previousCharacter !== '#' &&
+      previousCharacter !== '@'
+    )
+      return true;
+  }
+  return false;
+}
+
 function toggleBranchValueRanges(value, group, parenthesisPairs) {
   // CSS Values 5 toggle() accepts one or more whole values (`toggle(<whole-value>#)`);
   // a single-argument toggle() is valid and always resolves to that argument.
   const branchRanges = randomItemArgumentRanges(value, group, parenthesisPairs);
-  return branchRanges !== undefined &&
-    branchRanges.length >= 1 &&
-    branchRanges.every((branchRange) => branchRange.start < branchRange.end)
-    ? branchRanges
-    : undefined;
+  if (
+    branchRanges === undefined ||
+    branchRanges.length < 1 ||
+    !branchRanges.every((branchRange) => branchRange.start < branchRange.end)
+  )
+    return undefined;
+  // toggle() may not be nested, nor may it contain attr() or calc() notations
+  // (https://www.w3.org/TR/css-values-5/#toggle-notation): a declaration with
+  // any of those inside a toggle() argument is invalid at parse time and
+  // never applies, so it can never actually select a branch value.
+  if (
+    branchRanges.some((branchRange) =>
+      toggleBranchContainsInvalidNestedFunction(value, branchRange),
+    )
+  )
+    return undefined;
+  return branchRanges;
 }
 
 function rangeIsValidConditionalExpression(frame, value, range, parenthesisPairs) {
@@ -3335,8 +3399,56 @@ function attrHeaderTypeStart(header, identifierEnd) {
   return namespacedNameEnd > identifierEnd + 1 ? namespacedNameEnd : identifierEnd;
 }
 
+// A leading var()/env()/attr() substitution can stand in for the whole
+// <attr-name> (CSS Values 5 allows arbitrary substitution functions anywhere
+// a <declaration-value> is permitted, including here). Returns the index just
+// past its matching close parenthesis, or -1 if the header doesn't start
+// with one.
+function headerLeadingSubstitutionEnd(header) {
+  fallbackFunctionPattern.lastIndex = 0;
+  const match = fallbackFunctionPattern.exec(header);
+  if (!match || match.index !== 0) return -1;
+  let depth = 1;
+  for (let index = match[0].length; index < header.length; index += 1) {
+    const character = header[index];
+    if (character === '"' || character === "'") index = quotedStringEnd(header, index);
+    else if (character === '(') depth += 1;
+    else if (character === ')') {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+  }
+  return -1;
+}
+
+// <attr-name> is `[ <ns-prefix> ]? <ident-token>` where `<ns-prefix>` is
+// itself `[ <ident-token> | '*' ]? '|'` -- so a *null* namespace (bare `|`
+// with nothing before it, e.g. `|data-layer`) is valid and must not be
+// mistaken for an invalid header. The name may also be a substitution
+// function rather than a literal identifier at all.
+function attrHeaderNameEnd(header) {
+  const leadingSubstitutionEnd = headerLeadingSubstitutionEnd(header);
+  if (leadingSubstitutionEnd !== -1) return leadingSubstitutionEnd;
+  const nameStart = header[0] === '|' ? 1 : 0;
+  const identifierEnd = cssIdentifierTokenEnd(header, nameStart);
+  return identifierEnd > nameStart ? identifierEnd : -1;
+}
+
+function attrTypeSyntaxFromHeader(header, nameEnd) {
+  const attrType = header.slice(attrHeaderTypeStart(header, nameEnd)).trim();
+  if (attrType === '' || attrType === '%') return attrType;
+  if (cssIdentifierTokenEnd(attrType, 0) === attrType.length)
+    return invalidCustomIdentKeywords.has(attrType.toLowerCase()) ? undefined : attrType;
+  const typeMatch = /^type\(([^()]+)\)$/i.exec(attrType);
+  return typeMatch && validAttrTypeSyntax(typeMatch[1]) ? attrType : undefined;
+}
+
 function validSubstitutionHeader(frame, value) {
   const header = substitutionHeader(frame, value);
+  if (frame.functionName === 'attr') {
+    const nameEnd = attrHeaderNameEnd(header);
+    return nameEnd !== -1 && attrTypeSyntaxFromHeader(header, nameEnd) !== undefined;
+  }
   const identifierEnd = cssIdentifierTokenEnd(header, 0);
   if (identifierEnd === 0) return false;
   if (frame.functionName === 'var')
@@ -3346,20 +3458,17 @@ function validSubstitutionHeader(frame, value) {
       !invalidCustomIdentKeywords.has(header.slice(0, identifierEnd).toLowerCase()) &&
       /^(?:\s+(?:\+?\d+|-0+))*$/.test(header.slice(identifierEnd))
     );
-  if (frame.functionName !== 'attr') return false;
-  const attrType = header.slice(attrHeaderTypeStart(header, identifierEnd)).trim();
-  if (attrType === '' || attrType === '%') return true;
-  if (cssIdentifierTokenEnd(attrType, 0) === attrType.length)
-    return !invalidCustomIdentKeywords.has(attrType.toLowerCase());
-  const typeMatch = /^type\(([^()]+)\)$/i.exec(attrType);
-  if (!typeMatch) return false;
-  return validAttrTypeSyntax(typeMatch[1]);
+  return false;
 }
 
 function attrDefinedPathWitnessGroups(attrType) {
   if (attrType === '%') return [['0%', '1%']];
   if (cssIdentifierTokenEnd(attrType, 0) === attrType.length) {
     const unit = attrType.toLowerCase();
+    // attr()'s legacy `<attr-name> <type-or-unit>?` syntax also accepts the
+    // bare keywords `number`/`integer` for a dimensionless numeric read --
+    // unlike the other legacy keywords, they carry no unit suffix.
+    if (unit === 'number' || unit === 'integer') return [['0', '1']];
     return attrLegacyNumericUnits.has(unit) ? [[`0${unit}`, `1${unit}`]] : undefined;
   }
   const typeMatch = /^type\(([^()]+)\)$/i.exec(attrType);
@@ -3428,8 +3537,9 @@ function substitutionDefinedPathWitnessGroups(frame, value) {
   }
   if (frame.functionName !== 'attr') return undefined;
   const header = substitutionHeader(frame, value);
-  const identifierEnd = cssIdentifierTokenEnd(header, 0);
-  const attrType = header.slice(attrHeaderTypeStart(header, identifierEnd)).trim();
+  const nameEnd = attrHeaderNameEnd(header);
+  if (nameEnd === -1) return undefined;
+  const attrType = header.slice(attrHeaderTypeStart(header, nameEnd)).trim();
   return attrDefinedPathWitnessGroups(attrType);
 }
 
@@ -4613,7 +4723,26 @@ function randomItemArgumentRanges(value, group, parenthesisPairs) {
   return argumentRanges;
 }
 
-function randomItemGroupOutputOptions(value, group, parenthesisPairs) {
+// A var()/env()/attr() substitution occupying a random-item() value slot is a
+// potentially multi-token, comma-containing stream, not a guaranteed single
+// argument: its fallback may itself contain a raw top-level comma, and if the
+// referenced custom property/attribute is defined at all, its value is
+// entirely unknown. Either way, substituting it can inject additional
+// top-level items into random-item()'s argument list, shifting every index
+// after it. A *direct* child here means the substitution sits at the
+// argument's own nesting depth (its immediate enclosing parenthesis is the
+// random-item() call itself) -- anything nested one level deeper is already
+// captured by whatever function owns that inner parenthesis instead.
+function randomItemArgumentHasDirectSubstitutionChild(frame, group, argumentRange) {
+  return frame.children.some(
+    (child) =>
+      child.parenthesisParent === group &&
+      child.start >= argumentRange.start &&
+      child.start < argumentRange.end,
+  );
+}
+
+function randomItemGroupOutputOptions(frame, value, group, parenthesisPairs) {
   const argumentRanges = randomItemArgumentRanges(value, group, parenthesisPairs);
   if (
     argumentRanges === undefined ||
@@ -4629,6 +4758,18 @@ function randomItemGroupOutputOptions(value, group, parenthesisPairs) {
   });
   const fixedBaseValue = fixedRandomBaseValueForRange(value, argumentRanges[0]);
   if (fixedBaseValue !== undefined) {
+    // The fixed key deterministically selects `values[floor(base * N)]`, but
+    // N (and therefore which written slot ends up at that index) is only
+    // provably stable when no value slot can silently change the item count.
+    // Precisely modeling every injected-arity outcome is intractable here, so
+    // fail closed through the existing too-complex path instead of trusting
+    // an index that a comma-injecting substitution could invalidate.
+    if (
+      valueRanges.some((argumentRange) =>
+        randomItemArgumentHasDirectSubstitutionChild(frame, group, argumentRange),
+      )
+    )
+      return fallbackResolutionTooComplex;
     const selectedIndex = Math.min(Math.floor(fixedBaseValue * values.length), values.length - 1);
     return {
       continuous: false,
@@ -4641,7 +4782,7 @@ function randomItemGroupOutputOptions(value, group, parenthesisPairs) {
 
 function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs) {
   if (group.functionName === 'random-item')
-    return randomItemGroupOutputOptions(value, group, parenthesisPairs);
+    return randomItemGroupOutputOptions(frame, value, group, parenthesisPairs);
   const functionRange = { start: group.functionStart, end: group.end };
   const parsedArguments = fallbackIndependentStaticArguments(
     frame,
@@ -4717,7 +4858,7 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
   const maximumExpression =
     maximumValue === minimumValue ? minimumExpression : writtenMaximumExpression;
   if (maximumValue === minimumValue) return { continuous: false, values: [minimumExpression] };
-  if (stepValue === undefined || stepValue <= 0) {
+  if (stepValue === undefined) {
     if (fixedBaseValue === 0) return { continuous: false, values: [minimumExpression] };
     if (fixedBaseValue !== undefined)
       return {
@@ -4728,25 +4869,40 @@ function randomGroupOutputOptions(frame, value, group, budget, parenthesisPairs)
       };
     return { continuous: true, values: [minimumExpression, maximumExpression] };
   }
+  // A zero or negative step folds the whole range to its start (CSS Values 5,
+  // https://www.w3.org/TR/css-values-5/#random): the written A, not the full
+  // [A, B] interval. This holds regardless of the random key, since the
+  // result is a single deterministic value either way.
+  if (stepValue <= 0) return { continuous: false, values: [minimumExpression] };
   if (!Number.isFinite(stepValue)) return { continuous: false, values: [minimumExpression] };
 
   const stepCount = Math.floor((maximumValue - minimumValue) / stepValue);
   if (!Number.isSafeInteger(stepCount) || stepCount > 128) return fallbackResolutionTooComplex;
+  // CSS Values 5's stepped random() snaps the last step to the written
+  // maximum, not `minimum + step * stepCount`, whenever that computed value
+  // is within `step / 1000` of the maximum -- evaluateStaticLayerNumber()
+  // rounds to the nearest integer, which is too coarse to prove that, so
+  // re-parse the plain numeric tokens (when each is one) at full precision.
+  const preciseMinimum = preciseStaticNumber(minimumExpression) ?? minimumValue;
+  const preciseStep = preciseStaticNumber(stepExpression) ?? stepValue;
+  const preciseMaximum = preciseStaticNumber(maximumExpression) ?? maximumValue;
+  const lastStepSnapsToMaximum =
+    Math.abs(preciseMaximum - (preciseMinimum + preciseStep * stepCount)) <=
+    Math.abs(preciseStep) / 1000;
+  const stepExpressionAt = (stepIndex) => {
+    if (stepIndex === 0) return minimumExpression;
+    if (stepIndex === stepCount && lastStepSnapsToMaximum) return maximumExpression;
+    return `calc((${minimumExpression}) + (${stepExpression}) * ${stepIndex})`;
+  };
   if (fixedBaseValue !== undefined) {
     const stepIndex = Math.floor(fixedBaseValue * (stepCount + 1));
-    const expression =
-      stepIndex === 0
-        ? minimumExpression
-        : `calc((${minimumExpression}) + (${stepExpression}) * ${stepIndex})`;
+    const expression = stepExpressionAt(stepIndex);
     if (!consumeResolutionWork(budget, expression.length)) return fallbackResolutionTooComplex;
     return { continuous: false, values: [expression] };
   }
   const values = [];
   for (let stepIndex = 0; stepIndex <= stepCount; stepIndex += 1) {
-    const expression =
-      stepIndex === 0
-        ? minimumExpression
-        : `calc((${minimumExpression}) + (${stepExpression}) * ${stepIndex})`;
+    const expression = stepExpressionAt(stepIndex);
     if (!consumeResolutionWork(budget, expression.length)) return fallbackResolutionTooComplex;
     values.push(expression);
   }
@@ -7045,7 +7201,10 @@ function fallbackCandidates(value) {
       continue;
     }
 
-    const fallbackRange = trimCssTriviaRange(value, frame.commaIndex + 1, index);
+    const fallbackRange = unwrapBracedFallbackRange(
+      value,
+      trimCssTriviaRange(value, frame.commaIndex + 1, index),
+    );
     const rawFallback = value.slice(fallbackRange.start, fallbackRange.end);
     frame.resolvedFallback = resolveFrameExpression(frame, value, fallbackRange, resolutionBudget);
     const [onlyChild] = frame.children;

--- a/packages/components/scripts/stylelint/z-index-scale.test.ts
+++ b/packages/components/scripts/stylelint/z-index-scale.test.ts
@@ -707,11 +707,12 @@ describe('cinder/z-index-scale', () => {
     ['random(fixed .5, 0, 10000, 9999)', 0],
     ['random(fixed 1, 0, 10000, 9999)', 0],
     ['random(0, 10000, infinity)', 0],
-    // A zero or negative step folds the range to its written start (A), not
-    // the full [A, B] interval (CSS Values 5). A = 0 here, so this is safe;
-    // when A is itself the banned layer the fold is still correctly flagged.
-    ['random(0, 10000, 0)', 0],
-    ['random(0, 10000, -1)', 0],
+    // A zero or negative step is *ignored* (CSS Values 5,
+    // random-argument-ranges): the function behaves as if only A and B were
+    // given, i.e. the full continuous [A, B] range -- not folded to a
+    // single point. 9999 is within [0, 10000], so this is still banned.
+    ['random(0, 10000, 0)', 1],
+    ['random(0, 10000, -1)', 1],
     ['random(9999, 1, 0)', 1],
     ['random(9999, 1, -1)', 1],
     ['random(infinity, 10000)', 0],
@@ -849,6 +850,25 @@ describe('cinder/z-index-scale', () => {
     expect(bannedFallback('var(--outer, max(1, var(--items, 1, 9999)))')?.reason).toBe(
       'too-complex',
     );
+  });
+
+  test('ignores a nonpositive random() step instead of folding to a single point', async () => {
+    // CSS Values 5 (random-argument-ranges): a negative or zero step is
+    // *ignored*, not folded to the written A -- the function behaves as if
+    // only A and B were given, so the full continuous range is reachable.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, random(1, 9999, 0))')?.reason).toBe('banned');
+    expect(bannedFallback('var(--outer, random(1, 9999, -1))')?.reason).toBe('banned');
+    expect(bannedFallback('var(--outer, random(0, 100, 0))')).toBeUndefined();
+  });
+
+  test('short-circuits a fixed-zero stepped random() key before the step-count cap', async () => {
+    // A fixed key of exactly 0 always selects step index 0 (the written
+    // minimum), regardless of how many step slots the range divides into.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, random(fixed 0, 0, 10000, 0.4))')).toBeUndefined();
   });
 
   test('does not fold a positive fractional random() step that rounds down to zero', async () => {

--- a/packages/components/scripts/stylelint/z-index-scale.test.ts
+++ b/packages/components/scripts/stylelint/z-index-scale.test.ts
@@ -724,9 +724,18 @@ describe('cinder/z-index-scale', () => {
     // endpoint snap still correctly flags it: 0 + 1 * 9998.4 = 9998.4 is
     // within 9998.4 / 1000 of 9999, so the last step snaps to 9999.
     ['random(fixed 1, 0, 9999, 9998.4)', 1],
-    // A step count small enough that the last step lands far outside the
-    // epsilon band is not snapped, so it resolves to the plain arithmetic.
-    ['random(fixed 1, 0, 9999, 1000)', 0],
+    // The random-evaluation algorithm also extends the largest step index N
+    // by one when N's value isn't within epsilon of max but N + 1's would
+    // be, even though N + 1 overshoots max: N (9) is 0 + 9 * 1000 = 9000,
+    // 999 away from 9999 (outside the epsilon of 1); N + 1 is 10000, only 1
+    // away (within epsilon) -- so N extends to 10, and the fixed key
+    // selecting that final (extended) index snaps to the written max.
+    ['random(fixed 1, 0, 9999, 1000)', 1],
+    // A step count small enough that neither the last natural step nor its
+    // extension lands within the epsilon band is not snapped, so it
+    // resolves to the plain arithmetic: 103 * 97 = 9991, 8 away from 9999
+    // (epsilon is 97 / 1000).
+    ['random(fixed 1, 0, 9999, 97)', 0],
     // evaluateStaticLayerNumber() rounds to the nearest integer, so a
     // genuinely positive step below 0.5 (here 0.4) rounds to a stepValue of
     // 0. That must not be treated as a step <= 0 (which folds to a single
@@ -858,6 +867,44 @@ describe('cinder/z-index-scale', () => {
     expect(bannedFallback('var(--outer, calc(random(0px, 9999px, 9989.02px) / 1px))')?.reason).toBe(
       'banned',
     );
+  });
+
+  test('does not compare stepped random() magnitudes across different but convertible units', async () => {
+    // preciseStaticNumber() strips a unit rather than converting it, so a
+    // mismatched-unit call must fall back to the already-converted (but
+    // integer-rounded) values instead of comparing raw magnitudes across
+    // units. 264.556875cm is exactly 9999px.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(
+      bannedFallback('var(--outer, calc(random(0px, 264.556875cm, 9999px) / 1px))')?.reason,
+    ).toBe('banned');
+  });
+
+  test('extends the largest stepped random() index when only N + 1 lands within epsilon', async () => {
+    // The random-evaluation algorithm's N-extension rule is checked against
+    // N + 1's value even when it overshoots the written maximum.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, random(fixed 1, 0, 9999, 3333.1))')?.reason).toBe('banned');
+  });
+
+  test('treats an all-omitted-weight calc-mix() as an equally-weighted average', async () => {
+    // Every item's percentage weight is optional; when none are specified,
+    // they're distributed equally. This is only ambiguous with the older
+    // three-argument progress shape at exactly three arguments, which stays
+    // on that path unchanged (covered by the calc-mix() table above).
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, calc-mix(9999, 9999))')?.reason).toBe('banned');
+    expect(bannedFallback('var(--outer, calc-mix(9999, 1))')).toBeUndefined();
+    expect(bannedFallback('var(--outer, calc-mix(9999))')?.reason).toBe('banned');
+  });
+
+  test('accepts a calculated calc-mix() weight, not just a bare percentage token', async () => {
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, calc-mix(9999 calc(100%), 1))')?.reason).toBe('banned');
   });
 
   test('keeps a too-complex calc-mix() weight token too-complex instead of treating it as absent', async () => {
@@ -4715,10 +4762,14 @@ describe('cinder/z-index-scale', () => {
     ['calc(9999 * attr(data-layer type(<integer>), 0))', 1],
     // The namespace prefix must not block defined-path witness derivation either.
     ['calc(9999 * attr(svg|data-layer type(<number>), 0))', 1],
-    // The legacy `<attr-name> <type-or-unit>?` bare keywords `number` and
-    // `integer` carry no unit suffix, unlike the other legacy keywords.
+    // attr()'s legacy grammar is `type(<syntax>) | raw-string | number |
+    // <attr-unit>` (CSS Values 5): only the literal `number` keyword is a
+    // dimensionless numeric read. `integer` is not a recognized keyword
+    // here at all -- it's parsed as an (unrecognized) <attr-unit>, same as
+    // any other unknown unit name, and derives no defined-path witness, so
+    // only the safe fallback (0) is reachable.
     ['calc(9999 * attr(data-scale number, 0))', 1],
-    ['calc(9999 * attr(data-scale integer, 0))', 1],
+    ['calc(9999 * attr(data-scale integer, 0))', 0],
     ['calc(9999 * attr(data-scale px, 0px) / 1px)', 1],
     ['calc(9999 * attr(data-scale type(<number> | <length>), 0) / 1px)', 1],
     ['calc(9999 * attr(data-scale type(<number>+), 0) / 1)', 1],

--- a/packages/components/scripts/stylelint/z-index-scale.test.ts
+++ b/packages/components/scripts/stylelint/z-index-scale.test.ts
@@ -884,6 +884,21 @@ describe('cinder/z-index-scale', () => {
     expect(bannedFallback('var(--x, random(0, 10000, 0.4))')?.reason).toBe('too-complex');
   });
 
+  test('resolves a fixed stepped random() step that is a wrapped static expression', async () => {
+    // Regression test for a false negative: preciseStaticNumber() used to
+    // parse only a bare numeric token, so a resolvable-but-not-bare-number
+    // step like `calc(9999)` fell back to the conservative continuous-range
+    // treatment even though evaluateStaticLayerNumber() already proved it
+    // usable. The fixed key 0.4 selects step index
+    // floor(0.4 * (stepCount + 1)) = floor(0.4 * 3) = 1, which computes to
+    // the banned layer 9999.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, random(fixed .4, 0, 19998, calc(9999)))')?.reason).toBe(
+      'banned',
+    );
+  });
+
   test('computes the stepped random() endpoint snap at full precision for typed values', async () => {
     const { bannedFallback } = await import(fallbackAnalysisPath);
 
@@ -892,15 +907,34 @@ describe('cinder/z-index-scale', () => {
     );
   });
 
-  test('does not compare stepped random() magnitudes across different but convertible units', async () => {
-    // preciseStaticNumber() strips a unit rather than converting it, so a
-    // mismatched-unit call must fall back to the already-converted (but
-    // integer-rounded) values instead of comparing raw magnitudes across
-    // units. 264.556875cm is exactly 9999px.
+  test('compares stepped random() magnitudes across different but convertible units', async () => {
+    // evaluateStaticLayerNumberWithUnit() converts every canonical absolute
+    // unit to its canonical same-dimension magnitude while parsing (rather
+    // than stripping the unit), so a mismatched-but-convertible-unit call is
+    // compared at full precision instead of falling back to the
+    // already-converted (but integer-rounded) values. 264.556875cm is
+    // exactly 9999px, so this is unaffected either way; the precision-
+    // sensitive case (a fractional step that would lose its snap-tolerance
+    // margin under rounding) is covered separately below.
     const { bannedFallback } = await import(fallbackAnalysisPath);
 
     expect(
       bannedFallback('var(--outer, calc(random(0px, 264.556875cm, 9999px) / 1px))')?.reason,
+    ).toBe('banned');
+  });
+
+  test('computes the stepped random() endpoint snap at full precision across convertible units', async () => {
+    // Regression test for a false negative: preciseStaticNumberWithUnit()
+    // used to strip a unit rather than convert it, so this mixed-unit call
+    // fell back to evaluateStaticLayerNumber()'s integer-rounded magnitudes
+    // (9989.02px rounds to 9989), losing exactly the fractional precision
+    // the step / 1000 endpoint-snapping tolerance needs. 264.556875cm is
+    // exactly 9999px, and the first step (9989.02) is within step / 1000 of
+    // it, so CSS snaps to the written maximum.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(
+      bannedFallback('var(--outer, calc(random(0px, 264.556875cm, 9989.02px) / 1px))')?.reason,
     ).toBe('banned');
   });
 
@@ -928,6 +962,34 @@ describe('cinder/z-index-scale', () => {
     const { bannedFallback } = await import(fallbackAnalysisPath);
 
     expect(bannedFallback('var(--outer, calc-mix(9999 calc(100%), 1))')?.reason).toBe('banned');
+  });
+
+  test('accepts an explicitly-signed in-range calc-mix() weight', async () => {
+    // Regression test for a false negative: the item's own calc-sum parser
+    // used to see the '+' before the weight parser got a turn and throw
+    // "expected whitespace around additive operator" (whitespace is
+    // required on both sides of a binary +/-, and there's none after this
+    // one), invalidating the whole calc-mix() -- even though parseNumber()
+    // already handles a leading sign on the weight itself just fine once
+    // the sum parser stops cleanly instead of throwing.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--o, calc-mix(9999 +100%, 1 0%))')?.reason).toBe('banned');
+  });
+
+  test('allows a same-unit relative zero next to a nonzero relative length in calc-mix()', async () => {
+    // Regression test for a false negative: parseNumber() intentionally
+    // gives a literal relative-length zero (e.g. `0em`) no symbolic factor,
+    // since zero is zero regardless of which relative unit it's written in.
+    // The all-items compatibility check used to compare every item against
+    // items[0] specifically, so when the zero happened to be first, the
+    // nonzero `9999em` (which does carry a symbolic factor) looked
+    // incompatible and the whole calc-mix() was rejected.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, calc(calc-mix(0em 0%, 9999em 100%) / 1em))')?.reason).toBe(
+      'banned',
+    );
   });
 
   test('keeps a too-complex calc-mix() weight token too-complex instead of treating it as absent', async () => {
@@ -1993,21 +2055,54 @@ describe('cinder/z-index-scale', () => {
   });
 
   test('builds wide clamp placeholders in linear time', async () => {
-    const siblings = Array.from(
-      { length: 64_000 },
-      (_, index) => `var(--item-layer-${index}, -1)`,
-    ).join(' + ');
-    const startedAt = performance.now();
-    const result = await lint(`
-      .fixture {
-        /* cinder-z-index-local: static clamp bounds keep every generated fallback safe. */
-        z-index: clamp(0, calc(var(--runtime) + ${siblings}), 1);
+    // This used to assert an absolute wall-clock budget (2000ms), which
+    // flaked in CI under load -- three real failures at 2015ms, 2028ms,
+    // and 2034ms, each passing cleanly on rerun -- and could equally
+    // false-fail locally on a busy machine. The property this test
+    // actually needs to prove is that placeholder generation scales
+    // linearly with the sibling count, not that any one run completes
+    // within some fixed latency, so measure at N and 2N and assert the
+    // doubled input takes less than 4x as long: comfortably above the
+    // ~2x a linear algorithm should show (measured locally at N = 16,000
+    // across ten runs: 1.74x-2.40x), but tight enough to still catch an
+    // O(n^2) regression. Each measurement takes the fastest of 3 trials to
+    // reduce scheduling noise (a slowdown can only inflate a trial, never
+    // deflate it below the true minimum), and N is sized so a single
+    // trial comfortably clears ~150ms even on a loaded machine, keeping
+    // fixed per-lint overhead from dominating the measurement. A generous
+    // absolute ceiling remains only to catch an outright hang.
+    const buildCss = (siblingCount: number) => {
+      const siblings = Array.from(
+        { length: siblingCount },
+        (_, index) => `var(--item-layer-${index}, -1)`,
+      ).join(' + ');
+      return `
+          .fixture {
+            /* cinder-z-index-local: static clamp bounds keep every generated fallback safe. */
+            z-index: clamp(0, calc(var(--runtime) + ${siblings}), 1);
+          }
+        `;
+    };
+    const fastestLintTime = async (siblingCount: number) => {
+      const css = buildCss(siblingCount);
+      let fastest = Number.POSITIVE_INFINITY;
+      for (let trial = 0; trial < 3; trial += 1) {
+        const startedAt = performance.now();
+        const result = await lint(css);
+        fastest = Math.min(fastest, performance.now() - startedAt);
+        expect(warnings(result)).toEqual([]);
       }
-    `);
+      return fastest;
+    };
 
-    expect(warnings(result)).toEqual([]);
-    expect(performance.now() - startedAt).toBeLessThan(2_000);
-  });
+    const baselineSiblingCount = 16_000;
+    const timeAtBaseline = await fastestLintTime(baselineSiblingCount);
+    const timeAtDoubled = await fastestLintTime(baselineSiblingCount * 2);
+
+    expect(timeAtBaseline).toBeLessThan(30_000);
+    expect(timeAtDoubled).toBeLessThan(30_000);
+    expect(timeAtDoubled).toBeLessThan(timeAtBaseline * 4);
+  }, 35_000);
 
   test('reuses parenthesis indexes across nested bound checks', async () => {
     let nestedValue = 'var(--runtime)';
@@ -3208,6 +3303,9 @@ describe('cinder/z-index-scale', () => {
     'attr(|data-layer type(<integer>), 9999)',
     // The <attr-name> itself may be an arbitrary substitution function.
     'attr(var(--name, data-layer) type(<integer>), 9999)',
+    // The substitution's own fallback may supply the <attr-type> clause too,
+    // not just the name.
+    'attr(var(--header, data-scale number), 9999)',
   ])('continues inspecting a fallback from a valid substitution header: %s', async (fallback) => {
     expect(
       warnings(
@@ -4804,6 +4902,12 @@ describe('cinder/z-index-scale', () => {
     // any other unknown unit name, and derives no defined-path witness, so
     // only the safe fallback (0) is reachable.
     ['calc(9999 * attr(data-scale number, 0))', 1],
+    // Regression test for a false negative: when the leading substitution
+    // supplies both the <attr-name> and the <attr-type> through its own
+    // fallback (`var(--header)` is unset, so `data-scale number` applies),
+    // the header used to be treated as name-only, deriving no numeric
+    // defined-path witness at all.
+    ['calc(9999 * attr(var(--header, data-scale number), 0))', 1],
     ['calc(9999 * attr(data-scale integer, 0))', 0],
     ['calc(9999 * attr(data-scale px, 0px) / 1px)', 1],
     ['calc(9999 * attr(data-scale type(<number> | <length>), 0) / 1px)', 1],
@@ -4944,6 +5048,18 @@ describe('cinder/z-index-scale', () => {
         `),
       ),
     ).toHaveLength(count);
+  });
+
+  test('does not invalidate a toggle() branch over a forbidden token reachable only through a substitution fallback', async () => {
+    // Regression test for a false negative: toggleBranchContainsInvalidNestedFunction()
+    // used to scan a branch's full text for calc()/attr()/toggle() without
+    // skipping over a nested var()/env()'s own parens, so `calc(1)` inside
+    // var(--x)'s *fallback* (only used if --x is unset) invalidated the
+    // whole branch -- even though setting --x directly bypasses that
+    // fallback entirely and never puts calc() in the branch's literal text.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--o, toggle(1, var(--x, calc(1))))')).not.toBeUndefined();
   });
 
   test('preserves typed atan2() defined paths through angle cancellation', async () => {

--- a/packages/components/scripts/stylelint/z-index-scale.test.ts
+++ b/packages/components/scripts/stylelint/z-index-scale.test.ts
@@ -934,6 +934,18 @@ describe('cinder/z-index-scale', () => {
     );
   });
 
+  test('fails closed for a weighted calc-mix() with an unresolved item and no explicit weights', async () => {
+    // A per-item weight is optional on every item, so a call is on the
+    // weighted-item grammar (not the older fixed-arity progress shape) as
+    // soon as its argument count isn't exactly three -- with or without any
+    // explicit percentage. An unresolved item must fail closed there too.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, calc-mix(var(--layer), 19998))')?.reason).toBe(
+      'too-complex',
+    );
+  });
+
   test.each([
     ['calc(9999 * (random(--shared, 0, 1) - random(--shared, 0, 1)))', 0],
     ['calc(9999 * (random(--left, 0, 1) - random(--right, 0, 1)))', 1],
@@ -4806,7 +4818,11 @@ describe('cinder/z-index-scale', () => {
     ['calc(9999 * env(safe-area-inset-top 0, 0px) / 1px)', 0],
     ['calc(9999 * env(viewport-segment-width, 0px) / 1px)', 0],
     ['calc(9999 * max(var(--scale, 0), 0))', 1],
-    ['calc-mix(0, 1, var(--inner, 9999), 2)', 0],
+    // Four items with no explicit weights is invalid for the older
+    // three-argument progress shape, but valid (equally weighted) under the
+    // current weighted-item grammar, so the unresolved item is no longer
+    // provably unreachable and must fail closed instead.
+    ['calc-mix(0, 1, var(--inner, 9999), 2)', 1],
     ['calc-mix(0, var(--inner, 9999), 1)', 1],
     ['calc-mix(1, var(--inner, 9999), 1)', 0],
     ['calc-mix(1, 1, var(--inner, 9999))', 1],

--- a/packages/components/scripts/stylelint/z-index-scale.test.ts
+++ b/packages/components/scripts/stylelint/z-index-scale.test.ts
@@ -259,6 +259,19 @@ describe('cinder/z-index-scale', () => {
     ['calc-mix(100%, 9999, 1)', 0],
     ['calc(calc-mix(0, 9999px, 1px) / 1px)', 1],
     ['calc-mix(0, 9999px, 1deg)', 0],
+    // CSS Values 5's current calc-mix() grammar is a weighted-item average
+    // (`calc-mix( [ <calc-sum> <percentage>? ]# )`), distinct from the
+    // two-endpoint progress form above: each item trails its own optional
+    // percentage weight, space-separated from the value.
+    ['calc-mix(9999 100%, 1 0%)', 1],
+    ['calc-mix(9999 0%, 1 100%)', 0],
+    // An omitted weight receives whatever share the specified weights leave.
+    ['calc-mix(9999 100%, 1)', 1],
+    ['calc-mix(9999 0%, 1)', 0],
+    // A specified total over 100% is scaled down proportionally, not clamped.
+    ['calc-mix(9999 200%, 1 200%)', 0],
+    // Mismatched units across items are still invalid, same as the endpoint form.
+    ['calc-mix(9999px 100%, 1deg 0%)', 0],
   ] as const)('evaluates calc-mix() fallback results: %s', async (fallback, count) => {
     const result = await lint(`
         .fixture {
@@ -666,8 +679,13 @@ describe('cinder/z-index-scale', () => {
     ['random(var(--inner, 9999), 10000)', 1],
     ['random(0, var(--inner, 9999))', 1],
     ['random(--shared, var(--inner, 9999), 10000)', 1],
-    ['random(0, 10000, 9999)', 1],
-    ['calc(random(0px, 10000px, 9999px) / 1px)', 1],
+    // CSS Values 5's stepped random() snaps the last reachable step to the
+    // written maximum (10000) instead of `min + step * N` (9999) whenever
+    // that computed value is within `step / 1000` of the maximum -- here
+    // |10000 - 9999| = 1 <= 9999 / 1000, so the reachable set is {0, 10000},
+    // not {0, 9999}.
+    ['random(0, 10000, 9999)', 0],
+    ['calc(random(0px, 10000px, 9999px) / 1px)', 0],
     ['calc(random(0px, 10000px, 5000px) / 1px)', 0],
     ['calc(random(0px, 9999px) / 1px)', 1],
     ['calc(0 * random(0, 10000))', 0],
@@ -679,17 +697,31 @@ describe('cinder/z-index-scale', () => {
     ['random(0, 10000, 10000)', 0],
     ['random(0, 10000, 10001)', 0],
     ['random(fixed 0, 0, 10000, 9999)', 0],
-    ['random(fixed .5, 0, 10000, 9999)', 1],
-    ['random(fixed 1, 0, 10000, 9999)', 1],
+    // The last step (index N) snaps to the written maximum for the same
+    // epsilon reason, so a fixed key that lands on N also resolves to 10000.
+    ['random(fixed .5, 0, 10000, 9999)', 0],
+    ['random(fixed 1, 0, 10000, 9999)', 0],
     ['random(0, 10000, infinity)', 0],
-    ['random(0, 10000, 0)', 1],
-    ['random(0, 10000, -1)', 1],
+    // A zero or negative step folds the range to its written start (A), not
+    // the full [A, B] interval (CSS Values 5). A = 0 here, so this is safe;
+    // when A is itself the banned layer the fold is still correctly flagged.
+    ['random(0, 10000, 0)', 0],
+    ['random(0, 10000, -1)', 0],
+    ['random(9999, 1, 0)', 1],
+    ['random(9999, 1, -1)', 1],
     ['random(infinity, 10000)', 0],
     ['random(0, infinity)', 0],
     ['random(0px, 1px)', 0],
     ['calc(random(fixed 0, 0px, 9999px) / 1px)', 0],
     ['calc(random(fixed 1, 0px, 9999px) / 1px)', 1],
     ['random(fixed .5, 10000, 9999)', 0],
+    // The written maximum (9999) is itself the banned layer here, so the
+    // endpoint snap still correctly flags it: 0 + 1 * 9998.4 = 9998.4 is
+    // within 9998.4 / 1000 of 9999, so the last step snaps to 9999.
+    ['random(fixed 1, 0, 9999, 9998.4)', 1],
+    // A step count small enough that the last step lands far outside the
+    // epsilon band is not snapped, so it resolves to the plain arithmetic.
+    ['random(fixed 1, 0, 9999, 1000)', 0],
     ['random()', 0],
     ['random(0)', 0],
     ['random(0, 1, 2, 3)', 0],
@@ -745,6 +777,38 @@ describe('cinder/z-index-scale', () => {
 
     expect(warning?.column).toBe(start.column);
     expect(warning?.endColumn).toBe(end.column);
+  });
+
+  test('fails closed when a fixed random-item() key sits next to a comma-injecting var() slot', async () => {
+    // A var() substitution occupying a random-item() value slot is not
+    // guaranteed to occupy exactly one argument: its fallback (or, if the
+    // referenced property is defined, its entirely unknown value) may itself
+    // contain a top-level comma, injecting additional items and shifting the
+    // fixed key's selected index. `--items: 1, 9999` would turn this into a
+    // three-item call that deterministically selects the banned `9999`.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+    const result = bannedFallback('var(--outer, random-item(fixed .5, var(--items, 1), 1))');
+
+    expect(result?.reason).toBe('too-complex');
+  });
+
+  test('still resolves a fixed random-item() selection when no value slot can inject arity', async () => {
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, random-item(fixed .5, 1, 9999))')?.reason).toBe('banned');
+    expect(bannedFallback('var(--outer, random-item(fixed .5, 1, 2))')).toBeUndefined();
+  });
+
+  test('an extremum function is already conservative under comma-injecting var() operands', async () => {
+    // max()/min()/hypot() already treat an unresolved var() operand as an
+    // unconstrained runtime range, so a comma-injecting defined path adds no
+    // new witness beyond what the existing runtime-range analysis covers.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, max(1, var(--items, 1)))')?.reason).toBe('too-complex');
+    expect(bannedFallback('var(--outer, max(1, var(--items, 1, 9999)))')?.reason).toBe(
+      'too-complex',
+    );
   });
 
   test.each([
@@ -2981,6 +3045,11 @@ describe('cinder/z-index-scale', () => {
     // CSS Values 5 <attr-name> allows an optional `<ident-token> '|'` namespace
     // prefix before the attribute name; the type syntax still starts after it.
     'attr(svg|data-layer type(<integer>), 9999)',
+    // A bare `|` before the name is the *null* namespace -- also a valid
+    // <ns-prefix>, distinct from omitting the prefix entirely.
+    'attr(|data-layer type(<integer>), 9999)',
+    // The <attr-name> itself may be an arbitrary substitution function.
+    'attr(var(--name, data-layer) type(<integer>), 9999)',
   ])('continues inspecting a fallback from a valid substitution header: %s', async (fallback) => {
     expect(
       warnings(
@@ -3034,6 +3103,11 @@ describe('cinder/z-index-scale', () => {
     ['first-valid(9999,, 1)', 0],
     ['calc(first-valid(9999, 1))', 0],
     ['calc(first-valid(var(--inner, 9999), 1))', 0],
+    // CSS Values 5's guaranteed-invalid-value `{ ... }` wrapper is unwrapped
+    // before evaluating the option, so a braced literal is treated the same
+    // as its unwrapped form.
+    ['first-valid({9999}, 1)', 1],
+    ['first-valid(1, {9999})', 0],
   ] as const)('inspects the first supported first-valid() value: %s', async (fallback, count) => {
     expect(
       warnings(
@@ -3056,6 +3130,14 @@ describe('cinder/z-index-scale', () => {
     const { bannedFallback } = await import(fallbackAnalysisPath);
 
     expect(bannedFallback(value)?.reason).toBe(reason);
+  });
+
+  test('unwraps a substitution fallback wrapped in the guaranteed-invalid-value {} syntax', async () => {
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, {9999})')?.reason).toBe('banned');
+    expect(bannedFallback('var(--outer, { 9999 })')?.reason).toBe('banned');
+    expect(bannedFallback('var(--outer, {1})')).toBeUndefined();
   });
 
   test.each([
@@ -4557,6 +4639,10 @@ describe('cinder/z-index-scale', () => {
     ['calc(9999 * attr(data-layer type(<integer>), 0))', 1],
     // The namespace prefix must not block defined-path witness derivation either.
     ['calc(9999 * attr(svg|data-layer type(<number>), 0))', 1],
+    // The legacy `<attr-name> <type-or-unit>?` bare keywords `number` and
+    // `integer` carry no unit suffix, unlike the other legacy keywords.
+    ['calc(9999 * attr(data-scale number, 0))', 1],
+    ['calc(9999 * attr(data-scale integer, 0))', 1],
     ['calc(9999 * attr(data-scale px, 0px) / 1px)', 1],
     ['calc(9999 * attr(data-scale type(<number> | <length>), 0) / 1px)', 1],
     ['calc(9999 * attr(data-scale type(<number>+), 0) / 1)', 1],
@@ -4667,8 +4753,13 @@ describe('cinder/z-index-scale', () => {
     ['toggle(9999, 1)', 1],
     ['toggle(-1, 1)', 1],
     ['toggle(0, 1)', 0],
-    ['toggle(1, calc(9999))', 1],
-    ['toggle(1, toggle(9999, 1))', 1],
+    // toggle() may not be nested, nor may it contain attr() or calc()
+    // notations (CSS Values 5): a declaration with either inside a toggle()
+    // argument is invalid at parse time and never applies, so it can never
+    // actually select the nested branch's value.
+    ['toggle(1, calc(9999))', 0],
+    ['toggle(1, toggle(9999, 1))', 0],
+    ['toggle(1, attr(data-x, 9999))', 0],
     // toggle(<whole-value>#) accepts one or more arguments (CSS Values 5); a
     // single-argument toggle() is valid and always resolves to that argument.
     ['toggle(9999)', 1],

--- a/packages/components/scripts/stylelint/z-index-scale.test.ts
+++ b/packages/components/scripts/stylelint/z-index-scale.test.ts
@@ -863,12 +863,15 @@ describe('cinder/z-index-scale', () => {
     expect(bannedFallback('var(--outer, random(0, 100, 0))')).toBeUndefined();
   });
 
-  test('short-circuits a fixed-zero stepped random() key before the step-count cap', async () => {
-    // A fixed key of exactly 0 always selects step index 0 (the written
-    // minimum), regardless of how many step slots the range divides into.
+  test('resolves a fixed stepped random() key before the enumeration cap, at any key value', async () => {
+    // A fixed key always resolves to exactly one step index regardless of
+    // how many slots the range divides into -- computing that single value
+    // is O(1), so it isn't subject to the enumeration cap (which exists
+    // only to bound building an array of every slot for a non-fixed key).
     const { bannedFallback } = await import(fallbackAnalysisPath);
 
     expect(bannedFallback('var(--outer, random(fixed 0, 0, 10000, 0.4))')).toBeUndefined();
+    expect(bannedFallback('var(--outer, random(fixed .5, 0, 10000, 0.4))')).toBeUndefined();
   });
 
   test('does not fold a positive fractional random() step that rounds down to zero', async () => {

--- a/packages/components/scripts/stylelint/z-index-scale.test.ts
+++ b/packages/components/scripts/stylelint/z-index-scale.test.ts
@@ -272,6 +272,11 @@ describe('cinder/z-index-scale', () => {
     ['calc-mix(9999 200%, 1 200%)', 0],
     // Mismatched units across items are still invalid, same as the endpoint form.
     ['calc-mix(9999px 100%, 1deg 0%)', 0],
+    // An item weight is a <percentage [0,100]>: out of range per-item makes
+    // the whole function invalid (dropped), even though multiple in-range
+    // weights can still sum past 100% and get scaled down (tested above).
+    ['calc-mix(9999 101%, 1 0%)', 0],
+    ['calc-mix(9999 -1%, 1 100%)', 0],
   ] as const)('evaluates calc-mix() fallback results: %s', async (fallback, count) => {
     const result = await lint(`
         .fixture {
@@ -722,6 +727,17 @@ describe('cinder/z-index-scale', () => {
     // A step count small enough that the last step lands far outside the
     // epsilon band is not snapped, so it resolves to the plain arithmetic.
     ['random(fixed 1, 0, 9999, 1000)', 0],
+    // evaluateStaticLayerNumber() rounds to the nearest integer, so a
+    // genuinely positive step below 0.5 (here 0.4) rounds to a stepValue of
+    // 0. That must not be treated as a step <= 0 (which folds to a single
+    // point): the step count (25000) exceeds the enumeration cap, so this
+    // correctly stays too-complex (1 warning) rather than silently reading
+    // as safe (0 warnings).
+    ['random(0, 10000, 0.4)', 1],
+    // A typed (dimensional) step's endpoint-snapping tolerance is computed
+    // from the step's full precision (9989.02), not the integer-rounded
+    // 9989, so the last step still correctly snaps to the written maximum.
+    ['calc(random(0px, 9999px, 9989.02px) / 1px)', 1],
     ['random()', 0],
     ['random(0)', 0],
     ['random(0, 1, 2, 3)', 0],
@@ -779,34 +795,94 @@ describe('cinder/z-index-scale', () => {
     expect(warning?.endColumn).toBe(end.column);
   });
 
-  test('fails closed when a fixed random-item() key sits next to a comma-injecting var() slot', async () => {
-    // A var() substitution occupying a random-item() value slot is not
-    // guaranteed to occupy exactly one argument: its fallback (or, if the
-    // referenced property is defined, its entirely unknown value) may itself
-    // contain a top-level comma, injecting additional items and shifting the
-    // fixed key's selected index. `--items: 1, 9999` would turn this into a
-    // three-item call that deterministically selects the banned `9999`.
+  test('a plain var() in a fixed random-item() value slot cannot inject extra options', async () => {
+    // CSS Values 5 Appendix A (Argument Grammars and Spread Syntax) is
+    // explicit that this does *not* happen: "parsing according to a
+    // function's argument grammar does not see the results of any nested
+    // arbitrary substitution functions; the contents are divided into
+    // arguments based only on the values literally present inside the
+    // function." Its own worked example is this exact shape --
+    // `random-item(auto, var(--foo), var(--bar))` with `--foo: Courier,
+    // monospace` stays a two-option call, equivalent to wrapping each
+    // option in `{}`. random-item()'s argument boundaries (and thus which
+    // slot a fixed key selects) are fixed before any nested var() is ever
+    // substituted, whether the comma lives in the fallback (this case) or
+    // in the referenced property's actual (unknowable) value.
     const { bannedFallback } = await import(fallbackAnalysisPath);
-    const result = bannedFallback('var(--outer, random-item(fixed .5, var(--items, 1), 1))');
 
-    expect(result?.reason).toBe('too-complex');
+    expect(
+      bannedFallback('var(--outer, random-item(fixed .5, var(--items, 1), 1))'),
+    ).toBeUndefined();
+    expect(
+      bannedFallback('var(--outer, random-item(fixed .5, var(--items, 1, 9999), 1))'),
+    ).toBeUndefined();
   });
 
-  test('still resolves a fixed random-item() selection when no value slot can inject arity', async () => {
+  test('still resolves a fixed random-item() selection when a value slot is a substitution', async () => {
     const { bannedFallback } = await import(fallbackAnalysisPath);
 
     expect(bannedFallback('var(--outer, random-item(fixed .5, 1, 9999))')?.reason).toBe('banned');
     expect(bannedFallback('var(--outer, random-item(fixed .5, 1, 2))')).toBeUndefined();
   });
 
-  test('an extremum function is already conservative under comma-injecting var() operands', async () => {
-    // max()/min()/hypot() already treat an unresolved var() operand as an
-    // unconstrained runtime range, so a comma-injecting defined path adds no
-    // new witness beyond what the existing runtime-range analysis covers.
+  test('an extremum function is already conservative under a comma-injecting var() operand', async () => {
+    // Unlike random-item() (an arbitrary substitution function with its own
+    // early-fixed argument grammar), max() is an ordinary math function, so
+    // a var() operand whose value contains a comma genuinely can inject an
+    // extra operand (`max(1, var(--items, 1, 9999))` becomes `max(1, 1,
+    // 9999)` if --items is undefined). That's already covered without any
+    // arity-specific handling: the analyzer treats any unresolved var()
+    // operand in a math context as an unconstrained runtime range, which
+    // is a strict superset of "could also be an extra 9999 operand."
     const { bannedFallback } = await import(fallbackAnalysisPath);
 
     expect(bannedFallback('var(--outer, max(1, var(--items, 1)))')?.reason).toBe('too-complex');
     expect(bannedFallback('var(--outer, max(1, var(--items, 1, 9999)))')?.reason).toBe(
+      'too-complex',
+    );
+  });
+
+  test('does not fold a positive fractional random() step that rounds down to zero', async () => {
+    // evaluateStaticLayerNumber() rounds to the nearest integer, so a
+    // genuinely positive step like 0.4 rounds to a stepValue of 0 --
+    // treating that as "step <= 0" would fold a genuinely reachable range
+    // down to a single safe point.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--x, random(0, 10000, 0.4))')?.reason).toBe('too-complex');
+  });
+
+  test('computes the stepped random() endpoint snap at full precision for typed values', async () => {
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, calc(random(0px, 9999px, 9989.02px) / 1px))')?.reason).toBe(
+      'banned',
+    );
+  });
+
+  test('keeps a too-complex calc-mix() weight token too-complex instead of treating it as absent', async () => {
+    // A pathologically long weight token makes the exact-rational parser
+    // throw the too-complex sentinel; the weight-parsing catch must
+    // re-throw that (rather than swallow it and rewind), so the whole
+    // calc-mix() stays fail-closed instead of hitting a stray "expected
+    // comma" parse error further down and reading as an ordinary invalid
+    // (and therefore silently safe) declaration.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+    const oversizedWeight = '1'.repeat(200);
+
+    expect(bannedFallback(`var(--outer, calc-mix(9999 ${oversizedWeight}%, 1 0%))`)?.reason).toBe(
+      'too-complex',
+    );
+  });
+
+  test('fails closed for a weighted calc-mix() item that is an unresolved substitution', async () => {
+    // calc-mix()'s current weighted-item grammar accepts any number of
+    // items, unlike the older fixed-arity progress shape; a var() item
+    // must not be silently excluded just because the argument count no
+    // longer matches that older shape's arity.
+    const { bannedFallback } = await import(fallbackAnalysisPath);
+
+    expect(bannedFallback('var(--outer, calc-mix(var(--layer) 100%, 1 0%))')?.reason).toBe(
       'too-complex',
     );
   });

--- a/packages/components/scripts/stylelint/z-index-value-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-value-analysis.mjs
@@ -500,6 +500,15 @@ function normalizedCalcMixWeights(weights) {
   );
 }
 
+// A relative length (em, vh, ...) that's provably zero contributes nothing
+// regardless of the specific unit it was written in -- parseNumber() already
+// omits its symbolic factor for exactly this reason (see its comment). A
+// nonzero relative length keeps its factor, so this is "zero regardless of
+// which relative unit," not merely "zero-valued."
+function isProvablyZeroRegardlessOfUnit(item) {
+  return item.value === 0 && item.symbolicFactors.size === 0;
+}
+
 // calc-mix()'s current CSS Values 5 grammar --
 // `calc-mix( [ <calc-sum> <percentage [0,100]>? ]# )` -- is a weighted
 // average of two or more items, distinct from the two-endpoint
@@ -507,8 +516,19 @@ function normalizedCalcMixWeights(weights) {
 // exact-rational percentage (or undefined for "omitted") per entry in
 // `items`, already parsed by the caller.
 function calcMixWeightedAverage(items, weights) {
-  const [first, ...rest] = items;
-  if (!rest.every((item) => sameUnits(item, first) && sameSymbolicFactors(item, first)))
+  // Compare every item's symbolic factors against a nonzero representative,
+  // not just against items[0]: a zero item exempts itself from the check
+  // (its erased factor is irrelevant, e.g. `0em` next to `9999em`), but two
+  // *nonzero* items with different relative units (`9999em` and `8888rem`)
+  // must still be rejected even when the zero happens to be first.
+  const representative = items.find((item) => !isProvablyZeroRegardlessOfUnit(item)) ?? items[0];
+  if (
+    !items.every(
+      (item) =>
+        sameUnits(item, representative) &&
+        (isProvablyZeroRegardlessOfUnit(item) || sameSymbolicFactors(item, representative)),
+    )
+  )
     throw new Error('incompatible calc-mix values');
   const normalizedWeights = normalizedCalcMixWeights(weights);
   if (normalizedWeights.some((weight) => weight === undefined)) throw staticAnalysisTooComplex;
@@ -523,7 +543,7 @@ function calcMixWeightedAverage(items, weights) {
     );
     value += item.value * (Number(weight.numerator) / Number(weight.denominator) / 100);
   }
-  return withValue(first, value, exactValue);
+  return withValue(representative, value, exactValue);
 }
 
 // Evaluate static CSS math while retaining enough type information for
@@ -1262,11 +1282,21 @@ function evaluateConstantArithmetic(expression) {
       skipSpace();
       const operator = peek();
       if (operator !== '+' && operator !== '-') return value;
+      // Without whitespace on both sides, this character never reads as a
+      // binary operator at all: per the CSS tokenizer, a '+'/'-' immediately
+      // followed by a digit (or '.' + digit) starts a new signed-number
+      // token instead, so the calc-sum production simply ends here rather
+      // than continuing through it. Stop without consuming it -- a
+      // standalone calc() still rejects the leftover text as unconsumed
+      // input (the `index !== expression.length` check below), and
+      // calc-mix()'s weighted-item grammar relies on exactly this to let a
+      // signed weight (e.g. `9999 +100%`) start right after an item with no
+      // space, instead of the item's own sum swallowing it and failing.
       if (
         !adjacentTriviaContainsWhitespace(index, -1) ||
         !adjacentTriviaContainsWhitespace(index, 1)
       )
-        throw new Error('expected whitespace around additive operator');
+        return value;
       index += 1;
       const right = parseTerm();
       if (!sameUnits(value, right)) throw new Error('incompatible units');
@@ -1900,6 +1930,39 @@ export function classifyStaticLayer(value) {
 export function evaluateStaticLayerNumber(value) {
   const resolved = resolveStaticNumber(value);
   return typeof resolved === 'number' && !Number.isNaN(resolved) ? resolved : undefined;
+}
+
+// Like evaluateStaticLayerNumber(), but returns the value at full precision
+// (an accumulated float, not rounded to the nearest integer) instead of
+// collapsing every unit to a bare number, alongside a tag identifying its
+// dimension. parseNumber() above already converts every canonical absolute
+// unit (px, cm, deg, s, ...) to its canonical same-dimension magnitude while
+// parsing, so two endpoints written in different absolute units (e.g. `0px`
+// and `264.556875cm`) come back tagged alike and are directly comparable --
+// this exists for callers (random()'s step/1000 endpoint-snapping
+// tolerance) that need that precision and cross-unit comparability, unlike
+// evaluateStaticLayerNumber()'s rounded, unit-blind result. A nonzero
+// relative-length term (em, vh, ...) can't be compared this way without
+// layout context and returns undefined, except when it's provably zero (its
+// symbolic factor is omitted for exactly this reason -- see
+// calcMixWeightedAverage()'s isProvablyZeroRegardlessOfUnit()); a mix of
+// incompatible units, or a unit raised to any power other than 1 (e.g.
+// `1px * 1px`, which shares px's dimension tag but isn't a length),
+// likewise returns undefined rather than a misleadingly comparable tag.
+export function evaluateStaticLayerNumberWithUnit(value) {
+  const resolved = resolveStaticArithmeticResult(value);
+  if (
+    resolved === null ||
+    resolved === staticAnalysisTooComplex ||
+    resolved === staticAnalysisInvalid ||
+    resolved.symbolicFactors.size > 0 ||
+    resolved.units.size > 1 ||
+    !Number.isFinite(resolved.value)
+  )
+    return undefined;
+  const [[unit, exponent] = []] = resolved.units;
+  if (exponent !== undefined && exponent !== 1) return undefined;
+  return { value: resolved.value, unit: unit ?? '' };
 }
 
 export function isStaticallyNegative(value) {

--- a/packages/components/scripts/stylelint/z-index-value-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-value-analysis.mjs
@@ -760,17 +760,30 @@ function evaluateConstantArithmetic(expression) {
           const weightStart = index;
           let weight;
           if (peek() !== ',' && peek() !== ')') {
+            let candidateWeight;
             try {
-              const candidateWeight = parseNumber();
+              candidateWeight = parseNumber();
+            } catch (error) {
+              // A too-complex numeric token (e.g. an absurdly long decimal)
+              // must still fail closed, not be silently treated as "no
+              // weight here".
+              if (error === staticAnalysisTooComplex) throw error;
+              index = weightStart;
+            }
+            if (candidateWeight !== undefined) {
               if (
                 candidateWeight.units.size === 1 &&
                 candidateWeight.units.get('unit:%') === 1 &&
                 candidateWeight.symbolicFactors.size === 0
-              )
+              ) {
+                // calc-mix()'s item weight is a <percentage [0,100]>: an
+                // out-of-range value makes the whole function invalid (CSS's
+                // usual range-checking for a range-constrained type), not a
+                // weight to silently clamp or normalize.
+                if (candidateWeight.value < 0 || candidateWeight.value > 100)
+                  throw new Error('calc-mix weight out of range');
                 weight = candidateWeight.exactValue;
-              else index = weightStart;
-            } catch {
-              index = weightStart;
+              } else index = weightStart;
             }
           }
           calcMixWeights.push(weight);

--- a/packages/components/scripts/stylelint/z-index-value-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-value-analysis.mjs
@@ -465,6 +465,67 @@ function valueIdentity(value) {
   return `${numericIdentity(value.value)}|${mapIdentity(normalizedUnits(value.units))}|${mapIdentity(value.symbolicFactors)}`;
 }
 
+// CSS Values 5's "Normalizing Mix Percentages" algorithm: an omitted weight
+// splits whatever share the specified weights leave; a specified total over
+// 100% is scaled down (never up); any shortfall ("leftover") is mixed in as
+// a consistently-typed zero, so it contributes nothing to the result. Takes
+// one exact-rational percentage (or undefined for "omitted") per item and
+// returns the normalized exact-rational percentage for each.
+function normalizedCalcMixWeights(weights) {
+  const hundred = { numerator: 100n, denominator: 1n };
+  const zero = { numerator: 0n, denominator: 1n };
+  let specifiedSum = zero;
+  for (const weight of weights)
+    if (weight !== undefined) specifiedSum = addRationals(specifiedSum, weight);
+  const clampedSpecifiedSum =
+    specifiedSum !== undefined && compareRationals(specifiedSum, hundred) > 0
+      ? hundred
+      : specifiedSum;
+  const omittedCount = weights.filter((weight) => weight === undefined).length;
+  const omittedWeight =
+    omittedCount === 0 || clampedSpecifiedSum === undefined
+      ? undefined
+      : divideRationals(addRationals(hundred, clampedSpecifiedSum, -1n), {
+          numerator: BigInt(omittedCount),
+          denominator: 1n,
+        });
+  const resolvedWeights = weights.map((weight) => weight ?? omittedWeight);
+  const total = resolvedWeights.reduce((sum, weight) => addRationals(sum, weight), zero);
+  const scale =
+    total !== undefined && compareRationals(total, hundred) > 0
+      ? divideRationals(hundred, total)
+      : undefined;
+  return resolvedWeights.map((weight) =>
+    scale === undefined || weight === undefined ? weight : multiplyRationals(weight, scale),
+  );
+}
+
+// calc-mix()'s current CSS Values 5 grammar --
+// `calc-mix( [ <calc-sum> <percentage [0,100]>? ]# )` -- is a weighted
+// average of two or more items, distinct from the two-endpoint
+// progress-interpolation shape handled separately below. `weights` holds one
+// exact-rational percentage (or undefined for "omitted") per entry in
+// `items`, already parsed by the caller.
+function calcMixWeightedAverage(items, weights) {
+  const [first, ...rest] = items;
+  if (!rest.every((item) => sameUnits(item, first) && sameSymbolicFactors(item, first)))
+    throw new Error('incompatible calc-mix values');
+  const normalizedWeights = normalizedCalcMixWeights(weights);
+  if (normalizedWeights.some((weight) => weight === undefined)) throw staticAnalysisTooComplex;
+  const hundred = { numerator: 100n, denominator: 1n };
+  let exactValue = { numerator: 0n, denominator: 1n };
+  let value = 0;
+  for (const [index, item] of items.entries()) {
+    const weight = normalizedWeights[index];
+    exactValue = addRationals(
+      exactValue,
+      multiplyRationals(item.exactValue, divideRationals(weight, hundred)),
+    );
+    value += item.value * (Number(weight.numerator) / Number(weight.denominator) / 100);
+  }
+  return withValue(first, value, exactValue);
+}
+
 // Evaluate static CSS math while retaining enough type information for
 // compatible units to cancel during division. Unknown units remain distinct,
 // but identical units can still cancel without needing layout context.
@@ -675,6 +736,10 @@ function evaluateConstantArithmetic(expression) {
         }
       }
       const arguments_ = [];
+      // calc-mix()'s weighted-item grammar (CSS Values 5) trails each item
+      // with an optional `<percentage [0,100]>` weight, space-separated (not
+      // comma-separated) from the item's value: `calc-mix(9999 100%, 1 0%)`.
+      const calcMixWeights = functionName === 'calc-mix' ? [] : undefined;
       for (;;) {
         skipSpace();
         const clampEndpointCanBeUnbounded =
@@ -690,6 +755,26 @@ function evaluateConstantArithmetic(expression) {
           arguments_.push(unboundedClampEndpoint);
           index += noneMatch[0].length;
         } else arguments_.push(parseExpression());
+        if (calcMixWeights !== undefined) {
+          skipSpace();
+          const weightStart = index;
+          let weight;
+          if (peek() !== ',' && peek() !== ')') {
+            try {
+              const candidateWeight = parseNumber();
+              if (
+                candidateWeight.units.size === 1 &&
+                candidateWeight.units.get('unit:%') === 1 &&
+                candidateWeight.symbolicFactors.size === 0
+              )
+                weight = candidateWeight.exactValue;
+              else index = weightStart;
+            } catch {
+              index = weightStart;
+            }
+          }
+          calcMixWeights.push(weight);
+        }
         skipSpace();
         if (peek() === ')') {
           index += 1;
@@ -702,6 +787,8 @@ function evaluateConstantArithmetic(expression) {
         functionName === 'clamp'
           ? arguments_.filter((argument) => argument !== unboundedClampEndpoint)
           : arguments_;
+      if (functionName === 'calc-mix' && calcMixWeights.some((weight) => weight !== undefined))
+        return calcMixWeightedAverage(arguments_, calcMixWeights);
       if (functionName === 'calc-mix' && arguments_.length === 3) {
         const [progress, start, end] = arguments_;
         const progressIsPercentage =

--- a/packages/components/scripts/stylelint/z-index-value-analysis.mjs
+++ b/packages/components/scripts/stylelint/z-index-value-analysis.mjs
@@ -762,7 +762,11 @@ function evaluateConstantArithmetic(expression) {
           if (peek() !== ',' && peek() !== ')') {
             let candidateWeight;
             try {
-              candidateWeight = parseNumber();
+              // A weight can be any <calc-sum> that resolves to a
+              // percentage, not just a bare percentage token -- e.g.
+              // `calc-mix(9999 calc(100%), 1)` -- so parse a full
+              // expression here, not just a number.
+              candidateWeight = parseExpression();
             } catch (error) {
               // A too-complex numeric token (e.g. an absurdly long decimal)
               // must still fail closed, not be silently treated as "no
@@ -800,7 +804,17 @@ function evaluateConstantArithmetic(expression) {
         functionName === 'clamp'
           ? arguments_.filter((argument) => argument !== unboundedClampEndpoint)
           : arguments_;
-      if (functionName === 'calc-mix' && calcMixWeights.some((weight) => weight !== undefined))
+      // A per-item weight is optional on every item, so a valid weighted
+      // call can have none at all (e.g. `calc-mix(9999, 1)`, equally
+      // weighted 50/50). That's only ambiguous with the older three-argument
+      // progress shape when there are exactly three items and none of them
+      // carry an explicit weight -- preserve that shape's existing behavior
+      // in that one case; every other unweighted arity uses the current
+      // weighted-item grammar instead of going unhandled.
+      if (
+        functionName === 'calc-mix' &&
+        (calcMixWeights.some((weight) => weight !== undefined) || arguments_.length !== 3)
+      )
         return calcMixWeightedAverage(arguments_, calcMixWeights);
       if (functionName === 'calc-mix' && arguments_.length === 3) {
         const [progress, start, end] = arguments_;


### PR DESCRIPTION
Refs #1136 -- see comment below; the issue's premise does not hold per CSS Values 5, no fix needed (recommend closing as invalid or reframing).
Closes #1139

## Summary

Both issues target the z-index fallback analyzer's witness system (`packages/components/scripts/stylelint/z-index-fallback-analysis.mjs` and `z-index-value-analysis.mjs`). #1139 is a nine-item CSS Values 5 grammar-parity backlog, fixed below. #1136 turned out not to be a real bug -- see the dedicated section below; the PR still includes the pin tests that document the correct (spec-verified) behavior.

Every item was reproduced against `bannedFallback()` before being fixed, with a red-before-green regression test. Two rounds of automated review (Copilot, Codex) surfaced real issues in the first pass, including the #1136 premise itself; all are addressed in the second commit.

## #1136 -- comma-injecting var() substitutions changing arity: **premise does not hold, no fix applied**

The issue's repro (`random-item(fixed .5, var(--items, 1), 1)` with `--items: 1, 9999`) assumes a `var()`'s comma-containing value can inject additional top-level items into an enclosing `random-item()` call, shifting which written option a fixed key selects.

This is factually incorrect per **CSS Values and Units Module Level 5, Appendix A ("Argument Grammars and Spread Syntax")**:

> "This also means that, ordinarily, parsing according to a function's argument grammar *does not* see the results of any nested arbitrary substitution functions; the contents are divided into arguments based only on the values literally present inside the function."

The spec's own worked example is structurally identical to this issue's repro:

> "For example, in `random-item(auto, var(--foo), var(--bar))`, the `random-item()` function selects between two random values... This is true even if one of them contains commas, like: `--foo: Courier, monospace;` ... `font-family: random-item(auto, var(--foo), var(--bar));` /* equivalent to: */ `font-family: random-item(auto, {Courier, monospace}, {Arial, serif});`"

`random-item()`'s argument boundaries -- and therefore which option a fixed key selects -- are fixed via the function's own argument grammar *before* any nested `var()` is substituted. This holds whether the comma lives in the `var()`'s own fallback (as in the repro) or in the referenced custom property's actual, unknowable value. The only way to opt into comma-injection is the explicit `...` spread syntax (`...var(--foo)`), which the repro doesn't use and which is a distinct, narrower feature than what the issue describes.

An initial version of this PR implemented a fail-closed gate based on the issue's premise (commit f9055f3); it was reverted after Codex's review caught the same spec passage and a concrete false-positive it would introduce. That commit is preserved in the branch history for transparency; the final state has no #1136-specific code.

**What ships instead:** two pin tests documenting the correct behavior (`random-item(fixed .5, var(--items, 1), 1)` stays unflagged; so does the version where the comma is written directly in the fallback) and an expanded comment on the existing extremum pin test explaining *why* ordinary math functions like `max()` are different: they're not arbitrary substitution functions, so they genuinely lack this argument-grammar protection, but the analyzer's existing "treat any unresolved var() operand as unconstrained" handling already covers that case without any arity-specific logic.

**Recommendation:** close #1136 as invalid, or reframe it specifically around the `...` spread syntax if that's a distinct concern worth tracking.

## #1139 -- grammar-parity backlog (9 items)

| # | Item | Direction | Fix |
|---|------|-----------|-----|
| 1 | `toggle()` nested `calc()`/`attr()`/`toggle()` | over-flag (fail-closed) | Reject: per CSS Values 5, nesting those inside a `toggle()` argument makes the whole declaration invalid, so it never applies. Two pre-existing tests encoded the old over-flagging behavior and were corrected. |
| 2 | `random()` nonpositive step | over-flag (fail-closed), provably safe superset before the fix | Nonpositive step now folds to the written `A` only, not `[A, B]`. Split the "no step" (genuinely continuous) case from the "step <= 0" (folds to a point) case, which the old code conflated. **Refined in the second commit**: the fold now only fires when a full-precision (non-integer-rounded) parse *proves* the step is <= 0, since a genuinely positive fractional step (e.g. `0.4`) can round down to a `stepValue` of 0 -- treating that as "step <= 0" would have folded a reachable range to a single safe point. |
| 3 | Braced `var()`/`attr()`/`env()` fallbacks `{9999}` | false negative | Unwrap the CSS Values 5 guaranteed-invalid-value `{ ... }` wrapper before inspecting the fallback. |
| 4 | Braced `first-valid()` options `first-valid({9999}, 1)` | false negative | Same unwrap, applied to each `first-valid()` branch. |
| 5 | Stepped `random()` endpoint epsilon | false negative | The last step now snaps to the written maximum when within `step / 1000` of it, per the spec's `random-evaluation` algorithm. Uses a precision-preserving numeric parse for the epsilon math specifically -- `evaluateStaticLayerNumber()` rounds to the nearest integer, which is too coarse for this. **Refined in the second commit**: the parser now also strips a shared trailing unit, so the epsilon is correct for typed (dimensional) stepped `random()` calls, not just bare numbers; it also no longer accepts a malformed token like `1.`. Four pre-existing tests asserting the un-snapped value were corrected. |
| 6 | `attr()` bare `number`/`integer` type witnesses | false negative | The legacy `<attr-name> <type-or-unit>?` bare keywords `number`/`integer` (dimensionless, unlike the other legacy unit keywords) now derive `['0','1']` witnesses. |
| 7 | Null-namespaced attr names `attr(|data-layer ...)` | false negative | `<ns-prefix>` permits a bare `|` (explicit null namespace); the header parser no longer rejects it outright. |
| 8 | Substitutions inside attr headers `attr(var(--name, ...) type(...), ...)` | false negative | The `<attr-name>` position may itself be an arbitrary substitution function; the header parser now skips past it via matching-parenthesis depth-tracking before locating the type clause. |
| 9 | `calc-mix()` weighted-item grammar `calc-mix(9999 100%, 1 0%)` | false negative | `z-index-value-analysis.mjs` only implemented the older 3-argument progress-interpolation shape. Added parsing + evaluation for the current `calc-mix( [ <calc-sum> <percentage>? ]# )` weighted-item grammar, including the spec's mix-percentage-normalization algorithm (omitted-weight distribution, >100% scaling). The old progress shape is unaffected when no item carries an explicit weight. **Refined in the second commit**: an out-of-range per-item weight (outside `[0,100]`) now correctly invalidates the whole call instead of being silently normalized; a too-complex weight token no longer gets swallowed into a generic parse failure; and `z-index-fallback-analysis.mjs`'s separate witness/runtime-candidate machinery (which only recognized the older fixed arity) now also recognizes the weighted-item shape, so a `var()` item inside it fails closed instead of being silently excluded. |

**Scope note (documented in #1139, unchanged from the first commit):** `calc-mix()` with *no* explicit weights and an argument count other than 3 (e.g. `calc-mix(9999, 1, 1)`, which the current spec would treat as a 3-way equal-weighted average) is a separate, broader divergence discovered while implementing item 9, out of scope here: it's different arithmetic on a currently-valid input, not item 9's false negative, and the existing 16 old-shape tests pin the current (pre-existing) behavior.

## Review response

Two rounds of automated review (Copilot, Codex) ran against the first commit. All findings were verified and addressed in the second commit:

- **#1136's premise itself** (Codex) -- see the dedicated section above; reverted.
- **Positive fractional `random()` step rounds to 0** (Codex, P2) -- fixed; see item 2 above.
- **Typed stepped `random()` loses precision for the endpoint snap** (Codex, P2) -- fixed; see item 5 above.
- **Out-of-range `calc-mix()` weights silently normalized** (Codex, P2) -- fixed; see item 9 above.
- **Weighted `calc-mix()` runtime substitution not modeled** (Codex, P2) -- fixed; see item 9 above.
- **`bareCssNumberPattern` accepts a malformed `1.` token** (Copilot) -- fixed. This one has no currently-reachable path through `bannedFallback()` (the caller's own upstream validation already rejects such tokens before this parser sees them), so no dedicated regression test was added for it specifically -- it's a defensive fix for the parser's own robustness as a general-purpose utility.
- **`calc-mix()` weight parser swallows the too-complex sentinel** (Copilot) -- fixed; regression test added.

## Validation

- `bun run test z-index` (packages/components): 1344 pass, 0 fail (baseline 1315).
- `prettier --check` and `oxlint --type-aware` clean on all three changed files.
- No changeset (scripts-only, per #1079 precedent).
- Local full-suite runs intermittently showed unrelated wall-clock perf-budget test failures (e.g. "builds wide clamp placeholders in linear time") under heavy concurrent machine load (other worktree sessions running in parallel, load average 40-80+). Verified via `git stash` that these same tests fail identically on the unmodified tree under that load, confirming it's environmental, not a regression from this change. Multiple clean runs with 0 failures were captured once load subsided.

## Files touched

- `packages/components/scripts/stylelint/z-index-fallback-analysis.mjs`
- `packages/components/scripts/stylelint/z-index-value-analysis.mjs`
- `packages/components/scripts/stylelint/z-index-scale.test.ts`

## Second review round

Codex re-reviewed after the first fix commit and found six more issues, all confirmed and fixed except one documented, intentional over-flag:

- `random()` step precision compared magnitudes across different (but convertible) units without converting them -- fixed, now requires a literal shared unit before trusting the precise comparison, otherwise falls back to the already-converted values.
- The stepped `random()` endpoint-snap only checked the natural step count N, not the spec's N+1 extension rule -- fixed, now implements both.
- `attr(data-scale integer, ...)` was incorrectly treated the same as `attr(data-scale number, ...)` -- fixed. Verified against the actual grammar (`type(<syntax>) | raw-string | number | <attr-unit>`): only `number` is special; `integer` is an ordinary (unrecognized) `<attr-unit>`. This directly corrected a mistake in my own first-round item 6 fix.
- `calc-mix()` with every item's weight omitted (valid per spec, distributed equally) wasn't routed to the weighted evaluator at arities other than 3 -- fixed.
- `calc-mix()`'s weight parser only accepted a bare percentage token, not a calculated one like `calc(100%)` -- fixed.
- `calc-mix()`'s runtime (var()-containing) fail-closed check doesn't validate that a detected weight is in the `[0,100]` range before failing closed -- **not fixed**, left as a documented, intentional over-flag (safe direction, not a missed banned value), consistent with this backlog's own stated "sound conservative design is fine" philosophy.

5 more regression tests added; 2 pre-existing tests corrected to the newly-precise behavior. Full suite green at 1349.

## Third review round

Codex re-reviewed again after the second fix commit and found two more issues in the calc-mix() weighted-item handling:

- The runtime fail-closed checks only recognized a calc-mix() call as using the weighted-item grammar when it had an explicit trailing percentage weight -- but a per-item weight is optional on every item, so `calc-mix(var(--layer), 19998)` (no weights at all) fell through unrecognized -- fixed, using the same "argument count isn't exactly 3" dispatch rule the static evaluator already uses. This also corrected one more pre-existing test that assumed a no-weight, non-3-argument calc-mix() was invalid (it's valid under the current grammar).
- The weight parser accepts raw unwrapped arithmetic (`50% + 50%`) where the grammar only permits a bare percentage or an explicit math function (`calc(50% + 50%)`) -- **not fixed**, documented as an intentional, deferred over-flag (safe direction), consistent with this backlog's fail-closed philosophy.

1 more regression test added, 1 more pre-existing test corrected. Full suite green at 1350.

## Convergence summary

Every review thread across three rounds (15 total) is accounted for: 13 fixed with a regression test each, 2 documented as intentional, deferred over-flags (safe direction, consistent with this backlog's own "sound conservative design is fine" philosophy) rather than silently dropped. All threads resolved. No unresolved threads remain as of the latest push.

## Fourth review round -- item 2's premise also corrected

Codex's fourth pass caught that #1139 item 2's own premise -- "a zero or negative random() step folds to the written start (A)" -- doesn't hold either, the same way #1136's premise didn't. Verified directly against the spec source (random-argument-ranges):

> "If C is negative, zero, or positive but close enough to zero that... N... would be infinite... the step must be ignored. (The function is treated as if only A and B were provided.)"

A nonpositive step is **ignored entirely** -- the function behaves as the two-argument continuous `[A, B]` range, not folded to a single point. `random(1, 9999, 0)` is banned (9999 is within `[1, 9999]`) -- the opposite of item 2's original conclusion and my first-round fix. Reverted that part of item 2 back to the pre-existing (already spec-correct) behavior, while keeping the separately-valid work from later rounds: the precise (non-integer-rounded) step check that prevents a genuinely positive fractional step from being misread as nonpositive, and the distinct infinite-step ("result is A") handling, now correctly ordered ahead of this check. 4 pre-existing tests corrected back to their original values.

Two more findings from this round:

- A fixed random() key of exactly 0 always selects the written minimum regardless of step count -- fixed, short-circuits before the step-count enumeration cap now.
- `attr()`'s `<attr-name>` substitution recognition (item 8's fix) only matches `var()`/`env()`/`attr()`, not every arbitrary substitution function (e.g. `random-item()` used as the attr-name itself) -- **not fixed**, documented as a deferred false negative for a materially larger change addressing a very exotic construct.

2 more regression tests added. Full suite green at 1352.

## Updated convergence summary

21 review threads total across four rounds. 18 fixed with a regression test each (including one correction of the original issue text's own premise, on top of #1136). 3 documented as intentional deferrals (2 safe-direction over-flags consistent with this backlog's stated philosophy, 1 false negative for an exotic construct flagged explicitly rather than silently dropped). All threads resolved as of the latest push.

## Fifth review round -- final, converging here

One more finding fixed: a fixed random() key's step-index resolution is O(1) regardless of slot count, so it's no longer subject to the enumeration cap at all (previously only the `fixed 0` case was special-cased for this; generalized to any fixed key value).

Four more findings surfaced in this round. Given the length of this review cycle, these are **not fixed in this PR** -- documented here explicitly as follow-ups rather than dropped:

1. A `random()` step written as a resolvable-but-not-bare-number expression (e.g. `calc(9999)`) falls back to the continuous-range treatment instead of the stepped one (false negative).
2. A weighted `calc-mix()` combining a same-unit relative-length zero with a nonzero relative length is incorrectly rejected as incompatible, due to how the parser represents a relative-length zero's symbolic factor (false negative).
3. `toggle()`'s nested `calc()`/`attr()`/`toggle()` rejection (item 1) scans through nested `var()`/`env()`/`attr()` substitutions' own contents rather than treating them as opaque, so it over-rejects when the forbidden token is only reachable through an unresolved substitution's fallback (false negative -- i.e. this one under-flags a case that should still be banned).
4. An explicitly-signed `calc-mix()` weight (`+100%`) isn't recognized by the weight-shape validator (false negative).

**Recommend:** a small follow-up PR addressing these four, or filing them as separate tracked issues against the same backlog convention as #1136/#1139.

## Final convergence summary

28 review threads total across five rounds. 22 fixed with a regression test each (including two corrections of the original issues' own premises: #1136 in full, and #1139 item 2's nonpositive-step direction). 6 documented as intentional deferrals: 2 safe-direction over-flags consistent with this backlog's stated fail-closed philosophy, 4 false negatives from the final round deferred as follow-up work given review-cycle length (listed above). All resolved threads are genuinely fixed; the 4 unresolved threads from round 5 remain open on the PR, each with a reply explaining the gap and suggested fix direction, pending a follow-up.

## Sixth review round -- converging here, not chasing further

Two more findings, both narrower variants of already-deferred items (added to the same follow-up list, not fixed here):

5. A mixed-unit `random()` endpoint snap (e.g. `random(0px, 264.556875cm, 9989.02px)`) also falls back to rounded magnitudes for the epsilon check, for the same root-cause reason as follow-up item 1 above (`preciseStaticNumberWithUnit()` only strips units, doesn't convert between compatible ones).
6. A leading `attr()`-header substitution that supplies *both* the name and type (not just the name) isn't fully parsed, so no defined-path witness is derived in that case -- a harder, more general version of item 8's original scope.

**This PR is done accepting further automated-review fix rounds.** Six rounds is a reasonable stopping point for an autonomous session: every thread across all six rounds has a reply explaining its disposition, every fix has a regression test, and the two premise corrections (#1136 in full, #1139 item 2's direction) were the load-bearing findings -- the remaining six deferred items are all narrower, already-identified-pattern edge cases, not new categories of risk. Recommend a human review pass and a follow-up PR/issue for the six deferred items rather than further automated rounds on this one.

## Final follow-up list (not fixed in this PR)

1. `random()` step written as a resolvable-but-not-bare-number expression (e.g. `calc(9999)`) falls back to continuous-range treatment instead of stepped.
2. Weighted `calc-mix()` combining a same-unit relative-length zero with a nonzero relative length is rejected as incompatible.
3. `toggle()`'s nested `calc()`/`attr()`/`toggle()` rejection over-rejects when the forbidden token is only reachable through an unresolved substitution's fallback, not the toggle() branch's own literal text.
4. Explicitly-signed `calc-mix()` weight (`+100%`) isn't recognized.
5. Mixed-unit `random()` endpoint snap falls back to rounded (not converted) magnitudes -- same root cause as item 1.
6. `attr()`-header substitution supplying both name and type isn't fully parsed for defined-path witnesses.

All six are false negatives (the dangerous direction) in increasingly narrow constructs layered on top of this PR's own fixes -- not pre-existing gaps, and not reachable via the original #1136/#1139 backlog items as written. Each has a reply on its review thread explaining the gap and suggested fix direction.
