### PR TITLE
fix(ci): stop asserting hydration against the vite dev server

### DIFF
--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1234,8 +1234,26 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
       );
     }
 
-    await assertSvelteKitClientRoutesHydrate(httpPort, label, ['/chat-layout', '/dev-ssr']);
-
+    // Deliberately NO client-hydration assertion here. This phase owns dev-mode
+    // SSR only — that transform-on-request HTML renders — which the marker check
+    // above proves deterministically.
+    //
+    // Client hydration MUST NOT be asserted against a `vite dev` server. The
+    // fixture sets `optimizeDeps: { noDiscovery: true, holdUntilCrawlEnd: false }`,
+    // so /dev-ssr's nine cinder subpath imports are served as unbundled ESM
+    // through Vite's transform-on-request pipeline. On a cold CI runner that is
+    // a request waterfall of hundreds of sequential module transforms, and any
+    // on-request dep discovery triggers a full page reload that resets the
+    // route's `hydrated` $effect mid-wait. Either mechanism outruns a bounded
+    // wait; both produced 22 red `main` runs between 2026-07-24 and 2026-08-05
+    // against ~100 passes on unchanged code, including a docs-only commit.
+    //
+    // The client JS is identical under dev and prod, so this costs no coverage:
+    // /dev-ssr's hydration — including the ConfirmDialog interaction and focus
+    // restoration — is asserted against the prebuilt adapter-node server in
+    // `runSveltekitFixture`, where dependencies are bundled at build time and
+    // the race cannot exist. Raising the timeout here would mask the waterfall,
+    // not fix it.
     devSsrAssertionsPassed = true;
   } finally {
     devServer.kill();
@@ -1546,7 +1564,16 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
         );
       }
 
-      await assertSvelteKitClientRoutesHydrate(httpPort, label, ['/subpath', '/chat-layout']);
+      // Every client-hydration assertion belongs here, against the prebuilt
+      // adapter-node server — never against the `vite dev` server in
+      // `assertSvelteKitDevSsrRoute` (see the note there). Dependencies are
+      // bundled at build time, so there is no transform waterfall and no
+      // optimizer-triggered reload to race.
+      await assertSvelteKitClientRoutesHydrate(httpPort, label, [
+        '/subpath',
+        '/chat-layout',
+        '/dev-ssr',
+      ]);
 
       // Subpath page
       const subpathResponse = await fetchWithTimeout(


### PR DESCRIPTION
> **Scope reduced.** This PR originally also carried the `src/_internal/*.svelte` packaging fix. [#1141](https://github.com/stevekinney/cinder/pull/1141) got there first and does it better — it unifies *both* glob surfaces into one exported `PUBLISHED_SOURCE_FILES_GLOBS` and validates the packed import closure in per-PR CI, where mine only checked at pack time. Those commits are dropped; this PR is now just the hydration fix. **It should merge after #1141** — see "Merge order" below.

## The problem

`main-green`'s `Consumer hydration smoke (cinder)` step has failed **22 times between 2026-07-24 and 2026-08-05**, interleaved with ~100 passes on unchanged code. It is the single largest source of red `main` in the last month — `main-green` failed 73 of 282 runs (25.9%) over that window.

Every failure has the same signature:

```
at assertSvelteKitHydrationRouteContent (validate-consumers.ts:2114)
TimeoutError: waitFor: Timeout 5000ms exceeded.
  - waiting for locator('[data-dev-ssr-hydrated="true"]') to be visible
```

The most recent failure was on `942214d18`, a **docs-only commit**. A change to `docs/validation-topology.md` cannot break client hydration, which rules out a code regression and establishes this as environmental.

## Root cause

The `/dev-ssr` hydration assertion ran against a raw `vite dev` server. The fixture's `vite.config.ts` sets:

```ts
optimizeDeps: { holdUntilCrawlEnd: false, noDiscovery: true }
```

`noDiscovery: true` disables dependency pre-bundling, so `/dev-ssr`'s nine cinder subpath imports (Card, ConfirmDialog, Sidebar, SideNavigation(+Item), Tabs/TabList/Tab/TabPanel) are served as unbundled ESM through Vite's transform-on-request pipeline. Two mechanisms follow, and the same change fixes both:

1. On a cold CI runner, that first request is a waterfall of hundreds of sequential module transforms before the route's `$effect` can set `data-dev-ssr-hydrated`.
2. Any on-request dependency discovery triggers a full page reload, which resets `hydrated` to `false` mid-wait.

`waitForReadyHtml` polls correctly, but only for **SSR** markers — it structurally cannot wait on `data-dev-ssr-hydrated`, which does not exist until after client hydration runs.

Timing in the failing run corroborates it: types checked at `22:32:34`, hydration attempt began ~`22:32:37`, timed out at `22:32:42`.

## The fix

**No timeout raised. No retry added. No assertion weakened.**

The dev phase owns dev-mode **SSR** — that transform-on-request HTML renders — which its marker check already proves deterministically. Client hydration is not a dev-vs-prod concern: the client JS is identical either way, and `runSveltekitFixture` already builds the fixture and serves it via `node build/index.js` (adapter-node), where dependencies are bundled at build time and the race cannot exist.

- Removed the `assertSvelteKitClientRoutesHydrate` call from the dev-server phase.
- Added `/dev-ssr` to the production-build phase's route list.

## Coverage is unchanged

- `/chat-layout` was already asserted on the built server, so its dev-phase assertion was fully redundant.
- `/dev-ssr`'s assertions move across intact — still waits for the hydration marker, clicks "Reset state", waits for the ConfirmDialog, cancels, and verifies focus restoration.
- `hydrationSmoke` calls the same `runSveltekitFixture`, which runs both phases, so `main-green` keeps exercising this path every merge. Nothing moved to release-only.
- The fixture declares no `prerender`, `ssr`, or `csr` overrides, so `/dev-ssr` hydrates under adapter-node exactly as under dev.

Both call sites carry comments recording why dev-server hydration assertions are prohibited.

## Merge order: after #1141

Removing the dev-server assertion lets the smoke reach the production-build phase — which is how I found the `src/_internal/*.svelte` packaging break that #1141 fixes. **The flake was masking a real publish break**: anyone installing cinder and importing `input`, `checkbox`, or `form-field` through the Svelte source condition got `UNRESOLVED_IMPORT`. `validate:consumer` does catch that; it just never got past the timeout to run.

So on `main` today, this PR alone would turn a timeout into a build failure. Merged after #1141, the smoke goes green.

## Verification

Verified end-to-end locally on a tree carrying both this fix and #1141's:

```
[validate-consumers] hydration smoke passed.
EXIT=0
```

Local runs are not the ongoing gate — this flake is runner-latency-dependent and passed locally even with the bug fully present. The real gate is the absence of this signature from `gh run list --branch main` over the next 7 days, which I'll watch.

Note that `validate:consumer:hydration-smoke` runs **only in `main-green`**, post-merge. None of the four required PR checks exercise it, so PR CI cannot validate the change this PR is about — it can only be proven after merge. That is the same topology gap that produced all 73 of last month's `main-green` failures.

## Follow-ups (not in this PR)

1. **Nothing reports a red `main`.** `main-green.yaml` has `permissions: contents: read` and zero `if: failure()` steps; across all seven workflows there is exactly one, an artifact upload in `browser-tests.yaml`. This flake ran 11 days because the only detection channel was `release` tripping days later.
2. **`strict` is `false` on `main` right now**, though #1140 records "`strict: true` is the steady state" — its drain protocol lifts strict and restores it manually, and the restore didn't happen. Merge queues require an org-owned repo (this one is user-owned), so strict is the only mitigation for the #972/#1011 stale-base class, and it is currently off.
3. **Coverage is entirely ungated** since `3529694c5` removed the ratchet rather than fixing its global-aggregate design.
