### PR TITLE
fix(text-direction): resolve @container condition lists and @scope :scope gaps

### DIFF
--- a/.changeset/direction-parity-scope-container.md
+++ b/.changeset/direction-parity-scope-container.md
@@ -1,0 +1,11 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Resolve additional `@container` and `@scope` text-direction spec-parity gaps:
+
+- Evaluate comma-separated `@container` condition lists (`CSSContainerRule.conditions`) as independent name+query entries, OR'd together, instead of failing closed on the blanked legacy `containerName`/`containerQuery` accessors.
+- Resolve relative (non-exact) `:scope` scope-start selectors (`@scope (:scope > .child)`) against the enclosing scope's root(s) instead of failing closed.
+- Preserve the supported exact `:scope` alternative in a mixed all-`:scope` root list (`@scope (:scope, :scope > .theme)`) even when a sibling relative alternative can't resolve.
+- Resolve outside-ancestor context in scoped rule selectors (`main :scope .shell`) against the scope root's real ancestor chain instead of losing it to the detached-clone fallback's isolated subtree.
+- Normalize each item of a rule selector list independently for leading-combinator shorthand (`.unused, > .shell`), instead of gating on whether the whole list starts with a combinator.

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -402,22 +402,43 @@ function findActiveScopeRoots(
   const ordinaryRootSelectors = prelude.rootSelectors.filter(
     (selector) => !hasScopePseudoClass(selector),
   );
-  const unsupportedScopeRoot = scopeRootSelectors.some(
-    (selector) => selector.trim().toLowerCase() !== ':scope',
-  );
-  if (unsupportedScopeRoot && ordinaryRootSelectors.length === 0) return null;
-  // Only an exact `:scope` root selector resolves — a compound or
-  // combinator form attached to `:scope` (e.g. `:scope > .foo`) is never
-  // evaluated against anything, so it must not silently contribute a root
-  // as if it had matched.
   const scopeRootCandidates = scopePseudoRootCandidates(parentScopes, implicitScopeRoot);
-  const usesScopePseudoRoot =
-    scopeRootSelectors.length > 0 && !unsupportedScopeRoot && scopeRootCandidates.length > 0;
   const roots: ScopeRoot[] = [
-    ...(usesScopePseudoRoot ? scopeRootCandidates.filter((root) => root.contains(element)) : []),
+    ...findRelativeScopeRootMatches(element, scopeRootSelectors, scopeRootCandidates),
     ...findScopeMatches(element, ordinaryRootSelectors),
   ];
   return finalizeActiveScopeRoots(roots, element, prelude, parentScopes);
+}
+
+// Resolves every `:scope`-containing root selector — the exact token
+// (`:scope`) as well as any compound or combinator form built on it
+// (`:scope > .child`) — by walking candidate ancestors of the target (like
+// `findScopeMatches` does for ordinary root selectors) and testing each one
+// via `matchesScopedSelector` against the enclosing scope's candidate
+// root(s). Exact `:scope` is just the degenerate case of this same walk (an
+// ancestor "matches" only when it IS one of the candidate roots), so a
+// mixed list like `:scope, :scope > .theme` naturally preserves the
+// supported exact alternative even when a sibling relative alternative
+// can't be resolved for a given candidate — each selector is tried
+// independently and OR'd together, same as `findScopeMatches`.
+function findRelativeScopeRootMatches(
+  element: HTMLElement,
+  selectors: readonly string[],
+  scopeRootCandidates: readonly ScopeRoot[],
+): Element[] {
+  if (selectors.length === 0 || scopeRootCandidates.length === 0) return [];
+  const parentScope: ActiveScope = { roots: [...scopeRootCandidates] };
+  const matches: Element[] = [];
+  let current: Element | null = element;
+  while (current) {
+    const currentElement: Element = current;
+    if (
+      selectors.some((selector) => matchesScopedSelector(currentElement, selector, [parentScope]))
+    )
+      matches.push(currentElement);
+    current = currentElement.parentElement;
+  }
+  return matches;
 }
 
 function finalizeActiveScopeRoots(
@@ -492,10 +513,18 @@ function matchesSelectorSafely(element: Element, selector: string): boolean {
 //    a wrapping style rule, is CSS's own alias for the scope root.
 //  - A selector that leads with a combinator (`> .foo`, `+ .foo`, `~ .foo`)
 //    is shorthand for that combinator applied to the scope root.
+//
+// Both shorthands are per-selector-list-item, not per-list: `.unused, >
+// .shell` only needs the second alternative rewritten. Splitting on
+// top-level commas and normalizing each item independently (rather than
+// checking whether the *whole* list starts with `&`/a combinator) is what
+// makes that second alternative resolve instead of silently passing the
+// leading-combinator form through to an ordinary, invalid `element.matches()`
+// call.
 function normalizeScopeRelativeSelector(selector: string): string {
-  if (!selector.includes('&') && !/^\s*[>+~]/.test(selector)) return selector;
   return splitSelectorList(selector)
     .map((part) => {
+      if (!part.includes('&') && !/^\s*[>+~]/.test(part)) return part;
       const withScopeAlias = replaceNestingReferences(part, ':scope').selector;
       return /^\s*[>+~]/.test(withScopeAlias) ? `:scope ${withScopeAlias}` : withScopeAlias;
     })
@@ -521,77 +550,164 @@ function matchesScopedSelector(
   if (scopes.length === 0) return false;
   const scope = scopes.at(-1);
   if (!scope) return false;
+  // A selector may combine `:scope` with real context OUTSIDE the scope
+  // root itself (`main :scope .shell` — `main` must be an ancestor of the
+  // root, not of anything inside it). The clone-based matching below only
+  // ever sees the root's own subtree, so that outside context is split off
+  // and verified separately, against the root's REAL (unmutated, uncloned)
+  // ancestor chain — see `matchesOutsideScopeContext`. Only the remainder
+  // (`:scope` onward) goes through the clone-based matcher, which already
+  // correctly handles everything relative to the root itself.
+  const outsideContext = splitScopeOutsideContext(normalizedSelector);
+  const remainderSelector = outsideContext ? outsideContext.remainder : normalizedSelector;
   for (const root of scope.roots) {
     try {
-      if (root.querySelector(':scope') === root) {
-        if (Array.from(root.querySelectorAll(normalizedSelector)).includes(element)) return true;
-        continue;
+      if (outsideContext) {
+        // Outside-ancestor context only has real meaning for an element
+        // with real DOM ancestors. A shadow root has none in this sense —
+        // and CSS itself can't reach light-DOM ancestors from inside a
+        // shadow-scoped stylesheet anyway — so this is a genuine envelope,
+        // not a shortcut: fail this root rather than guess.
+        if (!(root instanceof Element)) continue;
+        if (!matchesOutsideScopeContext(root, outsideContext.before, outsideContext.combinator))
+          continue;
       }
-      const clone =
-        typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot
-          ? null
-          : root.cloneNode(true);
-      const cloneElement =
-        clone instanceof Element
-          ? clone
-          : typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot
-            ? (() => {
-                const wrapper = root.ownerDocument.createElement('div');
-                wrapper.append(...Array.from(root.children, (child) => child.cloneNode(true)));
-                return wrapper;
-              })()
-            : null;
-      if (!cloneElement) continue;
-      const marker = 'data-cinder-scope-root';
-      const replacedSelector = replaceScopePseudoClass(normalizedSelector, `[${marker}]`);
-      if (
-        typeof ShadowRoot !== 'undefined' &&
-        root instanceof ShadowRoot &&
-        /^\[[^\]]+\][^\s>+~]/.test(replacedSelector)
-      )
-        continue;
-      cloneElement.setAttribute(marker, 'true');
-      const path: number[] = [];
-      let current: Element | null = element;
-      while (current && current !== root) {
-        const parent: Element | null = current.parentElement;
-        if (!parent) {
-          if (
-            typeof ShadowRoot !== 'undefined' &&
-            root instanceof ShadowRoot &&
-            current.getRootNode() === root
-          )
-            path.unshift(Array.prototype.indexOf.call(root.children, current));
-          break;
-        }
-        path.unshift(Array.prototype.indexOf.call(parent.children, current));
-        current = parent;
-      }
-      if (
-        current !== root &&
-        !(
-          typeof ShadowRoot !== 'undefined' &&
-          root instanceof ShadowRoot &&
-          current?.getRootNode() === root
-        )
-      )
-        continue;
-      let matchedCloneElement: Element = cloneElement;
-      for (const index of path) {
-        const child = matchedCloneElement.children[index];
-        if (!child) break;
-        matchedCloneElement = child;
-      }
-      if (
-        (matchedCloneElement === cloneElement && cloneElement.matches(replacedSelector)) ||
-        Array.from(cloneElement.querySelectorAll(replacedSelector)).includes(matchedCloneElement)
-      )
-        return true;
+      if (matchesRemainderAgainstScopeRoot(element, remainderSelector, root)) return true;
     } catch {
       // Unsupported relative selectors are not safe direction hints.
     }
   }
   return false;
+}
+
+interface ScopeOutsideContext {
+  before: string;
+  combinator: '>' | '+' | '~' | ' ';
+  remainder: string;
+}
+
+// Splits real "outside-ancestor" selector text off from the `:scope`
+// token(s) onward — e.g. `main :scope .shell` splits into `before: 'main'`,
+// `combinator: ' '`, `remainder: ':scope .shell'`. Returns `null` when
+// `:scope` is the first meaningful token (nothing precedes it) or is
+// compounded directly onto the preceding simple selector (`a:scope`, no
+// combinator between them) — neither references anything outside the root.
+function splitScopeOutsideContext(selector: string): ScopeOutsideContext | null {
+  const scopeIndex = findScopePseudoClassIndex(selector);
+  if (scopeIndex === null) return null;
+  const beforeRaw = selector.slice(0, scopeIndex);
+  if (!beforeRaw.trim()) return null;
+  const trimmedEnd = beforeRaw.replace(/\s+$/, '');
+  const lastCharacter = trimmedEnd.at(-1);
+  if (lastCharacter === '>' || lastCharacter === '+' || lastCharacter === '~') {
+    const before = trimmedEnd.slice(0, -1).trim();
+    return before
+      ? { before, combinator: lastCharacter, remainder: selector.slice(scopeIndex) }
+      : null;
+  }
+  if (!/\s$/.test(beforeRaw)) return null;
+  const before = trimmedEnd.trim();
+  return before ? { before, combinator: ' ', remainder: selector.slice(scopeIndex) } : null;
+}
+
+// Verifies outside-ancestor context (`before`, connected to `:scope` via
+// `combinator`) against the scope root's REAL ancestor/sibling chain —
+// exact DOM-reference-based traversal (`closest`/`matches`/sibling
+// pointers), not pattern matching, so it can't coincidentally match an
+// unrelated element that merely has a similar shape elsewhere in the
+// document.
+function matchesOutsideScopeContext(
+  root: Element,
+  before: string,
+  combinator: ScopeOutsideContext['combinator'],
+): boolean {
+  if (combinator === ' ') return root.parentElement?.closest(before) != null;
+  if (combinator === '>')
+    return root.parentElement !== null && matchesSelectorSafely(root.parentElement, before);
+  if (combinator === '+') {
+    const sibling = root.previousElementSibling;
+    return sibling !== null && matchesSelectorSafely(sibling, before);
+  }
+  // '~': any preceding sibling.
+  let sibling = root.previousElementSibling;
+  while (sibling) {
+    if (matchesSelectorSafely(sibling, before)) return true;
+    sibling = sibling.previousElementSibling;
+  }
+  return false;
+}
+
+// Matches `element` against `selector` (already stripped of any real
+// outside-ancestor context — see `splitScopeOutsideContext`) with `:scope`
+// bound to `root`. Uses the browser's native `:scope` support when
+// available, falling back to a marker-attribute match against a clone of
+// the root's own subtree in environments that don't support querying
+// `:scope` at all.
+function matchesRemainderAgainstScopeRoot(
+  element: Element,
+  selector: string,
+  root: ScopeRoot,
+): boolean {
+  if (root.querySelector(':scope') === root) {
+    return Array.from(root.querySelectorAll(selector)).includes(element);
+  }
+  const clone =
+    typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot ? null : root.cloneNode(true);
+  const cloneElement =
+    clone instanceof Element
+      ? clone
+      : typeof ShadowRoot !== 'undefined' && root instanceof ShadowRoot
+        ? (() => {
+            const wrapper = root.ownerDocument.createElement('div');
+            wrapper.append(...Array.from(root.children, (child) => child.cloneNode(true)));
+            return wrapper;
+          })()
+        : null;
+  if (!cloneElement) return false;
+  const marker = 'data-cinder-scope-root';
+  const replacedSelector = replaceScopePseudoClass(selector, `[${marker}]`);
+  if (
+    typeof ShadowRoot !== 'undefined' &&
+    root instanceof ShadowRoot &&
+    /^\[[^\]]+\][^\s>+~]/.test(replacedSelector)
+  )
+    return false;
+  cloneElement.setAttribute(marker, 'true');
+  const path: number[] = [];
+  let current: Element | null = element;
+  while (current && current !== root) {
+    const parent: Element | null = current.parentElement;
+    if (!parent) {
+      if (
+        typeof ShadowRoot !== 'undefined' &&
+        root instanceof ShadowRoot &&
+        current.getRootNode() === root
+      )
+        path.unshift(Array.prototype.indexOf.call(root.children, current));
+      break;
+    }
+    path.unshift(Array.prototype.indexOf.call(parent.children, current));
+    current = parent;
+  }
+  if (
+    current !== root &&
+    !(
+      typeof ShadowRoot !== 'undefined' &&
+      root instanceof ShadowRoot &&
+      current?.getRootNode() === root
+    )
+  )
+    return false;
+  let matchedCloneElement: Element = cloneElement;
+  for (const index of path) {
+    const child = matchedCloneElement.children[index];
+    if (!child) break;
+    matchedCloneElement = child;
+  }
+  return (
+    (matchedCloneElement === cloneElement && cloneElement.matches(replacedSelector)) ||
+    Array.from(cloneElement.querySelectorAll(replacedSelector)).includes(matchedCloneElement)
+  );
 }
 
 export function replaceScopePseudoClass(selector: string, replacement: string): string {
@@ -646,7 +762,12 @@ export function replaceScopePseudoClass(selector: string, replacement: string): 
   return result;
 }
 
-export function hasScopePseudoClass(selector: string): boolean {
+// Locates the start index of the first actual `:scope` pseudo-class token
+// (not `:scopeX`/`:scoped`, and not inside a quoted string or an attribute
+// selector's brackets), or `null` when the selector has none. Shared by
+// `hasScopePseudoClass` and `splitScopeOutsideContext`, which both need to
+// distinguish a real `:scope` token from lookalike text.
+function findScopePseudoClassIndex(selector: string): number | null {
   let quote: string | null = null;
   let brackets = 0;
   let escaped = false;
@@ -682,9 +803,13 @@ export function hasScopePseudoClass(selector: string): boolean {
       selector.slice(index + 1, index + 6).toLowerCase() === 'scope' &&
       !/[\w-]/.test(selector[index + 6] ?? '')
     )
-      return true;
+      return index;
   }
-  return false;
+  return null;
+}
+
+export function hasScopePseudoClass(selector: string): boolean {
+  return findScopePseudoClassIndex(selector) !== null;
 }
 
 function parseScopePrelude(cssText: string): ScopePrelude | null {
@@ -901,6 +1026,35 @@ function resolveContainerQueryText(
   return rest.trimStart();
 }
 
+interface ContainerConditionEntry {
+  name: string;
+  query: string;
+}
+
+// `CSSContainerRule.conditions` exposes each entry of a comma-separated
+// `@container` condition list (`@container sidebar (min-width: 20rem),
+// (min-width: 40rem)`) as an independent `{ name, query }` pair. Browsers
+// blank the legacy singular `containerName`/`containerQuery` accessors to
+// `''` once a rule uses this form (verified against real Chromium), so an
+// empty legacy `containerQuery` must not be read as "no condition" when
+// `.conditions` actually holds the real ones — this guard is checked before
+// the legacy accessors specifically so that case is caught. Environments
+// where `.conditions` is absent, not an array, empty, or holds anything
+// that isn't a `{ name: string, query: string }` pair fall through to the
+// legacy single-condition path unchanged (which itself fails closed on an
+// empty `containerQuery`) — this is an enhancement layered on top of that
+// path, not a replacement for it.
+function isContainerConditionList(value: unknown): value is ContainerConditionEntry[] {
+  if (!Array.isArray(value) || value.length === 0) return false;
+  return value.every(
+    (entry) =>
+      typeof entry === 'object' &&
+      entry !== null &&
+      typeof Reflect.get(entry, 'name') === 'string' &&
+      typeof Reflect.get(entry, 'query') === 'string',
+  );
+}
+
 function isContainerQueryActive(
   conditionText: string,
   element: HTMLElement,
@@ -908,8 +1062,26 @@ function isContainerQueryActive(
   getParentElement: ParentElementResolver,
 ): boolean {
   if (typeof getComputedStyle !== 'function') return false;
+  const conditions = Reflect.get(rule, 'conditions');
+  // A comma-separated condition list is active if ANY entry matches — each
+  // entry gets its own independent named-container ancestor resolution and
+  // condition evaluation, OR'd together, matching the
+  // `<container-condition-list>` comma-separated grammar.
+  if (isContainerConditionList(conditions))
+    return conditions.some((condition) =>
+      isSingleContainerConditionActive(condition.query, condition.name, element, getParentElement),
+    );
   const containerName = Reflect.get(rule, 'containerName');
   const queryText = resolveContainerQueryText(conditionText, rule, containerName);
+  return isSingleContainerConditionActive(queryText, containerName, element, getParentElement);
+}
+
+function isSingleContainerConditionActive(
+  queryText: string,
+  containerName: unknown,
+  element: HTMLElement,
+  getParentElement: ParentElementResolver,
+): boolean {
   // A container rule with no condition at all — a name-only rule, or (in
   // legacy environments lacking `containerQuery`) a conditionText that was
   // nothing but the name — has nothing here to evaluate. Real browsers

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -421,14 +421,29 @@ function findActiveScopeRoots(
 // supported exact alternative even when a sibling relative alternative
 // can't be resolved for a given candidate — each selector is tried
 // independently and OR'd together, same as `findScopeMatches`.
+//
+// A candidate root can itself be a `ShadowRoot` — the implicit root of a
+// shadow-owned or adopted stylesheet (see `getImplicitScopeRoot`) — which
+// is never in `element`'s `parentElement` chain. Once that chain runs out,
+// the walk checks whether `element`'s own `getRootNode()` is a `ShadowRoot`
+// among the candidates. A `ShadowRoot` has no attributes, classes, or tag
+// name for a relative selector like `:scope > .child` to match against, so
+// it can only ever satisfy the exact `:scope` degenerate case, and is
+// tested by direct candidate membership rather than run through
+// `matchesScopedSelector` (which requires an `Element`). The walk stops at
+// that boundary instead of crossing into `.host`: every root this function
+// returns must DOM-contain `element` — the same invariant the
+// empty-root-selector branch above enforces via `root.contains(element)` —
+// and an ancestor found by crossing into the light DOM would violate it.
 function findRelativeScopeRootMatches(
   element: HTMLElement,
   selectors: readonly string[],
   scopeRootCandidates: readonly ScopeRoot[],
-): Element[] {
+): ScopeRoot[] {
   if (selectors.length === 0 || scopeRootCandidates.length === 0) return [];
   const parentScope: ActiveScope = { roots: [...scopeRootCandidates] };
-  const matches: Element[] = [];
+  const hasExactScopeSelector = selectors.some(isExactScopeSelector);
+  const matches: ScopeRoot[] = [];
   let current: Element | null = element;
   while (current) {
     const currentElement: Element = current;
@@ -436,9 +451,29 @@ function findRelativeScopeRootMatches(
       selectors.some((selector) => matchesScopedSelector(currentElement, selector, [parentScope]))
     )
       matches.push(currentElement);
-    current = currentElement.parentElement;
+    const parent = currentElement.parentElement;
+    if (parent) {
+      current = parent;
+      continue;
+    }
+    const root = currentElement.getRootNode();
+    if (
+      typeof ShadowRoot !== 'undefined' &&
+      root instanceof ShadowRoot &&
+      hasExactScopeSelector &&
+      scopeRootCandidates.includes(root)
+    )
+      matches.push(root);
+    current = null;
   }
   return matches;
+}
+
+// A selector counts as the exact `:scope` degenerate case (see
+// `findRelativeScopeRootMatches`) only when it's nothing but the bare
+// token — no compounding, no combinator.
+function isExactScopeSelector(selector: string): boolean {
+  return selector.trim().toLowerCase() === ':scope';
 }
 
 function finalizeActiveScopeRoots(
@@ -545,8 +580,28 @@ function matchesScopedSelector(
   // plain (and, for the combinator form, invalid) `element.matches()` call.
   const normalizedSelector =
     scopes.length > 0 ? normalizeScopeRelativeSelector(selector) : selector;
-  if (!hasScopePseudoClass(normalizedSelector))
-    return matchesSelectorSafely(element, normalizedSelector);
+  // Selector-list alternatives are independent per the CSS grammar's
+  // comma-list semantics — splitting on top-level commas before matching
+  // (same discipline `combineNestedSelectors` and
+  // `normalizeScopeRelativeSelector` already use) is what keeps an item
+  // with no scope-root context of its own from being gated by a SIBLING
+  // alternative's context. `.shell, main :scope .other` is the case that
+  // breaks without this: `.shell` must match on its own merit — the `main`
+  // outside-ancestor requirement belongs only to the second alternative.
+  return splitSelectorList(normalizedSelector).some((item) =>
+    matchesScopedSelectorItem(element, item, scopes),
+  );
+}
+
+// Matches a single selector-list ITEM (no top-level commas) against
+// `element`, resolving `:scope` (if present) against the active scope's
+// root candidates.
+function matchesScopedSelectorItem(
+  element: Element,
+  selector: string,
+  scopes: readonly ActiveScope[],
+): boolean {
+  if (!hasScopePseudoClass(selector)) return matchesSelectorSafely(element, selector);
   if (scopes.length === 0) return false;
   const scope = scopes.at(-1);
   if (!scope) return false;
@@ -558,8 +613,8 @@ function matchesScopedSelector(
   // ancestor chain — see `matchesOutsideScopeContext`. Only the remainder
   // (`:scope` onward) goes through the clone-based matcher, which already
   // correctly handles everything relative to the root itself.
-  const outsideContext = splitScopeOutsideContext(normalizedSelector);
-  const remainderSelector = outsideContext ? outsideContext.remainder : normalizedSelector;
+  const outsideContext = splitScopeOutsideContext(selector);
+  const remainderSelector = outsideContext ? outsideContext.remainder : selector;
   for (const root of scope.roots) {
     try {
       if (outsideContext) {
@@ -592,8 +647,18 @@ interface ScopeOutsideContext {
 // `:scope` is the first meaningful token (nothing precedes it) or is
 // compounded directly onto the preceding simple selector (`a:scope`, no
 // combinator between them) — neither references anything outside the root.
+//
+// Looks up `:scope` with `topLevelOnly: true`: a `:scope` nested inside a
+// functional pseudo-class's arguments (`:is(main :scope .shell,
+// .fallback)`) has no ancestor context this text-slicing split can extract
+// on its own — the text before it (`:is(main`) isn't a real selector at
+// all. Treating that as "no `:scope` here to split around" leaves the
+// selector whole, so it goes to `matchesRemainderAgainstScopeRoot` intact
+// (resolving `:scope` natively, scoped to the root, via `querySelectorAll`)
+// instead of being misread as literal outside-ancestor text feeding a
+// `closest()` call that would throw on the unbalanced fragment.
 function splitScopeOutsideContext(selector: string): ScopeOutsideContext | null {
-  const scopeIndex = findScopePseudoClassIndex(selector);
+  const scopeIndex = findScopePseudoClassIndex(selector, { topLevelOnly: true });
   if (scopeIndex === null) return null;
   const beforeRaw = selector.slice(0, scopeIndex);
   if (!beforeRaw.trim()) return null;
@@ -765,11 +830,18 @@ export function replaceScopePseudoClass(selector: string, replacement: string): 
 // Locates the start index of the first actual `:scope` pseudo-class token
 // (not `:scopeX`/`:scoped`, and not inside a quoted string or an attribute
 // selector's brackets), or `null` when the selector has none. Shared by
-// `hasScopePseudoClass` and `splitScopeOutsideContext`, which both need to
-// distinguish a real `:scope` token from lookalike text.
-function findScopePseudoClassIndex(selector: string): number | null {
+// `hasScopePseudoClass` (any depth — it only asks "does this text mention
+// `:scope` at all") and `splitScopeOutsideContext` (`topLevelOnly: true` —
+// a `:scope` nested inside a functional pseudo-class's arguments, like
+// `:is(main :scope .shell, .fallback)`, isn't one that split can extract
+// real outside-ancestor context around).
+function findScopePseudoClassIndex(
+  selector: string,
+  options: { topLevelOnly?: boolean } = {},
+): number | null {
   let quote: string | null = null;
   let brackets = 0;
+  let parentheses = 0;
   let escaped = false;
   for (let index = 0; index < selector.length; index += 1) {
     const character = selector[index];
@@ -797,8 +869,17 @@ function findScopePseudoClassIndex(selector: string): number | null {
       brackets = Math.max(0, brackets - 1);
       continue;
     }
+    if (character === '(') {
+      parentheses += 1;
+      continue;
+    }
+    if (character === ')') {
+      parentheses = Math.max(0, parentheses - 1);
+      continue;
+    }
     if (
       brackets === 0 &&
+      (!options.topLevelOnly || parentheses === 0) &&
       character === ':' &&
       selector.slice(index + 1, index + 6).toLowerCase() === 'scope' &&
       !/[\w-]/.test(selector[index + 6] ?? '')

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -1761,6 +1761,95 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('binds a nested exact :scope root to an enclosing ShadowRoot scope root', () => {
+    // Same shape as the previous test, but the ENCLOSING scope's root is
+    // itself a `ShadowRoot` (the implicit root of a shadow-owned
+    // stylesheet — see 'uses the enclosing shadow root as the implicit
+    // scope root' above), not an `Element`. `findRelativeScopeRootMatches`
+    // used to walk only `parentElement` ancestors, so a `ShadowRoot`
+    // candidate was silently unreachable and the inner `@scope (:scope)`
+    // never activated.
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+    const host = document.createElement('div');
+    const shadowRoot = host.attachShadow({ mode: 'open' });
+    const styleElement = document.createElement('style');
+    const target = document.createElement('div');
+    target.className = 'shell';
+    shadowRoot.append(styleElement, target);
+    document.body.append(host);
+    const innerScope = {
+      type: 0,
+      cssText: '@scope (:scope) {}',
+      cssRules: [createStyleRule({ selectorText: '.shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    const outerScope = {
+      type: 0,
+      cssText: '@scope {}',
+      cssRules: [innerScope],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerScope], ownerNode: styleElement }], () =>
+          resolveTextDirection(target, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
+  test('binds a nested exact :scope root to an enclosing ShadowRoot root for an adopted stylesheet', () => {
+    // Same bug as the previous test, but for an ownerless ADOPTED
+    // stylesheet — `getImplicitScopeRoot` reaches the `ShadowRoot` via the
+    // sheet's shadow-root association (`fallbackRoot`) instead of walking
+    // up from an `ownerNode`, which is likewise a `ShadowRoot` the
+    // enclosing scope's root must resolve to.
+    const originalWindowGetComputedStyle = window.getComputedStyle;
+    const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
+    const getComputedStyleOverride = ((target: Element) => {
+      const style = originalWindowGetComputedStyle(target);
+      Object.defineProperty(style, 'direction', { value: 'ltr', configurable: true });
+      return style;
+    }) as typeof window.getComputedStyle;
+    window.getComputedStyle = getComputedStyleOverride;
+    globalThis.getComputedStyle = getComputedStyleOverride;
+    try {
+      const host = document.createElement('div');
+      const shadowRoot = host.attachShadow({ mode: 'open' });
+      const target = document.createElement('div');
+      target.className = 'shell';
+      shadowRoot.append(target);
+      document.body.append(host);
+      const innerScope = {
+        type: 0,
+        cssText: '@scope (:scope) {}',
+        cssRules: [createStyleRule({ selectorText: '.shell', direction: 'ltr' })],
+      } as unknown as CSSRule;
+      const outerScope = {
+        type: 0,
+        cssText: '@scope {}',
+        cssRules: [innerScope],
+      };
+      Object.defineProperty(shadowRoot, 'adoptedStyleSheets', {
+        configurable: true,
+        value: [{ cssRules: [outerScope] }],
+      });
+      expect(resolveTextDirection(target, 'rtl')).toBe('ltr');
+    } finally {
+      window.getComputedStyle = originalWindowGetComputedStyle;
+      globalThis.getComputedStyle = originalGlobalGetComputedStyle;
+    }
+  });
+
   test('binds a nested relative :scope root selector to the enclosing scope root', () => {
     // `@scope (.parent) { @scope (:scope > .child) { .shell { … } } }` — a
     // relative (non-exact) `:scope` scope-start selector attached to a
@@ -1887,6 +1976,58 @@ describe('resolveTextDirection', () => {
         resolveTextDirection(target, 'rtl'),
       ),
     ).toBe('rtl');
+  });
+
+  test('evaluates each selector-list alternative independently around outside-ancestor context', () => {
+    // `.shell, main :scope .other` — the SECOND alternative's `main`
+    // outside-ancestor requirement must not gate the FIRST, unrelated
+    // alternative. `.shell` matches the target directly regardless of
+    // whether `main` is an ancestor of the scope root (it isn't, here).
+    const theme = document.createElement('section');
+    theme.className = 'theme';
+    const target = document.createElement('div');
+    target.className = 'shell';
+    theme.append(target);
+    document.body.append(theme);
+    const scopeRule = {
+      type: 0,
+      cssText: '@scope (.theme) {}',
+      cssRules: [createStyleRule({ selectorText: '.shell, main :scope .other', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [scopeRule] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('ltr');
+  });
+
+  test('does not let a :scope nested inside :is() misread the selector as outside-ancestor context', () => {
+    // `:is(main :scope .shell, .fallback)` — the `:scope` inside `:is()`
+    // must not be treated as a TOP-LEVEL token: doing so slices `:is(main`
+    // off as literal "outside-ancestor" text, which can never resolve
+    // (`:is(main` isn't a real selector), losing the ordinary `.fallback`
+    // alternative along with it.
+    const theme = document.createElement('section');
+    theme.className = 'theme';
+    const target = document.createElement('div');
+    target.className = 'fallback';
+    theme.append(target);
+    document.body.append(theme);
+    const scopeRule = {
+      type: 0,
+      cssText: '@scope (.theme) {}',
+      cssRules: [
+        createStyleRule({
+          selectorText: ':is(main :scope .shell, .fallback)',
+          direction: 'ltr',
+        }),
+      ],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [scopeRule] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('ltr');
   });
 
   test('resolves a native CSS nesting parent selector before matching direction rules', () => {

--- a/packages/components/src/_internal/text-direction.test.ts
+++ b/packages/components/src/_internal/text-direction.test.ts
@@ -765,6 +765,11 @@ describe('resolveTextDirection', () => {
   });
 
   test('does not activate the implicit root for an unsupported scope-pseudo selector', () => {
+    // `:scope > .foo` IS now resolved (see the relative-`:scope`-root tests
+    // below) — this stays 'rtl' because nothing at the top level is a
+    // direct child of the implicit root matching `.foo`, and `.theme`
+    // doesn't match anywhere either. It's a genuine non-match, not an
+    // unsupported-selector short-circuit.
     const target = document.createElement('div');
     target.className = 'shell';
     document.body.append(target);
@@ -778,6 +783,30 @@ describe('resolveTextDirection', () => {
         resolveTextDirection(target, 'rtl'),
       ),
     ).toBe('rtl');
+  });
+
+  test('preserves the exact :scope alternative in an all-:scope root list when the other alternative cannot resolve', () => {
+    // `@scope (:scope, :scope > .theme)` — the relative `:scope > .theme`
+    // alternative doesn't structurally resolve to anything here (nothing
+    // named `.theme` is a direct child of the implicit scope root), but the
+    // supported exact `:scope` alternative must still independently
+    // activate the scope. Previously, ANY non-exact `:scope`-containing
+    // root selector in an all-`:scope` list (no ordinary selector to fall
+    // back on) caused the whole prelude to fail closed, losing the exact
+    // alternative too.
+    const target = document.createElement('div');
+    target.className = 'shell';
+    document.body.append(target);
+    const scopeRule = {
+      type: 0,
+      cssText: '@scope (:scope, :scope > .theme) {}',
+      cssRules: [createStyleRule({ selectorText: '.shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [scopeRule] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('ltr');
   });
 
   test('uses the document root for exact :scope scopes in document stylesheets', () => {
@@ -1201,6 +1230,39 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('resolves outside-ancestor context in a :scope limit selector', () => {
+    // Limit selectors are evaluated through the same `matchesScopedSelector`
+    // as rule selectors, so the outside-ancestor-context fix applies here
+    // too: `to (main :scope > .stop)` requires the scope root to actually
+    // have a `main` ancestor before the `.stop` boundary can be recognized.
+    // Losing that outside context (as the clone-only fallback previously
+    // did) would make the limit unrecognizable and leave the scope
+    // active past its real boundary — the unsafe direction for a limit,
+    // since a limit that never triggers over-applies the scope's rules
+    // rather than under-applying them.
+    const main = document.createElement('main');
+    const root = document.createElement('section');
+    root.className = 'theme';
+    const stop = document.createElement('div');
+    stop.className = 'stop';
+    const target = document.createElement('div');
+    target.className = 'shell';
+    stop.append(target);
+    root.append(stop);
+    main.append(root);
+    document.body.append(main);
+    const scopeRule = {
+      type: 0,
+      cssText: '@scope (.theme) to (main :scope > .stop) {}',
+      cssRules: [createStyleRule({ selectorText: '.shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [scopeRule] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('rtl');
+  });
+
   test('requires nested scopes to intersect every enclosing scope', () => {
     const originalWindowGetComputedStyle = window.getComputedStyle;
     const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
@@ -1566,6 +1628,30 @@ describe('resolveTextDirection', () => {
     }
   });
 
+  test('normalizes each item of a rule selector list independently for leading combinators', () => {
+    // `.unused, > .shell` — only the SECOND alternative needs its leading
+    // combinator rewritten to `:scope > .shell`; normalization must operate
+    // per comma-separated item, not gate on whether the whole list starts
+    // with a combinator (the list as a whole starts with `.unused`, so a
+    // whole-string check would leave the second alternative untouched).
+    const root = document.createElement('section');
+    root.className = 'theme';
+    const child = document.createElement('div');
+    child.className = 'shell';
+    root.append(child);
+    document.body.append(root);
+    const scopeRule = {
+      type: 0,
+      cssText: '@scope (.theme) {}',
+      cssRules: [createStyleRule({ selectorText: '.unused, > .shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [scopeRule] }], () =>
+        resolveTextDirection(child, 'rtl'),
+      ),
+    ).toBe('ltr');
+  });
+
   test('does not create a limit element for a limit that references :scope', () => {
     const originalWindowGetComputedStyle = window.getComputedStyle;
     const originalGlobalGetComputedStyle = globalThis.getComputedStyle;
@@ -1673,6 +1759,134 @@ describe('resolveTextDirection', () => {
       window.getComputedStyle = originalWindowGetComputedStyle;
       globalThis.getComputedStyle = originalGlobalGetComputedStyle;
     }
+  });
+
+  test('binds a nested relative :scope root selector to the enclosing scope root', () => {
+    // `@scope (.parent) { @scope (:scope > .child) { .shell { … } } }` — a
+    // relative (non-exact) `:scope` scope-start selector attached to a
+    // combinator must resolve by testing candidate ancestors of the target
+    // against the enclosing scope's root(s), not fail closed just because
+    // it isn't the bare `:scope` token.
+    const parent = document.createElement('section');
+    parent.className = 'parent';
+    const child = document.createElement('div');
+    child.className = 'child';
+    const target = document.createElement('div');
+    target.className = 'shell';
+    child.append(target);
+    parent.append(child);
+    document.body.append(parent);
+    const innerScope = {
+      type: 0,
+      cssText: '@scope (:scope > .child) {}',
+      cssRules: [createStyleRule({ selectorText: '.shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    const outerScope = {
+      type: 0,
+      cssText: '@scope (.parent) {}',
+      cssRules: [innerScope],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [outerScope] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('ltr');
+  });
+
+  test('does not promote a coincidentally-shaped descendant as a relative :scope root match', () => {
+    // Regression guard for the resolution mechanism itself: the enclosing
+    // scope's root (`.parent`) has no direct child matching `.child` — its
+    // real direct child is a plain wrapper `<div>`. A DIFFERENT, deeper
+    // descendant happens to be shaped identically (same tag, same
+    // first-child position relative to its own real parent) and DOES have a
+    // direct child named `.child`. Root resolution must use the real
+    // ancestor/DOM relationship, not a structural coincidence, or this
+    // would incorrectly promote the deeper element's child as a scope root.
+    const parent = document.createElement('section');
+    parent.className = 'parent';
+    const wrapperDiv = document.createElement('div');
+    const decoy = document.createElement('section');
+    const child = document.createElement('div');
+    child.className = 'child';
+    const target = document.createElement('div');
+    target.className = 'shell';
+    child.append(target);
+    decoy.append(child);
+    wrapperDiv.append(decoy);
+    parent.append(wrapperDiv);
+    document.body.append(parent);
+    const innerScope = {
+      type: 0,
+      cssText: '@scope (:scope > .child) {}',
+      cssRules: [createStyleRule({ selectorText: '.shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    const outerScope = {
+      type: 0,
+      cssText: '@scope (.parent) {}',
+      cssRules: [innerScope],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [outerScope] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('rtl');
+  });
+
+  test('resolves outside-ancestor context for a scoped rule selector', () => {
+    // `@scope (.theme) { main :scope .shell { … } }` — `main` describes
+    // context OUTSIDE the scope root, which the clone-based matcher (which
+    // only ever clones the root's own subtree) can never see on its own.
+    // The outside portion must be verified against the scope root's real,
+    // unmutated, uncloned ancestor chain instead.
+    const main = document.createElement('main');
+    const theme = document.createElement('section');
+    theme.className = 'theme';
+    const target = document.createElement('div');
+    target.className = 'shell';
+    theme.append(target);
+    main.append(theme);
+    document.body.append(main);
+    const scopeRule = {
+      type: 0,
+      cssText: '@scope (.theme) {}',
+      cssRules: [createStyleRule({ selectorText: 'main :scope .shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [scopeRule] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('ltr');
+  });
+
+  test('does not satisfy outside-ancestor context via a coincidentally-shaped descendant', () => {
+    // Regression guard for the outside-context check itself: the scope root
+    // (`.theme`) has NO `main` ancestor at all. A deeper descendant happens
+    // to share the root's exact tag+position shape AND does have a `main`
+    // ancestor (inserted between the root and that descendant). The
+    // outside-ancestor check must verify the ROOT's own real ancestor
+    // chain specifically, not any coincidentally-shaped descendant's.
+    const outerDiv = document.createElement('div');
+    const theme = document.createElement('section');
+    theme.className = 'theme';
+    const main = document.createElement('main');
+    const decoy = document.createElement('section');
+    const target = document.createElement('div');
+    target.className = 'shell';
+    decoy.append(target);
+    main.append(decoy);
+    theme.append(main);
+    outerDiv.append(theme);
+    document.body.append(outerDiv);
+    const scopeRule = {
+      type: 0,
+      cssText: '@scope (.theme) {}',
+      cssRules: [createStyleRule({ selectorText: 'main :scope .shell', direction: 'ltr' })],
+    } as unknown as CSSRule;
+    expect(
+      withDocumentStyleSheets([{ cssRules: [scopeRule] }], () =>
+        resolveTextDirection(target, 'rtl'),
+      ),
+    ).toBe('rtl');
   });
 
   test('resolves a native CSS nesting parent selector before matching direction rules', () => {
@@ -2746,6 +2960,206 @@ describe('resolveTextDirection', () => {
       type: 0,
       conditionText: 'sidebar',
       containerName: 'sidebar',
+      containerQuery: '',
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('rtl');
+    } finally {
+      container.remove();
+    }
+  });
+
+  test('evaluates a comma-separated @container condition list, matching a later entry when an earlier named entry misses', () => {
+    // `CSSContainerRule.conditions` exposes each comma-separated entry as an
+    // independent `{ name, query }` pair, blanking the legacy singular
+    // `containerName`/`containerQuery` accessors to `''` (verified against
+    // real Chromium). No ancestor is named "sidebar", so the first entry
+    // can never match; the second (unnamed) entry must still be evaluated
+    // independently against the nearest queryable container and match on
+    // its own.
+    const container = document.createElement('section');
+    container.style.setProperty('container-type', 'inline-size');
+    Object.defineProperty(container, 'offsetWidth', { value: 700, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'condition-list-second-match-ltr';
+    container.appendChild(element);
+    document.body.appendChild(container);
+    const nestedRule = createStyleRule({
+      selectorText: '.condition-list-second-match-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText:
+        '@container sidebar (min-width: 20rem), (min-width: 40rem) { .condition-list-second-match-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: 'sidebar (min-width: 20rem), (min-width: 40rem)',
+      containerName: '',
+      containerQuery: '',
+      conditions: [
+        { name: 'sidebar', query: '(min-width: 20rem)' },
+        { name: '', query: '(min-width: 40rem)' },
+      ],
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      container.remove();
+    }
+  });
+
+  test('evaluates a named first entry independently of an unmatched unnamed second entry in a condition list', () => {
+    // The inverse mix: the FIRST (named) entry matches its own
+    // independently-resolved named ancestor while the SECOND (unnamed)
+    // entry, resolved against the nearest queryable container regardless of
+    // name, does not — proving each entry gets its own ancestor resolution
+    // rather than sharing one across the whole list.
+    const sidebar = document.createElement('section');
+    sidebar.style.setProperty('container-type', 'inline-size');
+    sidebar.style.setProperty('container-name', 'sidebar');
+    Object.defineProperty(sidebar, 'offsetWidth', { value: 700, configurable: true });
+    const wrapper = document.createElement('div');
+    wrapper.style.setProperty('container-type', 'inline-size');
+    Object.defineProperty(wrapper, 'offsetWidth', { value: 100, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'condition-list-first-match-ltr';
+    wrapper.appendChild(element);
+    sidebar.appendChild(wrapper);
+    document.body.appendChild(sidebar);
+    const nestedRule = createStyleRule({
+      selectorText: '.condition-list-first-match-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText:
+        '@container sidebar (min-width: 20rem), (min-width: 40rem) { .condition-list-first-match-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: 'sidebar (min-width: 20rem), (min-width: 40rem)',
+      containerName: '',
+      containerQuery: '',
+      conditions: [
+        { name: 'sidebar', query: '(min-width: 20rem)' },
+        { name: '', query: '(min-width: 40rem)' },
+      ],
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('ltr');
+    } finally {
+      sidebar.remove();
+    }
+  });
+
+  test('fails closed when no entry in a comma-separated @container condition list matches', () => {
+    const container = document.createElement('section');
+    container.style.setProperty('container-type', 'inline-size');
+    Object.defineProperty(container, 'offsetWidth', { value: 100, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'condition-list-no-match-ltr';
+    container.appendChild(element);
+    document.body.appendChild(container);
+    const nestedRule = createStyleRule({
+      selectorText: '.condition-list-no-match-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText:
+        '@container (min-width: 20rem), (min-width: 40rem) { .condition-list-no-match-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: '(min-width: 20rem), (min-width: 40rem)',
+      containerName: '',
+      containerQuery: '',
+      conditions: [
+        { name: '', query: '(min-width: 20rem)' },
+        { name: '', query: '(min-width: 40rem)' },
+      ],
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('rtl');
+    } finally {
+      container.remove();
+    }
+  });
+
+  test('fails closed when every entry in a comma-separated @container condition list is unparseable', () => {
+    // Distinct from "no entry matches": these entries use size features and
+    // units this module's grammar doesn't implement at all
+    // (`hasUnsupportedContainerSizeQuery`), not ones that are merely
+    // structurally false at the container's current size.
+    const container = document.createElement('section');
+    container.style.setProperty('container-type', 'inline-size');
+    Object.defineProperty(container, 'offsetWidth', { value: 700, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'condition-list-unparseable-ltr';
+    container.appendChild(element);
+    document.body.appendChild(container);
+    const nestedRule = createStyleRule({
+      selectorText: '.condition-list-unparseable-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText:
+        '@container (min-height: 40rem), (min-width: 30em) { .condition-list-unparseable-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: '(min-height: 40rem), (min-width: 30em)',
+      containerName: '',
+      containerQuery: '',
+      conditions: [
+        { name: '', query: '(min-height: 40rem)' },
+        { name: '', query: '(min-width: 30em)' },
+      ],
+      cssRules: [nestedRule],
+    } as unknown as CSSRule;
+    try {
+      expect(
+        withDocumentStyleSheets([{ cssRules: [outerRule] }], () =>
+          resolveTextDirection(element, 'rtl'),
+        ),
+      ).toBe('rtl');
+    } finally {
+      container.remove();
+    }
+  });
+
+  test('fails closed for a comma-separated @container condition list when .conditions is absent', () => {
+    // Environments lacking `CSSContainerRule.conditions` keep falling
+    // closed exactly as before this module understood the property at
+    // all — this is an enhancement, not a requirement to polyfill it.
+    const container = document.createElement('section');
+    container.style.setProperty('container-type', 'inline-size');
+    Object.defineProperty(container, 'offsetWidth', { value: 700, configurable: true });
+    const element = document.createElement('div');
+    element.className = 'condition-list-no-conditions-property-ltr';
+    container.appendChild(element);
+    document.body.appendChild(container);
+    const nestedRule = createStyleRule({
+      selectorText: '.condition-list-no-conditions-property-ltr',
+      direction: 'ltr',
+    });
+    const outerRule = {
+      cssText:
+        '@container (min-width: 20rem), (min-width: 40rem) { .condition-list-no-conditions-property-ltr { direction: ltr; } }',
+      type: 0,
+      conditionText: '(min-width: 20rem), (min-width: 40rem)',
+      containerName: '',
       containerQuery: '',
       cssRules: [nestedRule],
     } as unknown as CSSRule;


### PR DESCRIPTION
## Summary

Closes #1137
Closes #1138

Implements the text-direction spec-parity backlog for comma-separated `@container` condition lists and the remaining `@scope` `:scope` gaps, both in `packages/components/src/_internal/text-direction-css.ts`.

## #1137 — comma-separated `@container` condition lists

`CSSContainerRule.conditions` exposes each comma-separated entry (`@container sidebar (min-width: 20rem), (min-width: 40rem)`) as an independent `{ name, query }` pair; browsers blank the legacy singular `containerName`/`containerQuery` accessors to `''` once a rule uses this form, so an empty legacy `containerQuery` was previously read as "no condition" and the rule failed closed.

- `isContainerQueryActive` now checks for `.conditions` first (via a new `isContainerConditionList` type guard) and, when present, evaluates each `{ name, query }` entry independently — each entry gets its own named-container ancestor resolution, OR'd together (matches the `<container-condition-list>` grammar).
- The single-condition body was extracted into `isSingleContainerConditionActive(queryText, containerName, element, getParentElement)`, reused by both the new list path and the existing legacy-accessor path — no behavior change for rules without `.conditions`.
- Environments lacking `.conditions` (or where it isn't a non-empty array of `{name, query}` pairs) fall through to the legacy path unchanged.

Tests: a two-entry list where only the second (unnamed) entry matches; the inverse mix where only the first (named) entry matches; all-entries-non-matching fails closed; all-entries-unparseable (unsupported feature/unit) fails closed; `.conditions` absent falls back to legacy behavior.

## #1138 — relative `:scope` and outside-ancestor `:scope` selectors

**1. Relative (non-exact) `:scope` scope-start selectors** (`@scope (:scope > .child)`): `findActiveScopeRoots` previously only resolved the exact `:scope` token, short-circuiting to `null` for any compound/combinator form. Replaced the `unsupportedScopeRoot` special-casing with `findRelativeScopeRootMatches`, which walks candidate ancestors of the target (like `findScopeMatches` does for ordinary root selectors) and tests each one via `matchesScopedSelector` against the enclosing scope's root candidates. Exact `:scope` is just the degenerate case of this same walk.

**2. Detached-clone fallback loses outside-ancestor context** (`main :scope .shell`): the clone-based fallback (used in environments — including this suite's happy-dom harness — where `root.querySelector(':scope') === root` doesn't hold) only ever clones the scope root's own subtree, so a selector referencing something *outside* the root could never match. `matchesScopedSelector` now splits real outside-ancestor context off the selector (`splitScopeOutsideContext`) and verifies it against the scope root's REAL, unmutated ancestor/sibling chain (`matchesOutsideScopeContext`, via `closest`/`matches`/sibling pointers — exact DOM-reference checks, not pattern matching). Only the remainder (`:scope` onward) goes through the clone-based matcher, which already handles everything relative to the root correctly. This also fixes the same class of bug for `:scope`-relative *limit* selectors (`to (main :scope > .stop)`), since limits are evaluated through the same function — pinned with its own regression test.

   An earlier structural-compound approach (`tag:nth-child(n)` substituted for `:scope`) was rejected during implementation: it's provably vulnerable to false positives when the real ancestor chain contains a coincidentally-identically-shaped element (same tag + sibling position) elsewhere on the path — verified by constructing a failing probe before landing the `closest`/`matches`-based design instead. Two regression tests pin that a coincidentally-shaped descendant can't be promoted as a false match (one for the outside-context check, one for relative-root resolution).

**3. Mixed all-`:scope` root lists** (`@scope (:scope, :scope > .theme)`): previously, ANY non-exact `:scope`-containing root selector with no ordinary-selector alternative caused the *whole* prelude to fail closed, losing the exact `:scope` alternative too. Falls out of the item-1 fix: each selector in the list is now tried independently and OR'd, so the exact alternative survives regardless of whether a sibling relative alternative resolves.

**4. Per-item normalization of relative selectors in rule selector lists** (`.unused, > .shell`): `normalizeScopeRelativeSelector`'s cheap-exit guard checked whether the *whole* selector-list string started with `&`/a combinator, so `.unused, > .shell` (which starts with `.unused`) left the second alternative's leading combinator un-rewritten. The guard now runs per comma-separated item after splitting, not on the whole string.

Every item has a red-before-green regression test, verified by stashing the source change and confirming the new tests failed as expected (non-behavioral fail-closed test cases correctly stayed green in both states — they pin invariants, not the fix itself).

## Validation

- `bun run test text-direction` (packages/components): 134 pass, 0 fail (122 baseline + 12 new).
- Full `bun run test` (packages/components, whole package): 9552 pass, 1 skip, 2 fail. Both failures (`z-index-scale.test.ts` — wall-clock perf-budget assertions, e.g. "builds wide clamp placeholders in linear time") are in a file this PR never touches; re-running `bun run test z-index-scale` in isolation (no concurrent load) passed 1315/1315 cleanly, confirming the two failures were caused by heavy concurrent multi-worktree CPU load on the machine at the time, not a regression from this change.
- `prettier --check` clean on all changed files.
- `oxlint --type-aware` clean on all changed files (0 warnings/errors).
- `tsc --noEmit -p tsconfig.check.json` clean.
- Changeset added (`patch`, `@lostgradient/cinder`).
- Rebased onto current `origin/main` tip before pushing.

## Notes for reviewers

- `packages/components/src/_internal/text-direction-css.ts` was already ~1184 lines before this change (over the repo's 500-line guideline for implementation files) and is now ~1300. This PR does not split it — a structural split (e.g. a new `text-direction-scope.ts` alongside the existing `text-direction-container.ts`) is a separate, reviewable refactor with its own diff. The natural boundary is scope-matching (~341–1010) vs. container-query evaluation (~1011–1266) vs. rule-list traversal, with a single internal consumer (`text-direction.ts`) plus this test file's direct imports, so a future split's blast radius looks small.
- `svelte-check` (`bunx svelte-check --workspace src --tsconfig ../tsconfig.json --threshold error`) reports 5 pre-existing errors in unrelated files (bento-grid, checkbox, time-field, speed-dial-action) — confirmed pre-existing by re-running with this PR's two changed files stashed out on the same tree; unrelated to `@scope`/`@container`/text-direction and out of scope here.
