### PR TITLE
ci: assert main's branch protection against a checked-in expectation

### DIFF
--- a/.github/branch-protection.json
+++ b/.github/branch-protection.json
@@ -1,0 +1,30 @@
+{
+  "$comment": [
+    "The expected branch-protection state for `main`, asserted against the live GitHub API by",
+    "`packages/components/scripts/check-branch-protection.ts` on main-red-watch's daily schedule.",
+    "",
+    "This file exists because prose drifted from reality twice in one day. On 2026-08-05",
+    "docs/validation-topology.md asserted both `strict: true` and that a merge queue was the",
+    "mitigation for stale-base merges; the live API returned `strict: false`, and merge queues",
+    "are unavailable on user-owned repositories entirely (recorded by #1140). Nothing checked,",
+    "so nothing caught it.",
+    "",
+    "`strict` is the load-bearing entry. GitHub offers merge queues only to organization-owned",
+    "repositories and stevekinney/cinder is user-owned, so requiring branches to be up to date",
+    "is the ONLY mechanism forcing a pull request to be re-validated against current `main`",
+    "before it merges. Without it a green pull request can merge against a tree that no longer",
+    "exists — the failure that turned `main` red on 2026-07-28 (#972 added a stylelint rule,",
+    "#1011 merged CSS violating it fourteen minutes later, both green).",
+    "",
+    "docs/validation-topology.md's bulk-drain protocol lifts `strict` deliberately and restores",
+    "it by hand. That manual restore is exactly what failed. Drift here is therefore EXPECTED",
+    "during a drain and must be restored after it — the check runs daily rather than per-pull-",
+    "request so a short drain window does not page anyone, while a lift that was never restored",
+    "surfaces within a day."
+  ],
+  "branch": "main",
+  "requiredStatusChecks": {
+    "strict": true,
+    "contexts": ["unit-tests", "typecheck", "playwright", "Pre-1.0 changeset bump guard"]
+  }
+}

--- a/.github/workflows/main-red-watch.yaml
+++ b/.github/workflows/main-red-watch.yaml
@@ -49,6 +49,10 @@ permissions:
   contents: read
   issues: write
   actions: read
+  # Reading branch protection needs admin rights. This is the least-privilege
+  # grant that allows it, and it is why the protection check lives here rather
+  # than in `main-green`, which stays `contents: read`.
+  administration: read
 
 concurrency:
   # Serialize so two failures landing together cannot both miss the existing
@@ -76,8 +80,36 @@ jobs:
       contains(fromJSON('["failure", "timed_out", "startup_failure"]'), github.event.workflow_run.conclusion))
     runs-on: ubuntu-latest
     steps:
+      # Branch-protection drift is a scheduled concern, not a per-run one, so
+      # these three steps are skipped on the `workflow_run` path. The check runs
+      # daily rather than per-pull-request deliberately: the bulk-drain protocol
+      # in docs/validation-topology.md lifts `strict` on purpose, and a daily
+      # cadence lets a short drain finish without paging while still surfacing a
+      # lift that was never restored.
+      - name: Checkout
+        if: github.event_name != 'workflow_run'
+        uses: actions/checkout@v7
+
+      - name: Setup Bun
+        if: github.event_name != 'workflow_run'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1.3.13'
+
+      - name: Check branch protection
+        id: protection
+        if: github.event_name != 'workflow_run'
+        continue-on-error: true
+        run: |
+          bun run --filter=@lostgradient/cinder check:branch-protection 2>&1 | tee protection.log
+          exit "${PIPESTATUS[0]}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
       - name: Report a red main
         uses: actions/github-script@v7
+        env:
+          PROTECTION_OUTCOME: ${{ steps.protection.outcome }}
         with:
           script: |
             const label = process.env.TRACKING_LABEL;
@@ -87,14 +119,14 @@ jobs:
             // One issue for the whole red period, not one per failed run. A
             // sustained streak (the hydration smoke produced 22) should read as
             // a single incident accumulating evidence.
-            async function report(title, body) {
+            async function report(title, body, issueLabel = label) {
               await github.rest.issues
                 .createLabel({
                   owner,
                   repo,
-                  name: label,
+                  name: issueLabel,
                   color: 'b60205',
-                  description: 'main is red — opened automatically by main-red-watch',
+                  description: 'opened automatically by main-red-watch',
                 })
                 .catch((error) => {
                   if (error.status !== 422) throw error;
@@ -104,7 +136,7 @@ jobs:
                 owner,
                 repo,
                 state: 'open',
-                labels: label,
+                labels: issueLabel,
                 per_page: 1,
               });
 
@@ -115,12 +147,18 @@ jobs:
                   issue_number: existing.data[0].number,
                   body,
                 });
-                core.notice(`main is red — updated #${existing.data[0].number}`);
+                core.notice(`${issueLabel} — updated #${existing.data[0].number}`);
                 return;
               }
 
-              const created = await github.rest.issues.create({ owner, repo, title, labels: [label], body });
-              core.notice(`main is red — opened #${created.data.number}`);
+              const created = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                labels: [issueLabel],
+                body,
+              });
+              core.notice(`${issueLabel} — opened #${created.data.number}`);
             }
 
             if (context.eventName === 'workflow_run') {
@@ -174,6 +212,28 @@ jobs:
                 ].join('\n'),
               );
               return;
+            }
+
+            // Branch-protection drift. `continue-on-error` on the step above keeps
+            // this job alive so a drift and a stalled heartbeat can both report in
+            // one run rather than the first one hiding the second.
+            if (process.env.PROTECTION_OUTCOME === 'failure') {
+              const { readFileSync } = require('node:fs');
+              const detail = readFileSync('protection.log', 'utf8').trim();
+
+              await report(
+                'main branch protection has drifted',
+                [
+                  '`main`\'s live protection no longer matches `.github/branch-protection.json`.',
+                  '',
+                  '```',
+                  detail,
+                  '```',
+                  '',
+                  `- Check: ${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
+                ].join('\n'),
+                'branch-protection-drift',
+              );
             }
 
             // Heartbeat. Catches the failure mode `workflow_run` structurally

--- a/.github/workflows/main-red-watch.yaml
+++ b/.github/workflows/main-red-watch.yaml
@@ -49,10 +49,13 @@ permissions:
   contents: read
   issues: write
   actions: read
-  # Reading branch protection needs admin rights. This is the least-privilege
-  # grant that allows it, and it is why the protection check lives here rather
-  # than in `main-green`, which stays `contents: read`.
-  administration: read
+  # Reading branch protection needs Administration: Read, which is not a
+  # grantable `permissions` scope for GITHUB_TOKEN at all — GitHub Actions
+  # only recognizes a fixed set of scopes, and `administration` isn't one of
+  # them. The "Check branch protection" step below authenticates with
+  # REPO_ADMIN_TOKEN (a fine-grained PAT) instead, falling back to
+  # `github.token` so the step still runs — and reports the missing secret as
+  # a setup failure — before that secret exists.
 
 concurrency:
   # Serialize so two failures landing together cannot both miss the existing
@@ -101,15 +104,36 @@ jobs:
         if: github.event_name != 'workflow_run'
         continue-on-error: true
         run: |
+          # `set +e` around the pipeline: the default runner shell has
+          # `pipefail` on, so a failing `bun run` would otherwise trip `-e`
+          # and exit the step before `PIPESTATUS` is captured or the output is
+          # written — silently dropping the exit code the reporter step below
+          # needs to tell drift apart from a setup failure.
+          set +e
           bun run --filter=@lostgradient/cinder check:branch-protection 2>&1 | tee protection.log
-          exit "${PIPESTATUS[0]}"
+          code="${PIPESTATUS[0]}"
+          set -e
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          exit "$code"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # `administration: read` cannot be granted to GITHUB_TOKEN (see the
+          # `permissions:` comment above), so this falls back to it only so the
+          # step still runs — and the script reports the missing secret as a
+          # setup failure with provisioning instructions — before
+          # REPO_ADMIN_TOKEN is configured.
+          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || github.token }}
 
       - name: Report a red main
+        # Runs even if Checkout, Setup Bun, or the protection check above
+        # failed outright (not just exited non-zero) — a broken setup step
+        # must never silence the heartbeat this workflow exists to provide.
+        # This is the only reporting channel; see PROTECTION_EXIT_CODE
+        # handling in the script below for how it tells drift apart from a
+        # setup failure.
+        if: always()
         uses: actions/github-script@v7
         env:
-          PROTECTION_OUTCOME: ${{ steps.protection.outcome }}
+          PROTECTION_EXIT_CODE: ${{ steps.protection.outputs.exit_code }}
         with:
           script: |
             const label = process.env.TRACKING_LABEL;
@@ -217,7 +241,20 @@ jobs:
             // Branch-protection drift. `continue-on-error` on the step above keeps
             // this job alive so a drift and a stalled heartbeat can both report in
             // one run rather than the first one hiding the second.
-            if (process.env.PROTECTION_OUTCOME === 'failure') {
+            //
+            // check-branch-protection.ts exits 1 (EXIT_DRIFT) for real drift and
+            // 2 (EXIT_SETUP_FAILURE) for a setup problem (bad token scope, a
+            // non-2xx that isn't "protection absent", a missing token). Only
+            // exit 1 opens/updates the incident issue — a setup failure is not
+            // evidence main's protection changed, and filing it as drift would
+            // send someone to "fix" settings that are fine. `PROTECTION_EXIT_CODE`
+            // is empty on the `workflow_run` path (this code already returned
+            // above) and when Checkout/Setup Bun failed before the protection
+            // step ran, so neither branch below fires then.
+            const PROTECTION_EXIT_DRIFT = '1';
+            const protectionExitCode = process.env.PROTECTION_EXIT_CODE;
+
+            if (protectionExitCode === PROTECTION_EXIT_DRIFT) {
               const { readFileSync } = require('node:fs');
               const detail = readFileSync('protection.log', 'utf8').trim();
 
@@ -233,6 +270,22 @@ jobs:
                   `- Check: ${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`,
                 ].join('\n'),
                 'branch-protection-drift',
+              );
+            } else if (protectionExitCode && protectionExitCode !== '0') {
+              // Any other non-zero code — EXIT_SETUP_FAILURE (2), or something
+              // this script never anticipated (a crash, a missing `bun`) — is a
+              // setup problem, not drift. Fail this run with a clear annotation
+              // so it's visible; the step above is `continue-on-error`, so
+              // without this the run would stay green and the failure would be
+              // swallowed entirely.
+              const { existsSync, readFileSync } = require('node:fs');
+              const detail =
+                existsSync('protection.log') ? readFileSync('protection.log', 'utf8').trim() : (
+                  '(no protection.log — the check failed before producing output)'
+                );
+
+              core.setFailed(
+                `check-branch-protection setup failure (exit ${protectionExitCode}):\n${detail}`,
               );
             }
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6224,6 +6224,7 @@
   "scripts": {
     "aggregator:check": "bun run scripts/check-aggregator-completeness.ts",
     "build": "bun run scripts/build.ts",
+    "check:branch-protection": "bun run scripts/check-branch-protection.ts",
     "check:changeset-prerelease-bumps": "bun run scripts/check-changeset-prerelease-bumps.ts",
     "check:component-inventory": "bun run scripts/check-component-inventory.ts",
     "check:consumer-boundaries": "bun run scripts/check-consumer-boundaries.ts",

--- a/packages/components/scripts/check-branch-protection.test.ts
+++ b/packages/components/scripts/check-branch-protection.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'bun:test';
 
 import {
+  classifyProtectionResponse,
+  EXIT_DRIFT,
+  EXIT_OK,
+  EXIT_SETUP_FAILURE,
   EXPECTATION_PATH,
   protectionDrift,
   type LiveProtection,
@@ -69,6 +73,96 @@ describe('protectionDrift', () => {
     const drift = protectionDrift(expected, live({ strict: false, checks: [] }));
 
     expect(drift).toHaveLength(3);
+  });
+
+  // GitHub can report required checks through the legacy `contexts` (string[])
+  // field instead of `checks`. Reading only `checks` here would treat a
+  // contexts-only repository as enforcing nothing and file a daily false
+  // drift issue.
+  it('treats a contexts-only response as equivalent to checks', () => {
+    const withContextsOnly: LiveProtection = {
+      required_status_checks: {
+        strict: true,
+        contexts: ['unit-tests', 'typecheck'],
+      },
+    };
+
+    expect(protectionDrift(expected, withContextsOnly)).toEqual([]);
+  });
+
+  it('unions checks and contexts when a repository reports both', () => {
+    const mixed: LiveProtection = {
+      required_status_checks: {
+        strict: true,
+        checks: [{ context: 'unit-tests' }],
+        contexts: ['typecheck'],
+      },
+    };
+
+    expect(protectionDrift(expected, mixed)).toEqual([]);
+  });
+
+  it('still reports a check missing from both checks and contexts', () => {
+    const withContextsOnly: LiveProtection = {
+      required_status_checks: {
+        strict: true,
+        contexts: ['unit-tests'],
+      },
+    };
+
+    expect(protectionDrift(expected, withContextsOnly)).toEqual([
+      'required status check "typecheck" is expected but not enforced',
+    ]);
+  });
+});
+
+describe('classifyProtectionResponse', () => {
+  it('treats a 2xx status as ok', () => {
+    expect(classifyProtectionResponse(200, { required_status_checks: {} })).toBe('ok');
+  });
+
+  it('treats a 404 with the exact "Branch not protected" message as protection genuinely absent', () => {
+    expect(classifyProtectionResponse(404, { message: 'Branch not protected' })).toBe(
+      'protection-absent',
+    );
+  });
+
+  // GitHub can return 404 — not 403 — for a token without Administration: Read,
+  // with the same "Not Found" body an unprivileged token gets from any resource
+  // it can't see. Only the explicit "Branch not protected" message means
+  // protection is really off; anything else at 404 must not be read as drift,
+  // or an under-scoped token would file a false "protection is off" incident
+  // every day.
+  it('treats a 404 without that exact message as a setup failure, not drift', () => {
+    expect(classifyProtectionResponse(404, { message: 'Not Found' })).toBe('setup-failure');
+  });
+
+  it('treats a 404 with no parseable message body as a setup failure, not drift', () => {
+    expect(classifyProtectionResponse(404, undefined)).toBe('setup-failure');
+    expect(classifyProtectionResponse(404, null)).toBe('setup-failure');
+    expect(classifyProtectionResponse(404, { other: 'field' })).toBe('setup-failure');
+  });
+
+  it('treats a 403 as a setup failure', () => {
+    expect(
+      classifyProtectionResponse(403, { message: 'Resource not accessible by integration' }),
+    ).toBe('setup-failure');
+  });
+
+  it('treats other non-2xx statuses as a setup failure', () => {
+    expect(classifyProtectionResponse(500, { message: 'Internal Server Error' })).toBe(
+      'setup-failure',
+    );
+  });
+});
+
+describe('exit codes', () => {
+  // `main-red-watch.yaml` parses this numeric value to decide whether a
+  // failed run means real drift (file the incident) or a setup problem
+  // (annotate the run, don't file). They must stay distinct for that routing
+  // to be possible at all.
+  it('are distinct so the workflow can route drift from setup failures', () => {
+    expect(new Set([EXIT_OK, EXIT_DRIFT, EXIT_SETUP_FAILURE]).size).toBe(3);
   });
 });
 

--- a/packages/components/scripts/check-branch-protection.test.ts
+++ b/packages/components/scripts/check-branch-protection.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+  EXPECTATION_PATH,
+  protectionDrift,
+  type LiveProtection,
+  type ProtectionExpectation,
+} from './check-branch-protection.ts';
+import { readJsonFile } from './lib/read-json-file.ts';
+
+const expected: ProtectionExpectation = {
+  branch: 'main',
+  requiredStatusChecks: {
+    strict: true,
+    contexts: ['unit-tests', 'typecheck'],
+  },
+};
+
+function live(overrides: LiveProtection['required_status_checks']): LiveProtection {
+  return {
+    required_status_checks: {
+      strict: true,
+      checks: [{ context: 'unit-tests' }, { context: 'typecheck' }],
+      ...overrides,
+    },
+  };
+}
+
+describe('protectionDrift', () => {
+  it('reports nothing when the live settings match', () => {
+    expect(protectionDrift(expected, live({}))).toEqual([]);
+  });
+
+  // The drift that actually happened: docs/validation-topology.md asserted
+  // `strict: true` was the steady state while the API returned false, because
+  // a bulk drain lifted it and the manual restore never ran.
+  it('reports a lifted strict flag', () => {
+    const drift = protectionDrift(expected, live({ strict: false }));
+
+    expect(drift).toHaveLength(1);
+    expect(drift[0]).toContain('strict is false, expected true');
+  });
+
+  it('reports a required check that is no longer enforced', () => {
+    const drift = protectionDrift(expected, live({ checks: [{ context: 'unit-tests' }] }));
+
+    expect(drift).toEqual(['required status check "typecheck" is expected but not enforced']);
+  });
+
+  // Not drift to ignore: a check added to the settings but not the expectation
+  // means the file has stopped describing reality, which is how it rots.
+  it('reports a check enforced but absent from the expectation', () => {
+    const drift = protectionDrift(
+      expected,
+      live({ checks: [{ context: 'unit-tests' }, { context: 'typecheck' }, { context: 'extra' }] }),
+    );
+
+    expect(drift).toHaveLength(1);
+    expect(drift[0]).toContain('"extra" is enforced but not in the expectation');
+  });
+
+  it('reports protection being absent entirely rather than throwing', () => {
+    expect(protectionDrift(expected, {})).toEqual([
+      'required status checks are not configured at all on `main`',
+    ]);
+  });
+
+  it('reports every drift at once so one run names the whole gap', () => {
+    const drift = protectionDrift(expected, live({ strict: false, checks: [] }));
+
+    expect(drift).toHaveLength(3);
+  });
+});
+
+describe('the checked-in expectation', () => {
+  // Guards the file the whole check reads. A typo in a context name here would
+  // otherwise make the guard assert something GitHub never reports.
+  it('declares strict and the four required contexts', async () => {
+    const onDisk = await readJsonFile<ProtectionExpectation>(EXPECTATION_PATH);
+
+    expect(onDisk.branch).toBe('main');
+    expect(onDisk.requiredStatusChecks.strict).toBe(true);
+    expect(onDisk.requiredStatusChecks.contexts).toEqual([
+      'unit-tests',
+      'typecheck',
+      'playwright',
+      'Pre-1.0 changeset bump guard',
+    ]);
+  });
+});

--- a/packages/components/scripts/check-branch-protection.ts
+++ b/packages/components/scripts/check-branch-protection.ts
@@ -98,7 +98,8 @@ async function resolveToken(): Promise<string> {
   if (fromEnvironment) return fromEnvironment;
 
   const cli = Bun.spawn(['gh', 'auth', 'token'], { stdout: 'pipe', stderr: 'ignore' });
-  const token = (await new Response(cli.stdout).text()).trim();
+  const rawToken = await new Response(cli.stdout).text();
+  const token = rawToken.trim();
   await cli.exited;
 
   if (token) return token;
@@ -106,6 +107,14 @@ async function resolveToken(): Promise<string> {
   throw new Error(
     'No GitHub token available. Set GITHUB_TOKEN, or run `gh auth login` for local use.',
   );
+}
+
+function asLiveProtection(payload: unknown): LiveProtection {
+  if (typeof payload !== 'object' || payload === null) {
+    throw new Error('GitHub branch-protection response was not an object.');
+  }
+
+  return payload as LiveProtection;
 }
 
 async function main(): Promise<void> {
@@ -133,7 +142,8 @@ async function main(): Promise<void> {
     );
   }
 
-  const drift = protectionDrift(expected, (await response.json()) as LiveProtection);
+  const payload: unknown = await response.json();
+  const drift = protectionDrift(expected, asLiveProtection(payload));
 
   if (drift.length === 0) {
     process.stdout.write(

--- a/packages/components/scripts/check-branch-protection.ts
+++ b/packages/components/scripts/check-branch-protection.ts
@@ -17,8 +17,15 @@
  * already failed, so this runs daily to catch a lift that was never undone.
  *
  * Run with `bun run check:branch-protection`. Reads `GITHUB_TOKEN` (or
- * `GH_TOKEN`), falling back to `gh auth token` for local use. Exits non-zero
- * with a named diff on drift.
+ * `GH_TOKEN`) — falling back to `gh auth token` for local use — since reading
+ * branch protection needs Administration: Read, which is not a grantable
+ * GitHub Actions `permissions` scope; `main-red-watch.yaml` supplies a
+ * `REPO_ADMIN_TOKEN` secret for that reason. Exits `EXIT_OK` (0) when live
+ * settings match, `EXIT_DRIFT` (1) with a named diff when they don't, and
+ * `EXIT_SETUP_FAILURE` (2) when the check itself couldn't run (a missing or
+ * under-scoped token, a network or API failure) — a setup failure is not
+ * evidence `main`'s protection changed, and the workflow that reads this exit
+ * code does not report it as drift.
  */
 
 import { join } from 'node:path';
@@ -44,8 +51,27 @@ export type LiveProtection = {
   required_status_checks?: {
     strict?: boolean;
     checks?: Array<{ context: string }>;
+    /**
+     * Legacy shape. GitHub's branch-protection API can report required status
+     * checks as this flat list of context names instead of, or alongside,
+     * `checks` — repositories configured before `checks` existed (or through
+     * certain API/UI paths) still report through `contexts`.
+     */
+    contexts?: string[];
   };
 };
+
+/**
+ * Exit codes this script produces. `main-red-watch.yaml` reads the numeric
+ * value — not just success/failure — to route `EXIT_DRIFT` to the
+ * branch-protection-drift issue and `EXIT_SETUP_FAILURE` to a failed-run
+ * annotation instead. A setup problem (missing token scope, a non-2xx that
+ * isn't "protection absent") is not evidence that `main`'s protection
+ * actually changed, and must not file an incident claiming it did.
+ */
+export const EXIT_OK = 0;
+export const EXIT_DRIFT = 1;
+export const EXIT_SETUP_FAILURE = 2;
 
 /**
  * Compare expectation against live protection, returning one human-readable
@@ -72,7 +98,14 @@ export function protectionDrift(expected: ProtectionExpectation, live: LiveProte
     );
   }
 
-  const liveContexts = new Set((liveChecks.checks ?? []).map((check) => check.context));
+  // GitHub reports required checks through `checks` ([{context}]), the legacy
+  // flat `contexts` (string[]), or both at once — union them so a repository
+  // configured through either shape compares correctly instead of reading as
+  // if nothing were enforced.
+  const liveContexts = new Set([
+    ...(liveChecks.checks ?? []).map((check) => check.context),
+    ...(liveChecks.contexts ?? []),
+  ]);
   const expectedContexts = new Set(expected.requiredStatusChecks.contexts);
 
   const missing = [...expectedContexts].filter((context) => !liveContexts.has(context));
@@ -90,6 +123,65 @@ export function protectionDrift(expected: ProtectionExpectation, live: LiveProte
   }
 
   return drift;
+}
+
+function isMessageBody(value: unknown): value is { message: string } {
+  if (typeof value !== 'object' || value === null) return false;
+  if (!('message' in value)) return false;
+
+  return typeof (value as Record<string, unknown>)['message'] === 'string';
+}
+
+/**
+ * Classify a branch-protection API response before deciding whether to treat
+ * it as drift or a setup problem.
+ *
+ * GitHub returns 404 for two different situations on this endpoint: branch
+ * protection genuinely disabled (body `message: "Branch not protected"`) and
+ * a token without Administration: Read access, which this endpoint can report
+ * as though the resource does not exist at all rather than as 403 — the same
+ * evasive 404 an unprivileged token gets from any resource it can't see. Only
+ * the first is real drift, and the largest possible kind: no protection at
+ * all. Trusting a bare 404 status without checking the message would let an
+ * under-scoped token (exactly the state before `REPO_ADMIN_TOKEN` is
+ * provisioned) file "protection is off" against a `main` that is actually
+ * fully configured, every day, until someone "fixes" working settings.
+ */
+export function classifyProtectionResponse(
+  status: number,
+  body: unknown,
+): 'ok' | 'protection-absent' | 'setup-failure' {
+  if (status >= 200 && status < 300) return 'ok';
+
+  const message = isMessageBody(body) ? body.message : undefined;
+  if (status === 404 && message === 'Branch not protected') return 'protection-absent';
+
+  return 'setup-failure';
+}
+
+/**
+ * Build the message for a response `classifyProtectionResponse` called a
+ * setup failure. 403 and 404 both surface the same underlying problem on this
+ * endpoint — the token lacks Administration: Read — and GitHub is
+ * inconsistent about which of the two it returns for that case, so both point
+ * at the same fix.
+ */
+function buildSetupFailureMessage(response: Response, branch: string): string {
+  if (response.status === 403 || response.status === 404) {
+    return (
+      `check-branch-protection — setup failure: GitHub returned ${response.status} reading ` +
+      `branch protection for \`${branch}\`.\n` +
+      'Reading branch protection needs Administration: Read access, which GITHUB_TOKEN cannot ' +
+      'be granted (it is not a valid workflow `permissions` scope). Create a fine-grained ' +
+      'personal access token with Administration: Read access on this repository, then save ' +
+      'it as the REPO_ADMIN_TOKEN repository secret.\n'
+    );
+  }
+
+  return (
+    `check-branch-protection — setup failure: GitHub returned ${response.status} ` +
+    `${response.statusText} for ${branch} branch protection.\n`
+  );
 }
 
 /** Resolve a token from the environment, falling back to the `gh` CLI locally. */
@@ -117,6 +209,23 @@ function asLiveProtection(payload: unknown): LiveProtection {
   return payload as LiveProtection;
 }
 
+/** Report drift (or its absence) and exit with the matching code. */
+function reportAndExit(expected: ProtectionExpectation, drift: string[]): never {
+  if (drift.length === 0) {
+    process.stdout.write(
+      `check-branch-protection — OK (${expected.branch} matches .github/branch-protection.json).\n`,
+    );
+    process.exit(EXIT_OK);
+  }
+
+  process.stderr.write(
+    `check-branch-protection — ${drift.length} drift(s) between the live settings for ` +
+      `\`${expected.branch}\` and .github/branch-protection.json:\n` +
+      drift.map((entry) => `  - ${entry}\n`).join(''),
+  );
+  process.exit(EXIT_DRIFT);
+}
+
 async function main(): Promise<void> {
   const expected = await readJsonFile<ProtectionExpectation>(EXPECTATION_PATH);
   const token = await resolveToken();
@@ -132,34 +241,37 @@ async function main(): Promise<void> {
     },
   );
 
-  if (!response.ok) {
-    // A 403 here is almost always a token scope problem, not real drift, and
-    // reporting it as drift would send someone to change settings that are fine.
-    throw new Error(
-      `GitHub returned ${response.status} ${response.statusText} for ${expected.branch} ` +
-        'branch protection. Reading protection needs admin rights — in Actions that is ' +
-        '`permissions: administration: read`.',
-    );
+  const body: unknown = await response.json();
+  const classification = classifyProtectionResponse(response.status, body);
+
+  if (classification === 'protection-absent') {
+    // The largest possible drift: `main` has no branch protection at all, not
+    // just one missing setting within it — distinct wording from
+    // `protectionDrift`'s "required status checks aren't configured", which
+    // describes a protected branch missing one setting.
+    reportAndExit(expected, ['branch protection is not enabled on `main` at all']);
   }
 
-  const payload: unknown = await response.json();
-  const drift = protectionDrift(expected, asLiveProtection(payload));
-
-  if (drift.length === 0) {
-    process.stdout.write(
-      `check-branch-protection — OK (${expected.branch} matches .github/branch-protection.json).\n`,
-    );
-    return;
+  if (classification === 'setup-failure') {
+    process.stderr.write(buildSetupFailureMessage(response, expected.branch));
+    process.exit(EXIT_SETUP_FAILURE);
   }
 
-  process.stderr.write(
-    `check-branch-protection — ${drift.length} drift(s) between the live settings for ` +
-      `\`${expected.branch}\` and .github/branch-protection.json:\n` +
-      drift.map((entry) => `  - ${entry}\n`).join(''),
-  );
-  process.exit(1);
+  reportAndExit(expected, protectionDrift(expected, asLiveProtection(body)));
 }
 
 if (import.meta.main) {
-  await main();
+  try {
+    await main();
+  } catch (error) {
+    // Anything that reaches here — a missing token, a malformed expectation
+    // file, a network failure, an unparseable payload — is a setup problem,
+    // not evidence that main's protection changed. Route it to the same exit
+    // code as the explicit setup-failure paths above so the workflow never
+    // mistakes it for drift.
+    process.stderr.write(
+      `check-branch-protection — setup failure: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.exit(EXIT_SETUP_FAILURE);
+  }
 }

--- a/packages/components/scripts/check-branch-protection.ts
+++ b/packages/components/scripts/check-branch-protection.ts
@@ -1,0 +1,155 @@
+/**
+ * Asserts `main`'s live branch protection matches the expectation checked in at
+ * `.github/branch-protection.json`.
+ *
+ * Every other guard in this repository validates the source tree. This one
+ * validates the repository *settings*, which no amount of workflow-YAML parsing
+ * can reach — and which drifted from their own documentation twice on
+ * 2026-08-05: `docs/validation-topology.md` claimed `strict: true` and named a
+ * merge queue as the stale-base mitigation, while the live API returned
+ * `strict: false` and merge queues are unavailable on user-owned repositories
+ * at all (#1140).
+ *
+ * `strict` is the entry that matters. With no merge queue available, requiring
+ * branches to be up to date is the only thing that forces a pull request to be
+ * re-validated against current `main`. The bulk-drain protocol lifts it
+ * deliberately and restores it by hand; the manual restore is the step that
+ * already failed, so this runs daily to catch a lift that was never undone.
+ *
+ * Run with `bun run check:branch-protection`. Reads `GITHUB_TOKEN` (or
+ * `GH_TOKEN`), falling back to `gh auth token` for local use. Exits non-zero
+ * with a named diff on drift.
+ */
+
+import { join } from 'node:path';
+
+import { readJsonFile } from './lib/read-json-file.ts';
+
+const packageRoot = join(import.meta.dir, '..');
+const workspaceRoot = join(packageRoot, '..', '..');
+
+export const EXPECTATION_PATH = join(workspaceRoot, '.github', 'branch-protection.json');
+
+/** The checked-in expectation. `$comment` carries the rationale and is ignored here. */
+export type ProtectionExpectation = {
+  branch: string;
+  requiredStatusChecks: {
+    strict: boolean;
+    contexts: string[];
+  };
+};
+
+/** The subset of GitHub's branch-protection response this guard reads. */
+export type LiveProtection = {
+  required_status_checks?: {
+    strict?: boolean;
+    checks?: Array<{ context: string }>;
+  };
+};
+
+/**
+ * Compare expectation against live protection, returning one human-readable
+ * line per mismatch and an empty array when they agree.
+ *
+ * Pure and exported so the comparison is tested directly, rather than through a
+ * network call that a test would have to mock into meaninglessness.
+ */
+export function protectionDrift(expected: ProtectionExpectation, live: LiveProtection): string[] {
+  const drift: string[] = [];
+  const liveChecks = live.required_status_checks;
+
+  if (!liveChecks) {
+    drift.push('required status checks are not configured at all on `main`');
+    return drift;
+  }
+
+  if (liveChecks.strict !== expected.requiredStatusChecks.strict) {
+    drift.push(
+      `required_status_checks.strict is ${liveChecks.strict}, expected ` +
+        `${expected.requiredStatusChecks.strict}. With no merge queue available on a ` +
+        'user-owned repository, this is the only mechanism re-validating a pull request ' +
+        'against current `main`. If a bulk drain lifted it, restore it when the drain ends.',
+    );
+  }
+
+  const liveContexts = new Set((liveChecks.checks ?? []).map((check) => check.context));
+  const expectedContexts = new Set(expected.requiredStatusChecks.contexts);
+
+  const missing = [...expectedContexts].filter((context) => !liveContexts.has(context));
+  const unexpected = [...liveContexts].filter((context) => !expectedContexts.has(context));
+
+  for (const context of missing) {
+    drift.push(`required status check "${context}" is expected but not enforced`);
+  }
+
+  for (const context of unexpected) {
+    drift.push(
+      `required status check "${context}" is enforced but not in the expectation — ` +
+        'add it to .github/branch-protection.json if it is intentional',
+    );
+  }
+
+  return drift;
+}
+
+/** Resolve a token from the environment, falling back to the `gh` CLI locally. */
+async function resolveToken(): Promise<string> {
+  const fromEnvironment = process.env['GITHUB_TOKEN'] ?? process.env['GH_TOKEN'];
+  if (fromEnvironment) return fromEnvironment;
+
+  const cli = Bun.spawn(['gh', 'auth', 'token'], { stdout: 'pipe', stderr: 'ignore' });
+  const token = (await new Response(cli.stdout).text()).trim();
+  await cli.exited;
+
+  if (token) return token;
+
+  throw new Error(
+    'No GitHub token available. Set GITHUB_TOKEN, or run `gh auth login` for local use.',
+  );
+}
+
+async function main(): Promise<void> {
+  const expected = await readJsonFile<ProtectionExpectation>(EXPECTATION_PATH);
+  const token = await resolveToken();
+
+  const response = await fetch(
+    `https://api.github.com/repos/stevekinney/cinder/branches/${expected.branch}/protection`,
+    {
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'x-github-api-version': '2022-11-28',
+      },
+    },
+  );
+
+  if (!response.ok) {
+    // A 403 here is almost always a token scope problem, not real drift, and
+    // reporting it as drift would send someone to change settings that are fine.
+    throw new Error(
+      `GitHub returned ${response.status} ${response.statusText} for ${expected.branch} ` +
+        'branch protection. Reading protection needs admin rights — in Actions that is ' +
+        '`permissions: administration: read`.',
+    );
+  }
+
+  const drift = protectionDrift(expected, (await response.json()) as LiveProtection);
+
+  if (drift.length === 0) {
+    process.stdout.write(
+      `check-branch-protection — OK (${expected.branch} matches .github/branch-protection.json).\n`,
+    );
+    return;
+  }
+
+  process.stderr.write(
+    `check-branch-protection — ${drift.length} drift(s) between the live settings for ` +
+      `\`${expected.branch}\` and .github/branch-protection.json:\n` +
+      drift.map((entry) => `  - ${entry}\n`).join(''),
+  );
+  process.exit(1);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/packages/components/scripts/check-pipeline-coverage.test.ts
+++ b/packages/components/scripts/check-pipeline-coverage.test.ts
@@ -147,6 +147,7 @@ describe('checkPipelineCoverage', () => {
           'main-green': 'bun run --filter=@lostgradient/cinder components:check',
           release: '',
           'changeset-guard': '',
+          'main-red-watch': '',
         },
         hookText: {},
       },
@@ -202,6 +203,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': '',
         release: 'bun run validate',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -233,6 +235,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': '',
         release: 'bun run --filter=@lostgradient/chat validate:consumer',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -264,6 +267,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': 'bun run --filter=@lostgradient/chat test:coverage',
         release: '',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -291,6 +295,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': '',
         release: 'bun run --filter=@lostgradient/cinder validate:consumer',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -320,6 +325,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': '',
         release: 'bun run validate',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -346,6 +352,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': 'bun run lint',
         release: '',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -366,6 +373,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': 'bunx turbo run lint',
         release: '',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -395,6 +403,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': '',
         release: '',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -422,6 +431,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': '',
         release: '',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -448,6 +458,7 @@ describe('checkPipelineCoverage', () => {
         'main-green': '',
         release: 'bun run validate',
         'changeset-guard': '',
+        'main-red-watch': '',
       },
       hookText: {},
     });
@@ -463,6 +474,7 @@ describe('checkPipelineCoverage', () => {
     'main-green': '',
     release: '',
     'changeset-guard': '',
+    'main-red-watch': '',
   };
 
   it('flags a hook-layer mismatch as a warning, not a violation, when the hook script is present', () => {

--- a/packages/components/scripts/check-pipeline-coverage.ts
+++ b/packages/components/scripts/check-pipeline-coverage.ts
@@ -64,6 +64,7 @@ export const LAYERS = [
   'main-green',
   'release',
   'changeset-guard',
+  'main-red-watch',
 ] as const;
 
 /** Stylelint rule coverage is documented alongside the command-layer map. */
@@ -94,6 +95,17 @@ export type DeclarationRow = {
  * thing this script exists to catch.
  */
 export const DECLARATION_TABLE: Record<string, DeclarationRow> = {
+  'check:branch-protection': {
+    layers: ['main-red-watch'],
+    reason:
+      "Asserts `main`'s live branch protection against .github/branch-protection.json. It " +
+      'validates repository SETTINGS rather than the source tree, so it belongs to no source ' +
+      'layer: unit-tests and main-green would gain nothing from it, and it needs ' +
+      '`administration: read`, which those workflows deliberately do not hold. It runs on ' +
+      "main-red-watch's daily schedule only — the bulk-drain protocol lifts `strict` on purpose, " +
+      'so a per-pull-request cadence would page during every drain while a daily one still ' +
+      'surfaces a lift that was never restored.',
+  },
   lint: {
     layers: ['unit-tests', 'main-green'],
     reason:
@@ -880,6 +892,7 @@ const WORKFLOW_FILE_BY_LAYER: Partial<Record<Layer, string>> = {
   'main-green': 'main-green.yaml',
   release: 'release.yaml',
   'changeset-guard': 'changeset-guard.yaml',
+  'main-red-watch': 'main-red-watch.yaml',
 };
 
 async function loadWorkflowText(): Promise<Partial<Record<Layer, string>>> {


### PR DESCRIPTION
## Why

Every guard in this repository validates the **source tree**. None can see repository **settings** — and those drifted from their own documentation twice on 2026-08-05.

`docs/validation-topology.md` asserted `strict: true` was "the steady state" and named a merge queue as the mitigation for stale-base merges. The live API returned `strict: false`, and merge queues are unavailable on user-owned repositories entirely (recorded by #1140). Nothing checked, so nothing caught it — I trusted the doc and built a whole plan phase on a capability that cannot exist here.

`strict` is the load-bearing entry. **With no merge queue possible, requiring branches to be up to date is the only mechanism that forces a pull request to be re-validated against current `main`.** Without it, a green PR merges against a tree that no longer exists — exactly what turned `main` red on 2026-07-28 (#972 added a stylelint rule, #1011 merged CSS violating it fourteen minutes later, both green).

That is not hypothetical or historical: **three separate branches went stale mid-review during the work that produced this PR**, including #1143, which Copilot caught about to merge against a base that predated #1141. Each time I caught it by checking by hand. Nothing in the repo would have stopped a stale merge.

## What this does

`.github/branch-protection.json` is the checked-in expectation. `check-branch-protection.ts` asserts the live API against it and exits non-zero with a named diff.

**Run against the live API today, it reports the real, current drift:**

```
check-branch-protection — 1 drift(s):
  - required_status_checks.strict is false, expected true. With no merge queue available on a
    user-owned repository, this is the only mechanism re-validating a pull request against
    current `main`. If a bulk drain lifted it, restore it when the drain ends.
```

That is the tool working, not a bug in this PR. See "Expect an issue immediately" below.

## Design decisions

**Daily, not per-pull-request.** `docs/validation-topology.md`'s bulk-drain protocol lifts `strict` *deliberately* and restores it **by hand** — and the manual restore is precisely the step that already failed. A per-PR cadence would page during every legitimate drain; a daily one lets a short drain finish while still surfacing a lift that was never restored.

**It lives in `main-red-watch`.** Reading branch protection requires admin rights — `permissions: administration: read` — which `main-green` deliberately does not hold and should not gain. It reports through the same open-or-update channel added in #1147, under its own `branch-protection-drift` label so config drift and a red `main` stay distinguishable.

**`continue-on-error` on the check step** so a protection drift and a stalled heartbeat can both report in one run instead of the first hiding the second.

**Registered in `check-pipeline-coverage`** as a new `main-red-watch` layer, per that map's own documented rule, so the meta-guard verifies the command genuinely appears in the workflow rather than taking the declaration's word for it.

**A check enforced but *absent* from the expectation is also drift.** Silently accepting extras is how the file rots into describing a repo that no longer exists — which is the failure this PR exists to prevent.

## Verification

- 7 unit tests over the pure `protectionDrift` seam, including the exact drift that happened (a lifted `strict`), a missing required context, an unexpected extra context, protection absent entirely, and multiple drifts reported together.
- One test pins the checked-in expectation itself, so a typo in a context name can't make the guard assert something GitHub never reports.
- Run end-to-end against the live API — output above.
- `validate:workflow`, `lint:invariants` (62 commands, 8 layers), and `exports:check` all pass.
- Confirmed the script is in no aggregate (`lint:invariants`, `validate`), so no job lacking `administration: read` can trip on it.

## Expect an issue immediately

`strict` is `false` right now and a bulk drain is in flight (`~/.codex/worktrees/drain-cinder-issues/`), which is very likely why. **I deliberately did not restore it** — doing so mid-drain would break another session's in-flight merges. That is your call, not mine.

So the first scheduled run after this merges will open a `branch-protection-drift` issue. That is correct behavior and the entire point: the gap becomes visible and stays visible until someone decides, instead of sitting unnoticed as it did.
