### PR TITLE
test: replace five non-asserting tests with real behavioral assertions

### DIFF
--- a/packages/components/src/components/capability-gate/capability-gate.test.ts
+++ b/packages/components/src/components/capability-gate/capability-gate.test.ts
@@ -6,7 +6,12 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 setupHappyDom();
 
 const { cleanup, fireEvent, render } = await import('@testing-library/svelte');
+const { createRawSnippet } = await import('svelte');
 const { default: CapabilityGate } = await import('./capability-gate.svelte');
+
+function snippet(text: string) {
+  return createRawSnippet(() => ({ render: () => `<span>${text}</span>` }));
+}
 
 afterEach(() => {
   cleanup();
@@ -120,15 +125,22 @@ describe('CapabilityGate', () => {
   });
 
   test('renders children content', () => {
-    const { getByText } = render(CapabilityGate, {
+    const { container } = render(CapabilityGate, {
       feature: 'MIDI',
       state: 'unsupported',
-      // Svelte snippet children passed via testing-library requires a slot approach.
-      // Test the container instead.
+      children: snippet('Custom content'),
     });
-    // Basic existence check — children are tested via the container query.
-    const root = document.querySelector('.cinder-capability-gate');
-    expect(root ?? getByText('MIDI')).not.toBeNull();
+    const content = container.querySelector('.cinder-capability-gate__content');
+    expect(content).not.toBeNull();
+    expect(content?.textContent).toContain('Custom content');
+  });
+
+  test('omits the content wrapper entirely when no children are passed', () => {
+    const { container } = render(CapabilityGate, {
+      feature: 'MIDI',
+      state: 'unsupported',
+    });
+    expect(container.querySelector('.cinder-capability-gate__content')).toBeNull();
   });
 
   test('renders with data-cinder-presentation attribute', () => {

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
@@ -114,8 +114,9 @@ describe('JsonSchemaEditor — Diff tab Badge indicator', () => {
     await flushEffects();
     const applyButton = screen
       .getAllByRole('button')
-      .find((button) => button.textContent?.trim() === 'Apply') as HTMLElement;
-    await fireEvent.click(applyButton);
+      .find((button) => button.textContent?.trim() === 'Apply');
+    expect(applyButton).toBeDefined();
+    await fireEvent.click(applyButton as HTMLElement);
     await flushEffects();
 
     await fireEvent.click(diffTab);

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
@@ -51,16 +51,6 @@ describe('JsonSchemaEditor — Diff tab source contract', () => {
     expect(hasSemanticIndicator).toBe(true);
   });
 
-  test('json-schema-editor-impl.svelte uses Badge in the trailing snippet for the Diff tab', async () => {
-    const source = await Bun.file(
-      new URL('./json-schema-editor-impl.svelte', import.meta.url),
-    ).text();
-
-    // The Diff tab should use the trailing snippet with a Badge for the visual indicator
-    expect(source).toContain('trailing');
-    expect(source).toContain('Badge');
-  });
-
   test('json-schema-editor-toolbar.svelte has role=toolbar and an accessible label', async () => {
     const source = await Bun.file(new URL('./json-schema-toolbar.svelte', import.meta.url)).text();
 
@@ -89,6 +79,52 @@ describe('JsonSchemaEditor — Diff tab source contract', () => {
     expect(source).toContain('setChildValidationErrorCount(`${keyword}:${removedBranchKey}`, 0)');
     expect(source).not.toContain('.toSpliced(');
     expect(source).toContain('onvalidationErrorcount?.(0)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mounted: Diff tab Badge indicator only appears once a change is committed
+// ---------------------------------------------------------------------------
+describe('JsonSchemaEditor — Diff tab Badge indicator', () => {
+  afterEach(() => cleanup());
+
+  /** Wait a macrotask so debounced state work and Svelte effects settle. */
+  function flushEffects(): Promise<void> {
+    return new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+
+  test('renders a Badge in the Diff tab only after a change is committed', async () => {
+    render(JsonSchemaEditorImplementation, {
+      props: { id: 'jse-diff-badge', schema: { type: 'string' }, view: 'json' as const },
+    });
+    await flushEffects();
+
+    const diffTab = screen.getByRole('tab', { name: /Diff/ });
+
+    // Before any edit is committed, editorState.hasChanges is false — the
+    // {#if editorState.hasChanges} branch around the Badge must not render it.
+    expect(diffTab.querySelector('.cinder-badge')).toBeNull();
+
+    // Commit a real edit through the JSON view (same sequence as the
+    // 'Apply disables for an invalid draft...' test below).
+    const textarea = screen.getByRole('textbox', { name: 'JSON' });
+    await fireEvent.input(textarea, {
+      target: { value: JSON.stringify({ type: 'string', title: 'Changed' }) },
+    });
+    await flushEffects();
+    const applyButton = screen
+      .getAllByRole('button')
+      .find((button) => button.textContent?.trim() === 'Apply') as HTMLElement;
+    await fireEvent.click(applyButton);
+    await flushEffects();
+
+    await fireEvent.click(diffTab);
+    await flushEffects();
+
+    const badge = diffTab.querySelector('.cinder-badge');
+    expect(badge).not.toBeNull();
+    expect(badge?.textContent).toBe('●');
+    expect(badge?.getAttribute('aria-hidden')).toBe('true');
   });
 });
 

--- a/packages/components/src/components/pagination/pagination.test.ts
+++ b/packages/components/src/components/pagination/pagination.test.ts
@@ -153,6 +153,42 @@ describe('Pagination', () => {
     expect(currentButtons.length).toBe(1);
   });
 
+  // §Ellipsis window (totalPages > 7) — pageItems boundary rule
+  //
+  // pageItems is a sorted Set of {1, totalPages} ∪ [currentPage-1, currentPage+1].
+  // Walking consecutive pairs of that set: a gap of 1 means the pages are already
+  // adjacent (nothing inserted), a gap of exactly 2 fills the single missing page
+  // directly (no ellipsis — hiding just one number would be silly), and a gap
+  // greater than 2 inserts an 'ellipsis-start' (immediately after the leading
+  // boundary) or 'ellipsis-end' (everywhere else) marker instead of the pages
+  // it collapses.
+
+  test('renders ellipsis markers and the correct page window for totalPages > 7', () => {
+    // totalPages: 10, currentPage: 5 → boundary {1, 10}, window {4, 5, 6} →
+    // sorted [1, 4, 5, 6, 10] → gaps 3, 1, 1, 4 → ellipsis-start, -, -, ellipsis-end.
+    const { container } = render(Pagination, {
+      props: { currentPage: 5, totalPages: 10 },
+    });
+    const items = Array.from(container.querySelectorAll('.cinder-pagination__pages > li')).map(
+      (item) => item.textContent?.trim(),
+    );
+    expect(items).toEqual(['1', '…', '4', '5', '6', '…', '10']);
+    expect(container.querySelectorAll('.cinder-pagination__ellipsis-item').length).toBe(2);
+  });
+
+  test('fills a two-page gap directly instead of inserting an ellipsis', () => {
+    // totalPages: 8, currentPage: 4 → boundary {1, 8}, window {3, 4, 5} →
+    // sorted [1, 3, 4, 5, 8] → gaps 2, 1, 1, 3 → fill 2 directly, -, -, ellipsis-end.
+    const { container } = render(Pagination, {
+      props: { currentPage: 4, totalPages: 8 },
+    });
+    const items = Array.from(container.querySelectorAll('.cinder-pagination__pages > li')).map(
+      (item) => item.textContent?.trim(),
+    );
+    expect(items).toEqual(['1', '2', '3', '4', '5', '…', '8']);
+    expect(container.querySelectorAll('.cinder-pagination__ellipsis-item').length).toBe(1);
+  });
+
   // §Native attribute passthrough — rest spread
 
   test('forwards id and data-* attributes to the nav element', () => {

--- a/packages/components/src/components/textarea/textarea.test.ts
+++ b/packages/components/src/components/textarea/textarea.test.ts
@@ -265,18 +265,20 @@ describe('Textarea — character count', () => {
     expect(countElement?.textContent?.trim()).toBe('5/500');
   });
 
-  test('counter does not update without bind:value (initial value is locked)', async () => {
+  test('counter updates locally via $bindable even without a parent bind:value', async () => {
     const { container } = render(Textarea, {
       props: { id: 'unbound', countVisible: true, maxlength: 100, value: 'hi' },
     });
     const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
     const countElement = container.querySelector('#unbound-count');
     expect(countElement?.textContent?.trim()).toBe('2/100');
-    // Simulate typing without a bind — the prop does not flow back
+
+    // Simulate typing without a parent bind: — `value = $bindable('')` still
+    // mutates the local prop under Svelte 5, so both the textarea's own value
+    // and the derived counter update even though no parent is listening.
     await fireEvent.input(textarea, { target: { value: 'hi there' } });
-    // The textarea element value updates via DOM but the prop-bound counter
-    // may or may not update depending on binding. We assert the textarea DOM value changed.
     expect(textarea.value).toBe('hi there');
+    expect(countElement?.textContent?.trim()).toBe('8/100');
   });
 });
 

--- a/packages/playground/src/examples/featured-example-mount-id.test.ts
+++ b/packages/playground/src/examples/featured-example-mount-id.test.ts
@@ -86,35 +86,3 @@ describe('featured example mounts — no duplicate element IDs (#399)', () => {
     });
   }
 });
-
-describe('mountIdPrefix derivation — two mounts never collide (#399)', () => {
-  /**
-   * Models the exact idiom every featured example uses for an emitted id:
-   * `${mountIdPrefix ?? uid}-${suffix}`. The duplicate-id bug existed because a
-   * hardcoded literal produced the SAME string in both the Overview and Examples
-   * mounts. The fix makes every id a function of the per-mount prefix, so this
-   * pure-function check is the structural proof the source-shape guards above
-   * pin in each file: distinct prefixes ⇒ distinct ids, by construction.
-   */
-  const derivedId = (prefix: string, suffix: string): string => `${prefix}-${suffix}`;
-
-  it('produces distinct ids for the two mount containers', () => {
-    const overview = derivedId('overview-mount-basic', 'field');
-    const examples = derivedId('example-mount-basic', 'field');
-    expect(overview).not.toBe(examples);
-  });
-
-  it('keeps every child id distinct across mounts when one prefix scopes many suffixes', () => {
-    const suffixes = ['label', 'description', 'error', 'listbox'];
-    const overviewIds = suffixes.map((suffix) => derivedId('overview-mount-basic', suffix));
-    const exampleIds = suffixes.map((suffix) => derivedId('example-mount-basic', suffix));
-    const all = new Set([...overviewIds, ...exampleIds]);
-    expect(all.size).toBe(overviewIds.length + exampleIds.length);
-  });
-
-  it('falls back to the per-instance $props.id() so two standalone copies also differ', () => {
-    // No injected prefix → each copy reads its own stable `$props.id()` (modeled
-    // here as two distinct uids), so even unscoped duplicates never collide.
-    expect(derivedId('s1abc', 'field')).not.toBe(derivedId('s2xyz', 'field'));
-  });
-});


### PR DESCRIPTION
## Summary

Cluster H — test quality. Fixes five tests that passed regardless of whether
the feature they claimed to cover actually worked, as identified in #1161's
5-expert audit. Test-only change; no production code touched (all temporary
breaks used to gather revert-evidence below were reverted before commit — `git
diff` on this branch touches only `*.test.ts` files).

- **`packages/playground/src/examples/featured-example-mount-id.test.ts`** —
  deleted the `mountIdPrefix derivation — two mounts never collide (#399)`
  describe block. Its `derivedId` helper was an inline template-literal
  defined in the test file itself, not imported from any production module —
  the three tests only proved that JS string interpolation with two different
  inputs produces two different outputs. The source-shape describe block
  above it (unaffected) already covers the real invariant.
- **`packages/components/src/components/capability-gate/capability-gate.test.ts`**
  — rewrote `renders children content`. It never passed a `children` snippet
  and asserted a tautology true for any successful render. Now passes a real
  Svelte snippet (`createRawSnippet`, matching `kbd.test.ts`'s idiom) and
  asserts `.cinder-capability-gate__content` contains it. Added a negative
  case asserting the wrapper is entirely absent with no children, proving the
  `{#if children}` branch is genuinely conditional.
- **`packages/components/src/components/json-schema-editor/json-schema-editor.test.ts`**
  — replaced the source-text `uses Badge in the trailing snippet for the Diff
  tab` test (which only grepped the `.svelte` file for the strings `'trailing'`
  and `'Badge'`) with a mounted test: commits a real JSON-view edit (same
  sequence as the file's own `Apply disables for an invalid draft...` test),
  clicks the Diff tab, and asserts `.cinder-badge` renders with `textContent
  === '●'` and `aria-hidden="true"` — plus a negative assertion that it's
  absent before any edit is committed. The validation-count source-text test
  at the same location is **intentionally left unchanged** per the issue's
  `## Dropped findings` (mounting `form` view trips a documented happy-dom
  `nextSibling` limitation with no safe workaround).
- **`packages/components/src/components/pagination/pagination.test.ts`** —
  added two tests reading the actual rendered page-button/ellipsis sequence
  for the `totalPages > 7` windowing branch: the ellipsis-insert case
  (`totalPages: 10, currentPage: 5` → `[1, …, 4, 5, 6, …, 10]`) and the
  gap-of-2 direct-fill case (`totalPages: 8, currentPage: 4` →
  `[1, 2, 3, 4, 5, …, 8]`, proving a two-page gap renders the page directly
  instead of eliding it). Every existing `totalPages: 10` test exercised this
  logic without ever reading its output.
- **`packages/components/src/components/textarea/textarea.test.ts`** —
  rewrote `counter does not update without bind:value`, whose title claimed
  "counter does not update" but whose body only re-checked `textarea.value`
  (never the counter text). Under Svelte 5's `$bindable` semantics the local
  prop mutates even without a parent `bind:`, so the counter DOES update.
  Renamed to `counter updates locally via $bindable even without a parent
  bind:value` and now re-queries `#unbound-count` after `fireEvent.input` and
  asserts it reads `'8/100'`.

## Revert-evidence (acceptance criteria)

For each rewritten/added test, the change below was made **temporarily**
against a clean tree, run, and reverted — confirmed by `git diff --stat`
showing no production-file changes on this branch.

### 1. `capability-gate.test.ts` — children content

**Break** (`capability-gate.svelte`):
```diff
-    {#if children}
+    {#if false && children}
```
**Failure** (`bun run test capability-gate.test.ts`):
```
error: expect(received).not.toBeNull()
Received: null
      at capability-gate.test.ts:134:25
(fail) CapabilityGate > renders children content [0.93ms]
 16 pass
 1 fail
```
**After revert** — `17 pass / 0 fail`.

### 2. `json-schema-editor.test.ts` — Diff tab Badge

**Break** (`json-schema-editor-impl.svelte`):
```diff
-          {#if editorState.hasChanges}
+          {#if false && editorState.hasChanges}
             <Badge variant="neutral" aria-hidden="true">●</Badge>
```
**Failure** (`bun run test json-schema-editor.test.ts`):
```
error: expect(received).not.toBeNull()
Received: null
      at json-schema-editor.test.ts:125:23
(fail) JsonSchemaEditor — Diff tab Badge indicator > renders a Badge in the Diff tab only after a change is committed [239.26ms]
 7 pass
 1 fail
```
**After revert** — `8 pass / 0 fail`.

### 3. `pagination.test.ts` — ellipsis window (both new tests)

**Break** (`pagination.svelte`):
```diff
-        } else if (gap > 2) {
+        } else if (gap > 2 && false) {
           result.push(index === 1 ? 'ellipsis-start' : 'ellipsis-end');
```
**Failure** (`bun run test pagination.test.ts`):
```
error: expect(received).toEqual(expected)
  Expected  - 2 / + 0 ("…" markers missing)
(fail) Pagination > renders ellipsis markers and the correct page window for totalPages > 7 [4.50ms]
error: expect(received).toEqual(expected)
  Expected  - 1 / + 0
(fail) Pagination > fills a two-page gap directly instead of inserting an ellipsis [4.39ms]
 21 pass
 2 fail
```
**After revert** — `23 pass / 0 fail`.

### 4. `textarea.test.ts` — counter updates via $bindable

**Break** (`textarea.svelte`):
```diff
-  const currentCount = $derived(value?.length ?? 0);
+  const initialCountSnapshot = value?.length ?? 0;
+  const currentCount = $derived(initialCountSnapshot);
```
**Failure** (`bun run test textarea.test.ts`):
```
error: expect(received).toBe(expected)
Expected: "5/100"
Received: "0/100"
(fail) Textarea — character count > count updates on input [5.88ms]
error: expect(received).toBe(expected)
Expected: "8/100"
Received: "2/100"
(fail) Textarea — character count > counter updates locally via $bindable even without a parent bind:value [1.25ms]
 54 pass
 2 fail
```
(Note: this break also caught a pre-existing test, `count updates on input` —
confirming both assert the same real behavior.)
**After revert** — `56 pass / 0 fail`.

## Out of scope (per issue)

- `json-schema-editor.test.ts:71-79` (validation-count scoping) — left as a
  source-contract test; the issue's `## Dropped findings` verifies a mounted
  version isn't safely achievable in this PR (constructing the `form` view's
  `PropertyEditor` subtree trips a documented happy-dom `nextSibling` crash).
- The two `toContain` tests and the `property-editor.svelte` aggregation test
  in `json-schema-editor.test.ts` — not verified findings, untouched.
- `pagination.svelte`'s ellipsis logic itself — unchanged; this PR only adds
  coverage.
- `message.test.ts` default-role-name gap — separate, unverified finding, not
  part of this cluster.

## Test plan

- [x] `cd packages/components && bun run test capability-gate.test.ts
      json-schema-editor.test.ts pagination.test.ts textarea.test.ts` — 104
      pass, 0 fail.
- [x] `cd packages/playground && bun test --conditions browser --conditions
      svelte --parallel=1 src/examples/featured-example-mount-id.test.ts` —
      124 pass, 0 fail (down from 127, matching the 3 deleted tests).
- [x] `prettier --check` on all five touched files — clean.
- [x] Pre-commit (lint-staged/prettier) and pre-push (fast sanity) hooks
      passed on this branch.
- [ ] Full-suite `bun run test` in both packages, `components:check`,
      `typecheck`, and `lint:invariants` are left to PR CI
      (`unit-tests.yaml` / `browser-tests.yaml`) — the machine this branch was
      built on had 5+ concurrent `bun test` processes from other worktrees in
      this drain wave saturating memory, which made a full local
      `--parallel=1` run impractical to complete locally; the repo's own
      current pre-push hook (see its header comment) deliberately fails open
      for the same reason and defers the full gate to CI.

Closes #1161

Claude-Session: https://claude.ai/code/session_01BSu4BJmyZUpeac7p6vH3fU
