### PR TITLE
playground: complete compound-family registry, group .dx-nav, share title regex

### DIFF
--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -24,6 +24,7 @@
   import Sliders from 'lucide-svelte/icons/sliders-horizontal';
   import Sun from 'lucide-svelte/icons/sun';
   import X from 'lucide-svelte/icons/x';
+  import { COMPOUND_COMPONENT_PARENTS } from './shell-app/compound-families.ts';
   import {
     buildComponentHref,
     readFocusModeFromSearch,
@@ -311,6 +312,35 @@
     return sidebarComponents.filter(
       (name) => name.includes(query) || humanizeId(name).toLowerCase().includes(query),
     );
+  });
+
+  /**
+   * Groups `visibleComponents` by compound-family root, keyed on first
+   * appearance so alphabetical ordering is preserved (`chat` sorts immediately
+   * before `chat-composer-popover`, so its group lands in the same spot the
+   * flat list already put it). A group is created on demand under a child's
+   * root key even when the root itself is absent from `visibleComponents` —
+   * the nav filter can hide the root while keeping a matching child (a search
+   * for "conversation" hides `chat` but keeps `chat-conversation-list`), and a
+   * fixture or filtered caller can pass a compose-only leaf directly without
+   * its root — either way the child stays reachable under a synthesized group
+   * rather than rendering as an orphaned top-level entry.
+   */
+  type NavigationGroup = { name: string; children: string[] };
+
+  const navigationGroups = $derived.by((): NavigationGroup[] => {
+    const groups = new Map<string, NavigationGroup>();
+    for (const name of visibleComponents) {
+      const root = COMPOUND_COMPONENT_PARENTS[name];
+      if (root !== undefined) {
+        const group = groups.get(root) ?? { name: root, children: [] };
+        group.children.push(name);
+        groups.set(root, group);
+        continue;
+      }
+      if (!groups.has(name)) groups.set(name, { name, children: [] });
+    }
+    return [...groups.values()];
   });
 
   /*
@@ -1723,15 +1753,30 @@
           />
         </div>
         <ul class="dx-nav__list">
-          {#each visibleComponents as name (name)}
+          {#each navigationGroups as group (group.name)}
             <li>
               <a
                 class="dx-nav__link"
-                href={buildComponentHref(name)}
-                aria-current={name === componentName ? 'page' : undefined}
+                href={buildComponentHref(group.name)}
+                aria-current={group.name === componentName ? 'page' : undefined}
               >
-                {humanizeId(name)}
+                {humanizeId(group.name)}
               </a>
+              {#if group.children.length > 0}
+                <ul class="dx-nav__sublist">
+                  {#each group.children as child (child)}
+                    <li>
+                      <a
+                        class="dx-nav__link dx-nav__link--child"
+                        href={buildComponentHref(child)}
+                        aria-current={child === componentName ? 'page' : undefined}
+                      >
+                        {humanizeId(child)}
+                      </a>
+                    </li>
+                  {/each}
+                </ul>
+              {/if}
             </li>
           {/each}
           {#if visibleComponents.length === 0}
@@ -1853,6 +1898,17 @@
     color: var(--cinder-text-muted);
     font-size: var(--cinder-text-sm);
     text-decoration: none;
+  }
+
+  .dx-nav__sublist {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .dx-nav__link--child {
+    padding-inline-start: var(--cinder-space-7);
+    font-size: var(--cinder-text-xs);
   }
 
   @media (hover: hover) {

--- a/packages/playground/src/component-page.test.ts
+++ b/packages/playground/src/component-page.test.ts
@@ -1,6 +1,8 @@
 /// <reference lib="dom" />
 /**
- * Regression tests for the example-mount `$effect` in `component-page.svelte`.
+ * Regression tests for the example-mount `$effect` in `component-page.svelte`,
+ * plus (see the `.dx-nav` describe block below) coverage of the sidebar's
+ * compound-family grouping.
  *
  * The original effect deferred each mount into a `queueMicrotask` callback that
  * pushed into a per-run `localApps` array. When the effect re-ran, the previous
@@ -10,13 +12,20 @@
  * fix mounts synchronously in the effect body (the container exists post
  * DOM-patch in Svelte 5), so cleanup and mount share the same `localApps` ref.
  *
- * Mounting the full `component-page.svelte` is impractical: it reads
- * `window.location.pathname`, the server-injected `__CINDER_EXAMPLES__` /
- * `__CINDER_SCENARIOS__` globals, and several deep-imported cinder components,
- * none of which the race depends on. These tests instead drive a fixture that
- * reproduces the effect verbatim (see `component-page-mount-fixture.svelte`)
- * and assert the load-bearing invariant: mount/unmount count parity, no
- * orphaned trees, and no duplicate scenario containers across rapid re-runs.
+ * Mounting the full `component-page.svelte` to exercise THAT race is
+ * impractical: it reads `window.location.pathname`, the server-injected
+ * `__CINDER_EXAMPLES__` / `__CINDER_SCENARIOS__` globals, and several
+ * deep-imported cinder components, none of which the race depends on. Those
+ * tests instead drive a fixture that reproduces the effect verbatim (see
+ * `component-page-mount-fixture.svelte`) and assert the load-bearing
+ * invariant: mount/unmount count parity, no orphaned trees, and no duplicate
+ * scenario containers across rapid re-runs.
+ *
+ * The `.dx-nav` describe block below mounts the real component directly
+ * instead — passing `documentation: null` explicitly (skipping the data-island
+ * read) and a fake global `EventSource` (the live-reload attach otherwise
+ * throws, since happy-dom and Bun's test runtime don't implement it) is enough
+ * to reach the nav markup without needing documentation or example data.
  *
  * Harness setup mirrors `shell-app/event-source.test.ts`: happy-dom is
  * installed onto `globalThis` before `@testing-library/svelte` loads.
@@ -34,7 +43,24 @@ import { setupHappyDom } from '../../components/src/test/happy-dom.ts';
 // `server.test.ts`'s `Bun.build` relies on.
 setupHappyDom();
 
+// `component-page.svelte`'s live-reload attach opens `new EventSource(...)`
+// whenever it renders outside snapshot mode (the branch that owns `.dx-nav`).
+// Neither happy-dom nor Bun's test runtime implements `EventSource`; stub a
+// minimal one so mounting the real component doesn't throw. Installed before
+// the dynamic import below, mirroring `shell-app/event-source.test.ts`.
+class FakeEventSource {
+  constructor(public url: string) {}
+  addEventListener(): void {}
+  close(): void {}
+}
+Object.defineProperty(globalThis, 'EventSource', {
+  configurable: true,
+  writable: true,
+  value: FakeEventSource,
+});
+
 const { render } = await import('@testing-library/svelte');
+const { default: ComponentPage } = await import('./component-page.svelte');
 const { default: Driver } = await import('./component-page-mount-driver.svelte');
 const { default: MountErrorFixture } = await import('./component-page-mount-error-fixture.svelte');
 // The probe's `<script module>` exports ledger helpers alongside the default
@@ -282,6 +308,108 @@ describe('component-page mount-error keying (overview vs example)', () => {
     // Both locations rendered their own probe — independent mounts, not a
     // single shared one.
     expect(document.querySelectorAll('.scenario-probe').length).toBe(2);
+
+    unmount();
+  });
+});
+
+describe('component-page .dx-nav compound-family grouping', () => {
+  /**
+   * A `<li>`'s own direct-child link, distinguished from a nested child's link
+   * one level down inside its `.dx-nav__sublist`. Implemented via `element`
+   * traversal rather than the CSS `:scope` combinator — happy-dom's
+   * `Element.querySelector` does not resolve `:scope` relative to the calling
+   * element (confirmed empirically: `li.querySelector(':scope > a')` returns
+   * `null` even when a direct-child `<a>` exists), so `:scope`-based direct-
+   * child queries silently find nothing under this harness.
+   */
+  function ownLink(element: Element): Element | undefined {
+    return [...element.children].find(
+      (child) => child.tagName === 'A' && child.classList.contains('dx-nav__link'),
+    );
+  }
+
+  function ownSublist(element: Element): Element | undefined {
+    return [...element.children].find((child) => child.classList.contains('dx-nav__sublist'));
+  }
+
+  /** The `<li>` under `.dx-nav__list` whose OWN link (not a nested child's) matches `href`. */
+  function findTopLevelListItem(href: string): Element | null {
+    const items = document.querySelectorAll('.dx-nav__list > li');
+    for (const item of items) {
+      if (ownLink(item)?.getAttribute('href') === href) return item;
+    }
+    return null;
+  }
+
+  test('groups chat sub-parts under the chat root; unrelated components stay top-level', async () => {
+    const { unmount } = render(ComponentPage, {
+      componentName: 'button',
+      documentation: null,
+      sidebarComponents: ['button', 'chat', 'chat-composer-popover', 'chat-conversation-header'],
+    });
+    await tick();
+
+    const chatItem = findTopLevelListItem('/page/chat');
+    expect(chatItem).not.toBeNull();
+
+    const sublist = chatItem === null ? undefined : ownSublist(chatItem);
+    expect(sublist).toBeDefined();
+    const childHrefs = [...(sublist?.querySelectorAll('a.dx-nav__link--child') ?? [])].map((link) =>
+      link.getAttribute('href'),
+    );
+    expect(childHrefs).toEqual(['/page/chat-composer-popover', '/page/chat-conversation-header']);
+
+    // chat-composer-popover's link is nested, not a direct .dx-nav__list child.
+    expect(findTopLevelListItem('/page/chat-composer-popover')).toBeNull();
+
+    // button remains a direct top-level entry with no sublist.
+    const buttonItem = findTopLevelListItem('/page/button');
+    expect(buttonItem).not.toBeNull();
+    expect(buttonItem === null ? undefined : ownSublist(buttonItem)).toBeUndefined();
+
+    unmount();
+  });
+
+  test('synthesizes the chat group when the nav filter hides the root but keeps a matching child', async () => {
+    // Simulates the filter box hiding "chat" itself while a search still
+    // matches its children — `sidebarComponents` here stands in for whatever
+    // `visibleComponents` filtered down to.
+    const { unmount } = render(ComponentPage, {
+      componentName: 'button',
+      documentation: null,
+      sidebarComponents: ['chat-composer-popover', 'chat-conversation-header', 'button'],
+    });
+    await tick();
+
+    const chatItem = findTopLevelListItem('/page/chat');
+    expect(chatItem).not.toBeNull();
+    const sublist = chatItem === null ? undefined : ownSublist(chatItem);
+    expect(sublist).toBeDefined();
+    const childHrefs = [...(sublist?.querySelectorAll('a.dx-nav__link--child') ?? [])].map((link) =>
+      link.getAttribute('href'),
+    );
+    expect(childHrefs).toEqual(['/page/chat-composer-popover', '/page/chat-conversation-header']);
+
+    unmount();
+  });
+
+  test('synthesizes a single-child tabs group for a directly-passed compose-only leaf', async () => {
+    const { unmount } = render(ComponentPage, {
+      componentName: 'button',
+      documentation: null,
+      sidebarComponents: ['tab'],
+    });
+    await tick();
+
+    const tabsItem = findTopLevelListItem('/page/tabs');
+    expect(tabsItem).not.toBeNull();
+    const sublist = tabsItem === null ? undefined : ownSublist(tabsItem);
+    expect(sublist).toBeDefined();
+    const childHrefs = [...(sublist?.querySelectorAll('a.dx-nav__link--child') ?? [])].map((link) =>
+      link.getAttribute('href'),
+    );
+    expect(childHrefs).toEqual(['/page/tab']);
 
     unmount();
   });

--- a/packages/playground/src/discover.ts
+++ b/packages/playground/src/discover.ts
@@ -27,9 +27,10 @@ export type DiscoveredComponent = {
  * standalone usage — they are always rendered inside a parent compound
  * (`Tabs`, `Table`, `Dropdown`, `Accordion`, `Tree`, `Feed`, `GridList`,
  * `Grid`, `SpeedDial`, `StatisticGroup`, `SideNavigation`, `CommandMenu`,
- * `SegmentedControl`). They are excluded from the playground sidebar so a
- * single parent entry covers the family, but they remain in
- * `discoverComponents()` so direct `/c/<leaf>` routing still works.
+ * `SegmentedControl`, `BentoGrid`, `ChoiceGrid`, `ContextMenu`). They are
+ * excluded from the playground sidebar so a single parent entry covers the
+ * family, but they remain in `discoverComponents()` so direct `/c/<leaf>`
+ * routing still works.
  */
 export const COMPOSE_ONLY_COMPONENTS: ReadonlySet<string> = new Set([
   'accordion-item',
@@ -62,12 +63,6 @@ export const COMPOSE_ONLY_COMPONENTS: ReadonlySet<string> = new Set([
   'side-navigation-item',
 ]);
 
-/**
- * Explicit compound-family relationships used by the playground shell.
- * Keeping this list keyed by component id makes the relationship reviewable
- * metadata instead of relying on a naming-prefix heuristic. Leaves remain
- * independently routable; the sidebar simply presents them under their root.
- */
 /**
  * Scans a component-source root for the absolute paths of every public
  * component `.svelte` file. Covers both the legacy flat layout

--- a/packages/playground/src/example-metadata.ts
+++ b/packages/playground/src/example-metadata.ts
@@ -26,7 +26,7 @@ export type ExampleMetadata = {
 // backreference `\k<quote>` enforces a same-quote close.
 const STRING_PATTERN = /(?<quote>['"`])(?<body>(?:[^\\]|\\.)*?)\k<quote>/.source;
 
-const TITLE_PATTERN = new RegExp(`export\\s+const\\s+title\\s*=\\s*${STRING_PATTERN}`);
+export const TITLE_PATTERN = new RegExp(`export\\s+const\\s+title\\s*=\\s*${STRING_PATTERN}`);
 const DESCRIPTION_PATTERN = new RegExp(`export\\s+const\\s+description\\s*=\\s*${STRING_PATTERN}`);
 const FEATURED_PATTERN = /export\s+const\s+featured\s*=\s*true\s*;?/;
 

--- a/packages/playground/src/shell-app/compound-families.test.ts
+++ b/packages/playground/src/shell-app/compound-families.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+
+import { COMPOSE_ONLY_COMPONENTS } from '../discover.ts';
+import { COMPOUND_COMPONENT_FAMILIES, COMPOUND_COMPONENT_PARENTS } from './compound-families.ts';
+
+describe('compound-families registry completeness', () => {
+  test('every compose-only leaf has a parent entry', () => {
+    for (const leaf of COMPOSE_ONLY_COMPONENTS) {
+      expect(COMPOUND_COMPONENT_PARENTS[leaf]).toBeDefined();
+    }
+  });
+
+  test('every family root has a non-empty children list, and every child points back to it', () => {
+    for (const [root, children] of Object.entries(COMPOUND_COMPONENT_FAMILIES)) {
+      expect(children.length).toBeGreaterThan(0);
+      for (const child of children) {
+        expect(COMPOUND_COMPONENT_PARENTS[child]).toBe(root);
+      }
+    }
+  });
+
+  test('every parent entry appears in the matching family children list', () => {
+    // The test above walks FAMILIES -> PARENTS; this walks the inverse direction,
+    // PARENTS -> FAMILIES, so a stray or mistyped COMPOUND_COMPONENT_PARENTS entry
+    // whose root has no matching FAMILIES entry (or whose child is missing from
+    // that root's array) fails here even though it would pass the test above.
+    for (const [child, root] of Object.entries(COMPOUND_COMPONENT_PARENTS)) {
+      expect(COMPOUND_COMPONENT_FAMILIES[root]).toBeDefined();
+      expect(COMPOUND_COMPONENT_FAMILIES[root]).toContain(child);
+    }
+  });
+});

--- a/packages/playground/src/shell-app/compound-families.ts
+++ b/packages/playground/src/shell-app/compound-families.ts
@@ -1,21 +1,71 @@
-/** Browser-safe compound component relationships used by the playground shell. */
+/**
+ * Browser-safe compound component relationships used by the playground shell.
+ *
+ * Hand-maintained rather than derived from `COMPOSE_ONLY_COMPONENTS`
+ * (`../discover.ts`) — the leaf → root mapping is not mechanically derivable
+ * from naming alone (`segment` → `segmented-control`, `tab` → `tabs`,
+ * `command-item` → `command-menu` don't share a prefix), so a generator would
+ * have nothing reliable to generate from. `compound-families.test.ts` guards
+ * this file's completeness against `COMPOSE_ONLY_COMPONENTS` and against
+ * internal drift between the two exports below.
+ */
 export const COMPOUND_COMPONENT_FAMILIES: Readonly<Record<string, readonly string[]>> = {
-  accordion: [],
-  'bento-grid': [],
-  card: [],
-  table: [],
+  accordion: ['accordion-item'],
+  'bento-grid': ['bento-cell'],
   chat: ['chat-composer-popover', 'chat-conversation-header', 'chat-conversation-list'],
+  'choice-grid': ['choice-grid-item'],
+  'command-menu': ['command-item'],
+  'context-menu': ['context-menu-trigger'],
+  dropdown: [
+    'dropdown-trigger',
+    'dropdown-menu',
+    'dropdown-item',
+    'dropdown-label',
+    'dropdown-separator',
+    'dropdown-group',
+  ],
+  feed: ['feed-event'],
+  grid: ['grid-item'],
+  'grid-list': ['grid-list-item'],
+  'segmented-control': ['segment'],
+  'side-navigation': ['side-navigation-group', 'side-navigation-item'],
+  'speed-dial': ['speed-dial-action'],
+  'statistic-group': ['statistic'],
+  table: ['table-body', 'table-cell', 'table-header', 'table-header-cell', 'table-row'],
+  tabs: ['tab-list', 'tab', 'tab-panel'],
+  tree: ['tree-item'],
 };
 
 export const COMPOUND_COMPONENT_PARENTS: Readonly<Record<string, string>> = {
   'accordion-item': 'accordion',
   'bento-cell': 'bento-grid',
+  'chat-composer-popover': 'chat',
+  'chat-conversation-header': 'chat',
+  'chat-conversation-list': 'chat',
+  'choice-grid-item': 'choice-grid',
+  'command-item': 'command-menu',
+  'context-menu-trigger': 'context-menu',
+  'dropdown-trigger': 'dropdown',
+  'dropdown-menu': 'dropdown',
+  'dropdown-item': 'dropdown',
+  'dropdown-label': 'dropdown',
+  'dropdown-separator': 'dropdown',
+  'dropdown-group': 'dropdown',
+  'feed-event': 'feed',
+  'grid-item': 'grid',
+  'grid-list-item': 'grid-list',
+  segment: 'segmented-control',
+  'side-navigation-group': 'side-navigation',
+  'side-navigation-item': 'side-navigation',
+  'speed-dial-action': 'speed-dial',
+  statistic: 'statistic-group',
   'table-body': 'table',
   'table-cell': 'table',
   'table-header': 'table',
   'table-header-cell': 'table',
   'table-row': 'table',
-  'chat-composer-popover': 'chat',
-  'chat-conversation-header': 'chat',
-  'chat-conversation-list': 'chat',
+  'tab-list': 'tabs',
+  tab: 'tabs',
+  'tab-panel': 'tabs',
+  'tree-item': 'tree',
 };

--- a/packages/playground/src/shell-app/sidebar.test.ts
+++ b/packages/playground/src/shell-app/sidebar.test.ts
@@ -149,12 +149,25 @@ describe('Sidebar', () => {
     expect(container.querySelector('a[href="/page/button"]')).not.toBeNull();
   });
 
-  test('keeps compose-only leaves out of sidebar navigation', () => {
+  test('nests a compose-only leaf under its family group now that compound-families.ts registers it', () => {
+    // Previously `accordion` had no registered children in
+    // `COMPOUND_COMPONENT_FAMILIES` (an incompleteness `compound-families.ts`'s
+    // registry-completeness test now forbids), so this assertion used to read
+    // the other way — `accordion-item` never appeared because nothing was
+    // registered under `accordion` to render. Now that the registry is
+    // complete, `accordion` behaves exactly like the pre-existing `chat`
+    // family case above: its real child renders nested inside the group.
     const { container } = render(Sidebar, {
       props: { components: ['accordion'], currentComponent: 'accordion', onSelect: () => {} },
     });
-    expect(container.querySelector('a[href="/page/accordion"]')).not.toBeNull();
-    expect(container.querySelector('a[href="/page/accordion-item"]')).toBeNull();
+
+    const groupToggle = container.querySelector<HTMLButtonElement>(
+      'nav[aria-label="Components"] button[aria-expanded]',
+    );
+    expect(groupToggle?.textContent).toContain('Accordion');
+    const group = groupToggle?.parentElement?.parentElement;
+    expect(group?.querySelector('a[href="/page/accordion"]')).not.toBeNull();
+    expect(group?.querySelector('a[href="/page/accordion-item"]')).not.toBeNull();
   });
 
   test('renders a family when only a child matches the filter', async () => {

--- a/packages/playground/src/title-pattern-cross-check.test.ts
+++ b/packages/playground/src/title-pattern-cross-check.test.ts
@@ -93,9 +93,12 @@ describe('title regex cross-check', () => {
       expect(runtimeTitle).toBe(expectedRuntimeTitle);
       // Parity claim this test actually enforces: the two functions agree on
       // MATCH/NO-MATCH for every case (both null/'Untitled', or both non-null).
-      expect(buildGateTitle === null).toBe(
-        runtimeTitle === 'Untitled' && expectedBuildGateTitle === null,
-      );
+      // A true biconditional, not a one-directional implication — the previous
+      // `&& expectedBuildGateTitle === null` term made the right-hand side
+      // unconditionally `false` whenever `expectedBuildGateTitle` was non-null,
+      // which vacuously passed regardless of `runtimeTitle` and silently
+      // dropped the non-null-implies-non-'Untitled' direction of the check.
+      expect(buildGateTitle === null).toBe(runtimeTitle === 'Untitled');
     });
   }
 

--- a/packages/playground/src/title-pattern-cross-check.test.ts
+++ b/packages/playground/src/title-pattern-cross-check.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Cross-check between the runtime example-title extractor (`example-metadata.ts`)
+ * and the build-time gate (`validate-playground.ts`). Both call sites now share
+ * a single `TITLE_PATTERN` object exported from `example-metadata.ts` — this
+ * file locks that architecture and the shared regex's behavior so a future
+ * change to either file is caught immediately instead of surfacing later as a
+ * silent rendering mismatch between the dev server and the build gate.
+ *
+ * The two functions under test do NOT return identical bodies for every input:
+ * `extractExampleMetadataFromSource` runs its match through
+ * `unescapeStringLiteral()` (decoding `\'`, `\n`, etc.); `readExampleTitle`
+ * returns the raw matched body verbatim. What IS shared, and what this file
+ * enforces, is that both read the same underlying `TITLE_PATTERN` — so they
+ * agree on whether a title was found at all, and on the raw substring matched
+ * before either applies its own post-processing.
+ */
+import { describe, expect, test } from 'bun:test';
+
+import { extractExampleMetadataFromSource, TITLE_PATTERN } from './example-metadata.ts';
+import { readExampleTitle } from './validate-playground.ts';
+
+const CASES: Array<{
+  name: string;
+  source: string;
+  expectedBuildGateTitle: string | null;
+  expectedRuntimeTitle: string;
+}> = [
+  {
+    name: 'single-quoted',
+    source: "export const title = 'Basic usage';",
+    expectedBuildGateTitle: 'Basic usage',
+    expectedRuntimeTitle: 'Basic usage',
+  },
+  {
+    name: 'double-quoted',
+    source: 'export const title = "Basic usage";',
+    expectedBuildGateTitle: 'Basic usage',
+    expectedRuntimeTitle: 'Basic usage',
+  },
+  {
+    name: 'backtick',
+    source: 'export const title = `Basic usage`;',
+    expectedBuildGateTitle: 'Basic usage',
+    expectedRuntimeTitle: 'Basic usage',
+  },
+  {
+    // Both regexes MATCH the same literal (proving parity of the shared
+    // TITLE_PATTERN); the two functions' returned bodies differ because only
+    // the runtime extractor decodes escapes — documented, pre-existing,
+    // unchanged-by-this-issue behavior. `readExampleTitle` returns the raw
+    // matched body verbatim. Verified empirically against the real
+    // implementation before writing this case (see PR description).
+    name: 'escaped quote inside literal',
+    source: "export const title = 'It\\'s basic';",
+    expectedBuildGateTitle: "It\\'s basic",
+    expectedRuntimeTitle: "It's basic",
+  },
+  {
+    name: 'no title export',
+    source: 'export const description = "x";',
+    expectedBuildGateTitle: null,
+    expectedRuntimeTitle: 'Untitled',
+  },
+  {
+    // Verified empirically: `TITLE_PATTERN` has no awareness of `${…}`
+    // interpolation syntax — it matches ANY run of non-backslash characters up
+    // to the next same-style quote, so a backtick literal containing `${…}`
+    // still matches, with the interpolation captured verbatim as literal text
+    // in the body. The source comments in both files calling this
+    // "intentionally not supported" describe the AUTHORING convention (titles
+    // should be plain literals), not an enforced regex rejection — this issue
+    // only shares the existing regex, it does not change what it matches, so
+    // the case is asserted against real behavior rather than the aspirational
+    // "must not match" description.
+    name: 'template literal with interpolation (regex has no awareness of ${…}; matches literally)',
+    source: 'export const title = `Count: ${count}`;',
+    expectedBuildGateTitle: 'Count: ${count}',
+    expectedRuntimeTitle: 'Count: ${count}',
+  },
+];
+
+describe('title regex cross-check', () => {
+  test('TITLE_PATTERN is not global or sticky (safe to share across two independent .match() call sites)', () => {
+    expect(TITLE_PATTERN.global).toBe(false);
+    expect(TITLE_PATTERN.sticky).toBe(false);
+  });
+
+  for (const { name, source, expectedBuildGateTitle, expectedRuntimeTitle } of CASES) {
+    test(`${name}: example-metadata.ts and validate-playground.ts agree on whether a title was found`, () => {
+      const runtimeTitle = extractExampleMetadataFromSource(source).title;
+      const buildGateTitle = readExampleTitle(source);
+      expect(buildGateTitle).toBe(expectedBuildGateTitle);
+      expect(runtimeTitle).toBe(expectedRuntimeTitle);
+      // Parity claim this test actually enforces: the two functions agree on
+      // MATCH/NO-MATCH for every case (both null/'Untitled', or both non-null).
+      expect(buildGateTitle === null).toBe(
+        runtimeTitle === 'Untitled' && expectedBuildGateTitle === null,
+      );
+    });
+  }
+
+  test('exactly one `const TITLE_PATTERN =` definition exists in the package, in example-metadata.ts', async () => {
+    const glob = new Bun.Glob('**/*.ts');
+    const definitionSites: string[] = [];
+    for await (const relativePath of glob.scan({ cwd: import.meta.dirname })) {
+      // Exclude this test file's own source — it contains the literal pattern
+      // name in prose/comments and would otherwise self-match.
+      if (relativePath === 'title-pattern-cross-check.test.ts') continue;
+      const text = await Bun.file(`${import.meta.dirname}/${relativePath}`).text();
+      if (/\bconst\s+TITLE_PATTERN\s*=/.test(text)) {
+        definitionSites.push(relativePath);
+      }
+    }
+    expect(definitionSites).toEqual(['example-metadata.ts']);
+  });
+
+  test('validate-playground.ts imports TITLE_PATTERN from example-metadata.ts rather than redefining it', async () => {
+    const source = await Bun.file(`${import.meta.dirname}/validate-playground.ts`).text();
+    expect(source).toMatch(
+      /import\s*\{[^}]*\bTITLE_PATTERN\b[^}]*\}\s*from\s*'\.\/example-metadata\.ts'/,
+    );
+  });
+});

--- a/packages/playground/src/validate-playground.ts
+++ b/packages/playground/src/validate-playground.ts
@@ -21,6 +21,11 @@ import {
   variablesList,
 } from './component-documentation-reference.ts';
 import { discoverComponents } from './discover.ts';
+// Shared with the runtime extractor in example-metadata.ts. That module has no
+// I/O and no import.meta.main guard, so importing it does not couple this
+// build-time gate to the runtime server's startup behavior — the concern a
+// previous version of this file duplicated the regex to avoid.
+import { TITLE_PATTERN } from './example-metadata.ts';
 import { type PlaygroundServer, PORT, startServer, triggerReload } from './playground-server.ts';
 
 class PlaygroundValidationError extends Error {
@@ -37,20 +42,8 @@ function fail(message: string): never {
 /** Minimum number of public components expected in src/components/. */
 const MINIMUM_COMPONENT_COUNT = 80;
 
-// Title-presence check for `.example.svelte` files. SELF-CONTAINED on purpose:
-// this duplicates a tiny title regex rather than importing from
-// `example-metadata.ts`/`server.ts` so the build-time gate has no coupling to
-// the runtime server module (importing server.ts would also auto-wire its
-// import.meta.main guard expectations into this validator's dependency graph).
-
 /** The sentinel a missing title falls back to; an explicit one is rejected too. */
 const UNTITLED_SENTINEL = 'Untitled';
-
-// Matches `export const title = '…' | "…" | `…``. Mirrors the runtime extractor:
-// a same-quote backreference close and `\\.` to skip escaped quotes inside the
-// literal. Interpolated template literals are intentionally not parsed — titles
-// must be plain string literals.
-const TITLE_PATTERN = /export\s+const\s+title\s*=\s*(['"`])((?:[^\\]|\\.)*?)\1/;
 
 /**
  * Read the `export const title` string literal from example source, or `null`
@@ -58,7 +51,7 @@ const TITLE_PATTERN = /export\s+const\s+title\s*=\s*(['"`])((?:[^\\]|\\.)*?)\1/;
  */
 export function readExampleTitle(source: string): string | null {
   const match = source.match(TITLE_PATTERN);
-  return match ? (match[2] ?? '') : null;
+  return match ? (match.groups?.['body'] ?? '') : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Cluster G — two independent playground-audit findings.

### #1177 — make `compound-families.ts` the complete grouping registry, group `.dx-nav`

- `compound-families.ts`'s `COMPOUND_COMPONENT_PARENTS` only mapped 7 of the 28 `COMPOSE_ONLY_COMPONENTS` leaves (`accordion-item` + the five `table-*` leaves + `bento-cell`) back to a family root. Filled in the other 21 (dropdown, tabs, tree, feed, grid, grid-list, speed-dial, statistic-group, side-navigation, choice-grid, command-menu, segmented-control, context-menu), removed the dead `card: []` root (no leaf anywhere referenced it), and filled the three previously-empty roots (`accordion`, `bento-grid`, `table`) with their real children. 17 real families total.
- Added `packages/playground/src/shell-app/compound-families.test.ts`: a completeness test walking both directions — every `COMPOSE_ONLY_COMPONENTS` leaf has a parent entry, every family's children list is non-empty and points back correctly, and every parent entry appears in its root's children list (catches a stray/mistyped entry the first check alone would miss).
- `component-page.svelte`: added a `navigationGroups` `$derived.by` next to the existing `visibleComponents`, and rewired `.dx-nav__list` to render nested groups (`.dx-nav__sublist` / `.dx-nav__link--child`, styled with existing `--cinder-space-7` / `--cinder-text-xs` tokens). A group is synthesized on demand under a child's root key even when the root itself isn't in the visible list — covers the nav filter hiding the root while keeping a matching child, and a fixture passing a compose-only leaf directly.
- `discover.ts`: `COMPOSE_ONLY_COMPONENTS`'s doc comment now names all 16 real families (added `BentoGrid`, `ChoiceGrid`, `ContextMenu`). Also removed a stray, orphaned doc comment ("Explicit compound-family relationships...") left over from when the family data lived in this file — noticed while editing the adjacent comment; it described a symbol no longer declared here.
- `component-page.test.ts`: added a `.dx-nav compound-family grouping` describe block that mounts the real `ComponentPage` (passing `documentation: null` to skip the data-island read, and a fake global `EventSource` since the live-reload attach otherwise throws under happy-dom/Bun). Three cases: chat nesting + unrelated component stays top-level, root-hidden-by-filter synthesis, and a directly-passed compose-only leaf (`tab`) synthesizing a `tabs` group. Direct-child assertions use manual `element.children` traversal instead of the `:scope` combinator — verified empirically that happy-dom's `Element.querySelector` doesn't resolve `:scope` relative to the calling element, so `li.querySelector(':scope > a')` returns `null` even when a direct-child `<a>` exists.
- **Side effect on the dead `shell-app/sidebar.svelte`** (unreferenced by any live route — confirmed via repo-wide grep — deletion tracked in a separate cluster): it reads `COMPOUND_COMPONENT_FAMILIES` unconditionally and now nests `accordion-item` under `accordion` the same way it already nested `chat`'s children. Its one test asserting the opposite ("keeps compose-only leaves out of sidebar navigation") was only true as an artifact of the previously-incomplete registry — `accordion: []` had nothing to render. Updated that test to assert the new, correct, and now-consistent-with-`chat` behavior rather than leaving a real failure in place.

### #1178 — share the example-title regex between the runtime extractor and the build gate

- Exported `TITLE_PATTERN` from `example-metadata.ts`; `validate-playground.ts` now imports it instead of re-deriving an equivalent positional-capture-group regex. `readExampleTitle` reads the shared pattern's named `body` group.
- Replaced the "SELF-CONTAINED on purpose" comment with one explaining why importing `example-metadata.ts` doesn't reintroduce the coupling the old comment worried about (no I/O, no `import.meta.main` guard, and `validate-playground.ts` already imports `playground-server.ts` transitively).
- Added `packages/playground/src/title-pattern-cross-check.test.ts`: parity cases across both call sites, a `TITLE_PATTERN.global`/`.sticky` invariant check, and a mechanical architecture assertion — exactly one `const TITLE_PATTERN =` definition in the package (via `Bun.Glob`, not a subprocess `rg` call, and explicitly excluding the test file's own source from the scan) plus a shape-based (not literal-string) check that `validate-playground.ts` imports it. That architecture assertion is the one that actually fails before this fix and passes after.
- **One test case deviates from the issue's own prescribed expected values**, verified empirically before writing it: `TITLE_PATTERN` has no awareness of `${…}` template-literal interpolation syntax. A backtick literal containing `${count}` still matches — the interpolation is captured as literal text in the body — rather than failing to match as the issue text assumed ("must not match... falls back to Untitled/null in both"). This is pre-existing, unchanged-by-this-issue behavior; the test asserts the real values (`'Count: ${count}'` for both extractors), not the aspirational ones. Flagging in case it's worth a separate follow-up issue about the regex's stated-vs-actual template-literal handling — not fixed here, out of scope per #1178's own text ("Changing the title-authoring convention itself... this issue only removes the duplication").

## Test plan

- [x] `cd packages/playground && bun run test` — 981 tests across 40 files, 0 failures (three expected `error: boom` lines from a pre-existing deliberate-throw fixture in `component-page-live-preview.test.ts`)
- [x] `cd packages/playground && bunx tsc --noEmit` — clean
- [x] `cd packages/playground && bunx svelte-check --tsconfig tsconfig.json --threshold error` — 0 errors
- [x] `cd packages/playground && bun run lint` (oxlint) — 0 warnings, 0 errors
- [x] `cd packages/components && bun run lint:invariants` — all 13 checks pass
- [x] `cd packages/components && bun run components:check` — OK
- [x] `npx prettier --check` on every touched file — clean (pre-commit's `prettier --write` also ran and made no further changes)
- [x] `npx stylelint packages/playground/src/component-page.svelte` — clean
- [x] `cd packages/testing && bun run test:playwright -- tests/playground-shell-styles.playwright.ts tests/playground-documentation.playwright.ts` — 9/9 passed (these are the only two specs referencing `.dx-nav`/`.dx-nav__link`/`.dx-nav__list`; none assert a total `.dx-nav__link` count that grouping would change, since the flat→nested restructure preserves the total link count and their filter-based assertions use "badge", unaffected by the chat family)
- [x] Repo-wide grep confirmed no other consumer of `COMPOUND_COMPONENT_FAMILIES`/`COMPOUND_COMPONENT_PARENTS` outside `packages/playground` (the only other consumer, `scripts/static-export.ts`, already deduplicates its route set against `discoverComponents()`, which already includes every compose-only leaf — its own test suite, 15/15, confirms no behavior change)

No changeset: `@cinder/playground` is in the changesets `ignore` list.

Closes #1177
Closes #1178

https://claude.ai/code/session_01BSu4BJmyZUpeac7p6vH3fU