### PR TITLE
fix(types): remove unnecessary assertions, fix type-erasing casts, close barrel export gaps

### DIFF
--- a/.changeset/type-hygiene-and-barrel-exports.md
+++ b/.changeset/type-hygiene-and-barrel-exports.md
@@ -1,0 +1,38 @@
+---
+'@lostgradient/cinder': minor
+---
+
+Type hygiene and barrel export cleanup across four areas:
+
+- Removed nine `as` type assertions that TypeScript already proved unnecessary
+  (context-menu, command-menu, dropdown-trigger, faceted-filter-bar, file-upload,
+  form-section, marquee, navigation-item, plus a playground-only cast). No behavior
+  change; `marquee`'s cast additionally erased a real `null` case from its
+  `aria-labelledby` prop type, so the fixed type is stricter and more accurate.
+- Fixed type-erasing casts and phantom generics across six components:
+  `FloatingAction`'s per-arm `onclick` is now correctly typed instead of pulled out
+  of the union; `NumberInput` forwards its rest props with their real type instead
+  of `Record<string, unknown>`; `GridList` composes with `Grid` through a single
+  cast instead of `as unknown as`; `PermissionMatrix` now genuinely wires its
+  `TRow`/`TColumn` generics (previously declared but never threaded through
+  `$props()`); `SchemaForm`'s `Schema` generic was removed because it only ever
+  narrowed the `schema` field itself; and a duplicated `ChoiceGridItemProps` type
+  was deleted in favor of its single canonical declaration.
+  **API-visible for three components:** `GridListProps`'s base element type
+  widened from `HTMLUListElement` to `HTMLElement`, `PermissionMatrixProps` gained
+  a real `<TRow, TColumn>` generic (previously a no-op default), and
+  `SchemaFormProps` lost its incomplete `<Schema>` generic. None of these change
+  runtime behavior, but a consumer relying on the old type shape (e.g. an
+  `HTMLUListElement`-typed inline handler on `GridList`, or an explicit
+  `SchemaFormProps<...>` type argument) may see a new `typecheck`/`svelte-check`
+  error, hence the minor bump.
+- Re-exported five public prop types that were reachable on their component's
+  `Props` type but not importable on their own: `PopoverFocusManagement`,
+  `PopoverWidthMode`, `SegmentCurrentToken`, `ResizablePanelSizeUnit`,
+  `TreeReorderTarget`, and `TreeItemSelectionState`, from both their component
+  barrel and the package root.
+- Re-exported `ChartDataTableVisibility` (aliased per-component, e.g.
+  `WaveformDataTableVisibility`) from all seven chart-family component barrels
+  (`waveform`, `bar-chart`, `area-chart`, `line-chart`, `matrix-chart`,
+  `spectrum-chart`, `spectrogram`) and the package root, closing the same gap
+  for a shared, non-directory-shaped type module.

--- a/packages/components/src/components/area-chart/index.ts
+++ b/packages/components/src/components/area-chart/index.ts
@@ -2,5 +2,6 @@ import './area-chart.css';
 import AreaChart from './area-chart.svelte';
 
 export default AreaChart;
+export type { ChartDataTableVisibility } from '../chart.types.ts';
 export type { AreaChartProps, AreaChartSchemaProps } from './area-chart.types.ts';
 export { AreaChart };

--- a/packages/components/src/components/bar-chart/index.ts
+++ b/packages/components/src/components/bar-chart/index.ts
@@ -2,5 +2,6 @@ import './bar-chart.css';
 import BarChart from './bar-chart.svelte';
 
 export default BarChart;
+export type { ChartDataTableVisibility } from '../chart.types.ts';
 export type { BarChartProps, BarChartSchemaProps } from './bar-chart.types.ts';
 export { BarChart };

--- a/packages/components/src/components/choice-grid-item/choice-grid-item.svelte
+++ b/packages/components/src/components/choice-grid-item/choice-grid-item.svelte
@@ -11,10 +11,7 @@
    * @avoidWhen Used outside a ChoiceGrid — this leaf requires the parent context.
    * @related choice-grid
    */
-  export type {
-    ChoiceGridItemProps,
-    ChoiceGridItemState,
-  } from '../choice-grid/choice-grid.types.ts';
+  export type { ChoiceGridItemProps, ChoiceGridItemState } from './choice-grid-item.types.ts';
 </script>
 
 <script lang="ts">

--- a/packages/components/src/components/choice-grid/choice-grid.types.test.ts
+++ b/packages/components/src/components/choice-grid/choice-grid.types.test.ts
@@ -8,9 +8,9 @@
 
 import { describe, expect, test } from 'bun:test';
 
+import type { ChoiceGridItemProps } from '../choice-grid-item/choice-grid-item.types.ts';
 import type {
   ChoiceGridColumns,
-  ChoiceGridItemProps,
   ChoiceGridItemState,
   ChoiceGridProps,
 } from './choice-grid.types.ts';

--- a/packages/components/src/components/choice-grid/choice-grid.types.ts
+++ b/packages/components/src/components/choice-grid/choice-grid.types.ts
@@ -124,29 +124,3 @@ export type ChoiceGridProps = Omit<
   /** `ChoiceGridItem` children. */
   children: Snippet;
 };
-
-/**
- * Props for the `<ChoiceGridItem>` leaf component.
- */
-export type ChoiceGridItemProps = {
-  /**
-   * The value this item represents. Used as the key for selection state,
-   * roving tabindex registration, and ARIA attributes.
-   */
-  value: string;
-
-  /**
-   * Feedback state for assessment / quiz usage. Defaults to `'neutral'`.
-   * Layout dimensions do NOT change across states (stable cell sizing guarantee).
-   */
-  state?: ChoiceGridItemState;
-
-  /** When true this item cannot be selected or focused. */
-  disabled?: boolean;
-
-  /** Additional class names merged with `.cinder-choice-grid-item`. */
-  class?: string;
-
-  /** Item content — label text, an icon, or richer markup. */
-  children: Snippet;
-};

--- a/packages/components/src/components/command-menu/command-menu.svelte
+++ b/packages/components/src/components/command-menu/command-menu.svelte
@@ -29,7 +29,7 @@
     computeGhostOverlayFontStyle,
     createInlineCompletionState,
   } from './command-menu-inline-completion.svelte.ts';
-  import type { Placement, VirtualElement } from '@floating-ui/dom';
+  import type { VirtualElement } from '@floating-ui/dom';
   import { on } from 'svelte/events';
 
   import { createAnchoredOverlay } from '../../_internal/anchored-overlay.svelte.ts';
@@ -115,7 +115,7 @@
     open: () => open,
     anchor: () => caretAnchor,
     panel: () => listElement,
-    placement: () => placement as Placement,
+    placement: () => placement,
     offset: () => offset,
     widthMode: () => 'content',
   });

--- a/packages/components/src/components/context-menu/context-menu.svelte
+++ b/packages/components/src/components/context-menu/context-menu.svelte
@@ -90,17 +90,16 @@
 
   function makeVirtualReference(x: number, y: number): VirtualElement {
     return {
-      getBoundingClientRect: () =>
-        ({
-          x,
-          y,
-          top: y,
-          left: x,
-          right: x,
-          bottom: y,
-          width: 0,
-          height: 0,
-        }) as DOMRect,
+      getBoundingClientRect: () => ({
+        x,
+        y,
+        top: y,
+        left: x,
+        right: x,
+        bottom: y,
+        width: 0,
+        height: 0,
+      }),
     };
   }
 

--- a/packages/components/src/components/dropdown-trigger/dropdown-trigger.svelte
+++ b/packages/components/src/components/dropdown-trigger/dropdown-trigger.svelte
@@ -41,15 +41,11 @@
     return () => registerTrigger(null);
   }
 
-  type DropdownTriggerClickHandler = (
-    event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
-  ) => void;
-
   function handleClick(
     event: MouseEvent & { currentTarget: EventTarget & HTMLButtonElement },
   ): void {
     if (typeof onclick === 'function') {
-      (onclick as DropdownTriggerClickHandler)(event);
+      onclick(event);
     }
     if (!event.defaultPrevented && !context.supportsPopover) {
       setOpen(!context.isOpen);

--- a/packages/components/src/components/faceted-filter-bar/faceted-filter-bar.svelte
+++ b/packages/components/src/components/faceted-filter-bar/faceted-filter-bar.svelte
@@ -30,7 +30,7 @@
   import Button from '../button/button.svelte';
   import { classNames } from '../../utilities/class-names.ts';
 
-  import type { FacetedFilterBarProps, SelectFacet } from './faceted-filter-bar.types.ts';
+  import type { FacetedFilterBarProps } from './faceted-filter-bar.types.ts';
 
   const generatedId = $props.id();
 
@@ -151,27 +151,26 @@
 
     {#each facets as facet (facet.key)}
       {#if facet.type === 'select'}
-        {@const selectFacet = facet as SelectFacet}
         <div class="cinder-faceted-filter-bar__facet">
           <label
             class="cinder-faceted-filter-bar__facet-label"
-            for={`${generatedId}-facet-${selectFacet.key}`}
+            for={`${generatedId}-facet-${facet.key}`}
           >
-            {selectFacet.label}
+            {facet.label}
           </label>
           <select
-            id={`${generatedId}-facet-${selectFacet.key}`}
+            id={`${generatedId}-facet-${facet.key}`}
             class="cinder-faceted-filter-bar__select"
-            value={resolveFacetValue(selectFacet.key)}
-            disabled={disabled || selectFacet.disabled}
-            aria-label={selectFacet.label}
+            value={resolveFacetValue(facet.key)}
+            disabled={disabled || facet.disabled}
+            aria-label={facet.label}
             onchange={(event) => {
               const target = event.currentTarget as HTMLSelectElement;
-              onFacetChange?.(selectFacet.key, target.value);
+              onFacetChange?.(facet.key, target.value);
             }}
           >
-            <option value="">{selectFacet.placeholder ?? selectFacet.label}</option>
-            {#each selectFacet.options as option (option.value)}
+            <option value="">{facet.placeholder ?? facet.label}</option>
+            {#each facet.options as option (option.value)}
               <option value={option.value} disabled={option.disabled}>{option.label}</option>
             {/each}
           </select>

--- a/packages/components/src/components/file-upload/file-upload.svelte
+++ b/packages/components/src/components/file-upload/file-upload.svelte
@@ -95,7 +95,7 @@
   function hasFilesPayload(dataTransfer: DataTransfer | null | undefined): boolean {
     const fileTypes = dataTransfer?.types;
     if (!fileTypes) return false;
-    return Array.from(fileTypes as ArrayLike<string>).includes('Files');
+    return Array.from(fileTypes).includes('Files');
   }
 
   function matchesAcceptToken(file: File, token: string): boolean {

--- a/packages/components/src/components/floating-action/floating-action.svelte
+++ b/packages/components/src/components/floating-action/floating-action.svelte
@@ -36,13 +36,13 @@
     href,
     'aria-label': ariaLabel,
     'aria-labelledby': ariaLabelledBy,
-    // Pulled out of `rest` so we can control them per disabled-state:
+    // Pulled out of `rest` so we can control it per disabled-state:
     // - tabindex: a disabled item forces -1, an enabled one honors the consumer value.
-    // - onclick: a disabled anchor must not run a consumer handler (pointer-events:none
-    //   blocks the mouse, but a handler in `rest` would still fire on keyboard/programmatic
-    //   activation). The button arm already blocks both via the native `disabled` attribute.
+    // `onclick` stays inside `...rest` — a disabled anchor must not run a consumer handler
+    // (pointer-events:none blocks the mouse, but a handler in `rest` would still fire on
+    // keyboard/programmatic activation), so it's read per-arm off `anchorAttributes` /
+    // `buttonAttributes` below instead of a single shared name.
     tabindex,
-    onclick,
     ...rest
   }: FloatingActionProps = $props();
 
@@ -73,15 +73,24 @@
   const anchorAttributes = $derived(
     rest as Omit<
       HTMLAnchorAttributes,
-      'class' | 'href' | 'aria-label' | 'aria-labelledby' | 'tabindex' | 'onclick'
+      'class' | 'href' | 'aria-label' | 'aria-labelledby' | 'tabindex'
     >,
   );
   const buttonAttributes = $derived(
     rest as Omit<
       HTMLButtonAttributes,
-      'class' | 'type' | 'disabled' | 'aria-label' | 'aria-labelledby' | 'tabindex' | 'onclick'
+      'class' | 'type' | 'disabled' | 'aria-label' | 'aria-labelledby' | 'tabindex'
     >,
   );
+  // Compile-time-only proof that `onclick` survived each per-arm `Omit` above with
+  // its real element-specific handler type. `typeof anchorAttributes`/`typeof
+  // buttonAttributes` are type queries erased at compile time — unlike reading
+  // `anchorAttributes.onclick` directly, this never dereferences the `$derived`
+  // value outside a reactive context, so it can't warn as a stale one-time read.
+  const anchorOnclickTypeProof = undefined as unknown as (typeof anchorAttributes)['onclick'];
+  const buttonOnclickTypeProof = undefined as unknown as (typeof buttonAttributes)['onclick'];
+  anchorOnclickTypeProof satisfies HTMLAnchorAttributes['onclick'];
+  buttonOnclickTypeProof satisfies HTMLButtonAttributes['onclick'];
 
   // Dev-mode guards. devWarn no-ops in production.
   $effect(() => {
@@ -120,7 +129,7 @@
     aria-labelledby={resolvedAriaLabelledBy}
     aria-disabled={disabled || undefined}
     tabindex={resolvedTabindex}
-    onclick={disabled ? undefined : onclick}
+    onclick={disabled ? undefined : anchorAttributes.onclick}
   >
     {#if children}
       {@render children()}
@@ -136,7 +145,6 @@
     aria-label={resolvedAriaLabel}
     aria-labelledby={resolvedAriaLabelledBy}
     tabindex={resolvedTabindex}
-    {onclick}
   >
     {#if children}
       {@render children()}

--- a/packages/components/src/components/form-section/form-section.svelte
+++ b/packages/components/src/components/form-section/form-section.svelte
@@ -48,7 +48,7 @@
     }
   });
 
-  const headingTag = $derived(headingTags[headingLevel as FormSectionHeadingLevel] ?? 'h2');
+  const headingTag = $derived(headingTags[headingLevel] ?? 'h2');
 </script>
 
 {#if as === 'fieldset'}

--- a/packages/components/src/components/grid-list/grid-list.svelte
+++ b/packages/components/src/components/grid-list/grid-list.svelte
@@ -23,7 +23,7 @@
   let { minColumnWidth, class: className, children, ...rest }: GridListProps = $props();
 
   const minWidth = $derived(minColumnWidth && minColumnWidth.length > 0 ? minColumnWidth : '16rem');
-  const gridRest = $derived(rest as unknown as Omit<GridProps, 'children'>);
+  const gridRest = $derived(rest as Omit<GridProps, 'children'>);
 </script>
 
 <Grid

--- a/packages/components/src/components/grid-list/grid-list.types.ts
+++ b/packages/components/src/components/grid-list/grid-list.types.ts
@@ -1,6 +1,6 @@
 import type { Snippet } from 'svelte';
 import type { HTMLAttributes } from 'svelte/elements';
-export type GridListProps = Omit<HTMLAttributes<HTMLUListElement>, 'role'> & {
+export type GridListProps = Omit<HTMLAttributes<HTMLElement>, 'role'> & {
   /**
    * Minimum width of each grid cell, expressed as a CSS `<length>` value
    * (e.g. `"16rem"`, `"240px"`, `"min(20rem, 100%)"`). Used as the first

--- a/packages/components/src/components/line-chart/index.ts
+++ b/packages/components/src/components/line-chart/index.ts
@@ -2,5 +2,6 @@ import './line-chart.css';
 import LineChart from './line-chart.svelte';
 
 export default LineChart;
+export type { ChartDataTableVisibility } from '../chart.types.ts';
 export type { LineChartProps, LineChartSchemaProps } from './line-chart.types.ts';
 export { LineChart };

--- a/packages/components/src/components/marquee/marquee.svelte
+++ b/packages/components/src/components/marquee/marquee.svelte
@@ -36,7 +36,7 @@
   const normalizedLabel = $derived(
     typeof label === 'string' && label.trim().length > 0 ? label.trim() : undefined,
   );
-  const ariaLabelledby = $derived((rest as { 'aria-labelledby'?: string })['aria-labelledby']);
+  const ariaLabelledby = $derived(rest['aria-labelledby']);
   const hasAccessibleName = $derived(
     Boolean(normalizedLabel) ||
       (typeof ariaLabelledby === 'string' && ariaLabelledby.trim().length > 0),

--- a/packages/components/src/components/marquee/marquee.test.ts
+++ b/packages/components/src/components/marquee/marquee.test.ts
@@ -268,6 +268,18 @@ describe('Marquee', () => {
     expect(element?.getAttribute('role')).toBe('region');
   });
 
+  test('treats an explicit null aria-labelledby the same as omitting it', () => {
+    const { container } = render(Marquee, {
+      props: {
+        'aria-labelledby': null,
+        children: textSnippet('content'),
+      } as never,
+    });
+    const element = container.querySelector('.cinder-marquee');
+    expect(element?.hasAttribute('aria-labelledby')).toBe(false);
+    expect(element?.hasAttribute('role')).toBe(false);
+  });
+
   test('reduced-motion CSS disables animation, restores overflow access, and hides duplicate', async () => {
     const css = await Bun.file(marqueeCssPath).text();
     expect(css).toContain('overflow: clip');

--- a/packages/components/src/components/matrix-chart/index.ts
+++ b/packages/components/src/components/matrix-chart/index.ts
@@ -2,6 +2,7 @@ import './matrix-chart.css';
 import MatrixChart from './matrix-chart.svelte';
 
 export default MatrixChart;
+export type { ChartDataTableVisibility } from '../chart.types.ts';
 export type {
   MatrixChartProps,
   MatrixChartSchemaProps,

--- a/packages/components/src/components/navigation-item/navigation-item.svelte
+++ b/packages/components/src/components/navigation-item/navigation-item.svelte
@@ -72,7 +72,7 @@
     // navigation (and let modified/middle clicks fall through to the browser), and
     // the button arm must not crash when `href={someUndefinedValue}` routes a
     // consumer into the button branch without supplying an onclick.
-    (onclick as ((event: MouseEvent) => void) | undefined)?.(event);
+    onclick?.(event);
   }
 </script>
 

--- a/packages/components/src/components/number-input/number-input.svelte
+++ b/packages/components/src/components/number-input/number-input.svelte
@@ -52,7 +52,6 @@
 
   const context = getFormFieldContext();
   const localeContext = getLocaleContext();
-  const inputRest = $derived(rest as Record<string, unknown>);
 
   let editorBuffer = $state('');
   let isFocused = $state(false);
@@ -494,9 +493,12 @@
   // sets aria-invalid without fabricating an error-element id that points at
   // nothing. The internal message is wired into describedBy via its own id.
   const internalInvalid = $derived(malformedError || requiredEmptyError ? 'true' : undefined);
-  const resolvedAriaInvalid = $derived(
-    internalInvalid ?? (inputRest['aria-invalid'] as 'true' | 'false' | undefined),
-  );
+
+  function toAriaInvalidValue(value: unknown): 'true' | 'false' | undefined {
+    return value === 'true' || value === 'false' ? value : undefined;
+  }
+
+  const resolvedAriaInvalid = $derived(internalInvalid ?? toAriaInvalidValue(rest['aria-invalid']));
 
   const incrementDisabled = $derived(
     resolvedDisabled || (value !== null && value !== undefined && value >= resolvedMax),
@@ -560,7 +562,7 @@
     required={resolvedRequired}
     class="cinder-number-input__input"
     groupClassName="cinder-number-input"
-    {...inputRest}
+    {...rest}
     type="text"
     role="spinbutton"
     inputmode="decimal"

--- a/packages/components/src/components/permission-matrix/permission-matrix.svelte
+++ b/packages/components/src/components/permission-matrix/permission-matrix.svelte
@@ -23,7 +23,10 @@
   } from './permission-matrix.types.ts';
 </script>
 
-<script lang="ts">
+<script
+  lang="ts"
+  generics="TRow extends PermissionMatrixAxisItem = PermissionMatrixAxisItem, TColumn extends PermissionMatrixAxisItem = PermissionMatrixAxisItem"
+>
   import Check from 'lucide-svelte/icons/check';
   import LockKeyhole from 'lucide-svelte/icons/lock-keyhole';
   import Minus from 'lucide-svelte/icons/minus';
@@ -51,7 +54,7 @@
     loadingContent,
     id,
     ...rest
-  }: PermissionMatrixProps = $props();
+  }: PermissionMatrixProps<TRow, TColumn> = $props();
 
   const generatedId = $props.id();
   const rootId = $derived(id ?? generatedId);

--- a/packages/components/src/components/permission-matrix/permission-matrix.type-test.svelte
+++ b/packages/components/src/components/permission-matrix/permission-matrix.type-test.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import PermissionMatrix from './permission-matrix.svelte';
+  import type {
+    PermissionMatrixAxisItem,
+    PermissionMatrixCellState,
+  } from './permission-matrix.types.ts';
+
+  type ScopeRow = { id: string; label: string; scopeKey: string };
+
+  let scopeRows = $state<ScopeRow[]>([
+    { id: 'billing-read', label: 'billing:read', scopeKey: 'billing' },
+    { id: 'billing-write', label: 'billing:write', scopeKey: 'billing' },
+  ]);
+
+  const columns: PermissionMatrixAxisItem[] = [
+    { id: 'read', label: 'Read' },
+    { id: 'write', label: 'Write' },
+  ];
+
+  function getScopedCellState(
+    row: ScopeRow,
+    column: PermissionMatrixAxisItem,
+  ): PermissionMatrixCellState {
+    return row.scopeKey === 'billing' && column.id === 'read' ? 'granted' : 'denied';
+  }
+
+  const plainRows: PermissionMatrixAxisItem[] = [
+    { id: 'users', label: 'Users' },
+    { id: 'billing', label: 'Billing' },
+  ];
+
+  function getPlainCellState(): PermissionMatrixCellState {
+    return 'not-applicable';
+  }
+</script>
+
+<PermissionMatrix
+  label="Reactive scope permissions"
+  rows={scopeRows}
+  {columns}
+  getCellState={getScopedCellState}
+/>
+
+<PermissionMatrix
+  label="Literal scope permissions"
+  rows={[
+    { id: 'runs-admin', label: 'runs:admin', scopeKey: 'runs' },
+    { id: 'runs-read', label: 'runs:read', scopeKey: 'runs' },
+  ]}
+  {columns}
+  getCellState={(row, column) =>
+    row.scopeKey === 'runs' && column.id === 'write' ? 'granted' : 'denied'}
+/>
+
+<PermissionMatrix
+  label="Default axis item shape"
+  rows={plainRows}
+  columns={plainRows}
+  getCellState={getPlainCellState}
+/>

--- a/packages/components/src/components/permission-matrix/permission-matrix.type-test.ts
+++ b/packages/components/src/components/permission-matrix/permission-matrix.type-test.ts
@@ -1,0 +1,43 @@
+import type {
+  PermissionMatrixAxisItem,
+  PermissionMatrixCellState,
+  PermissionMatrixProps,
+} from './permission-matrix.types.ts';
+
+const scopeRows = [
+  { id: 'billing-read', label: 'billing:read', scopeKey: 'billing' },
+  { id: 'billing-write', label: 'billing:write', scopeKey: 'billing' },
+] satisfies Array<{ id: string; label: string; scopeKey: string }>;
+
+const columns = [
+  { id: 'read', label: 'Read' },
+  { id: 'write', label: 'Write' },
+] satisfies PermissionMatrixAxisItem[];
+
+const _valid: PermissionMatrixProps<{ id: string; label: string; scopeKey: string }> = {
+  label: 'Scope permissions',
+  rows: scopeRows,
+  columns,
+  getCellState: (row, column): PermissionMatrixCellState => {
+    return row.scopeKey === 'billing' && column.id === 'read' ? 'granted' : 'denied';
+  },
+  onCellClick: (row, column, state) => {
+    void row.scopeKey;
+    void column.id;
+    void state;
+  },
+};
+
+const _invalid: PermissionMatrixProps = {
+  label: 'Scope permissions',
+  rows: columns,
+  columns,
+  getCellState: (row) => {
+    // @ts-expect-error - default PermissionMatrixAxisItem row has no scopeKey field
+    void row.scopeKey;
+    return 'granted';
+  },
+};
+
+void _valid;
+void _invalid;

--- a/packages/components/src/components/popover/index.ts
+++ b/packages/components/src/components/popover/index.ts
@@ -2,5 +2,11 @@ import './popover.css';
 import Popover from './popover.svelte';
 
 export default Popover;
-export type { PopoverPlacement, PopoverProps, PopoverRole } from './popover.types.ts';
+export type {
+  PopoverFocusManagement,
+  PopoverPlacement,
+  PopoverProps,
+  PopoverRole,
+  PopoverWidthMode,
+} from './popover.types.ts';
 export { Popover };

--- a/packages/components/src/components/resizable-panels/index.ts
+++ b/packages/components/src/components/resizable-panels/index.ts
@@ -7,6 +7,7 @@ export type {
   ResizablePanelRenderContext,
   ResizablePanelSize,
   ResizablePanelSizeState,
+  ResizablePanelSizeUnit,
   ResizablePanelsCollapseTarget,
   ResizablePanelsOrientation,
   ResizablePanelsProps,

--- a/packages/components/src/components/schema-form/schema-form-body.svelte
+++ b/packages/components/src/components/schema-form/schema-form-body.svelte
@@ -5,7 +5,7 @@
 
   This component is NOT part of the public API. Import SchemaForm instead.
 -->
-<script lang="ts" generics="Schema extends SchemaFormSchema = SchemaFormSchema">
+<script lang="ts">
   import { tick } from 'svelte';
 
   import { classNames } from '../../utilities/class-names.ts';
@@ -29,7 +29,7 @@
     setValueAtPath,
     type SchemaFormField,
   } from './schema-form-model.ts';
-  import type { SchemaFormOutput, SchemaFormProps, SchemaFormSchema } from './schema-form.types.ts';
+  import type { SchemaFormOutput, SchemaFormProps } from './schema-form.types.ts';
   import {
     issuesByPath,
     parseJsonDraft,
@@ -58,7 +58,7 @@
     onDraftChange,
     novalidate,
     ...rest
-  }: SchemaFormProps<Schema> = $props();
+  }: SchemaFormProps = $props();
 
   const generatedId = $props.id();
 

--- a/packages/components/src/components/schema-form/schema-form.schema.json
+++ b/packages/components/src/components/schema-form/schema-form.schema.json
@@ -30,7 +30,7 @@
       },
       {
         "name": "schema",
-        "reason": "generic-type-parameter",
+        "reason": "unknown-shape",
         "required": true,
         "description": "JSON Schema object used to render and validate the form."
       },

--- a/packages/components/src/components/schema-form/schema-form.schema.ts
+++ b/packages/components/src/components/schema-form/schema-form.schema.ts
@@ -33,7 +33,7 @@ const schema = {
       },
       {
         name: 'schema',
-        reason: 'generic-type-parameter',
+        reason: 'unknown-shape',
         required: true,
         description: 'JSON Schema object used to render and validate the form.',
       },

--- a/packages/components/src/components/schema-form/schema-form.svelte
+++ b/packages/components/src/components/schema-form/schema-form.svelte
@@ -25,8 +25,8 @@
   } from './schema-form.types.ts';
 </script>
 
-<script lang="ts" generics="Schema extends SchemaFormSchema = SchemaFormSchema">
-  import type { SchemaFormProps, SchemaFormSchema } from './schema-form.types.ts';
+<script lang="ts">
+  import type { SchemaFormProps } from './schema-form.types.ts';
   import SchemaFormBody from './schema-form-body.svelte';
 
   /**
@@ -48,7 +48,7 @@
    * `value` into a controlled binding. Draft callbacks run before schema
    * validation, while `onsubmit` runs only after validation passes.
    */
-  let { schema, ...rest }: SchemaFormProps<Schema> = $props();
+  let { schema, ...rest }: SchemaFormProps = $props();
 </script>
 
 <!--

--- a/packages/components/src/components/schema-form/schema-form.types.ts
+++ b/packages/components/src/components/schema-form/schema-form.types.ts
@@ -14,12 +14,9 @@ export type SchemaFormSubmitHandler = (
 ) => void | Promise<void>;
 
 /** Props for the SchemaForm component. */
-export type SchemaFormProps<Schema extends SchemaFormSchema = SchemaFormSchema> = Omit<
-  HTMLFormAttributes,
-  'class' | 'onsubmit'
-> & {
+export type SchemaFormProps = Omit<HTMLFormAttributes, 'class' | 'onsubmit'> & {
   /** JSON Schema object used to render and validate the form. */
-  schema: Schema;
+  schema: SchemaFormSchema;
   /**
    * Initial form value. Missing fields are seeded from the schema where possible.
    *

--- a/packages/components/src/components/segment/index.ts
+++ b/packages/components/src/components/segment/index.ts
@@ -1,5 +1,5 @@
 import Segment from './segment.svelte';
 
 export default Segment;
-export type { SegmentProps } from './segment.types.ts';
+export type { SegmentCurrentToken, SegmentProps } from './segment.types.ts';
 export { Segment };

--- a/packages/components/src/components/spectrogram/index.ts
+++ b/packages/components/src/components/spectrogram/index.ts
@@ -2,6 +2,7 @@ import './spectrogram.css';
 import Spectrogram from './spectrogram.svelte';
 
 export default Spectrogram;
+export type { ChartDataTableVisibility } from '../chart.types.ts';
 export type {
   SpectrogramFrame,
   SpectrogramProps,

--- a/packages/components/src/components/spectrum-chart/index.ts
+++ b/packages/components/src/components/spectrum-chart/index.ts
@@ -2,6 +2,7 @@ import './spectrum-chart.css';
 import SpectrumChart from './spectrum-chart.svelte';
 
 export default SpectrumChart;
+export type { ChartDataTableVisibility } from '../chart.types.ts';
 export type {
   SpectrumBin,
   SpectrumChartProps,

--- a/packages/components/src/components/tree-item/index.ts
+++ b/packages/components/src/components/tree-item/index.ts
@@ -1,5 +1,6 @@
 import TreeItem from './tree-item.svelte';
 
 export default TreeItem;
+export type { TreeItemSelectionState } from '../../_internal/tree-context.ts';
 export type { TreeItemProps, TreeItemRowContext } from './tree-item.types.ts';
 export { TreeItem };

--- a/packages/components/src/components/tree/index.ts
+++ b/packages/components/src/components/tree/index.ts
@@ -22,6 +22,7 @@ const Tree = Object.assign(TreeRoot, {
 
 export default Tree;
 export type { FlattenedTreeDataItem, TreeDataItem } from '../../_internal/tree-data.ts';
+export type { TreeReorderTarget } from '../../_internal/tree-drag-controller.svelte.ts';
 export type {
   TreeFilterPredicate,
   TreeProps,

--- a/packages/components/src/components/waveform/index.ts
+++ b/packages/components/src/components/waveform/index.ts
@@ -2,5 +2,6 @@ import './waveform.css';
 import Waveform from './waveform.svelte';
 
 export default Waveform;
+export type { ChartDataTableVisibility } from '../chart.types.ts';
 export type { WaveformProps, WaveformRenderMode, WaveformSchemaProps } from './waveform.types.ts';
 export { Waveform };

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -38,7 +38,11 @@ export type {
 } from './components/approval-card/index.ts';
 
 export { default as AreaChart } from './components/area-chart/index.ts';
-export type { AreaChartProps, AreaChartSchemaProps } from './components/area-chart/index.ts';
+export type {
+  ChartDataTableVisibility as AreaChartDataTableVisibility,
+  AreaChartProps,
+  AreaChartSchemaProps,
+} from './components/area-chart/index.ts';
 
 export { default as Autocomplete } from './components/autocomplete/index.ts';
 export type {
@@ -81,7 +85,11 @@ export { default as Banner } from './components/banner/index.ts';
 export type { BannerProps, BannerVariant } from './components/banner/index.ts';
 
 export { default as BarChart } from './components/bar-chart/index.ts';
-export type { BarChartProps, BarChartSchemaProps } from './components/bar-chart/index.ts';
+export type {
+  ChartDataTableVisibility as BarChartDataTableVisibility,
+  BarChartProps,
+  BarChartSchemaProps,
+} from './components/bar-chart/index.ts';
 export type {
   AreaChartMode,
   BarChartDatum,
@@ -523,7 +531,11 @@ export { default as Link } from './components/link/index.ts';
 export type { LinkColor, LinkProps, LinkUnderline } from './components/link/index.ts';
 
 export { default as LineChart } from './components/line-chart/index.ts';
-export type { LineChartProps, LineChartSchemaProps } from './components/line-chart/index.ts';
+export type {
+  ChartDataTableVisibility as LineChartDataTableVisibility,
+  LineChartProps,
+  LineChartSchemaProps,
+} from './components/line-chart/index.ts';
 
 export { default as LocaleProvider } from './components/locale-provider/index.ts';
 export type { LocaleProviderProps, TextDirection } from './components/locale-provider/index.ts';
@@ -568,7 +580,11 @@ export { default as Meter } from './components/meter/index.ts';
 export type { MeterProps, MeterSize, MeterState } from './components/meter/index.ts';
 
 export { default as MatrixChart } from './components/matrix-chart/index.ts';
-export type { MatrixChartProps, MatrixChartSchemaProps } from './components/matrix-chart/index.ts';
+export type {
+  ChartDataTableVisibility as MatrixChartDataTableVisibility,
+  MatrixChartProps,
+  MatrixChartSchemaProps,
+} from './components/matrix-chart/index.ts';
 export type { MatrixColorScale } from './components/matrix-chart/matrix-chart.types.ts';
 
 export { default as Masonry } from './components/masonry/index.ts';
@@ -648,7 +664,13 @@ export { default as PinInput } from './components/pin-input/index.ts';
 export type { PinInputMode, PinInputProps } from './components/pin-input/index.ts';
 
 export { default as Popover } from './components/popover/index.ts';
-export type { PopoverPlacement, PopoverProps, PopoverRole } from './components/popover/index.ts';
+export type {
+  PopoverFocusManagement,
+  PopoverPlacement,
+  PopoverProps,
+  PopoverRole,
+  PopoverWidthMode,
+} from './components/popover/index.ts';
 
 export { default as PricingCard } from './components/pricing-card/index.ts';
 export type { PricingCardProps } from './components/pricing-card/index.ts';
@@ -690,6 +712,7 @@ export type {
   ResizablePanelRenderContext,
   ResizablePanelSize,
   ResizablePanelSizeState,
+  ResizablePanelSizeUnit,
   ResizablePanelsCollapseTarget,
   ResizablePanelsOrientation,
   ResizablePanelsProps,
@@ -734,7 +757,7 @@ export type {
 } from './components/section-heading/index.ts';
 
 export { default as Segment } from './components/segment/index.ts';
-export type { SegmentProps } from './components/segment/index.ts';
+export type { SegmentCurrentToken, SegmentProps } from './components/segment/index.ts';
 
 export { default as SegmentedControl } from './components/segmented-control/index.ts';
 export type { SegmentedControlProps } from './components/segmented-control/index.ts';
@@ -822,6 +845,7 @@ export type {
 
 export { default as Spectrogram } from './components/spectrogram/index.ts';
 export type {
+  ChartDataTableVisibility as SpectrogramDataTableVisibility,
   SpectrogramFrame,
   SpectrogramProps,
   SpectrogramSchemaProps,
@@ -830,6 +854,7 @@ export type {
 export { default as SpectrumChart } from './components/spectrum-chart/index.ts';
 export type {
   SpectrumBin,
+  ChartDataTableVisibility as SpectrumChartDataTableVisibility,
   SpectrumChartProps,
   SpectrumChartSchemaProps,
 } from './components/spectrum-chart/index.ts';
@@ -1015,12 +1040,17 @@ export type {
 export { default as Tree } from './components/tree/index.ts';
 export type {
   TreeProps,
+  TreeReorderTarget,
   TreeSelectionBehavior,
   TreeSelectionMode,
 } from './components/tree/index.ts';
 
 export { default as TreeItem } from './components/tree-item/index.ts';
-export type { TreeItemProps, TreeItemRowContext } from './components/tree-item/index.ts';
+export type {
+  TreeItemProps,
+  TreeItemRowContext,
+  TreeItemSelectionState,
+} from './components/tree-item/index.ts';
 
 export { default as Tooltip } from './components/tooltip/index.ts';
 export type { TooltipPlacement, TooltipProps } from './components/tooltip/index.ts';
@@ -1054,6 +1084,7 @@ export type {
 
 export { default as Waveform } from './components/waveform/index.ts';
 export type {
+  ChartDataTableVisibility as WaveformDataTableVisibility,
   WaveformProps,
   WaveformRenderMode,
   WaveformSchemaProps,

--- a/packages/components/src/root-type-exports.test.ts
+++ b/packages/components/src/root-type-exports.test.ts
@@ -1,11 +1,24 @@
 import { expect, test } from 'bun:test';
 
 import type {
+  AreaChartDataTableVisibility,
+  BarChartDataTableVisibility,
   EventStreamEntry,
   EventStreamSchemaEntry,
   EventStreamViewerSchemaProps,
+  LineChartDataTableVisibility,
+  MatrixChartDataTableVisibility,
+  PopoverFocusManagement,
+  PopoverWidthMode,
+  ResizablePanelSizeUnit,
   RunStepLink,
+  SegmentCurrentToken,
+  SpectrogramDataTableVisibility,
+  SpectrumChartDataTableVisibility,
   StreamReconnectedBoundary,
+  TreeItemSelectionState,
+  TreeReorderTarget,
+  WaveformDataTableVisibility,
 } from './index.ts';
 
 test('root barrel exposes Stardust agent-ops public helper types', () => {
@@ -31,4 +44,43 @@ test('root barrel exposes Stardust agent-ops public helper types', () => {
   expect(entry.kind).toBe('reconnected');
   expect(link.label).toBe('Open run');
   expect(schemaProps.events[0]?.id).toBe('event-1');
+});
+
+test('root barrel exposes the five component barrel-gap public types', () => {
+  const focusManagement: PopoverFocusManagement = 'panel';
+  const widthMode: PopoverWidthMode = 'content';
+  const currentToken: SegmentCurrentToken = 'page';
+  const sizeUnit: ResizablePanelSizeUnit = 'px';
+  const reorderTarget: TreeReorderTarget = {
+    id: '1',
+    position: 'before',
+    fromParentId: null,
+    toParentId: null,
+  };
+  const selectionState: TreeItemSelectionState = { checked: true, indeterminate: false };
+
+  expect(focusManagement).toBe('panel');
+  expect(widthMode).toBe('content');
+  expect(currentToken).toBe('page');
+  expect(sizeUnit).toBe('px');
+  expect(reorderTarget.position).toBe('before');
+  expect(selectionState.checked).toBe(true);
+});
+
+test('root barrel exposes ChartDataTableVisibility from all seven chart component barrels', () => {
+  const areaChart: AreaChartDataTableVisibility = 'visible';
+  const barChart: BarChartDataTableVisibility = 'hidden';
+  const lineChart: LineChartDataTableVisibility = 'screen-reader-only';
+  const matrixChart: MatrixChartDataTableVisibility = 'visible';
+  const spectrogram: SpectrogramDataTableVisibility = 'hidden';
+  const spectrumChart: SpectrumChartDataTableVisibility = 'screen-reader-only';
+  const waveform: WaveformDataTableVisibility = 'visible';
+
+  expect(areaChart).toBe('visible');
+  expect(barChart).toBe('hidden');
+  expect(lineChart).toBe('screen-reader-only');
+  expect(matrixChart).toBe('visible');
+  expect(spectrogram).toBe('hidden');
+  expect(spectrumChart).toBe('screen-reader-only');
+  expect(waveform).toBe('visible');
 });

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -321,9 +321,7 @@ function findArtifactForFamily(family: ArtifactFamily, path: string): string | u
   // Cross-family fallback is restricted to chunk-style artifacts (no entry
   // prefix). Entries belong to their family and must not be served under
   // another family's route.
-  const isEntryName = (Object.values(ENTRY_PREFIXES) as readonly string[]).some((prefix) =>
-    path.startsWith(prefix),
-  );
+  const isEntryName = Object.values(ENTRY_PREFIXES).some((prefix) => path.startsWith(prefix));
   if (isEntryName) return undefined;
 
   // Search every map *except* the requesting family's own (already checked).


### PR DESCRIPTION
## Summary

Cluster B — type hygiene and barrel exports (4 issues), one batched PR.

### #1163 — Remove type assertions TypeScript already proves unnecessary
Deleted nine `as` type assertions across `context-menu`, `command-menu`, `dropdown-trigger`, `faceted-filter-bar`, `file-upload`, `form-section`, `marquee`, `navigation-item`, and `playground-server.ts`. Each was verified redundant by deleting it and confirming `bun run typecheck` still passes with zero new errors. `marquee`'s cast additionally erased a real `null` case from `aria-labelledby`'s prop type (`string | undefined | null`); a new test (`treats an explicit null aria-labelledby the same as omitting it`) locks in the already-correct runtime behavior now that the type is accurate.

### #1164 — Fix type-erasing casts and phantom generics across six components
- `FloatingAction`: `onclick` now flows through the same per-arm `Omit<...>` cast as every other rest attribute instead of being destructured out of the union separately. Added inline `satisfies` type-level proof after the two `$derived` casts (see note below on how this was implemented to avoid a Svelte warning).
- `NumberInput`: rest props forward with their real structural type instead of `Record<string, unknown>`; the `aria-invalid` read is now a runtime-checked helper (`toAriaInvalidValue`) instead of a blind cast.
- `GridList`: composes with `Grid` through a single cast instead of `as unknown as`, made possible by widening `GridListProps`'s base from `HTMLAttributes<HTMLUListElement>` to `HTMLAttributes<HTMLElement>` (matches `GridProps`).
- `PermissionMatrix`: `TRow`/`TColumn` are now genuinely wired via the Svelte `generics` attribute + `PermissionMatrixProps<TRow, TColumn>` on `$props()` (previously declared but never threaded through, so the generic was silently a no-op). Added `permission-matrix.type-test.ts` / `.type-test.svelte` mirroring `multi-select`'s type-test convention, including a `@ts-expect-error` negative case.
- `SchemaForm`: removed the `Schema` generic — it only ever narrowed the `schema` field itself, never `SchemaFormOutput`/`value`/the submit payload, so it promised more than it delivered. `schema` is now a plain `SchemaFormSchema`-typed field. No consumer instantiated `SchemaFormProps<...>` with an explicit type argument.
- `ChoiceGrid`: deleted the duplicated `ChoiceGridItemProps` in `choice-grid.types.ts`; the canonical declaration stays in `choice-grid-item.types.ts`. **Found during verification** (not in the issue's work list): `choice-grid-item.svelte`'s own module-script re-export block was a second real caller of the duplicate that the issue's grep missed — fixed it to re-export from its own canonical `./choice-grid-item.types.ts` instead.

### #1165 — Re-export missing public prop types from five component barrels
`PopoverFocusManagement`, `PopoverWidthMode`, `SegmentCurrentToken`, `ResizablePanelSizeUnit`, `TreeReorderTarget`, `TreeItemSelectionState` are now re-exported from their component barrel *and* the package root (`src/index.ts`). Added the prescribed test to `root-type-exports.test.ts`.

### #1166 — Re-export ChartDataTableVisibility from every chart-family barrel
`ChartDataTableVisibility` (from the shared, non-directory-shaped `chart.types.ts`) is now re-exported from all seven chart-family barrels (`waveform`, `bar-chart`, `area-chart`, `line-chart`, `matrix-chart`, `spectrum-chart`, `spectrogram`) and the package root, aliased per component (e.g. `WaveformDataTableVisibility`) to avoid a duplicate-export-name collision. Added the prescribed test to `root-type-exports.test.ts`.

## Notes on deviations from the issues' literal prescribed code

- **`floating-action.svelte`'s inline type proof**: issue #1164 prescribes `anchorAttributes.onclick satisfies HTMLAnchorAttributes['onclick'];` directly. That exact statement reads a `$derived` value at the top level of the instance script outside any reactive context, which trips Svelte's `state_referenced_locally` warning (confirmed empirically: 2 new warnings on `svelte-check --threshold warning`, absent on `origin/main`). Restructured to `const anchorOnclickTypeProof = undefined as unknown as (typeof anchorAttributes)['onclick']; anchorOnclickTypeProof satisfies HTMLAnchorAttributes['onclick'];` — `typeof anchorAttributes` is a type query, erased at compile time, so it never dereferences the derived value outside a reactive context. Same compile-time-only proof, same regression coverage, zero new warnings (verified against the `origin/main` baseline of 21 warnings / 18 files — identical after this change).
- **Changeset bump**: shipped as **minor**, not patch. #1164's own acceptance criteria explicitly calls for minor because three prop types change shape in ways that can surface new `typecheck`/`svelte-check` errors for a consumer (not runtime `build` breaks) — `GridListProps`'s base element widened, `PermissionMatrixProps` gained a real generic, `SchemaFormProps` lost an incomplete one. One changeset file covers the whole cluster.

## Cross-references (not actioned in this PR, called out per issue text)
- #1164's comment notes #1156's grid-list regression-test exclusion unblocks once this lands — removing that exclusion is explicitly scoped as a *follow-up*, not this PR.

## Test plan
- [x] `bun run typecheck` (components + playground, which rebuilds `@lostgradient/cinder` first) — 0 errors, 0 new warnings vs `origin/main` baseline
- [x] `bun run lint` (components) — 0 warnings, 0 errors
- [x] `bun run lint:invariants` (components) — all checks OK
- [x] `bun run exports:check` — OK
- [x] `bun run components:check` — OK
- [x] `bun run test` (components) — full package suite, two runs: 9727/9730 and 9728/9730 passing; the 1–2 failures were the same non-deterministic `speed-dial` transition-timing test both times, independently confirmed to pass 100% in isolation (`59 pass, 0 fail`) — consistent with load-induced flakiness under concurrent multi-worktree test runs on this machine, not a regression from this change
- [x] `bun run test` (playground) — `playground-server.test.ts`: 145 pass, 0 fail
- [x] `changeset status` — `@lostgradient/cinder` bumped minor

Closes #1163
Closes #1164
Closes #1165
Closes #1166

https://claude.ai/code/session_01BSu4BJmyZUpeac7p6vH3fU