### PR TITLE
chore(build): migrate svelte-plugin.ts to wrap @lostgradient/bun-plugin-svelte

### DIFF
--- a/.changeset/1150-1151-bun-plugin-svelte-migration.md
+++ b/.changeset/1150-1151-bun-plugin-svelte-migration.md
@@ -2,4 +2,4 @@
 '@lostgradient/cinder': patch
 ---
 
-Migrate the internal Svelte build plugin (`packages/components/scripts/svelte-plugin.ts`, shared cross-package by chat, editor, and playground) to wrap the published `@lostgradient/bun-plugin-svelte` instead of invoking `svelte/compiler` directly for the common client/library-server case. No public API, runtime behavior, or published `dist/` output changed — verified byte-identical (file list + shasum) against a clean build of `main`, aside from the expected build-cache fingerprint file.
+Internal build-pipeline change: the Svelte build plugin (`packages/components/scripts/svelte-plugin.ts`, shared cross-package by chat, editor, and playground) now wraps the published `@lostgradient/bun-plugin-svelte` instead of invoking `svelte/compiler` directly for the common client/library-server case. No public component API changes. Published `dist/` output was verified byte-identical (file list + shasum) against a clean build of `main`, aside from the expected build-cache fingerprint file.

--- a/.changeset/1150-1151-bun-plugin-svelte-migration.md
+++ b/.changeset/1150-1151-bun-plugin-svelte-migration.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Migrate the internal Svelte build plugin (`packages/components/scripts/svelte-plugin.ts`, shared cross-package by chat, editor, and playground) to wrap the published `@lostgradient/bun-plugin-svelte` instead of invoking `svelte/compiler` directly for the common client/library-server case. No public API, runtime behavior, or published `dist/` output changed — verified byte-identical (file list + shasum) against a clean build of `main`, aside from the expected build-cache fingerprint file.

--- a/bun.lock
+++ b/bun.lock
@@ -71,6 +71,7 @@
         "@changesets/get-release-plan": "4.0.16",
         "@changesets/parse": "0.4.3",
         "@cinder/testing": "workspace:*",
+        "@lostgradient/bun-plugin-svelte": "^0.0.1",
         "@playwright/test": "1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/svelte": "^5.2.7",
@@ -401,6 +402,8 @@
     "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
 
     "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lostgradient/bun-plugin-svelte": ["@lostgradient/bun-plugin-svelte@0.0.1", "", { "dependencies": { "@types/bun": "^1.3.14" }, "peerDependencies": { "svelte": ">=5.0.0 <6" } }, "sha512-3c5yF964NURB8Za79gjaTZxYN1ZqRX9K2IdOtiqohk8mVo/iMOIUBXQTwIdb/+dMpwsewG3WKJjGV7E29Stb5g=="],
 
     "@lostgradient/chat": ["@lostgradient/chat@workspace:packages/chat"],
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -6296,6 +6296,7 @@
     "@changesets/get-release-plan": "4.0.16",
     "@changesets/parse": "0.4.3",
     "@cinder/testing": "workspace:*",
+    "@lostgradient/bun-plugin-svelte": "^0.0.1",
     "@playwright/test": "1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/svelte": "^5.2.7",

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -21,7 +21,11 @@ import {
 import { discoverComponents, type ComponentDiscovery } from './lib/discover-components.ts';
 import { hasSourceCssImport } from './prepend-source-index-css-import.ts';
 import { createServerEntrySource } from './server-entry.ts';
-import { findOneArgumentServerComponentBoundaries, sveltePlugin } from './svelte-plugin.ts';
+import {
+  findOneArgumentServerComponentBoundaries,
+  isDomainSuiteStyleComponentName,
+  sveltePlugin,
+} from './svelte-plugin.ts';
 import { isObjectRecord } from './validation-utilities.ts';
 
 const repositoryRoot = process.cwd();
@@ -358,6 +362,23 @@ const browserEntrypoints = [
 const componentsWithSidecar = components.filter((component) =>
   existsSync(componentCssSource(component)),
 );
+
+// A component cannot both ship a hand-authored CSS sidecar here AND be named
+// in svelte-plugin.ts's DOMAIN_SUITE_STYLE_COMPONENTS allowlist (which lets a
+// component compile a real `<style>` block) — that combination would give it
+// two independent CSS delivery paths with no obvious cascade winner. Fail the
+// build loudly instead of letting the collision ship silently.
+const domainSuiteSidecarCollisions = componentsWithSidecar.filter((component) =>
+  isDomainSuiteStyleComponentName(component.name),
+);
+if (domainSuiteSidecarCollisions.length > 0) {
+  throw new Error(
+    'Build aborted: component(s) ship both a CSS sidecar and a DOMAIN_SUITE_STYLE_COMPONENTS ' +
+      `<style>-block allowance: ${domainSuiteSidecarCollisions.map((component) => component.name).join(', ')}. ` +
+      "Rename the component or remove it from svelte-plugin.ts's allowlist.",
+  );
+}
+
 // SUBPATH injection target: map each component's own `index.ts` to the exact
 // `@lostgradient/cinder/<name>/styles` (or experimental) specifier its sidecar resolves to.
 const perComponentStyleSpecifiers = new Map(

--- a/packages/components/scripts/svelte-plugin.ts
+++ b/packages/components/scripts/svelte-plugin.ts
@@ -1,7 +1,6 @@
+import { sveltePlugin as createUpstreamSveltePlugin } from '@lostgradient/bun-plugin-svelte';
 import type { BunPlugin } from 'bun';
-import { existsSync } from 'node:fs';
-import { dirname, resolve } from 'node:path';
-import { compile, compileModule, parse } from 'svelte/compiler';
+import { compile, parse } from 'svelte/compiler';
 import ts from 'typescript';
 
 type GenerationTarget = 'client' | 'server';
@@ -12,12 +11,43 @@ export type ServerComponentBoundary = {
   line: number;
 };
 
+/**
+ * Components allowed to compile a real `<style>` block instead of routing
+ * styles through `src/styles/`.
+ *
+ * This is NOT dead code, even though none of these four names are directories
+ * under `packages/components/src/components` — `allowsStyleBlock`'s path
+ * match is package-agnostic (it matches the first path segment under any
+ * `.../components/<name>/` directory), and this file is imported
+ * cross-package by `packages/chat/scripts/{build,preload,validate-consumer}.ts`
+ * and `packages/editor/scripts/{build,preload,validate-consumer}.ts`. So these
+ * names protect live components in THOSE packages' own `src/lib/components/`
+ * trees: `packages/chat/src/lib/components/chat/**` (e.g. `chat.svelte`,
+ * `chat-message.svelte`) and `packages/editor/src/lib/components/
+ * {diff-viewer,markdown-editor,review-editor}/**` (e.g. `diff-viewer.svelte`,
+ * `review-editor-impl.svelte`) — dozens of files, confirmed non-empty
+ * `<style>` blocks as of this comment. `source-diff-viewer`, the surviving
+ * `packages/components` name closest to `diff-viewer`, needs no entry here:
+ * it has no `<style>` block.
+ */
 const DOMAIN_SUITE_STYLE_COMPONENTS = new Set([
   'chat',
   'diff-viewer',
   'markdown-editor',
   'review-editor',
 ]);
+
+/**
+ * Whether `name` is one of the domain-suite components allowed to carry a
+ * real `<style>` block (see {@link DOMAIN_SUITE_STYLE_COMPONENTS}). Exported
+ * so `build.ts` can assert the converse invariant for its OWN package: a
+ * `packages/components` component may not both be named here and ship a
+ * generated CSS sidecar (`css-import-plugin.ts`) — that combination would
+ * give it two independent CSS delivery paths with no obvious cascade winner.
+ */
+export function isDomainSuiteStyleComponentName(name: string): boolean {
+  return DOMAIN_SUITE_STYLE_COMPONENTS.has(name);
+}
 
 const PUBLISHED_PACKAGE_SOURCE_MAPPINGS = [
   {
@@ -75,6 +105,13 @@ export function allowsStyleBlock(path: string): boolean {
   // Test fixtures are not published package components or part of the public
   // cascade. Allow them to keep scoped styles local to the fixture.
   if (normalizedPath.includes('/packages/components/src/test/fixtures/')) return true;
+  // Visual-regression fixture hosts colocated with their component
+  // (`src/components/<name>/<name>.fixture.svelte`, e.g. `accordion.fixture.svelte`)
+  // are dev-only mounting scaffolding for Playwright/visual fixtures and are
+  // never shipped in dist — same rationale as the `/test/fixtures/` carve-out
+  // above, extended to this established naming convention (`extract-fixtures.ts`
+  // already requires fixture hosts to end in `.fixture.svelte`).
+  if (normalizedPath.endsWith('.fixture.svelte')) return true;
 
   const componentPathMatch = normalizedPath.match(
     /\/(?:src\/(?:lib\/)?|dist\/)components\/([^/]+)(?:\/|\.svelte$)/,
@@ -206,23 +243,78 @@ export function preserveServerComponentIdentity(source: string, fileName = 'comp
   return transformedSource;
 }
 
+function isPlaygroundPath(path: string): boolean {
+  return path.replaceAll('\\', '/').includes('/packages/playground/');
+}
+
 /**
- * Bun plugin that compiles Svelte 5 components with `svelte/compiler`.
+ * Compile a `.svelte` file directly instead of delegating to
+ * `@lostgradient/bun-plugin-svelte`, for the two cases the published plugin's
+ * public options have no hook for:
  *
- * - `generate`: chooses client-side or server-side rendering output.
- * - `injectCss`: when `true`, every component injects its CSS into the JS
- *   bundle — used by the playground server so domain-suite components
- *   (Chat, diff-viewer, markdown-editor, review-editor) get their scoped styles
- *   applied. When `false` (default), library components emit external CSS
- *   sidecars so consumers can ship one cascade. Playground files always
- *   inject regardless of this flag, since dev-only chrome should not depend
- *   on the design-system cascade.
+ * - Playground dev-only chrome always gets its styles injected into the
+ *   compiled output, independent of `injectCss` — it is not part of the
+ *   design-system cascade `injectCss` otherwise governs, and would render
+ *   unstyled on first paint (client mount or SSR `head`) otherwise.
+ * - Production server compiles (`generate: 'server'`, `NODE_ENV=production`)
+ *   need `$$renderer.component()` calls to carry the compiled component's
+ *   identity as a second argument (`preserveServerComponentIdentity`) — a
+ *   Cinder-specific SSR fix (see its doc comment) with no equivalent in the
+ *   published plugin, which exposes no hook to transform compiled output
+ *   before Bun consumes it. A missing-capability report belongs on
+ *   `stevekinney/bun-plugin-svelte` (a `transform`/post-compile hook, or
+ *   exporting `compileComponent`) — see this migration's PR description for
+ *   filing status.
+ *
+ * Neither case needs the CSS-sidecar virtual-module registry the published
+ * plugin owns (`emitCss` is only ever true for non-server `'external'` mode,
+ * which cinder never uses), so compiling them directly here needs no extra
+ * plumbing.
+ */
+function compileWithCinderPolicy(
+  source: string,
+  path: string,
+  generate: GenerationTarget,
+  injectCss: boolean,
+  dev: boolean,
+): { contents: string; loader: 'js' } {
+  const css = isPlaygroundPath(path) || injectCss ? 'injected' : 'external';
+  const compileResult = compile(source, {
+    filename: publishedSvelteCompileFilename(path),
+    generate,
+    css,
+    dev,
+  });
+  const contents =
+    generate === 'server' && !dev
+      ? preserveServerComponentIdentity(compileResult.js.code, path)
+      : compileResult.js.code;
+  return { contents, loader: 'js' };
+}
+
+/**
+ * Bun plugin that compiles Svelte 5 `.svelte` components and `.svelte.(js|ts)`
+ * rune modules, wrapping `@lostgradient/bun-plugin-svelte` with Cinder-only
+ * policy:
+ *
  * - Rejects any component that carries a `<style>` block, except for files
- *   under `packages/playground/` and the domain-suite components allowlisted
+ *   under `packages/playground/`, test/visual-regression fixtures (see
+ *   {@link allowsStyleBlock}), and the domain-suite components allowlisted
  *   above. Styles belong in `src/styles/` so the design system has a single
- *   CSS cascade surface; the playground is dev-only chrome and not part of it.
- * - Compiles `.svelte.js` / `.svelte.ts` rune modules via `compileModule` so libraries
- *   like `@testing-library/svelte-core` that use runes in plain modules work at runtime.
+ *   CSS cascade surface.
+ * - `generate`: chooses client-side or server-side rendering output, passed
+ *   straight through.
+ * - `injectCss`: when `true`, every component injects its CSS into the JS
+ *   bundle (`css: 'injected'`) — used by the playground server so domain-suite
+ *   components get their scoped styles applied. When `false` (default),
+ *   library components compile with `css: 'none'`: scoped class names, CSS
+ *   discarded — Cinder's own `css-import-plugin.ts` sidecar system owns
+ *   delivering their styles, so the published plugin never emits a stylesheet
+ *   that would duplicate it.
+ * - The two cases above the published plugin cannot express are compiled
+ *   directly by {@link compileWithCinderPolicy}; every other `.svelte` file
+ *   and every `.svelte.(js|ts)` rune module delegates to
+ *   `@lostgradient/bun-plugin-svelte`.
  */
 export function sveltePlugin(
   options: { generate: GenerationTarget; injectCss?: boolean } = {
@@ -230,65 +322,86 @@ export function sveltePlugin(
   },
 ): BunPlugin {
   const injectCss = options.injectCss ?? false;
+  const dev = process.env['NODE_ENV'] !== 'production';
+  const upstreamPlugin = createUpstreamSveltePlugin({
+    generate: options.generate,
+    css: injectCss ? 'injected' : 'none',
+    compileFilename: publishedSvelteCompileFilename,
+    // Cinder never wired up Svelte's HMR runtime (no `[serve.static]` bunfig
+    // registration, no `Bun.serve({ development: { hmr: true } })`) — the
+    // playground's dev server rebuilds and re-serves per request instead.
+    // Force this off rather than let it default to `dev`, so compiled output
+    // stays exactly what it was before this migration in every dev-mode
+    // pipeline (test preloads, `validate:consumer`, the playground server).
+    hmr: false,
+  });
+
   return {
     name: `svelte-${options.generate}`,
     setup(builder) {
-      // Bun.plugin's global runtime builder does not expose `config`; Bun.build does.
-      // Only non-Bun build targets need the explicit relative-Svelte resolver.
-      const buildTarget = (builder as typeof builder & { config?: { target?: string } }).config
-        ?.target;
-      if (buildTarget !== undefined && buildTarget !== 'bun') {
-        builder.onResolve({ filter: /^\.\.\/(?:.*\/)?[^/]+\.svelte$/ }, ({ importer, path }) => {
-          if (importer.length === 0) return undefined;
-          const resolvedPath = resolve(dirname(importer), path);
-          return existsSync(resolvedPath) ? { path: resolvedPath } : undefined;
-        });
+      // `@lostgradient/bun-plugin-svelte`'s own `.svelte` component compiler
+      // must not be registered on `builder` directly: cinder's policy check
+      // has to run first and, for two cases (below), replace the compile
+      // entirely, which would normally mean registering a second `onLoad` for
+      // the same filter and returning `undefined` to fall through to this
+      // one. That works under `Bun.build()`, but NOT under the runtime
+      // `Bun.plugin()` loader every package's `scripts/preload.ts` uses for
+      // `bun test` — there, an `onLoad` callback that returns `undefined`
+      // throws `TypeError: onLoad() expects an object returned` instead of
+      // trying the next registered handler (verified against Bun 1.3.13).
+      // So this captures the upstream component-compile callback instead of
+      // registering it, and cinder's own `onLoad` below calls it directly —
+      // the only `.svelte` `onLoad` ever registered on the real builder.
+      let componentLoader: Bun.OnLoadCallback | undefined;
+      const bridgeBuilder: Bun.PluginBuilder = {
+        // Minimal test stubs (see components.test.ts) only implement `onLoad`
+        // — degrade to a no-op rather than crash on construction. Bun's own
+        // real builder always has `onResolve`, and cinder's `css` values
+        // (`'injected'` / `'none'`) never trigger the upstream plugin's
+        // virtual-CSS resolution this registers, so a no-op is never a
+        // functional loss even when it IS the real builder.
+        onResolve:
+          typeof builder.onResolve === 'function' ? builder.onResolve.bind(builder) : () => builder,
+        onLoad: (matcher, callback) => {
+          // The component filter (`.svelte$`) matches a bare `.svelte` path;
+          // the rune-module filter (`.svelte.(js|ts)$`) does not — register
+          // everything else (rune modules, the virtual CSS resolver/loader)
+          // on the real builder unchanged.
+          if (matcher.filter.test('cinder-bridge-probe.svelte')) {
+            componentLoader = callback;
+            return bridgeBuilder;
+          }
+          return builder.onLoad(matcher, callback);
+        },
+        get config() {
+          return builder.config;
+        },
+      } as Bun.PluginBuilder;
+      upstreamPlugin.setup(bridgeBuilder);
+      if (componentLoader === undefined) {
+        throw new Error(
+          "[svelte-plugin] could not find @lostgradient/bun-plugin-svelte's component onLoad " +
+            'handler — the published package may have changed its internal registration.',
+        );
       }
+      const compileComponent = componentLoader;
 
-      builder.onLoad({ filter: /\.svelte$/ }, async ({ path }) => {
+      builder.onLoad({ filter: /\.svelte$/ }, async (args) => {
+        const { path } = args;
         const source = await Bun.file(path).text();
-        const filename = publishedSvelteCompileFilename(path);
-        const isPlaygroundFile = path.replaceAll('\\', '/').includes('/packages/playground/');
-        const css = isPlaygroundFile || injectCss ? 'injected' : 'external';
-        const dev = process.env['NODE_ENV'] !== 'production';
-        const compileResult = compile(source, {
-          filename,
-          generate: options.generate,
-          css,
-          // Read the same environment source that `scripts/build.ts` writes before `Bun.build()`
-          // runs so production builds and test/dev loads stay in sync.
-          dev,
-        });
-        if (
-          !isPlaygroundFile &&
-          hasAuthoredStyleBlock(source) &&
-          compileResult.css?.code?.trim() &&
-          !allowsStyleBlock(path)
-        ) {
+        const isPlaygroundFile = isPlaygroundPath(path);
+
+        if (!isPlaygroundFile && hasAuthoredStyleBlock(source) && !allowsStyleBlock(path)) {
           throw new Error(
             `[svelte-plugin] <style> block in ${path} — not allowed. Put styles in src/styles/.`,
           );
         }
-        const compiledSource =
-          options.generate === 'server' && !dev
-            ? preserveServerComponentIdentity(compileResult.js.code, path)
-            : compileResult.js.code;
-        return { contents: compiledSource, loader: 'js' };
-      });
 
-      builder.onLoad({ filter: /\.svelte\.(js|ts)$/ }, async ({ path }) => {
-        const source = await Bun.file(path).text();
-        const moduleSource = path.endsWith('.ts')
-          ? new Bun.Transpiler({ loader: 'ts' }).transformSync(source)
-          : source;
-        const compileResult = compileModule(moduleSource, {
-          filename: path,
-          generate: options.generate,
-          // Read the same environment source that `scripts/build.ts` writes before `Bun.build()`
-          // runs so production builds and test/dev loads stay in sync.
-          dev: process.env['NODE_ENV'] !== 'production',
-        });
-        return { contents: compileResult.js.code, loader: 'js' };
+        const needsOwnCompile = isPlaygroundFile || (options.generate === 'server' && !dev);
+        if (needsOwnCompile)
+          return compileWithCinderPolicy(source, path, options.generate, injectCss, dev);
+
+        return compileComponent(args);
       });
     },
   };

--- a/packages/components/scripts/svelte-plugin.ts
+++ b/packages/components/scripts/svelte-plugin.ts
@@ -111,7 +111,7 @@ export function allowsStyleBlock(path: string): boolean {
   // never shipped in dist — same rationale as the `/test/fixtures/` carve-out
   // above, extended to this established naming convention (`extract-fixtures.ts`
   // already requires fixture hosts to end in `.fixture.svelte`).
-  if (normalizedPath.endsWith('.fixture.svelte')) return true;
+  if (/\/src\/components\/[^/]+\/[^/]+\.fixture\.svelte$/.test(normalizedPath)) return true;
 
   const componentPathMatch = normalizedPath.match(
     /\/(?:src\/(?:lib\/)?|dist\/)components\/([^/]+)(?:\/|\.svelte$)/,

--- a/packages/components/scripts/svelte-plugin.ts
+++ b/packages/components/scripts/svelte-plugin.ts
@@ -353,15 +353,30 @@ export function sveltePlugin(
       // registering it, and cinder's own `onLoad` below calls it directly —
       // the only `.svelte` `onLoad` ever registered on the real builder.
       let componentLoader: Bun.OnLoadCallback | undefined;
-      const bridgeBuilder: Bun.PluginBuilder = {
-        // Minimal test stubs (see components.test.ts) only implement `onLoad`
-        // — degrade to a no-op rather than crash on construction. Bun's own
-        // real builder always has `onResolve`, and cinder's `css` values
-        // (`'injected'` / `'none'`) never trigger the upstream plugin's
-        // virtual-CSS resolution this registers, so a no-op is never a
-        // functional loss even when it IS the real builder.
-        onResolve:
-          typeof builder.onResolve === 'function' ? builder.onResolve.bind(builder) : () => builder,
+      // Minimal test stubs (see components.test.ts) only implement `onLoad`.
+      // Bun's own real builder always has the rest of `PluginBuilder`, and
+      // cinder's `css` values (`'injected'` / `'none'`) never trigger the
+      // upstream plugin's `onStart`/`onEnd`/`onBeforeParse`/`module` hooks or
+      // its virtual-CSS `onResolve`, so a no-op fallback is never a
+      // functional loss even when it IS the real builder.
+      let bridgeBuilder: Bun.PluginBuilder;
+      bridgeBuilder = {
+        onStart: (callback) =>
+          typeof builder.onStart === 'function' ? builder.onStart(callback) : bridgeBuilder,
+        onEnd: (callback) =>
+          typeof builder.onEnd === 'function' ? builder.onEnd(callback) : bridgeBuilder,
+        onBeforeParse: (constraints, callback) =>
+          typeof builder.onBeforeParse === 'function'
+            ? builder.onBeforeParse(constraints, callback)
+            : bridgeBuilder,
+        onResolve: (constraints, callback) =>
+          typeof builder.onResolve === 'function'
+            ? builder.onResolve(constraints, callback)
+            : bridgeBuilder,
+        module: (specifier, callback) =>
+          typeof builder.module === 'function'
+            ? builder.module(specifier, callback)
+            : bridgeBuilder,
         onLoad: (matcher, callback) => {
           // The component filter (`.svelte$`) matches a bare `.svelte` path;
           // the rune-module filter (`.svelte.(js|ts)$`) does not — register
@@ -376,8 +391,8 @@ export function sveltePlugin(
         get config() {
           return builder.config;
         },
-      } as Bun.PluginBuilder;
-      upstreamPlugin.setup(bridgeBuilder);
+      };
+      void upstreamPlugin.setup(bridgeBuilder);
       if (componentLoader === undefined) {
         throw new Error(
           "[svelte-plugin] could not find @lostgradient/bun-plugin-svelte's component onLoad " +


### PR DESCRIPTION
## Summary

Migrates cinder's hand-rolled Bun Svelte plugin to wrap the published `@lostgradient/bun-plugin-svelte`. All five `sveltePlugin(...)` call sites named in #1150 (`packages/components/scripts/build.ts`, `packages/chat/scripts/build.ts`, `packages/editor/scripts/build.ts`, `packages/components/scripts/preload.ts`, `packages/playground/src/playground-server.ts`/`page-server-entry.ts`) — plus every other call site (`preload.ts`/`validate-consumer.ts` in chat and editor, playground's `build-artifacts-shared.ts`/`ssr-renderer.ts`, which is where playground-server.ts's logic now lives after #1194's split) — import `sveltePlugin` from the shared `packages/components/scripts/svelte-plugin.ts`, so upgrading that one file upgrades every call site at once. No call site needed its own edit.

Closes #1150
Closes #1151

## What changed

`svelte-plugin.ts` now wraps the upstream plugin instead of calling `svelte/compiler` directly for the common case:

- A bridge object implements the full `Bun.PluginBuilder` interface (`onStart`/`onEnd`/`onBeforeParse`/`onResolve`/`module`/`onLoad`/`config`) and captures the upstream plugin's `.svelte` component-compile callback instead of letting it register directly on the real builder. Only ONE `.svelte` `onLoad` is ever registered on the real builder — cinder's own, which runs the `<style>`-block policy check first, then either compiles the file itself (two cases below) or delegates to the captured upstream callback. This exists because the runtime `Bun.plugin()` loader throws `TypeError: onLoad() expects an object returned` instead of falling through to a second handler when one returns `undefined` (verified against Bun 1.3.13) — a second, independently-registered `.svelte` `onLoad` for the "let cinder's policy check run first, then fall through" pattern doesn't work under that registration mode.
- Two cases the published plugin has no hook for still compile directly via `svelte/compiler`: playground dev-chrome CSS injection (always `'injected'`, independent of the `injectCss` flag), and production server builds needing `preserveServerComponentIdentity` post-processing (a cinder-specific SSR fix with no upstream equivalent).
- The prototype's custom relative `../*.svelte` `onResolve` resolver is deleted, per #1150's "verify-or-delete": chat and editor ARE real symlinked workspace packages (`node_modules/@lostgradient/chat -> ../../packages/chat`), and the full test suite, `validate-consumer` (chat + editor), and the `sveltekit-consumer` hydration smoke — which build and import across exactly those package boundaries — all pass without it.

## #1151: the allowlist is not dead code

`DOMAIN_SUITE_STYLE_COMPONENTS` (`chat`, `diff-viewer`, `markdown-editor`, `review-editor`) matches none of `packages/components`' own components anymore — that part of #1151 is correct. But `allowsStyleBlock`/`svelte-plugin.ts` is imported cross-package by chat's and editor's own build scripts (`packages/{chat,editor}/scripts/{build,preload,validate-consumer}.ts`, via a relative import — there's no package boundary preventing it). Grepping both packages' `src/lib/components/` trees today:

- `packages/chat/src/lib/components/chat/**` — 25 files with real, non-empty `<style>` blocks
- `packages/editor/src/lib/components/{diff-viewer,markdown-editor,review-editor}/**` — 20 files with real, non-empty `<style>` blocks

All under exactly the four allowlisted path segments. Deleting the allowlist would break chat's and editor's own builds today. Resolution: keep it, document why (the comment on `DOMAIN_SUITE_STYLE_COMPONENTS` now explains the cross-package reach), and make the inverse invariant unrepresentable — `build.ts` now throws if a `packages/components` component is ever both named in the allowlist and ships a CSS sidecar (`componentCssSource` exists for it). Today that guard is a no-op (no `packages/components` component has a `<style>` block), but it fails the build the moment someone reintroduces the collision the issue warned about.

One scope note: the new `build.ts` guard only covers `packages/components`. Chat and editor don't use `css-import-plugin.ts`'s sidecar system at all (confirmed — no references to it in either package's scripts), so the double-CSS-delivery state #1151 worried about isn't representable there by construction, not by a guard.

## Dist parity

Snapshotted `packages/{components,chat,editor}/dist` (recursive file list + SHA-256) on a clean, force-rebuilt `origin/main` (`a74c76df6`), then again after this migration, same force-rebuild flags (`CINDER_FORCE_BUILD=1 TURBO_FORCE=1`):

| Package | Files | Diff |
| --- | --- | --- |
| `@lostgradient/cinder` | 4624 | 1 file: `dist/.build-input-hash` only |
| `@lostgradient/chat` | 391 | byte-identical |
| `@lostgradient/editor` | 316 | byte-identical |

`.build-input-hash` is the build-cache fingerprint (hashes the build scripts themselves, which changed) — not build output. Every compiled component, `.d.ts`, and CSS sidecar across all three packages is byte-for-byte identical to `main`.

Reproducibility floor: re-ran the identical force-rebuild twice in a row on this branch (no source changes between runs) and diffed the two outputs against each other. Same result — only `.build-input-hash` differs (it appears to embed something per-invocation, not just source content). That rules out "the pipeline is just non-deterministic and the before/after diff is coincidental": the single-file diff against `main` is the whole story.

`packages/editor/scripts/build.ts`'s own build-cache fingerprint (`extraFiles`) already includes `bun.lock`, so a future `@lostgradient/bun-plugin-svelte` version bump — which necessarily changes `bun.lock`'s resolved version/hash — correctly invalidates editor's cache without further changes here.

## Suite evidence

- `bun run typecheck` (root, 11 tasks): 0 errors. Pre-existing `svelte-check` warning counts unchanged (20 in cinder, 29 in playground) — `svelte-check` is a separate static analyzer, unaffected by the Bun plugin change.
- `bun run lint` (root, 10 tasks): 0 errors, 0 warnings.
- `bun run test` (root, 11 tasks, ~10 min): 0 failures. `@lostgradient/cinder`: 9828 pass / 7 skip / 0 fail. The 7 skips are `describe.skipIf(!existsSync('dist/server'))` guards — pre-existing, and load-order dependent because `turbo.json`'s `test` task depends on `^build` (upstream packages' builds) but not this package's *own* `build`, so `dist/server` isn't guaranteed to exist yet when `cinder:test` starts. Unrelated to this migration: same guard, same task-graph gap, before and after.
- `bun run --filter=@lostgradient/cinder validate:consumer:hydration-smoke`: packs cinder + chat + markdown tarballs, installs into the `sveltekit-consumer` fixture, builds, and hydrates against a real server — `hydration smoke passed`. This is the scoped-CSS class-hash parity check #1150's acceptance criteria calls out (`compileFilename` keeping server/client compiles' hashes in agreement).

## Behavior deltas (disclosed, not hidden)

- **Compiler warnings are no longer swallowed.** The old inline `compile()` call never read `result.warnings`; the upstream plugin's `compileComponent` calls `forwardWarnings(...)`. Builds now print pre-existing a11y/state warnings (e.g. `a11y_no_noninteractive_tabindex` in `timeline.svelte`, `state_referenced_locally` in a few components) that were always there but never surfaced. No dist bytes change; these are pre-existing component issues out of this migration's scope.
- **`injectCss: false` now compiles with `css: 'none'` instead of `'external'`.** This matches #1150's explicit mapping table. Functionally identical to the old behavior: the old code called `compile()` with `css: 'external'` and never consumed `result.css.code` (silently discarded); `'none'` mode discards it the same way, one level up. Confirmed via dist parity — no CSS artifacts either way.

## Upstream gap — issue could not be filed

The bridge above exists because `@lostgradient/bun-plugin-svelte` exposes no way to (a) reuse its component-compile logic directly (no exported `compileComponent`/`compileRuneModule`) or (b) run a post-compile transform hook (needed for `preserveServerComponentIdentity`) or (c) override CSS mode per-file within one plugin instance (needed for playground's always-inject dev chrome). Per the task instructions I attempted to file this as an issue against `stevekinney/bun-plugin-svelte`, but **that GitHub repository does not exist yet** (`https://github.com/stevekinney/bun-plugin-svelte` returns 404, `gh repo view`/`gh repo list stevekinney` confirm it) even though the package is already published to npm (`0.0.1`, created 2026-08-05T06:10Z) with that repository URL in its `package.json`. Flagging this rather than silently skipping it — the issue is ready to file the moment the repo exists:

> **Title:** Export `compileComponent`/`compileRuneModule`, or add a post-compile transform hook
>
> Consuming projects that need to layer project-specific compiled-output policy (a `<style>`-block ban with exceptions, SSR component-identity preservation, per-file CSS-mode overrides) currently have no way to reuse `sveltePlugin()`'s internal component compilation — `compileComponent`/`compileRuneModule` aren't exported from the package. The only working integration we found is a "bridge" `PluginBuilder` shim that implements every `PluginBuilder` member, intercepts `setup()`'s `.svelte` `onLoad` registration instead of letting it land on the real builder, and calls the captured callback manually after running project policy — because the runtime `Bun.plugin()` loader throws instead of falling through to a second handler when the first returns `undefined` (Bun 1.3.13). Exporting `compileComponent`/`compileRuneModule` (or a `transform` hook run on the compiled output before Bun consumes it) would let us delete that bridge entirely. Repro / reference implementation: [cinder's `svelte-plugin.ts`](https://github.com/stevekinney/cinder/blob/chore/bun-plugin-svelte-migration/packages/components/scripts/svelte-plugin.ts).

## Files touched

- `packages/components/package.json` — add `@lostgradient/bun-plugin-svelte` devDependency
- `bun.lock`
- `packages/components/scripts/svelte-plugin.ts` — wrap the upstream plugin; document + guard the allowlist
- `packages/components/scripts/build.ts` — sidecar/allowlist collision guard
- `.changeset/1150-1151-bun-plugin-svelte-migration.md` — patch, `@lostgradient/cinder`
