### PR TITLE
fix(playground): reject NUL bytes at the path-guard boundary

### DIFF
--- a/packages/playground/src/traversal-guard.test.ts
+++ b/packages/playground/src/traversal-guard.test.ts
@@ -53,9 +53,8 @@ describe('resolveSafePath', () => {
     // regardless of host OS, not just when the host happens to be POSIX.
     expect(resolveSafePath(baseDir, 'foo/..\\..\\secret.css')).toBeNull();
   });
-});
-
-it('rejects a path containing a NUL byte instead of passing it to the filesystem', () => {
-  const nulPath = 'tokens' + String.fromCharCode(0) + '.css';
-  expect(resolveSafePath('/tmp', nulPath)).toBeNull();
+  it('rejects a path containing a NUL byte instead of passing it to the filesystem', () => {
+    const nulPath = 'tokens' + String.fromCharCode(0) + '.css';
+    expect(resolveSafePath(baseDir, nulPath)).toBeNull();
+  });
 });

--- a/packages/playground/src/traversal-guard.test.ts
+++ b/packages/playground/src/traversal-guard.test.ts
@@ -54,3 +54,8 @@ describe('resolveSafePath', () => {
     expect(resolveSafePath(baseDir, 'foo/..\\..\\secret.css')).toBeNull();
   });
 });
+
+it('rejects a path containing a NUL byte instead of passing it to the filesystem', () => {
+  const nulPath = 'tokens' + String.fromCharCode(0) + '.css';
+  expect(resolveSafePath('/tmp', nulPath)).toBeNull();
+});

--- a/packages/playground/src/traversal-guard.ts
+++ b/packages/playground/src/traversal-guard.ts
@@ -30,6 +30,11 @@ import { isAbsolute, join, relative as relativePath } from 'node:path';
  * is not sufficient for that case.
  */
 export function resolveSafePath(baseDir: string, requestedPath: string): string | null {
+  // A NUL byte survives every string-level check here but makes Bun.file()
+  // throw a TypeError at the call site, surfacing as an unhandled rejection
+  // instead of a clean 404 — reject it at the boundary that owns the contract.
+  if (requestedPath.includes('\0')) return null;
+
   const segments = requestedPath.split(/[/\\]/);
   const hasUnsafeSegment = segments.some(
     (segment) => segment === '' || segment === '.' || segment === '..',


### PR DESCRIPTION
Wrap-up item from PR #1194's security review: NUL bytes pass resolveSafePath's string checks then throw from Bun.file() as unhandled rejections. Fixed at the chokepoint (validate-at-the-boundary) with a regression test; playground-only, no changeset. Also records a decision: docs/validation-topology.md's main-green step enumeration intentionally stays as-is — the section self-documents its drift and defers to main-green.yaml as source of truth.