### PR TITLE
refactor: extract independently-testable modules from eight oversized component files

### DIFF
--- a/.changeset/oversized-kanban-board-split.md
+++ b/.changeset/oversized-kanban-board-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: move KanbanBoard's pointer hit-testing helpers into `kanban-board-helpers.ts` (parameterized, no closures over component locals) and extract column lift/drop/collapse state into `KanbanBoardColumnReorder`. Also deduplicates the two identical drop-placeholder `<li>` blocks into a shared snippet. No behavior or public API change; markup is unchanged.

--- a/.changeset/oversized-schedule-builder-split.md
+++ b/.changeset/oversized-schedule-builder-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: deduplicate ScheduleBuilder's triplicated field-reseed block into `applySeedToFields` (all 12 fields, used by the prop-resync and allowed-modes-change effects) and `applyPresetSeedToFields` (the 8 preset-only fields, used by the presets branch of a mode switch, which must not touch `authoringMode`/cron/interval fields). No behavior or public API change; the 11 flat `$state` declarations and the three authoring-mode panels are unchanged.

--- a/.changeset/oversized-schema-form-body-split.md
+++ b/.changeset/oversized-schema-form-body-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: extract SchemaFormBody's path-keyed editing state (form value, validation errors, and five auxiliary draft maps) into `SchemaFormState`, instantiated fresh on every schema remount. No behavior or public API change; `renderField` and all markup are unchanged.

--- a/.changeset/oversized-selection-popover-split.md
+++ b/.changeset/oversized-selection-popover-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: extract SelectionPopover's virtual-keyboard-dismissal heuristic into `createVirtualKeyboardDismissal`, a factory that owns its own `$effect`. No behavior or public API change; adds unit test coverage for logic that was previously only reachable through a full popover mount plus real `visualViewport`/`navigator.virtualKeyboard` events.

--- a/.changeset/oversized-source-diff-viewer-split.md
+++ b/.changeset/oversized-source-diff-viewer-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: split `source-diff-viewer.utilities.ts` into path-normalization, git-header-parsing, binary-notice, and label-formatting modules. No behavior or public API change.

--- a/.changeset/oversized-table-of-contents-split.md
+++ b/.changeset/oversized-table-of-contents-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: extract `TableOfContents`'s heading-derivation and active-heading-tracking observer state machines into `table-of-contents-heading-registry.svelte.ts` and `table-of-contents-active-heading.svelte.ts`. No behavior or public API change; adds unit test coverage for logic that was previously only reachable through a full component mount.

--- a/.changeset/oversized-tree-item-split.md
+++ b/.changeset/oversized-tree-item-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: extract TreeItem's inline-rename state machine into `TreeItemRenameController`, keyboard/pointer drag handling into `TreeItemDragHandlers`, the async `loadChildren` lifecycle into `TreeItemAsyncLoader`, and the filter-highlight splitter into a plain `splitLabelForHighlight` function. Checkbox-selection reconciliation and tree registration stay inline, matching their existing precisely-ordered same-file guarantees. No behavior or public API change; markup is unchanged.

--- a/.changeset/oversized-tree-split.md
+++ b/.changeset/oversized-tree-split.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Internal restructuring: extract Tree's search/filter state (controlled-vs-uncontrolled value, debounced results announcement, filter input keyboard shortcuts) into `TreeFilterController`, and pointer-drag autoscroll (edge detection, scroll nudging, drop-target re-resolution while scrolling) into `TreeAutoscrollController`, both under `src/_internal/` alongside Tree's existing companion modules. Typeahead dispatch and both render paths (DOM-registry and virtualized) are unchanged. No behavior or public API change.

--- a/packages/components/src/_internal/tree-autoscroll.svelte.ts
+++ b/packages/components/src/_internal/tree-autoscroll.svelte.ts
@@ -1,0 +1,105 @@
+export type TreeAutoscrollControllerOptions = {
+  isPointerDragging: () => boolean;
+  /**
+   * Called with the resolved drop-target element once autoscroll has
+   * (re-)resolved a pointer position. Deliberately typed as `EventTarget |
+   * null` rather than `HTMLElement | null`: this class has no reason to know
+   * about `TreeDragController` or import it directly, so it hands the raw
+   * clientX/clientY back alongside the resolved element and lets the owning
+   * component (which already holds the drag controller) call
+   * `dragController.targetFromPointer(clientY, target)` itself.
+   */
+  setDropTarget: (clientX: number, clientY: number, target: EventTarget | null) => void;
+};
+
+const AUTOSCROLL_EDGE_PX = 32;
+const AUTOSCROLL_SPEED_PX = 8;
+
+/**
+ * Pointer-drag autoscroll for the tree's scroll container: while a pointer
+ * drag is active and near the top/bottom edge, nudges `scrollTop` on every
+ * animation frame and re-resolves the drop target as the content scrolls
+ * underneath the pointer. Modeled on the `$state`-fields-plus-`#options`-
+ * object shape of `TreeDragController` (private fields here since nothing
+ * outside this class reads pointer position or scroll-element state).
+ */
+export class TreeAutoscrollController {
+  #latestPointerX = 0;
+  #latestPointerY = 0;
+  #scrollElement: HTMLElement | null = null;
+  #animationFrame: number | null = null;
+  readonly #options: TreeAutoscrollControllerOptions;
+
+  constructor(options: TreeAutoscrollControllerOptions) {
+    this.#options = options;
+  }
+
+  #pointerTargetElement(
+    clientX: number,
+    clientY: number,
+    fallbackTarget: EventTarget | null,
+  ): HTMLElement | null {
+    if (typeof document !== 'undefined') {
+      const element = document.elementFromPoint(clientX, clientY);
+      if (element instanceof HTMLElement) return element;
+    }
+    return fallbackTarget instanceof HTMLElement ? fallbackTarget : null;
+  }
+
+  #updateDragTargetFromPointer(
+    clientX: number,
+    clientY: number,
+    fallbackTarget: EventTarget | null,
+  ): void {
+    const element = this.#pointerTargetElement(clientX, clientY, fallbackTarget);
+    if (!element) return;
+    this.#options.setDropTarget(clientX, clientY, element);
+  }
+
+  #scheduleAutoscroll(): void {
+    if (
+      this.#animationFrame !== null ||
+      !this.#options.isPointerDragging() ||
+      !this.#scrollElement ||
+      typeof requestAnimationFrame !== 'function'
+    ) {
+      return;
+    }
+
+    this.#animationFrame = requestAnimationFrame(() => {
+      this.#animationFrame = null;
+      const tree = this.#scrollElement;
+      if (!this.#options.isPointerDragging() || !tree) return;
+
+      const rect = tree.getBoundingClientRect();
+      const previousScrollTop = tree.scrollTop;
+      if (this.#latestPointerY - rect.top < AUTOSCROLL_EDGE_PX) {
+        tree.scrollTop -= AUTOSCROLL_SPEED_PX;
+      } else if (rect.bottom - this.#latestPointerY < AUTOSCROLL_EDGE_PX) {
+        tree.scrollTop += AUTOSCROLL_SPEED_PX;
+      }
+
+      if (tree.scrollTop === previousScrollTop) return;
+      this.#updateDragTargetFromPointer(this.#latestPointerX, this.#latestPointerY, tree);
+      this.#scheduleAutoscroll();
+    });
+  }
+
+  handlePointerMove(event: PointerEvent, scrollElement: HTMLElement): void {
+    if (!this.#options.isPointerDragging()) return;
+    event.preventDefault();
+    this.#latestPointerX = event.clientX;
+    this.#latestPointerY = event.clientY;
+    this.#scrollElement = scrollElement;
+    this.#updateDragTargetFromPointer(event.clientX, event.clientY, event.target);
+    this.#scheduleAutoscroll();
+  }
+
+  stop(): void {
+    if (this.#animationFrame !== null && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(this.#animationFrame);
+    }
+    this.#animationFrame = null;
+    this.#scrollElement = null;
+  }
+}

--- a/packages/components/src/_internal/tree-autoscroll.test.ts
+++ b/packages/components/src/_internal/tree-autoscroll.test.ts
@@ -1,0 +1,90 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { TreeAutoscrollController } = await import('./tree-autoscroll.svelte.ts');
+
+function stubScrollElement(rect: { top: number; bottom: number }): HTMLElement {
+  const element = document.createElement('div');
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      top: rect.top,
+      bottom: rect.bottom,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: rect.bottom - rect.top,
+      x: 0,
+      y: rect.top,
+      toJSON: () => ({}),
+    }),
+  });
+  return element;
+}
+
+function createController() {
+  return new TreeAutoscrollController({
+    isPointerDragging: () => true,
+    setDropTarget: () => {},
+  });
+}
+
+/**
+ * Captures every scheduled frame without auto-invoking it, so a test can
+ * decide exactly when (and how many times) to run the autoscroll callback —
+ * running it automatically would recurse indefinitely while the pointer
+ * stays within the edge threshold.
+ */
+function stubRaf(): { calls: FrameRequestCallback[] } {
+  const state: { calls: FrameRequestCallback[] } = { calls: [] };
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback): number => {
+    state.calls.push(callback);
+    return state.calls.length;
+  }) as typeof requestAnimationFrame;
+  return state;
+}
+
+describe('TreeAutoscrollController', () => {
+  const originalRaf = globalThis.requestAnimationFrame;
+
+  afterEach(() => {
+    globalThis.requestAnimationFrame = originalRaf;
+  });
+
+  test('keeps scheduling frames while the pointer stays within the edge threshold', () => {
+    const raf = stubRaf();
+    const controller = createController();
+    const scrollElement = stubScrollElement({ top: 0, bottom: 400 });
+    scrollElement.scrollTop = 50;
+
+    // 10px from the top edge — inside the 32px threshold, so the callback
+    // scrolls (changing scrollTop) and reschedules itself.
+    const event = new PointerEvent('pointermove', { clientX: 50, clientY: 10 });
+    controller.handlePointerMove(event, scrollElement);
+
+    expect(raf.calls.length).toBe(1);
+    raf.calls[0]?.(0);
+    expect(raf.calls.length).toBe(2);
+  });
+
+  test('stops scheduling frames once the pointer is away from both edges', () => {
+    const raf = stubRaf();
+    const controller = createController();
+    const scrollElement = stubScrollElement({ top: 0, bottom: 400 });
+    scrollElement.scrollTop = 50;
+
+    // 200px from the top edge and 200px from the bottom edge — outside the
+    // 32px threshold on both sides, so the callback leaves scrollTop
+    // unchanged and does not reschedule.
+    const event = new PointerEvent('pointermove', { clientX: 50, clientY: 200 });
+    controller.handlePointerMove(event, scrollElement);
+
+    expect(raf.calls.length).toBe(1);
+    raf.calls[0]?.(0);
+    expect(raf.calls.length).toBe(1);
+  });
+});

--- a/packages/components/src/_internal/tree-filter.svelte.ts
+++ b/packages/components/src/_internal/tree-filter.svelte.ts
@@ -1,0 +1,110 @@
+import { untrack } from 'svelte';
+
+export type TreeFilterControllerOptions = {
+  getFilterValue: () => string | undefined;
+  isControlled: () => boolean;
+  onFilterChange?: (value: string) => void;
+  focusFirstVisible: () => void;
+};
+
+/**
+ * Tree's search/filter input: controlled-vs-uncontrolled value resolution, a
+ * debounced "N results found" live-region announcement, and the filter
+ * input's own keyboard shortcuts (ArrowDown to jump into the tree, Escape to
+ * clear). Modeled on the `$state`-fields-plus-`#options`-object shape of
+ * `TreeDragController`.
+ *
+ * The debounce timer is bookkeeping only: `scheduleStatusAnnouncement` takes
+ * an explicit `resultCount` rather than reading a `getVisibleCount` getter,
+ * so the reactive dependency on `visibleIds.length` (a large, tree-shape-
+ * dependent computation) stays owned by the `$effect` in `tree.svelte` that
+ * calls it, not duplicated inside this class.
+ */
+export class TreeFilterController {
+  uncontrolledValue = $state('');
+  filterInputElement: HTMLInputElement | null = $state(null);
+  statusAnnouncement = $state('');
+  statusAnnouncementSequence = $state(0);
+  statusBusy = $state(false);
+
+  #statusTimer: ReturnType<typeof setTimeout> | null = null;
+  readonly #options: TreeFilterControllerOptions;
+
+  constructor(options: TreeFilterControllerOptions) {
+    this.#options = options;
+    this.uncontrolledValue = untrack(() => options.getFilterValue() ?? '');
+  }
+
+  get currentValue(): string {
+    return this.#options.isControlled()
+      ? (this.#options.getFilterValue() ?? '')
+      : this.uncontrolledValue;
+  }
+
+  get normalizedValue(): string {
+    return this.currentValue.trim();
+  }
+
+  get filtering(): boolean {
+    return this.normalizedValue.length > 0;
+  }
+
+  update(next: string): void {
+    if (!this.#options.isControlled()) this.uncontrolledValue = next;
+    this.#options.onFilterChange?.(next);
+  }
+
+  scheduleStatusAnnouncement(resultCount: number): void {
+    if (this.#statusTimer !== null) {
+      clearTimeout(this.#statusTimer);
+      this.#statusTimer = null;
+    }
+
+    if (!this.filtering) {
+      this.statusBusy = false;
+      this.statusAnnouncement = '';
+      return;
+    }
+
+    const query = this.normalizedValue;
+    this.statusBusy = true;
+    this.#statusTimer = setTimeout(() => {
+      this.statusAnnouncement =
+        resultCount === 0
+          ? `No results for ${query}.`
+          : `${resultCount} result${resultCount === 1 ? '' : 's'} found.`;
+      this.statusAnnouncementSequence += 1;
+      this.statusBusy = false;
+      this.#statusTimer = null;
+    }, 500);
+  }
+
+  handleInput = (event: Event): void => {
+    const target = event.currentTarget;
+    if (!(target instanceof HTMLInputElement)) return;
+    this.update(target.value);
+  };
+
+  handleKeydown = (event: KeyboardEvent): void => {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.#options.focusFirstVisible();
+      return;
+    }
+
+    if (event.key === 'Escape' && this.currentValue.length > 0) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.update('');
+      this.filterInputElement?.focus();
+    }
+  };
+
+  /** Clears any pending debounce timer. Call from the owner's unmount cleanup. */
+  destroy(): void {
+    if (this.#statusTimer !== null) {
+      clearTimeout(this.#statusTimer);
+      this.#statusTimer = null;
+    }
+  }
+}

--- a/packages/components/src/_internal/tree-filter.test.ts
+++ b/packages/components/src/_internal/tree-filter.test.ts
@@ -8,7 +8,7 @@ setupHappyDom();
 const { TreeFilterController } = await import('./tree-filter.svelte.ts');
 
 describe('TreeFilterController', () => {
-  test('update() sets currentValue and is idempotent when called with the same value twice', () => {
+  test('update() tracks currentValue and forwards every call to onFilterChange, including repeats', () => {
     const calls: string[] = [];
     const controller = new TreeFilterController({
       getFilterValue: () => undefined,

--- a/packages/components/src/_internal/tree-filter.test.ts
+++ b/packages/components/src/_internal/tree-filter.test.ts
@@ -1,0 +1,27 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { TreeFilterController } = await import('./tree-filter.svelte.ts');
+
+describe('TreeFilterController', () => {
+  test('update() sets currentValue and is idempotent when called with the same value twice', () => {
+    const calls: string[] = [];
+    const controller = new TreeFilterController({
+      getFilterValue: () => undefined,
+      isControlled: () => false,
+      onFilterChange: (value) => calls.push(value),
+      focusFirstVisible: () => {},
+    });
+
+    controller.update('alpha');
+    expect(controller.currentValue).toBe('alpha');
+
+    controller.update('alpha');
+    expect(controller.currentValue).toBe('alpha');
+    expect(calls).toEqual(['alpha', 'alpha']);
+  });
+});

--- a/packages/components/src/components/kanban-board/kanban-board-column-reorder.svelte.ts
+++ b/packages/components/src/components/kanban-board/kanban-board-column-reorder.svelte.ts
@@ -1,0 +1,149 @@
+import { moveKanbanColumn, toggleKanbanColumn } from './kanban-board-helpers.ts';
+import type { KanbanBoardChange, KanbanBoardColumn } from './kanban-board.types.ts';
+
+type CardControllerPhase = 'idle' | 'lifted';
+
+type KanbanBoardColumnReorderOptions<Card> = {
+  getColumns: () => KanbanBoardColumn<Card>[];
+  getReorderColumns: () => boolean;
+  getInvalidKeys: () => boolean;
+  announce: (message: string) => void;
+  onchange: (nextColumns: KanbanBoardColumn<Card>[], change: KanbanBoardChange) => void;
+};
+
+/**
+ * Owns column lift/drop/collapse state and the click/keyboard handlers that
+ * drive it. Deliberately does not read `cardController` directly — column
+ * reordering and card dragging are separate interaction modes, and the one
+ * place they need to know about each other (don't let a column reorder start
+ * while a card is lifted) is expressed by having the caller pass the card
+ * controller's current phase into each entry point instead.
+ */
+export class KanbanBoardColumnReorder<Card> {
+  liftedKey = $state<string | number | null>(null);
+  targetIndex = $state<number | null>(null);
+
+  readonly #options: KanbanBoardColumnReorderOptions<Card>;
+
+  constructor(options: KanbanBoardColumnReorderOptions<Card>) {
+    this.#options = options;
+  }
+
+  cancelColumnLift(columnTitle: string | undefined = undefined): void {
+    this.liftedKey = null;
+    this.targetIndex = null;
+    if (columnTitle) this.#options.announce(`${columnTitle} column move cancelled.`);
+  }
+
+  toggleColumn(column: KanbanBoardColumn<Card>): void {
+    const result = toggleKanbanColumn(this.#options.getColumns(), column.id);
+    if (!result) return;
+    this.#options.announce(
+      `${column.title} ${result.change.type === 'collapse' && result.change.collapsed ? 'collapsed' : 'expanded'}.`,
+    );
+    this.#options.onchange(result.nextColumns, result.change);
+  }
+
+  liftColumn(
+    column: KanbanBoardColumn<Card>,
+    columnIndex: number,
+    cardControllerPhase: CardControllerPhase,
+  ): void {
+    if (cardControllerPhase === 'lifted') return;
+    this.liftedKey = column.id;
+    this.targetIndex = columnIndex;
+    this.#options.announce(
+      `${column.title} column lifted, position ${columnIndex + 1} of ${this.#options.getColumns().length}.`,
+    );
+  }
+
+  dropColumn(column: KanbanBoardColumn<Card>, targetIndex: number): void {
+    const columns = this.#options.getColumns();
+    const result = moveKanbanColumn(columns, column.id, targetIndex);
+    this.liftedKey = null;
+    this.targetIndex = null;
+    this.#options.announce(
+      `${column.title} column dropped at position ${targetIndex + 1} of ${columns.length}.`,
+    );
+    if (result) this.#options.onchange(result.nextColumns, result.change);
+  }
+
+  handleColumnClick(
+    column: KanbanBoardColumn<Card>,
+    columnIndex: number,
+    cardControllerPhase: CardControllerPhase,
+  ): void {
+    if (
+      !this.#options.getReorderColumns() ||
+      this.#options.getInvalidKeys() ||
+      cardControllerPhase === 'lifted'
+    )
+      return;
+    if (this.liftedKey === null) {
+      this.liftColumn(column, columnIndex, cardControllerPhase);
+      return;
+    }
+    if (this.liftedKey === column.id) {
+      this.dropColumn(column, this.targetIndex ?? columnIndex);
+    }
+  }
+
+  handleColumnKeydown(
+    event: KeyboardEvent,
+    column: KanbanBoardColumn<Card>,
+    columnIndex: number,
+    cardControllerPhase: CardControllerPhase,
+  ): void {
+    if (
+      !this.#options.getReorderColumns() ||
+      this.#options.getInvalidKeys() ||
+      cardControllerPhase === 'lifted'
+    )
+      return;
+    if (this.liftedKey === null) {
+      // Space/Enter in the idle state: do nothing here. The native button will
+      // synthesize a click on Space/Enter keyup, which handleColumnClick will
+      // handle to liftColumn. Handling Space/Enter in both keydown and the
+      // subsequent synthesized click caused an immediate lift-then-drop.
+      return;
+    }
+    if (this.liftedKey !== column.id) return;
+    const columns = this.#options.getColumns();
+    const currentTarget = this.targetIndex ?? columnIndex;
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.cancelColumnLift(column.title);
+      return;
+    }
+    if (event.key === 'Tab') {
+      this.cancelColumnLift(column.title);
+      return;
+    }
+    if (event.key === ' ' || event.key === 'Enter') {
+      // Prevent the default action so the browser does not synthesize a click
+      // event on keyup — for Space, preventDefault() on keydown suppresses the
+      // synthetic keyup-click, so handleColumnClick never fires after the column
+      // is already dropped and this.liftedKey is null again.
+      event.preventDefault();
+      this.dropColumn(column, currentTarget);
+      return;
+    }
+    const nextIndex =
+      event.key === 'ArrowLeft'
+        ? currentTarget - 1
+        : event.key === 'ArrowRight'
+          ? currentTarget + 1
+          : event.key === 'Home'
+            ? 0
+            : event.key === 'End'
+              ? columns.length - 1
+              : currentTarget;
+    if (nextIndex !== currentTarget) {
+      event.preventDefault();
+      this.targetIndex = Math.max(0, Math.min(nextIndex, columns.length - 1));
+      this.#options.announce(
+        `${column.title} column moved to position ${(this.targetIndex ?? 0) + 1} of ${columns.length}.`,
+      );
+    }
+  }
+}

--- a/packages/components/src/components/kanban-board/kanban-board-helpers.ts
+++ b/packages/components/src/components/kanban-board/kanban-board-helpers.ts
@@ -208,3 +208,94 @@ export function findNextVisibleColumn<Card>(
   }
   return null;
 }
+
+export function getColumnCardListElement(columnElement: HTMLElement): HTMLElement | null {
+  return (
+    Array.from(columnElement.children).find(
+      (child): child is HTMLElement =>
+        child instanceof HTMLElement && child.classList.contains('cinder-kanban-board__cards'),
+    ) ?? null
+  );
+}
+
+export function sortableRowMatchesKey(row: HTMLElement, key: string | number): boolean {
+  return (
+    row.getAttribute('data-key') === String(key) && row.getAttribute('data-key-type') === typeof key
+  );
+}
+
+export function getLiftedRowElement(
+  columnsElement: HTMLElement | null,
+  liftedKey: string | number | null,
+): HTMLElement | null {
+  if (!columnsElement || liftedKey === null) return null;
+  return (
+    Array.from(columnsElement.querySelectorAll<HTMLElement>('[data-sortable-row]')).find((row) =>
+      sortableRowMatchesKey(row, liftedKey),
+    ) ?? null
+  );
+}
+
+export function getLiftedRowBlockSize(
+  columnsElement: HTMLElement | null,
+  liftedKey: string | number | null,
+): number {
+  return getLiftedRowElement(columnsElement, liftedKey)?.getBoundingClientRect().height ?? 0;
+}
+
+export function getColumnDropZoneBottom(cardList: HTMLElement, liftedRowBlockSize: number): number {
+  return cardList.getBoundingClientRect().bottom + liftedRowBlockSize;
+}
+
+/**
+ * Pure DOM hit-testing: resolves which column and card-insertion-index a
+ * pointer position maps to. Parameterized rather than closing over component
+ * locals so it can be unit tested and reused without a live component
+ * instance.
+ */
+export function locatePointerTarget<Card>(args: {
+  columnsElement: HTMLElement | null;
+  columns: KanbanBoardColumn<Card>[];
+  liftedKey: string | number | null;
+  pointerX: number;
+  pointerY: number;
+}): CardMoveTarget | null {
+  const { columnsElement, columns, liftedKey, pointerX, pointerY } = args;
+  if (!columnsElement) return null;
+  const liftedRowBlockSize = getLiftedRowBlockSize(columnsElement, liftedKey);
+  const columnElements = Array.from(columnsElement.children).filter(
+    (element): element is HTMLElement =>
+      element instanceof HTMLElement && element.classList.contains('cinder-kanban-board__column'),
+  );
+  const columnIndex = columnElements.findIndex((element) => {
+    const rect = element.getBoundingClientRect();
+    const cardList = getColumnCardListElement(element);
+    if (!cardList) return false;
+    return (
+      pointerX >= rect.left &&
+      pointerX <= rect.right &&
+      pointerY >= rect.top &&
+      pointerY <= getColumnDropZoneBottom(cardList, liftedRowBlockSize)
+    );
+  });
+  if (columnIndex < 0 || columns[columnIndex]?.collapsed) return null;
+  const columnElement = columnElements[columnIndex];
+  if (!columnElement) return null;
+  const cardList = getColumnCardListElement(columnElement);
+  // Exclude the dragged card by its stable data-key attribute so the filter
+  // works regardless of whether the card is in the keyboard-drag state
+  // (cinder-sortable-item--lifted) or the pointer-drag state
+  // (cinder-sortable-item--placeholder). Both states carry the same data-key.
+  const draggedKey = liftedKey;
+  const rows = Array.from(cardList?.children ?? []).filter(
+    (row): row is HTMLElement =>
+      row instanceof HTMLElement &&
+      row.hasAttribute('data-sortable-row') &&
+      (draggedKey === null || !sortableRowMatchesKey(row, draggedKey)),
+  );
+  const insertionIndex = rows.filter((row) => {
+    const rect = row.getBoundingClientRect();
+    return rect.top + rect.height / 2 < pointerY;
+  }).length;
+  return { columnIndex, cardIndex: insertionIndex };
+}

--- a/packages/components/src/components/kanban-board/kanban-board.svelte
+++ b/packages/components/src/components/kanban-board/kanban-board.svelte
@@ -37,12 +37,13 @@
     buildCardLocationMap,
     findCard,
     findNextVisibleColumn,
+    getLiftedRowElement,
+    locatePointerTarget,
     moveKanbanCard,
-    moveKanbanColumn,
-    toggleKanbanColumn,
     validateKanbanBoardKeys,
     type CardMoveTarget,
   } from './kanban-board-helpers.ts';
+  import { KanbanBoardColumnReorder } from './kanban-board-column-reorder.svelte.ts';
   import type {
     KanbanBoardCardContext,
     KanbanBoardColumn,
@@ -85,13 +86,19 @@
   let columnsElement = $state<HTMLElement | null>(null);
   let cardTarget = $state<CardMoveTarget | null>(null);
   let pointerColumnIndex = $state<number | null>(null);
-  let columnLiftedKey = $state<string | number | null>(null);
-  let columnTargetIndex = $state<number | null>(null);
   let crossColumnPlaceholderBlockSize = $state<string | null>(null);
   let lastInvalidKeyWarning = '';
 
   const keyValidation = $derived(validateKanbanBoardKeys(columns, getCardKey));
   const invalidKeys = $derived(!keyValidation.valid);
+
+  const columnReorder = new KanbanBoardColumnReorder<Card>({
+    getColumns: () => columns,
+    getReorderColumns: () => reorderColumns,
+    getInvalidKeys: () => invalidKeys,
+    announce: (message) => announcer.announce(message),
+    onchange: (nextColumns, change) => onchange(nextColumns, change),
+  });
 
   // Index cards by key once per render so the card loop can resolve each card's
   // original column/index in O(1) instead of calling findCard per-card (O(N²)).
@@ -148,7 +155,7 @@
   $effect(() => {
     if (!invalidKeys) return;
     if (cardController.phase === 'lifted') cancelCardLift();
-    if (columnLiftedKey !== null) cancelColumnLift();
+    if (columnReorder.liftedKey !== null) columnReorder.cancelColumnLift();
   });
 
   $effect(() => {
@@ -157,7 +164,7 @@
       return;
     }
 
-    const liftedRow = getLiftedRowElement();
+    const liftedRow = getLiftedRowElement(columnsElement, cardController.liftedKey);
     const liftedHeight = liftedRow?.getBoundingClientRect().height ?? 0;
 
     crossColumnPlaceholderBlockSize = liftedHeight > 0 ? `${liftedHeight}px` : null;
@@ -211,85 +218,12 @@
       column,
       columnIndex,
       totalColumns: columns.length,
-      isLifted: columnLiftedKey === column.id,
-      isDropTarget: columnTargetIndex === columnIndex,
+      isLifted: columnReorder.liftedKey === column.id,
+      isDropTarget: columnReorder.targetIndex === columnIndex,
       collapsed: Boolean(column.collapsed),
       canCollapse: collapsible,
       canReorder: reorderColumns && !invalidKeys,
     };
-  }
-
-  function getColumnCardListElement(columnElement: HTMLElement): HTMLElement | null {
-    return (
-      Array.from(columnElement.children).find(
-        (child): child is HTMLElement =>
-          child instanceof HTMLElement && child.classList.contains('cinder-kanban-board__cards'),
-      ) ?? null
-    );
-  }
-
-  function sortableRowMatchesKey(row: HTMLElement, key: string | number): boolean {
-    return (
-      row.getAttribute('data-key') === String(key) &&
-      row.getAttribute('data-key-type') === typeof key
-    );
-  }
-
-  function getLiftedRowElement(): HTMLElement | null {
-    if (!columnsElement || cardController.liftedKey === null) return null;
-    return (
-      Array.from(columnsElement.querySelectorAll<HTMLElement>('[data-sortable-row]')).find((row) =>
-        sortableRowMatchesKey(row, cardController.liftedKey as string | number),
-      ) ?? null
-    );
-  }
-
-  function getLiftedRowBlockSize(): number {
-    return getLiftedRowElement()?.getBoundingClientRect().height ?? 0;
-  }
-
-  function getColumnDropZoneBottom(cardList: HTMLElement, liftedRowBlockSize: number): number {
-    return cardList.getBoundingClientRect().bottom + liftedRowBlockSize;
-  }
-
-  function locatePointerTarget(pointerX: number, pointerY: number): CardMoveTarget | null {
-    if (!columnsElement) return null;
-    const liftedRowBlockSize = getLiftedRowBlockSize();
-    const columnElements = Array.from(columnsElement.children).filter(
-      (element): element is HTMLElement =>
-        element instanceof HTMLElement && element.classList.contains('cinder-kanban-board__column'),
-    );
-    const columnIndex = columnElements.findIndex((element) => {
-      const rect = element.getBoundingClientRect();
-      const cardList = getColumnCardListElement(element);
-      if (!cardList) return false;
-      return (
-        pointerX >= rect.left &&
-        pointerX <= rect.right &&
-        pointerY >= rect.top &&
-        pointerY <= getColumnDropZoneBottom(cardList, liftedRowBlockSize)
-      );
-    });
-    if (columnIndex < 0 || columns[columnIndex]?.collapsed) return null;
-    const columnElement = columnElements[columnIndex];
-    if (!columnElement) return null;
-    const cardList = getColumnCardListElement(columnElement);
-    // Exclude the dragged card by its stable data-key attribute so the filter
-    // works regardless of whether the card is in the keyboard-drag state
-    // (cinder-sortable-item--lifted) or the pointer-drag state
-    // (cinder-sortable-item--placeholder). Both states carry the same data-key.
-    const draggedKey = cardController.liftedKey;
-    const rows = Array.from(cardList?.children ?? []).filter(
-      (row): row is HTMLElement =>
-        row instanceof HTMLElement &&
-        row.hasAttribute('data-sortable-row') &&
-        (draggedKey === null || !sortableRowMatchesKey(row, draggedKey)),
-    );
-    const insertionIndex = rows.filter((row) => {
-      const rect = row.getBoundingClientRect();
-      return rect.top + rect.height / 2 < pointerY;
-    }).length;
-    return { columnIndex, cardIndex: insertionIndex };
   }
 
   function hasCrossColumnPlaceholder(columnIndex: number): boolean {
@@ -363,7 +297,7 @@
       pointerColumnIndex = null;
     },
     lift(key, fromIndex, itemLabel, total) {
-      if (invalidKeys || columnLiftedKey !== null) return;
+      if (invalidKeys || columnReorder.liftedKey !== null) return;
       const located = findCard(columns, getCardKey, key);
       if (!located || located.column.collapsed) return;
       cardTarget = { columnIndex: located.columnIndex, cardIndex: located.cardIndex };
@@ -394,7 +328,13 @@
       pointerColumnIndex = null;
     },
     getPointerTarget({ pointerX, pointerY }) {
-      const target = locatePointerTarget(pointerX, pointerY);
+      const target = locatePointerTarget({
+        columnsElement,
+        columns,
+        liftedKey: cardController.liftedKey,
+        pointerX,
+        pointerY,
+      });
       if (!target) return null;
       pointerColumnIndex = target.columnIndex;
       const column = columns[target.columnIndex];
@@ -430,113 +370,16 @@
     pointerColumnIndex = null;
   }
 
-  function cancelColumnLift(columnTitle: string | undefined = undefined): void {
-    columnLiftedKey = null;
-    columnTargetIndex = null;
-    if (columnTitle) announcer.announce(`${columnTitle} column move cancelled.`);
-  }
-
   function handleWindowKeydown(event: KeyboardEvent): void {
     if (cardController.phase === 'lifted' && event.key === 'Escape') {
       event.preventDefault();
       cancelCardLift();
       return;
     }
-    if (columnLiftedKey !== null && event.key === 'Escape') {
+    if (columnReorder.liftedKey !== null && event.key === 'Escape') {
       event.preventDefault();
-      const column = columns.find((currentColumn) => currentColumn.id === columnLiftedKey);
-      cancelColumnLift(column?.title);
-    }
-  }
-
-  function toggleColumn(column: KanbanBoardColumn<Card>): void {
-    const result = toggleKanbanColumn(columns, column.id);
-    if (!result) return;
-    announcer.announce(
-      `${column.title} ${result.change.type === 'collapse' && result.change.collapsed ? 'collapsed' : 'expanded'}.`,
-    );
-    onchange(result.nextColumns, result.change);
-  }
-
-  function liftColumn(column: KanbanBoardColumn<Card>, columnIndex: number): void {
-    if (cardController.phase === 'lifted') return;
-    columnLiftedKey = column.id;
-    columnTargetIndex = columnIndex;
-    announcer.announce(
-      `${column.title} column lifted, position ${columnIndex + 1} of ${columns.length}.`,
-    );
-  }
-
-  function dropColumn(column: KanbanBoardColumn<Card>, targetIndex: number): void {
-    const result = moveKanbanColumn(columns, column.id, targetIndex);
-    columnLiftedKey = null;
-    columnTargetIndex = null;
-    announcer.announce(
-      `${column.title} column dropped at position ${targetIndex + 1} of ${columns.length}.`,
-    );
-    if (result) onchange(result.nextColumns, result.change);
-  }
-
-  function handleColumnClick(column: KanbanBoardColumn<Card>, columnIndex: number): void {
-    if (!reorderColumns || invalidKeys || cardController.phase === 'lifted') return;
-    if (columnLiftedKey === null) {
-      liftColumn(column, columnIndex);
-      return;
-    }
-    if (columnLiftedKey === column.id) {
-      dropColumn(column, columnTargetIndex ?? columnIndex);
-    }
-  }
-
-  function handleColumnKeydown(
-    event: KeyboardEvent,
-    column: KanbanBoardColumn<Card>,
-    columnIndex: number,
-  ): void {
-    if (!reorderColumns || invalidKeys || cardController.phase === 'lifted') return;
-    if (columnLiftedKey === null) {
-      // Space/Enter in the idle state: do nothing here. The native button will
-      // synthesize a click on Space/Enter keyup, which handleColumnClick will
-      // handle to liftColumn. Handling Space/Enter in both keydown and the
-      // subsequent synthesized click caused an immediate lift-then-drop.
-      return;
-    }
-    if (columnLiftedKey !== column.id) return;
-    const currentTarget = columnTargetIndex ?? columnIndex;
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      cancelColumnLift(column.title);
-      return;
-    }
-    if (event.key === 'Tab') {
-      cancelColumnLift(column.title);
-      return;
-    }
-    if (event.key === ' ' || event.key === 'Enter') {
-      // Prevent the default action so the browser does not synthesize a click
-      // event on keyup — for Space, preventDefault() on keydown suppresses the
-      // synthetic keyup-click, so handleColumnClick never fires after the column
-      // is already dropped and columnLiftedKey is null again.
-      event.preventDefault();
-      dropColumn(column, currentTarget);
-      return;
-    }
-    const nextIndex =
-      event.key === 'ArrowLeft'
-        ? currentTarget - 1
-        : event.key === 'ArrowRight'
-          ? currentTarget + 1
-          : event.key === 'Home'
-            ? 0
-            : event.key === 'End'
-              ? columns.length - 1
-              : currentTarget;
-    if (nextIndex !== currentTarget) {
-      event.preventDefault();
-      columnTargetIndex = Math.max(0, Math.min(nextIndex, columns.length - 1));
-      announcer.announce(
-        `${column.title} column moved to position ${(columnTargetIndex ?? 0) + 1} of ${columns.length}.`,
-      );
+      const column = columns.find((currentColumn) => currentColumn.id === columnReorder.liftedKey);
+      columnReorder.cancelColumnLift(column?.title);
     }
   }
 </script>
@@ -559,6 +402,15 @@
     Space lifts. Arrow keys move. Space drops. Escape cancels.
   </p>
 
+  {#snippet dropPlaceholder()}
+    <li
+      class="cinder-kanban-board__card cinder-kanban-board__drop-placeholder cinder-sortable-item--placeholder"
+      role="presentation"
+      aria-hidden="true"
+      style={crossColumnPlaceholderStyle}
+    ></li>
+  {/snippet}
+
   <div bind:this={columnsElement} class="cinder-kanban-board__columns" role="list">
     {#each visualColumns as column, columnIndex (invalidKeys ? `${column.id}-${columnIndex}` : column.id)}
       {@const columnContext = makeColumnContext(column, columnIndex)}
@@ -574,11 +426,13 @@
               type="button"
               class="cinder-kanban-board__column-handle"
               aria-label={`Reorder ${column.title} column`}
-              aria-pressed={columnLiftedKey === column.id}
+              aria-pressed={columnReorder.liftedKey === column.id}
               aria-describedby={columnInstructionsId}
               disabled={invalidKeys}
-              onclick={() => handleColumnClick(column, columnIndex)}
-              onkeydown={(event) => handleColumnKeydown(event, column, columnIndex)}
+              onclick={() =>
+                columnReorder.handleColumnClick(column, columnIndex, cardController.phase)}
+              onkeydown={(event) =>
+                columnReorder.handleColumnKeydown(event, column, columnIndex, cardController.phase)}
             >
               <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
                 <path d="M2 4h12v1.5H2zM2 7.25h12v1.5H2zM2 10.5h12v1.5H2z" />
@@ -607,7 +461,7 @@
               class="cinder-kanban-board__collapse"
               aria-label={`${column.collapsed ? 'Expand' : 'Collapse'} ${column.title} (${column.cards.length} ${column.cards.length === 1 ? 'card' : 'cards'})`}
               aria-expanded={!column.collapsed}
-              onclick={() => toggleColumn(column)}
+              onclick={() => columnReorder.toggleColumn(column)}
             >
               <ChevronDown class="cinder-kanban-board__collapse-chevron" aria-hidden="true" />
             </button>
@@ -622,12 +476,7 @@
           >
             {#each column.cards as currentCard, cardIndex (invalidKeys ? `${getCardKey(currentCard)}-${cardIndex}` : getCardKey(currentCard))}
               {#if shouldRenderCrossColumnPlaceholder(columnIndex, cardIndex)}
-                <li
-                  class="cinder-kanban-board__card cinder-kanban-board__drop-placeholder cinder-sortable-item--placeholder"
-                  role="presentation"
-                  aria-hidden="true"
-                  style={crossColumnPlaceholderStyle}
-                ></li>
+                {@render dropPlaceholder()}
               {/if}
               {@const cardKey = getCardKey(currentCard)}
               {@const original = cardLocations.get(cardKey) ?? null}
@@ -664,12 +513,7 @@
               </SortableItem>
             {/each}
             {#if shouldRenderCrossColumnAppendPlaceholder(column, columnIndex)}
-              <li
-                class="cinder-kanban-board__card cinder-kanban-board__drop-placeholder cinder-sortable-item--placeholder"
-                role="presentation"
-                aria-hidden="true"
-                style={crossColumnPlaceholderStyle}
-              ></li>
+              {@render dropPlaceholder()}
             {/if}
             {#if column.cards.length === 0 && !hasCrossColumnPlaceholder(columnIndex)}
               <li class="cinder-kanban-board__empty">

--- a/packages/components/src/components/schedule-builder/schedule-builder.svelte
+++ b/packages/components/src/components/schedule-builder/schedule-builder.svelte
@@ -250,6 +250,51 @@
   let presetMonthlyDay = $state(initialSeed.presetMonthlyDay);
   let presetMonthlyTime = $state(initialSeed.presetMonthlyTime);
 
+  /**
+   * Applies every field a `seedFieldsFromValue` result carries — shared by
+   * the prop-resync effect and the allowed-modes-change effect, both of
+   * which reseed the whole authoring surface (mode, cron fields, interval
+   * fields, and every preset field) from a `ScheduleValue`.
+   *
+   * NOT used by `handleAuthoringModeChange`'s `presets` branch: that switch
+   * has already set `authoringMode` itself and must leave the cron/interval
+   * fields untouched (switching modes only re-seeds the destination mode's
+   * own fields) — see `applyPresetSeedToFields` below.
+   */
+  function applySeedToFields(seed: ReturnType<typeof seedFieldsFromValue>): void {
+    authoringMode = seed.authoringMode;
+    cronFields = seed.cronFields;
+    intervalEvery = seed.intervalEvery;
+    intervalUnit = seed.intervalUnit;
+    presetKind = seed.presetKind;
+    presetEveryValue = seed.presetEveryValue;
+    presetEveryUnit = seed.presetEveryUnit;
+    presetDailyTime = seed.presetDailyTime;
+    presetWeeklyDays = seed.presetWeeklyDays;
+    presetWeeklyTime = seed.presetWeeklyTime;
+    presetMonthlyDay = seed.presetMonthlyDay;
+    presetMonthlyTime = seed.presetMonthlyTime;
+  }
+
+  /**
+   * Applies only the 8 preset fields from a `seedFieldsFromValue` result.
+   * Used exclusively by `handleAuthoringModeChange`'s `presets` branch: at
+   * that call site `authoringMode` has already been set to `'presets'` and
+   * `seedFieldsFromValue` would recompute an `authoringMode` of its own from
+   * `lastKnownValue` — applying its full result via `applySeedToFields`
+   * would silently revert the mode switch the user just made.
+   */
+  function applyPresetSeedToFields(seed: ReturnType<typeof seedFieldsFromValue>): void {
+    presetKind = seed.presetKind;
+    presetEveryValue = seed.presetEveryValue;
+    presetEveryUnit = seed.presetEveryUnit;
+    presetDailyTime = seed.presetDailyTime;
+    presetWeeklyDays = seed.presetWeeklyDays;
+    presetWeeklyTime = seed.presetWeeklyTime;
+    presetMonthlyDay = seed.presetMonthlyDay;
+    presetMonthlyTime = seed.presetMonthlyTime;
+  }
+
   function valueForPresets(): ScheduleValue {
     switch (presetKind) {
       case 'every':
@@ -406,37 +451,13 @@
     // the UI in the browsed mode. Content equality still guards the echo case for
     // defined values (parent handing back exactly what we just emitted is a no-op).
     if (incoming !== undefined && scheduleValuesEqual(resolved, lastKnownValue)) return;
-    const seed = seedFieldsFromValue(resolved, resolvedAllowedModes);
-    authoringMode = seed.authoringMode;
-    cronFields = seed.cronFields;
-    intervalEvery = seed.intervalEvery;
-    intervalUnit = seed.intervalUnit;
-    presetKind = seed.presetKind;
-    presetEveryValue = seed.presetEveryValue;
-    presetEveryUnit = seed.presetEveryUnit;
-    presetDailyTime = seed.presetDailyTime;
-    presetWeeklyDays = seed.presetWeeklyDays;
-    presetWeeklyTime = seed.presetWeeklyTime;
-    presetMonthlyDay = seed.presetMonthlyDay;
-    presetMonthlyTime = seed.presetMonthlyTime;
+    applySeedToFields(seedFieldsFromValue(resolved, resolvedAllowedModes));
     lastKnownValue = resolved;
   });
 
   $effect(() => {
     if (resolvedAllowedModes.includes(authoringMode)) return;
-    const seed = seedFieldsFromValue(lastKnownValue, resolvedAllowedModes);
-    authoringMode = seed.authoringMode;
-    cronFields = seed.cronFields;
-    intervalEvery = seed.intervalEvery;
-    intervalUnit = seed.intervalUnit;
-    presetKind = seed.presetKind;
-    presetEveryValue = seed.presetEveryValue;
-    presetEveryUnit = seed.presetEveryUnit;
-    presetDailyTime = seed.presetDailyTime;
-    presetWeeklyDays = seed.presetWeeklyDays;
-    presetWeeklyTime = seed.presetWeeklyTime;
-    presetMonthlyDay = seed.presetMonthlyDay;
-    presetMonthlyTime = seed.presetMonthlyTime;
+    applySeedToFields(seedFieldsFromValue(lastKnownValue, resolvedAllowedModes));
   });
 
   /**
@@ -496,15 +517,7 @@
       // Daily/weekly/monthly and non-divisor/day/week intervals have no
       // general inverse, so they fall back to the same neutral defaults used
       // everywhere else a value gets seeded into the preset fields.
-      const seed = seedFieldsFromValue(lastKnownValue, resolvedAllowedModes);
-      presetKind = seed.presetKind;
-      presetEveryValue = seed.presetEveryValue;
-      presetEveryUnit = seed.presetEveryUnit;
-      presetDailyTime = seed.presetDailyTime;
-      presetWeeklyDays = seed.presetWeeklyDays;
-      presetWeeklyTime = seed.presetWeeklyTime;
-      presetMonthlyDay = seed.presetMonthlyDay;
-      presetMonthlyTime = seed.presetMonthlyTime;
+      applyPresetSeedToFields(seedFieldsFromValue(lastKnownValue, resolvedAllowedModes));
     }
   }
 

--- a/packages/components/src/components/schema-form/schema-form-body.svelte
+++ b/packages/components/src/components/schema-form/schema-form-body.svelte
@@ -16,23 +16,17 @@
   import Textarea from '../textarea/textarea.svelte';
 
   import {
-    arrayValueAtPath,
     createSchemaFormModel,
-    decodeEnumValue,
-    defaultValueForField,
     getValueAtPath,
     initialValueForField,
     pathId,
     pathKey,
-    pruneUndefined,
     rebaseFieldPath,
-    setValueAtPath,
     type SchemaFormField,
   } from './schema-form-model.ts';
+  import { createSchemaFormState } from './schema-form-state.svelte.ts';
   import type { SchemaFormOutput, SchemaFormProps } from './schema-form.types.ts';
   import {
-    issuesByPath,
-    parseJsonDraft,
     serializeValidatedValue,
     validateSchemaValue,
     type SchemaFormValidationIssue,
@@ -77,28 +71,28 @@
   const model = $derived(createSchemaFormModel(schema));
   let formElement = $state<HTMLFormElement>();
   let serializedInputElement = $state<HTMLInputElement>();
-  let formValue = $state<unknown>(initialFormValue);
-  let errors = $state<Record<string, string>>({});
-  let rawDrafts = $state<Record<string, string>>(
-    seedRawDrafts(initialModel.field, initialFormValue),
-  );
-  let parsedRawDrafts = $state<
-    Record<string, { ok: true; value: unknown } | { ok: false; message: string }>
-  >({});
-  let numericDrafts = $state<Record<string, string>>({});
-  let touchedValidationSequences = $state<Record<string, number>>({});
-  let serializedValue = $state('');
   let submitting = $state(false);
   let allowNativeSubmit = false;
   let activeSubmitId = 0;
-  let arrayKeyCounter = 0;
-  let arrayKeys = $state<Record<string, string[]>>(
-    seedArrayKeys(initialModel.field, initialFormValue),
-  );
+
+  const formState = createSchemaFormState(initialModel, initialFormValue, {
+    getSubmitting: () => submitting,
+    onDraftChange: (draft) => onDraftChange?.(draft),
+  });
+
+  // The hidden serialized-output input is a plain DOM ref, not a Svelte
+  // binding, so it needs an explicit sync whenever the state class's
+  // serializedValue changes (cleared on every edit, set on a successful
+  // submit).
+  $effect(() => {
+    if (serializedInputElement) serializedInputElement.value = formState.serializedValue;
+  });
 
   const formId = $derived((rest.id as string | undefined) ?? `${generatedId}-form`);
   const rootFields = $derived(model.field.kind === 'object' ? model.field.fields : [model.field]);
-  const rootError = $derived(model.field.kind === 'object' ? errors[pathKey([])] : undefined);
+  const rootError = $derived(
+    model.field.kind === 'object' ? formState.errors[pathKey([])] : undefined,
+  );
   const rootErrorId = $derived(`${formId}-${pathId([])}-error`);
 
   function fieldDomId(field: SchemaFormField): string {
@@ -106,25 +100,25 @@
   }
 
   function fieldError(field: SchemaFormField): string | undefined {
-    return errors[pathKey(field.path)];
+    return formState.errors[pathKey(field.path)];
   }
 
   function stringValue(field: SchemaFormField): string {
-    const current = getValueAtPath(formValue, field.path);
+    const current = getValueAtPath(formState.formValue, field.path);
     return current === undefined || current === null ? '' : String(current);
   }
 
   function numberValue(field: SchemaFormField): number | undefined {
-    const current = getValueAtPath(formValue, field.path);
+    const current = getValueAtPath(formState.formValue, field.path);
     return typeof current === 'number' ? current : undefined;
   }
 
   function booleanValue(field: SchemaFormField): boolean {
-    return getValueAtPath(formValue, field.path) === true;
+    return getValueAtPath(formState.formValue, field.path) === true;
   }
 
   function enumValue(field: SchemaFormField): string {
-    const current = getValueAtPath(formValue, field.path);
+    const current = getValueAtPath(formState.formValue, field.path);
     const option = field.options.find((candidate) => Object.is(candidate.value, current));
     return option?.encodedValue ?? field.options[0]?.encodedValue ?? '';
   }
@@ -143,322 +137,13 @@
 
   function rawJsonValue(field: SchemaFormField): string {
     const key = pathKey(field.path);
-    if (rawDrafts[key] !== undefined) return rawDrafts[key];
-    return JSON.stringify(getValueAtPath(formValue, field.path) ?? null, null, 2);
-  }
-
-  function bumpTouchedValidationSequence(path: readonly string[]) {
-    const key = pathKey(path);
-    touchedValidationSequences = {
-      ...touchedValidationSequences,
-      [key]: (touchedValidationSequences[key] ?? 0) + 1,
-    };
-  }
-
-  function currentDraft(): SchemaFormOutput {
-    let nextValue = formValue;
-    for (const field of currentNumericFields(model.field, formValue)) {
-      const draft = numericDrafts[pathKey(field.path)];
-      if (draft !== undefined) nextValue = setValueAtPath(nextValue, field.path, draft);
-    }
-    for (const field of currentJsonFields(model.field, formValue)) {
-      const key = pathKey(field.path);
-      const parsed = parsedRawDrafts[key];
-      if (parsed === undefined) continue;
-      nextValue = setValueAtPath(nextValue, field.path, parsed.ok ? parsed.value : rawDrafts[key]);
-    }
-    return pruneUndefined(nextValue) as SchemaFormOutput;
-  }
-
-  function reportDraftChange() {
-    onDraftChange?.(currentDraft());
-  }
-
-  function updateValue(path: readonly string[], next: unknown, reportChange = true) {
-    if (submitting) return;
-    formValue = setValueAtPath(formValue, path, next);
-    const key = pathKey(path);
-    if (numericDrafts[key] !== undefined) {
-      const { [key]: _removedDraft, ...remainingDrafts } = numericDrafts;
-      numericDrafts = remainingDrafts;
-    }
-    bumpTouchedValidationSequence(path);
-    if (errors[key]) {
-      const { [key]: _removed, ...remaining } = errors;
-      errors = remaining;
-    }
-    setSerializedValue('');
-    if (reportChange) reportDraftChange();
-  }
-
-  function updateNumberValue(field: SchemaFormField, next: number | null) {
-    const draft = numericDrafts[pathKey(field.path)];
-    if (next === null && draft !== undefined && draft.trim() !== '') return;
-    updateValue(field.path, next ?? undefined);
-  }
-
-  async function validateTouchedField(field: SchemaFormField) {
-    if (submitting) return;
-    const fieldKey = pathKey(field.path);
-    const sequence = (touchedValidationSequences[fieldKey] ?? 0) + 1;
-    touchedValidationSequences = { ...touchedValidationSequences, [fieldKey]: sequence };
-    const raw = rawJsonIssues();
-    const rawIssue = raw.issues.find((candidateIssue) => {
-      const candidateKey = pathKey(candidateIssue.path);
-      return candidateKey === fieldKey || candidateKey.startsWith(`${fieldKey}/`);
-    });
-    if (rawIssue) {
-      errors = { ...errors, [fieldKey]: rawIssue.message };
-      return;
-    }
-    const candidate = pruneUndefined(raw.value);
-    const result = await validateSchemaValue(schema, candidate);
-    if (touchedValidationSequences[fieldKey] !== sequence) return;
-    const issue = (result.valid ? [] : result.issues).find((candidateIssue) => {
-      const candidateKey = pathKey(candidateIssue.path);
-      return candidateKey === fieldKey || candidateKey.startsWith(`${fieldKey}/`);
-    });
-
-    if (issue) {
-      errors = { ...errors, [fieldKey]: issue.message };
-      return;
-    }
-
-    if (errors[fieldKey]) {
-      const { [fieldKey]: _removed, ...remaining } = errors;
-      errors = remaining;
-    }
-  }
-
-  function setSerializedValue(next: string) {
-    serializedValue = next;
-    if (serializedInputElement) serializedInputElement.value = next;
-  }
-
-  /** Enum Select is one-way (value + onchange) rather than a function binding:
-   *  the encode/decode round-trip is unstable inside Svelte's <select> binding
-   *  writeback, which reverts the selection. Decode the chosen option here. */
-  function updateEnum(field: SchemaFormField, event: Event) {
-    if (submitting) return;
-    const select = event.currentTarget as HTMLSelectElement;
-    updateValue(field.path, decodeEnumValue(select.value));
-  }
-
-  /** JSON fields hold a raw text draft (validated/parsed on submit), so the
-   *  textarea's value flows into `rawDrafts` rather than the typed value tree. */
-  function updateRawJsonValue(field: SchemaFormField, next: string) {
-    if (submitting) return;
-    const key = pathKey(field.path);
-    rawDrafts = { ...rawDrafts, [key]: next };
-    const parsed = parseJsonDraft(field.path, next);
-    parsedRawDrafts = {
-      ...parsedRawDrafts,
-      [key]: parsed.ok ? parsed : { ok: false, message: parsed.issue.message },
-    };
-    bumpTouchedValidationSequence(field.path);
-    if (errors[key]) {
-      const { [key]: _removed, ...remaining } = errors;
-      errors = remaining;
-    }
-    setSerializedValue('');
-    reportDraftChange();
-  }
-
-  function handleFieldInput(field: SchemaFormField, event: Event) {
-    if (submitting) return;
-    bumpTouchedValidationSequence(field.path);
-    if (field.kind !== 'number' && field.kind !== 'integer') return;
-    if (!(event.target instanceof HTMLInputElement)) return;
-    numericDrafts = { ...numericDrafts, [pathKey(field.path)]: event.target.value };
-    setSerializedValue('');
-    reportDraftChange();
-  }
-
-  function arrayRows(field: SchemaFormField): Array<{ key: string; index: number }> {
-    const values = arrayValueAtPath(formValue, field.path);
-    const keys = arrayKeys[pathKey(field.path)] ?? [];
-    return values.map((_, index) => ({
-      key: keys[index] ?? `${pathKey(field.path)}-${index}`,
-      index,
-    }));
-  }
-
-  function addArrayItem(field: SchemaFormField) {
-    if (submitting) return;
-    const values = arrayValueAtPath(formValue, field.path);
-    const nextValue = field.item ? defaultValueForField(field.item) : null;
-    updateValue(field.path, [...values, nextValue]);
-    const key = pathKey(field.path);
-    arrayKeys = {
-      ...arrayKeys,
-      [key]: [...(arrayKeys[key] ?? []), `${key}-${arrayKeyCounter++}`],
-    };
-  }
-
-  function removeArrayItem(field: SchemaFormField, index: number) {
-    if (submitting) return;
-    const values = arrayValueAtPath(formValue, field.path);
-    updateValue(
-      field.path,
-      values.filter((_, candidateIndex) => candidateIndex !== index),
-      false,
-    );
-    rawDrafts = reindexArrayPathState(rawDrafts, field.path, index);
-    parsedRawDrafts = reindexArrayPathState(parsedRawDrafts, field.path, index);
-    numericDrafts = reindexArrayPathState(numericDrafts, field.path, index);
-    errors = reindexArrayPathState(errors, field.path, index);
-    touchedValidationSequences = bumpPathValidationSequences(
-      reindexArrayPathState(touchedValidationSequences, field.path, index),
-      field.path,
-    );
-    const key = pathKey(field.path);
-    arrayKeys = {
-      ...arrayKeys,
-      [key]: (arrayKeys[key] ?? []).filter((_, candidateIndex) => candidateIndex !== index),
-    };
-    reportDraftChange();
-  }
-
-  function reindexArrayPathState<T>(
-    state: Record<string, T>,
-    arrayPath: readonly string[],
-    removedIndex: number,
-  ): Record<string, T> {
-    const prefix = pathKey(arrayPath);
-    const pathPrefix = prefix === '' ? '' : `${prefix}/`;
-    const next: Record<string, T> = {};
-
-    for (const [key, stateValue] of Object.entries(state)) {
-      if (!key.startsWith(pathPrefix)) {
-        next[key] = stateValue;
-        continue;
-      }
-
-      const relativeKey = key.slice(pathPrefix.length);
-      if (relativeKey === '') {
-        next[key] = stateValue;
-        continue;
-      }
-
-      const [indexSegment = '', ...remainingSegments] = relativeKey.split('/');
-      const index = Number(indexSegment);
-      if (!Number.isInteger(index) || index < 0) {
-        next[key] = stateValue;
-        continue;
-      }
-
-      if (index < removedIndex) {
-        next[key] = stateValue;
-        continue;
-      }
-
-      if (index === removedIndex) continue;
-
-      const shiftedKey = [String(index - 1), ...remainingSegments].join('/');
-      next[`${pathPrefix}${shiftedKey}`] = stateValue;
-    }
-
-    return next;
-  }
-
-  function bumpPathValidationSequences(
-    state: Record<string, number>,
-    path: readonly string[],
-  ): Record<string, number> {
-    const prefix = pathKey(path);
-    const pathPrefix = prefix === '' ? '' : `${prefix}/`;
-    const next: Record<string, number> = {};
-
-    for (const [key, sequence] of Object.entries(state)) {
-      next[key] = key === prefix || key.startsWith(pathPrefix) ? sequence + 1 : sequence;
-    }
-
-    return next;
-  }
-
-  function seedRawDrafts(field: SchemaFormField, currentValue: unknown): Record<string, string> {
-    const drafts: Record<string, string> = {};
-    for (const jsonField of currentJsonFields(field, currentValue)) {
-      drafts[pathKey(jsonField.path)] = JSON.stringify(
-        getValueAtPath(currentValue, jsonField.path) ?? null,
-        null,
-        2,
-      );
-    }
-    return drafts;
-  }
-
-  function currentJsonFields(field: SchemaFormField, currentValue: unknown): SchemaFormField[] {
-    const fields: SchemaFormField[] = [];
-
-    function visit(candidate: SchemaFormField) {
-      if (candidate.kind === 'json') fields.push(candidate);
-      for (const child of candidate.fields) visit(child);
-      if (candidate.kind === 'array' && candidate.item) {
-        for (const [index] of arrayValueAtPath(currentValue, candidate.path).entries()) {
-          visit(rebaseFieldPath(candidate.item, [...candidate.path, String(index)]));
-        }
-      }
-    }
-
-    visit(field);
-    return fields;
-  }
-
-  function currentNumericFields(field: SchemaFormField, currentValue: unknown): SchemaFormField[] {
-    const fields: SchemaFormField[] = [];
-
-    function visit(candidate: SchemaFormField) {
-      if (candidate.kind === 'number' || candidate.kind === 'integer') fields.push(candidate);
-      for (const child of candidate.fields) visit(child);
-      if (candidate.kind === 'array' && candidate.item) {
-        for (const [index] of arrayValueAtPath(currentValue, candidate.path).entries()) {
-          visit(rebaseFieldPath(candidate.item, [...candidate.path, String(index)]));
-        }
-      }
-    }
-
-    visit(field);
-    return fields;
-  }
-
-  function seedArrayKeys(field: SchemaFormField, currentValue: unknown): Record<string, string[]> {
-    const keys: Record<string, string[]> = {};
-
-    function visit(candidate: SchemaFormField) {
-      if (candidate.kind === 'array') {
-        const key = pathKey(candidate.path);
-        keys[key] = arrayValueAtPath(currentValue, candidate.path).map(
-          () => `${key}-${arrayKeyCounter++}`,
-        );
-      }
-      for (const child of candidate.fields) visit(child);
-      if (candidate.item) visit(candidate.item);
-    }
-
-    visit(field);
-    return keys;
-  }
-
-  function rawJsonIssues(): { value: unknown; issues: SchemaFormValidationIssue[] } {
-    let nextValue = formValue;
-    const issues: SchemaFormValidationIssue[] = [];
-    for (const field of currentJsonFields(model.field, formValue)) {
-      const parsed = parsedRawDrafts[pathKey(field.path)];
-      if (parsed === undefined) continue;
-      if (parsed.ok) {
-        nextValue = setValueAtPath(nextValue, field.path, parsed.value);
-      } else {
-        issues.push({ path: field.path, message: parsed.message });
-      }
-    }
-    return { value: nextValue, issues };
+    if (formState.rawDrafts[key] !== undefined) return formState.rawDrafts[key];
+    return JSON.stringify(getValueAtPath(formState.formValue, field.path) ?? null, null, 2);
   }
 
   async function reportSubmitIssues(issues: SchemaFormValidationIssue[], submitId: number) {
     if (activeSubmitId !== submitId) return;
-    errors = issuesByPath(issues);
-    setSerializedValue('');
+    formState.applyIssues(issues);
     submitting = false;
     await focusFirstError(submitId);
   }
@@ -509,19 +194,13 @@
     activeSubmitId = submitId;
     submitting = true;
     try {
-      const raw = rawJsonIssues();
-      if (raw.issues.length > 0) {
-        await reportSubmitIssues(raw.issues, submitId);
+      const draft = formState.buildSubmitCandidate();
+      if (!draft.ok) {
+        await reportSubmitIssues(draft.issues, submitId);
         return;
       }
 
-      let candidate = raw.value;
-      for (const field of currentNumericFields(model.field, formValue)) {
-        const draft = numericDrafts[pathKey(field.path)];
-        if (draft !== undefined) candidate = setValueAtPath(candidate, field.path, draft);
-      }
-      candidate = pruneUndefined(candidate);
-      const result = await validateSchemaValue(schema, candidate);
+      const result = await validateSchemaValue(schema, draft.value);
       if (!result.valid) {
         await reportSubmitIssues(result.issues, submitId);
         return;
@@ -533,9 +212,7 @@
         return;
       }
 
-      formValue = result.value;
-      errors = {};
-      setSerializedValue(serialized.value);
+      formState.commit(result.value, serialized.value);
       await onsubmit?.(result.value as SchemaFormOutput, event);
 
       if (shouldResumeNativeSubmit()) {
@@ -599,9 +276,9 @@
       {@render groupLegend(field)}
       <div
         class="cinder-schema-form__array"
-        data-cinder-empty={arrayRows(field).length === 0 || undefined}
+        data-cinder-empty={formState.arrayRows(field).length === 0 || undefined}
       >
-        {#each arrayRows(field) as row (row.key)}
+        {#each formState.arrayRows(field) as row (row.key)}
           {@const itemField = field.item
             ? rebaseFieldPath(field.item, [...field.path, String(row.index)])
             : undefined}
@@ -614,7 +291,7 @@
               class="cinder-schema-form__secondary-button"
               aria-label={`Remove ${field.label} item ${row.index + 1}`}
               disabled={submitting}
-              onclick={() => removeArrayItem(field, row.index)}
+              onclick={() => formState.removeArrayItem(field, row.index)}
             >
               Remove
             </button>
@@ -625,21 +302,24 @@
         type="button"
         class="cinder-schema-form__secondary-button"
         disabled={submitting}
-        onclick={() => addArrayItem(field)}
+        onclick={() => formState.addArrayItem(field)}
       >
         Add {field.label}
       </button>
     </fieldset>
   {:else}
-    <div class="cinder-schema-form__field" oninput={(event) => handleFieldInput(field, event)}>
+    <div
+      class="cinder-schema-form__field"
+      oninput={(event) => formState.handleFieldInput(field, event)}
+    >
       {#if field.kind === 'string'}
         <Input
           {id}
           {...labelledProps}
           required={field.required}
           disabled={submitting}
-          onblur={() => validateTouchedField(field)}
-          bind:value={() => stringValue(field), (next) => updateValue(field.path, next)}
+          onblur={() => formState.validateTouchedField(field)}
+          bind:value={() => stringValue(field), (next) => formState.updateValue(field.path, next)}
         />
       {:else if field.kind === 'number' || field.kind === 'integer'}
         <NumberInput
@@ -648,9 +328,9 @@
           required={field.required}
           disabled={submitting}
           step={field.kind === 'integer' ? 1 : undefined}
-          onblur={() => validateTouchedField(field)}
+          onblur={() => formState.validateTouchedField(field)}
           value={numberFieldValue(field)}
-          onchange={(next) => updateNumberValue(field, next)}
+          onchange={(next) => formState.updateNumberValue(field, next)}
         />
       {:else if field.kind === 'enum'}
         <Select
@@ -660,8 +340,8 @@
           disabled={submitting}
           options={selectOptions(field)}
           value={enumValue(field)}
-          onchange={(event) => updateEnum(field, event)}
-          onblur={() => validateTouchedField(field)}
+          onchange={(event) => formState.updateEnum(field, event)}
+          onblur={() => formState.validateTouchedField(field)}
         />
       {:else if field.kind === 'boolean'}
         <!-- A required boolean schema property means "the value must be present",
@@ -672,7 +352,9 @@
           {id}
           {...labelledProps}
           disabled={submitting}
-          bind:checked={() => booleanValue(field), (next) => updateValue(field.path, next)}
+          bind:checked={
+            () => booleanValue(field), (next) => formState.updateValue(field.path, next)
+          }
         />
       {:else}
         <Textarea
@@ -683,8 +365,10 @@
           rows={6}
           spellcheck={false}
           class="cinder-schema-form__json-control"
-          onblur={() => validateTouchedField(field)}
-          bind:value={() => rawJsonValue(field), (next) => updateRawJsonValue(field, next)}
+          onblur={() => formState.validateTouchedField(field)}
+          bind:value={
+            () => rawJsonValue(field), (next) => formState.updateRawJsonValue(field, next)
+          }
         />
       {/if}
     </div>
@@ -717,7 +401,12 @@
     {/each}
   </div>
 
-  <input bind:this={serializedInputElement} type="hidden" {name} value={serializedValue} />
+  <input
+    bind:this={serializedInputElement}
+    type="hidden"
+    {name}
+    value={formState.serializedValue}
+  />
 
   <button type="submit" class="cinder-schema-form__submit" disabled={submitting}>
     {submitting ? 'Validating...' : submitLabel}

--- a/packages/components/src/components/schema-form/schema-form-state.svelte.ts
+++ b/packages/components/src/components/schema-form/schema-form-state.svelte.ts
@@ -1,0 +1,438 @@
+import {
+  arrayValueAtPath,
+  decodeEnumValue,
+  defaultValueForField,
+  getValueAtPath,
+  pathKey,
+  pruneUndefined,
+  rebaseFieldPath,
+  setValueAtPath,
+  type SchemaFormField,
+  type SchemaFormModel,
+} from './schema-form-model.ts';
+import {
+  issuesByPath,
+  parseJsonDraft,
+  validateSchemaValue,
+  type SchemaFormValidationIssue,
+} from './schema-form-validation.ts';
+import type { SchemaFormDraftChangeHandler, SchemaFormOutput } from './schema-form.types.ts';
+
+type ParsedRawDraft = { ok: true; value: unknown } | { ok: false; message: string };
+
+export type SchemaFormStateOptions = {
+  /**
+   * The form is disabled (native `disabled` attributes) while a submit is
+   * in flight, but a synthetic event dispatched before the DOM catches up
+   * can still reach these handlers — `getSubmitting()` is this class's own
+   * belt-and-suspenders guard against that race (see
+   * schema-form-async.fixture.ts's "freezes edits until it resolves").
+   */
+  getSubmitting: () => boolean;
+  onDraftChange?: SchemaFormDraftChangeHandler;
+};
+
+export type SchemaFormSubmitCandidate =
+  | { ok: true; value: unknown }
+  | { ok: false; issues: SchemaFormValidationIssue[] };
+
+/**
+ * Owns every path-keyed piece of SchemaForm's mutable editing state: the
+ * form value itself, per-field validation errors, and five auxiliary draft
+ * maps that track in-progress edits which aren't valid typed values yet
+ * (raw JSON textareas, numeric input drafts, per-field validation
+ * "touched" sequence numbers, and per-array-item stable render keys).
+ *
+ * Each of the six maps stays a SEPARATE private field rather than one
+ * `Record<string, FieldState>` — the per-slot presence-check semantics
+ * (`numericDrafts[key] !== undefined`, `parsedRawDrafts[key] === undefined`,
+ * ...) are independently meaningful per map and would be lost if unified.
+ *
+ * Instantiated fresh inside schema-form-body.svelte's `<script>` on every
+ * `{#key schema}` remount — never at module scope.
+ */
+export class SchemaFormState {
+  formValue = $state<unknown>();
+  serializedValue = $state('');
+
+  #errors = $state<Record<string, string>>({});
+  #rawDrafts = $state<Record<string, string>>({});
+  #parsedRawDrafts = $state<Record<string, ParsedRawDraft>>({});
+  #numericDrafts = $state<Record<string, string>>({});
+  #touchedValidationSequences = $state<Record<string, number>>({});
+  #arrayKeys = $state<Record<string, string[]>>({});
+  #arrayKeyCounter = 0;
+
+  readonly #model: SchemaFormModel;
+  readonly #options: SchemaFormStateOptions;
+
+  constructor(model: SchemaFormModel, initialValue: unknown, options: SchemaFormStateOptions) {
+    this.#model = model;
+    this.#options = options;
+    this.formValue = initialValue;
+    this.#rawDrafts = this.#seedRawDrafts(model.field, initialValue);
+    this.#arrayKeys = this.#seedArrayKeys(model.field, initialValue);
+  }
+
+  get errors(): Record<string, string> {
+    return this.#errors;
+  }
+
+  get rawDrafts(): Record<string, string> {
+    return this.#rawDrafts;
+  }
+
+  clearSerializedValue(): void {
+    this.serializedValue = '';
+  }
+
+  #bumpTouchedValidationSequence(path: readonly string[]): void {
+    const key = pathKey(path);
+    this.#touchedValidationSequences = {
+      ...this.#touchedValidationSequences,
+      [key]: (this.#touchedValidationSequences[key] ?? 0) + 1,
+    };
+  }
+
+  #currentDraft(): SchemaFormOutput {
+    let nextValue = this.formValue;
+    for (const field of this.#currentNumericFields(this.#model.field, this.formValue)) {
+      const draft = this.#numericDrafts[pathKey(field.path)];
+      if (draft !== undefined) nextValue = setValueAtPath(nextValue, field.path, draft);
+    }
+    for (const field of this.#currentJsonFields(this.#model.field, this.formValue)) {
+      const key = pathKey(field.path);
+      const parsed = this.#parsedRawDrafts[key];
+      if (parsed === undefined) continue;
+      nextValue = setValueAtPath(
+        nextValue,
+        field.path,
+        parsed.ok ? parsed.value : this.#rawDrafts[key],
+      );
+    }
+    return pruneUndefined(nextValue);
+  }
+
+  #reportDraftChange(): void {
+    this.#options.onDraftChange?.(this.#currentDraft());
+  }
+
+  updateValue(path: readonly string[], next: unknown, reportChange = true): void {
+    if (this.#options.getSubmitting()) return;
+    this.formValue = setValueAtPath(this.formValue, path, next);
+    const key = pathKey(path);
+    if (this.#numericDrafts[key] !== undefined) {
+      const { [key]: _removedDraft, ...remainingDrafts } = this.#numericDrafts;
+      this.#numericDrafts = remainingDrafts;
+    }
+    this.#bumpTouchedValidationSequence(path);
+    if (this.#errors[key]) {
+      const { [key]: _removed, ...remaining } = this.#errors;
+      this.#errors = remaining;
+    }
+    this.clearSerializedValue();
+    if (reportChange) this.#reportDraftChange();
+  }
+
+  updateNumberValue(field: SchemaFormField, next: number | null): void {
+    const draft = this.#numericDrafts[pathKey(field.path)];
+    if (next === null && draft !== undefined && draft.trim() !== '') return;
+    this.updateValue(field.path, next ?? undefined);
+  }
+
+  async validateTouchedField(field: SchemaFormField): Promise<void> {
+    if (this.#options.getSubmitting()) return;
+    const fieldKey = pathKey(field.path);
+    const sequence = (this.#touchedValidationSequences[fieldKey] ?? 0) + 1;
+    this.#touchedValidationSequences = {
+      ...this.#touchedValidationSequences,
+      [fieldKey]: sequence,
+    };
+    const raw = this.#rawJsonIssues();
+    const rawIssue = raw.issues.find((candidateIssue) => {
+      const candidateKey = pathKey(candidateIssue.path);
+      return candidateKey === fieldKey || candidateKey.startsWith(`${fieldKey}/`);
+    });
+    if (rawIssue) {
+      this.#errors = { ...this.#errors, [fieldKey]: rawIssue.message };
+      return;
+    }
+    const candidate = pruneUndefined(raw.value);
+    const result = await validateSchemaValue(this.#model.sourceSchema, candidate);
+    if (this.#touchedValidationSequences[fieldKey] !== sequence) return;
+    const issue = (result.valid ? [] : result.issues).find((candidateIssue) => {
+      const candidateKey = pathKey(candidateIssue.path);
+      return candidateKey === fieldKey || candidateKey.startsWith(`${fieldKey}/`);
+    });
+
+    if (issue) {
+      this.#errors = { ...this.#errors, [fieldKey]: issue.message };
+      return;
+    }
+
+    if (this.#errors[fieldKey]) {
+      const { [fieldKey]: _removed, ...remaining } = this.#errors;
+      this.#errors = remaining;
+    }
+  }
+
+  /** Enum Select is one-way (value + onchange) rather than a function binding:
+   *  the encode/decode round-trip is unstable inside Svelte's <select> binding
+   *  writeback, which reverts the selection. Decode the chosen option here. */
+  updateEnum(field: SchemaFormField, event: Event): void {
+    if (this.#options.getSubmitting()) return;
+    const select = event.currentTarget;
+    if (!(select instanceof HTMLSelectElement)) return;
+    this.updateValue(field.path, decodeEnumValue(select.value));
+  }
+
+  /** JSON fields hold a raw text draft (validated/parsed on submit), so the
+   *  textarea's value flows into `rawDrafts` rather than the typed value tree. */
+  updateRawJsonValue(field: SchemaFormField, next: string): void {
+    if (this.#options.getSubmitting()) return;
+    const key = pathKey(field.path);
+    this.#rawDrafts = { ...this.#rawDrafts, [key]: next };
+    const parsed = parseJsonDraft(field.path, next);
+    this.#parsedRawDrafts = {
+      ...this.#parsedRawDrafts,
+      [key]: parsed.ok ? parsed : { ok: false, message: parsed.issue.message },
+    };
+    this.#bumpTouchedValidationSequence(field.path);
+    if (this.#errors[key]) {
+      const { [key]: _removed, ...remaining } = this.#errors;
+      this.#errors = remaining;
+    }
+    this.clearSerializedValue();
+    this.#reportDraftChange();
+  }
+
+  handleFieldInput(field: SchemaFormField, event: Event): void {
+    if (this.#options.getSubmitting()) return;
+    this.#bumpTouchedValidationSequence(field.path);
+    if (field.kind !== 'number' && field.kind !== 'integer') return;
+    if (!(event.target instanceof HTMLInputElement)) return;
+    this.#numericDrafts = { ...this.#numericDrafts, [pathKey(field.path)]: event.target.value };
+    this.clearSerializedValue();
+    this.#reportDraftChange();
+  }
+
+  arrayRows(field: SchemaFormField): Array<{ key: string; index: number }> {
+    const values = arrayValueAtPath(this.formValue, field.path);
+    const keys = this.#arrayKeys[pathKey(field.path)] ?? [];
+    return values.map((_, index) => ({
+      key: keys[index] ?? `${pathKey(field.path)}-${index}`,
+      index,
+    }));
+  }
+
+  addArrayItem(field: SchemaFormField): void {
+    if (this.#options.getSubmitting()) return;
+    const values = arrayValueAtPath(this.formValue, field.path);
+    const nextValue = field.item ? defaultValueForField(field.item) : null;
+    this.updateValue(field.path, [...values, nextValue]);
+    const key = pathKey(field.path);
+    this.#arrayKeys = {
+      ...this.#arrayKeys,
+      [key]: [...(this.#arrayKeys[key] ?? []), `${key}-${this.#arrayKeyCounter++}`],
+    };
+  }
+
+  removeArrayItem(field: SchemaFormField, index: number): void {
+    if (this.#options.getSubmitting()) return;
+    const values = arrayValueAtPath(this.formValue, field.path);
+    this.updateValue(
+      field.path,
+      values.filter((_, candidateIndex) => candidateIndex !== index),
+      false,
+    );
+    this.#rawDrafts = this.#reindexArrayPathState(this.#rawDrafts, field.path, index);
+    this.#parsedRawDrafts = this.#reindexArrayPathState(this.#parsedRawDrafts, field.path, index);
+    this.#numericDrafts = this.#reindexArrayPathState(this.#numericDrafts, field.path, index);
+    this.#errors = this.#reindexArrayPathState(this.#errors, field.path, index);
+    this.#touchedValidationSequences = this.#bumpPathValidationSequences(
+      this.#reindexArrayPathState(this.#touchedValidationSequences, field.path, index),
+      field.path,
+    );
+    const key = pathKey(field.path);
+    this.#arrayKeys = {
+      ...this.#arrayKeys,
+      [key]: (this.#arrayKeys[key] ?? []).filter((_, candidateIndex) => candidateIndex !== index),
+    };
+    this.#reportDraftChange();
+  }
+
+  #reindexArrayPathState<T>(
+    state: Record<string, T>,
+    arrayPath: readonly string[],
+    removedIndex: number,
+  ): Record<string, T> {
+    const prefix = pathKey(arrayPath);
+    const pathPrefix = prefix === '' ? '' : `${prefix}/`;
+    const next: Record<string, T> = {};
+
+    for (const [key, stateValue] of Object.entries(state)) {
+      if (!key.startsWith(pathPrefix)) {
+        next[key] = stateValue;
+        continue;
+      }
+
+      const relativeKey = key.slice(pathPrefix.length);
+      if (relativeKey === '') {
+        next[key] = stateValue;
+        continue;
+      }
+
+      const [indexSegment = '', ...remainingSegments] = relativeKey.split('/');
+      const index = Number(indexSegment);
+      if (!Number.isInteger(index) || index < 0) {
+        next[key] = stateValue;
+        continue;
+      }
+
+      if (index < removedIndex) {
+        next[key] = stateValue;
+        continue;
+      }
+
+      if (index === removedIndex) continue;
+
+      const shiftedKey = [String(index - 1), ...remainingSegments].join('/');
+      next[`${pathPrefix}${shiftedKey}`] = stateValue;
+    }
+
+    return next;
+  }
+
+  #bumpPathValidationSequences(
+    state: Record<string, number>,
+    path: readonly string[],
+  ): Record<string, number> {
+    const prefix = pathKey(path);
+    const pathPrefix = prefix === '' ? '' : `${prefix}/`;
+    const next: Record<string, number> = {};
+
+    for (const [key, sequence] of Object.entries(state)) {
+      next[key] = key === prefix || key.startsWith(pathPrefix) ? sequence + 1 : sequence;
+    }
+
+    return next;
+  }
+
+  #seedRawDrafts(field: SchemaFormField, currentValue: unknown): Record<string, string> {
+    const drafts: Record<string, string> = {};
+    for (const jsonField of this.#currentJsonFields(field, currentValue)) {
+      drafts[pathKey(jsonField.path)] = JSON.stringify(
+        getValueAtPath(currentValue, jsonField.path) ?? null,
+        null,
+        2,
+      );
+    }
+    return drafts;
+  }
+
+  #currentJsonFields(field: SchemaFormField, currentValue: unknown): SchemaFormField[] {
+    const fields: SchemaFormField[] = [];
+
+    const visit = (candidate: SchemaFormField) => {
+      if (candidate.kind === 'json') fields.push(candidate);
+      for (const child of candidate.fields) visit(child);
+      if (candidate.kind === 'array' && candidate.item) {
+        for (const [index] of arrayValueAtPath(currentValue, candidate.path).entries()) {
+          visit(rebaseFieldPath(candidate.item, [...candidate.path, String(index)]));
+        }
+      }
+    };
+
+    visit(field);
+    return fields;
+  }
+
+  #currentNumericFields(field: SchemaFormField, currentValue: unknown): SchemaFormField[] {
+    const fields: SchemaFormField[] = [];
+
+    const visit = (candidate: SchemaFormField) => {
+      if (candidate.kind === 'number' || candidate.kind === 'integer') fields.push(candidate);
+      for (const child of candidate.fields) visit(child);
+      if (candidate.kind === 'array' && candidate.item) {
+        for (const [index] of arrayValueAtPath(currentValue, candidate.path).entries()) {
+          visit(rebaseFieldPath(candidate.item, [...candidate.path, String(index)]));
+        }
+      }
+    };
+
+    visit(field);
+    return fields;
+  }
+
+  #seedArrayKeys(field: SchemaFormField, currentValue: unknown): Record<string, string[]> {
+    const keys: Record<string, string[]> = {};
+
+    const visit = (candidate: SchemaFormField) => {
+      if (candidate.kind === 'array') {
+        const key = pathKey(candidate.path);
+        keys[key] = arrayValueAtPath(currentValue, candidate.path).map(
+          () => `${key}-${this.#arrayKeyCounter++}`,
+        );
+      }
+      for (const child of candidate.fields) visit(child);
+      if (candidate.item) visit(candidate.item);
+    };
+
+    visit(field);
+    return keys;
+  }
+
+  #rawJsonIssues(): { value: unknown; issues: SchemaFormValidationIssue[] } {
+    let nextValue = this.formValue;
+    const issues: SchemaFormValidationIssue[] = [];
+    for (const field of this.#currentJsonFields(this.#model.field, this.formValue)) {
+      const parsed = this.#parsedRawDrafts[pathKey(field.path)];
+      if (parsed === undefined) continue;
+      if (parsed.ok) {
+        nextValue = setValueAtPath(nextValue, field.path, parsed.value);
+      } else {
+        issues.push({ path: field.path, message: parsed.message });
+      }
+    }
+    return { value: nextValue, issues };
+  }
+
+  /**
+   * Assembles the submit-ready candidate value from `formValue` plus every
+   * pending numeric/JSON draft, or reports the raw-JSON parse issues that
+   * block assembly. Called by schema-form-body.svelte's `handleSubmit`
+   * before running schema validation.
+   */
+  buildSubmitCandidate(): SchemaFormSubmitCandidate {
+    const raw = this.#rawJsonIssues();
+    if (raw.issues.length > 0) return { ok: false, issues: raw.issues };
+
+    let candidate = raw.value;
+    for (const field of this.#currentNumericFields(this.#model.field, this.formValue)) {
+      const draft = this.#numericDrafts[pathKey(field.path)];
+      if (draft !== undefined) candidate = setValueAtPath(candidate, field.path, draft);
+    }
+    return { ok: true, value: pruneUndefined(candidate) };
+  }
+
+  /** Records validation issues from a failed submit or field-level check. */
+  applyIssues(issues: SchemaFormValidationIssue[]): void {
+    this.#errors = issuesByPath(issues);
+    this.clearSerializedValue();
+  }
+
+  /** Applies a successfully validated + serialized submit result. */
+  commit(value: unknown, serializedValue: string): void {
+    this.formValue = value;
+    this.#errors = {};
+    this.serializedValue = serializedValue;
+  }
+}
+
+export function createSchemaFormState(
+  model: SchemaFormModel,
+  initialValue: unknown,
+  options: SchemaFormStateOptions,
+): SchemaFormState {
+  return new SchemaFormState(model, initialValue, options);
+}

--- a/packages/components/src/components/selection-popover/selection-popover.svelte
+++ b/packages/components/src/components/selection-popover/selection-popover.svelte
@@ -27,6 +27,7 @@
   import { createClickOutside } from '../../utilities/attachments.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import { createPortalAttachment } from '../portal/index.ts';
+  import { createVirtualKeyboardDismissal } from './virtual-keyboard-dismissal.svelte.ts';
 
   let {
     id,
@@ -143,22 +144,6 @@
     void tick().then(() => textareaElement?.focus({ preventScroll: true }));
   }
 
-  function isVirtualKeyboardResize(source: 'window' | 'visual-viewport'): boolean {
-    const visualViewport = window.visualViewport;
-    if (source === 'visual-viewport' && visualViewport?.scale !== 1) return false;
-
-    const virtualKeyboard = (
-      navigator as Navigator & {
-        virtualKeyboard?: { boundingRect?: { height: number } };
-      }
-    ).virtualKeyboard;
-    if ((virtualKeyboard?.boundingRect?.height ?? 0) > 0) return true;
-
-    if (source === 'window') return false;
-
-    return visualViewport != null && visualViewport.height < window.innerHeight;
-  }
-
   function handleCancel(): void {
     expanded = false;
     commentBody = '';
@@ -215,245 +200,16 @@
     }),
   );
 
-  $effect(() => {
-    if (!isPositionedOpen) return;
-    let viewportWidth = window.innerWidth;
-    let viewportHeight = window.innerHeight;
-    const visualViewport = window.visualViewport;
-    const virtualKeyboardWasVisible = {
-      window: isVirtualKeyboardResize('window'),
-      'visual-viewport': isVirtualKeyboardResize('visual-viewport'),
-    };
-    const virtualKeyboardTransitionFrames: Partial<Record<'window' | 'visual-viewport', number>> =
-      {};
-    let layoutKeyboardVisible = false;
-    let layoutKeyboardResizeActive = false;
-    let layoutKeyboardScrollsSeen = 0;
-    let layoutKeyboardSettleFrames: number[] = [];
-    const virtualKeyboard = (
-      navigator as Navigator & {
-        virtualKeyboard?: { boundingRect?: DOMRectReadOnly };
-      }
-    ).virtualKeyboard;
-    layoutKeyboardVisible = Boolean(virtualKeyboard?.boundingRect?.height);
-    const markLayoutKeyboardResize = () => {
-      layoutKeyboardResizeActive = true;
-      layoutKeyboardScrollsSeen = 0;
-      for (const frame of layoutKeyboardSettleFrames) window.cancelAnimationFrame(frame);
-      layoutKeyboardSettleFrames = [];
-      const settle = (remaining: number) => {
-        if (remaining === 0) {
-          layoutKeyboardResizeActive = false;
-          return;
-        }
-        layoutKeyboardSettleFrames.push(window.requestAnimationFrame(() => settle(remaining - 1)));
-      };
-      settle(2);
-    };
-    // Latches "the composer owned this keyboard transition" across the async
-    // close burst. A cancel/submit collapses the composer (and clears
-    // commentBody) synchronously, before the keyboard's closing resize
-    // arrives, so deriving ownership from the *current* expanded/commentBody
-    // state at event time would read false and let the collapse-triggered
-    // resize fall through to closeForMovement() — dismissing the popover the
-    // cancel was meant to leave open. Instead we remember ownership from the
-    // moment the keyboard was last seen visible and only forget it once the
-    // transition settles (mirrors the virtualKeyboardWasVisible bookkeeping).
-    const virtualKeyboardOwnedByComposer: Partial<Record<'window' | 'visual-viewport', boolean>> =
-      {};
-    // Once focus genuinely moves outside the popover, ownership is forgotten
-    // for the rest of this keyboard-visible transition — even if `expanded`
-    // or a draft still reads true — so a real external keyboard (belonging
-    // to whatever the user tabbed to) can't be re-claimed by the composer's
-    // now-stale state on the very next event.
-    const keyboardOwnershipForgotten = new Set<'window' | 'visual-viewport'>();
-    const readVirtualKeyboardTransition = (
-      source: 'window' | 'visual-viewport',
-      composerOwnsKeyboardNow: boolean,
-    ) => {
-      const isVisible = isVirtualKeyboardResize(source);
-      if (isVisible) {
-        const pendingFrame = virtualKeyboardTransitionFrames[source];
-        if (pendingFrame !== undefined) {
-          window.cancelAnimationFrame(pendingFrame);
-          delete virtualKeyboardTransitionFrames[source];
-        }
-        virtualKeyboardWasVisible[source] = true;
-        // Only ever latch ownership to true here, never downgrade an
-        // already-true latch back to false. A Cancel/submit collapses the
-        // composer (composerOwnsKeyboardNow -> false) before the keyboard
-        // reports itself hidden, and an intervening event while it's still
-        // visible would otherwise overwrite the ownership this latch exists
-        // to preserve across that gap. A forgotten latch stays forgotten
-        // until the transition settles, so it can't be immediately
-        // re-claimed by stale composer state either.
-        const ownedByComposer = keyboardOwnershipForgotten.has(source)
-          ? false
-          : (virtualKeyboardOwnedByComposer[source] ?? false) || composerOwnsKeyboardNow;
-        virtualKeyboardOwnedByComposer[source] = ownedByComposer;
-        return { active: true, isVisible, ownedByComposer };
-      }
-      if (!virtualKeyboardWasVisible[source])
-        return { active: false, isVisible, ownedByComposer: composerOwnsKeyboardNow };
-
-      if (composerOwnsKeyboardNow && !keyboardOwnershipForgotten.has(source))
-        virtualKeyboardOwnedByComposer[source] = true;
-      const ownedByComposer = virtualKeyboardOwnedByComposer[source] ?? composerOwnsKeyboardNow;
-
-      virtualKeyboardTransitionFrames[source] ??= window.requestAnimationFrame(() => {
-        virtualKeyboardWasVisible[source] = false;
-        delete virtualKeyboardTransitionFrames[source];
-        delete virtualKeyboardOwnedByComposer[source];
-        keyboardOwnershipForgotten.delete(source);
-      });
-      return { active: true, isVisible, ownedByComposer };
-    };
-    const closeForMovement = () => {
-      requestClose(true);
-    };
-    const dismiss = (event: Event) => {
-      if (event.target instanceof Node && popoverElement?.contains(event.target)) return;
-      if (event.type === 'scroll' && layoutKeyboardResizeActive) {
-        if (layoutKeyboardScrollsSeen < 2) {
-          layoutKeyboardScrollsSeen += 1;
-          return;
-        }
-        layoutKeyboardResizeActive = false;
-      }
-      if (event.type === 'resize') {
-        const viewportWidthChanged = window.innerWidth !== viewportWidth;
-        const viewportHeightChanged = window.innerHeight !== viewportHeight;
-        const previousViewportHeight = viewportHeight;
-        viewportWidth = window.innerWidth;
-        viewportHeight = window.innerHeight;
-        const composerHasFocus =
-          document.activeElement instanceof Node &&
-          composerFormElement?.contains(document.activeElement);
-        const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
-        const virtualKeyboardTransition = readVirtualKeyboardTransition(
-          'window',
-          composerOwnedKeyboardNow,
-        );
-        if (virtualKeyboardTransition.active && !virtualKeyboardTransition.isVisible)
-          markLayoutKeyboardResize();
-        const layoutKeyboardResize =
-          composerHasFocus &&
-          viewportHeightChanged &&
-          window.innerHeight < previousViewportHeight &&
-          visualViewport != null &&
-          visualViewport.height < previousViewportHeight;
-        if (layoutKeyboardResize) {
-          layoutKeyboardVisible = true;
-          markLayoutKeyboardResize();
-        }
-        const closingLayoutKeyboard =
-          composerHasFocus &&
-          viewportHeightChanged &&
-          window.innerHeight > previousViewportHeight &&
-          layoutKeyboardVisible;
-        if (closingLayoutKeyboard) {
-          layoutKeyboardVisible = false;
-          markLayoutKeyboardResize();
-        }
-        if (
-          !viewportWidthChanged &&
-          (!viewportHeightChanged ||
-            virtualKeyboardTransition.active ||
-            layoutKeyboardResize ||
-            closingLayoutKeyboard) &&
-          (composerHasFocus ||
-            (virtualKeyboardTransition.active && virtualKeyboardTransition.ownedByComposer))
-        ) {
-          return;
-        }
-      }
-      closeForMovement();
-    };
-    const dismissVisualViewport = (event: Event) => {
-      const composerHasFocus =
-        document.activeElement instanceof Node &&
-        composerFormElement?.contains(document.activeElement);
-      const composerOwnedKeyboardNow = expanded || commentBody.trim().length > 0;
-      const virtualKeyboardTransition =
-        visualViewport?.scale === 1
-          ? readVirtualKeyboardTransition('visual-viewport', composerOwnedKeyboardNow)
-          : { active: false, isVisible: false, ownedByComposer: composerOwnedKeyboardNow };
-      if ((event.type === 'resize' || event.type === 'scroll') && layoutKeyboardResizeActive) {
-        if (event.type === 'scroll' && layoutKeyboardScrollsSeen < 2) {
-          layoutKeyboardScrollsSeen += 1;
-          return;
-        }
-        if (event.type === 'resize') return;
-        layoutKeyboardResizeActive = false;
-      }
-      if (
-        (event.type === 'resize' || event.type === 'scroll') &&
-        virtualKeyboardTransition.active &&
-        (composerHasFocus || virtualKeyboardTransition.ownedByComposer)
-      ) {
-        return;
-      }
-      closeForMovement();
-    };
-    // A cancel/submit that only returns focus to the pre-open owner (or drops
-    // it entirely) still leaves the composer "in charge" of the in-flight
-    // keyboard close, so the latch above should survive it. But once focus
-    // lands on something outside this popover entirely, the interaction has
-    // genuinely moved on — drop the latch so a later keyboard-close resize is
-    // free to dismiss (see "an external visual-viewport keyboard close
-    // dismisses a collapsed popover").
-    const forgetComposerKeyboardOwnershipOnExternalFocus = (event: FocusEvent) => {
-      if (isRestoringFocus) return;
-      if (event.target instanceof Node && popoverElement?.contains(event.target)) {
-        // Focus genuinely returned to the composer (e.g. the user tapped
-        // away and back while the keyboard stayed up). A keyboard
-        // interaction it triggers from here should be able to establish
-        // ownership again, rather than staying forgotten until the whole
-        // transition settles.
-        keyboardOwnershipForgotten.delete('window');
-        keyboardOwnershipForgotten.delete('visual-viewport');
-        return;
-      }
-      // document.body is where the platform (and our own restoreFocus() calls)
-      // parks focus when the previously-focused element is removed or isn't
-      // focusable — it is never a real destination the user chose, so it
-      // isn't evidence the interaction moved on.
-      if (event.target === document.body) return;
-      // The user has deliberately moved focus to a real destination outside
-      // the popover (e.g. tabbing out to another control). A later movement
-      // dismissal's restoreFocus() must not steal focus back from it, so
-      // drop the saved restoration target along with the keyboard latches.
-      // Mark ownership forgotten (not just clear it) so `expanded` or a
-      // leftover draft can't immediately re-claim it as composer-owned on
-      // the very next event while the keyboard is still visible.
+  createVirtualKeyboardDismissal({
+    enabled: () => isPositionedOpen,
+    panel: () => popoverElement,
+    composerForm: () => composerFormElement,
+    composerOwnsKeyboard: () => expanded || commentBody.trim().length > 0,
+    isRestoringFocus: () => isRestoringFocus,
+    onDismiss: (preventScroll) => requestClose(preventScroll),
+    onFocusMovedOutside: () => {
       restoreFocusElement = null;
-      delete virtualKeyboardOwnedByComposer.window;
-      delete virtualKeyboardOwnedByComposer['visual-viewport'];
-      keyboardOwnershipForgotten.add('window');
-      keyboardOwnershipForgotten.add('visual-viewport');
-    };
-    const windowScrollOptions: AddEventListenerOptions = { capture: true, passive: true };
-    const visualViewportScrollOptions: AddEventListenerOptions = { passive: true };
-    window.addEventListener('scroll', dismiss, windowScrollOptions);
-    window.addEventListener('resize', dismiss);
-    window.addEventListener('focusin', forgetComposerKeyboardOwnershipOnExternalFocus);
-    visualViewport?.addEventListener('scroll', dismissVisualViewport, visualViewportScrollOptions);
-    visualViewport?.addEventListener('resize', dismissVisualViewport);
-    return () => {
-      for (const frame of Object.values(virtualKeyboardTransitionFrames)) {
-        if (frame !== undefined) window.cancelAnimationFrame(frame);
-      }
-      for (const frame of layoutKeyboardSettleFrames) window.cancelAnimationFrame(frame);
-      window.removeEventListener('scroll', dismiss, windowScrollOptions);
-      window.removeEventListener('resize', dismiss);
-      window.removeEventListener('focusin', forgetComposerKeyboardOwnershipOnExternalFocus);
-      visualViewport?.removeEventListener(
-        'scroll',
-        dismissVisualViewport,
-        visualViewportScrollOptions,
-      );
-      visualViewport?.removeEventListener('resize', dismissVisualViewport);
-    };
+    },
   });
 
   $effect(() => {

--- a/packages/components/src/components/selection-popover/virtual-keyboard-dismissal.svelte.ts
+++ b/packages/components/src/components/selection-popover/virtual-keyboard-dismissal.svelte.ts
@@ -1,0 +1,282 @@
+export type VirtualKeyboardDismissalOptions = {
+  enabled: () => boolean;
+  panel: () => HTMLElement | null;
+  composerForm: () => HTMLElement | null;
+  composerOwnsKeyboard: () => boolean;
+  isRestoringFocus: () => boolean;
+  onDismiss: (preventScroll: boolean) => void;
+  onFocusMovedOutside: () => void;
+};
+
+function isVirtualKeyboardResize(source: 'window' | 'visual-viewport'): boolean {
+  const visualViewport = window.visualViewport;
+  if (source === 'visual-viewport' && visualViewport?.scale !== 1) return false;
+
+  const virtualKeyboard = (
+    navigator as Navigator & {
+      virtualKeyboard?: { boundingRect?: { height: number } };
+    }
+  ).virtualKeyboard;
+  if ((virtualKeyboard?.boundingRect?.height ?? 0) > 0) return true;
+
+  if (source === 'window') return false;
+
+  return visualViewport != null && visualViewport.height < window.innerHeight;
+}
+
+/**
+ * Dismisses the popover when a virtual (on-screen) keyboard closes while the
+ * composer doesn't own it — distinguishing a real keyboard-close resize/scroll
+ * burst from the user manually resizing the window or scrolling the page.
+ *
+ * Called once at the owning component's top level; owns its own `$effect`
+ * gated on `options.enabled()`, matching `createAnchoredOverlay`'s shape.
+ * Cleans up via Svelte's effect-root scoping — there is no external destroy
+ * call.
+ */
+export function createVirtualKeyboardDismissal(options: VirtualKeyboardDismissalOptions): void {
+  $effect(() => {
+    if (!options.enabled()) return;
+    let viewportWidth = window.innerWidth;
+    let viewportHeight = window.innerHeight;
+    const visualViewport = window.visualViewport;
+    const virtualKeyboardWasVisible = {
+      window: isVirtualKeyboardResize('window'),
+      'visual-viewport': isVirtualKeyboardResize('visual-viewport'),
+    };
+    const virtualKeyboardTransitionFrames: Partial<Record<'window' | 'visual-viewport', number>> =
+      {};
+    let layoutKeyboardVisible = false;
+    let layoutKeyboardResizeActive = false;
+    let layoutKeyboardScrollsSeen = 0;
+    let layoutKeyboardSettleFrames: number[] = [];
+    const virtualKeyboard = (
+      navigator as Navigator & {
+        virtualKeyboard?: { boundingRect?: DOMRectReadOnly };
+      }
+    ).virtualKeyboard;
+    layoutKeyboardVisible = Boolean(virtualKeyboard?.boundingRect?.height);
+    const markLayoutKeyboardResize = () => {
+      layoutKeyboardResizeActive = true;
+      layoutKeyboardScrollsSeen = 0;
+      for (const frame of layoutKeyboardSettleFrames) window.cancelAnimationFrame(frame);
+      layoutKeyboardSettleFrames = [];
+      const settle = (remaining: number) => {
+        if (remaining === 0) {
+          layoutKeyboardResizeActive = false;
+          return;
+        }
+        layoutKeyboardSettleFrames.push(window.requestAnimationFrame(() => settle(remaining - 1)));
+      };
+      settle(2);
+    };
+    // Latches "the composer owned this keyboard transition" across the async
+    // close burst. A cancel/submit collapses the composer (and clears
+    // commentBody) synchronously, before the keyboard's closing resize
+    // arrives, so deriving ownership from the *current* expanded/commentBody
+    // state at event time would read false and let the collapse-triggered
+    // resize fall through to closeForMovement() — dismissing the popover the
+    // cancel was meant to leave open. Instead we remember ownership from the
+    // moment the keyboard was last seen visible and only forget it once the
+    // transition settles (mirrors the virtualKeyboardWasVisible bookkeeping).
+    const virtualKeyboardOwnedByComposer: Partial<Record<'window' | 'visual-viewport', boolean>> =
+      {};
+    // Once focus genuinely moves outside the popover, ownership is forgotten
+    // for the rest of this keyboard-visible transition — even if `expanded`
+    // or a draft still reads true — so a real external keyboard (belonging
+    // to whatever the user tabbed to) can't be re-claimed by the composer's
+    // now-stale state on the very next event.
+    const keyboardOwnershipForgotten = new Set<'window' | 'visual-viewport'>();
+    const readVirtualKeyboardTransition = (
+      source: 'window' | 'visual-viewport',
+      composerOwnsKeyboardNow: boolean,
+    ) => {
+      const isVisible = isVirtualKeyboardResize(source);
+      if (isVisible) {
+        const pendingFrame = virtualKeyboardTransitionFrames[source];
+        if (pendingFrame !== undefined) {
+          window.cancelAnimationFrame(pendingFrame);
+          delete virtualKeyboardTransitionFrames[source];
+        }
+        virtualKeyboardWasVisible[source] = true;
+        // Only ever latch ownership to true here, never downgrade an
+        // already-true latch back to false. A Cancel/submit collapses the
+        // composer (composerOwnsKeyboardNow -> false) before the keyboard
+        // reports itself hidden, and an intervening event while it's still
+        // visible would otherwise overwrite the ownership this latch exists
+        // to preserve across that gap. A forgotten latch stays forgotten
+        // until the transition settles, so it can't be immediately
+        // re-claimed by stale composer state either.
+        const ownedByComposer = keyboardOwnershipForgotten.has(source)
+          ? false
+          : (virtualKeyboardOwnedByComposer[source] ?? false) || composerOwnsKeyboardNow;
+        virtualKeyboardOwnedByComposer[source] = ownedByComposer;
+        return { active: true, isVisible, ownedByComposer };
+      }
+      if (!virtualKeyboardWasVisible[source])
+        return { active: false, isVisible, ownedByComposer: composerOwnsKeyboardNow };
+
+      if (composerOwnsKeyboardNow && !keyboardOwnershipForgotten.has(source))
+        virtualKeyboardOwnedByComposer[source] = true;
+      const ownedByComposer = virtualKeyboardOwnedByComposer[source] ?? composerOwnsKeyboardNow;
+
+      virtualKeyboardTransitionFrames[source] ??= window.requestAnimationFrame(() => {
+        virtualKeyboardWasVisible[source] = false;
+        delete virtualKeyboardTransitionFrames[source];
+        delete virtualKeyboardOwnedByComposer[source];
+        keyboardOwnershipForgotten.delete(source);
+      });
+      return { active: true, isVisible, ownedByComposer };
+    };
+    const closeForMovement = () => {
+      options.onDismiss(true);
+    };
+    const dismiss = (event: Event) => {
+      const panel = options.panel();
+      if (event.target instanceof Node && panel?.contains(event.target)) return;
+      if (event.type === 'scroll' && layoutKeyboardResizeActive) {
+        if (layoutKeyboardScrollsSeen < 2) {
+          layoutKeyboardScrollsSeen += 1;
+          return;
+        }
+        layoutKeyboardResizeActive = false;
+      }
+      if (event.type === 'resize') {
+        const viewportWidthChanged = window.innerWidth !== viewportWidth;
+        const viewportHeightChanged = window.innerHeight !== viewportHeight;
+        const previousViewportHeight = viewportHeight;
+        viewportWidth = window.innerWidth;
+        viewportHeight = window.innerHeight;
+        const composerFormElement = options.composerForm();
+        const composerHasFocus =
+          document.activeElement instanceof Node &&
+          composerFormElement?.contains(document.activeElement);
+        const composerOwnedKeyboardNow = options.composerOwnsKeyboard();
+        const virtualKeyboardTransition = readVirtualKeyboardTransition(
+          'window',
+          composerOwnedKeyboardNow,
+        );
+        if (virtualKeyboardTransition.active && !virtualKeyboardTransition.isVisible)
+          markLayoutKeyboardResize();
+        const layoutKeyboardResize =
+          composerHasFocus &&
+          viewportHeightChanged &&
+          window.innerHeight < previousViewportHeight &&
+          visualViewport != null &&
+          visualViewport.height < previousViewportHeight;
+        if (layoutKeyboardResize) {
+          layoutKeyboardVisible = true;
+          markLayoutKeyboardResize();
+        }
+        const closingLayoutKeyboard =
+          composerHasFocus &&
+          viewportHeightChanged &&
+          window.innerHeight > previousViewportHeight &&
+          layoutKeyboardVisible;
+        if (closingLayoutKeyboard) {
+          layoutKeyboardVisible = false;
+          markLayoutKeyboardResize();
+        }
+        if (
+          !viewportWidthChanged &&
+          (!viewportHeightChanged ||
+            virtualKeyboardTransition.active ||
+            layoutKeyboardResize ||
+            closingLayoutKeyboard) &&
+          (composerHasFocus ||
+            (virtualKeyboardTransition.active && virtualKeyboardTransition.ownedByComposer))
+        ) {
+          return;
+        }
+      }
+      closeForMovement();
+    };
+    const dismissVisualViewport = (event: Event) => {
+      const composerFormElement = options.composerForm();
+      const composerHasFocus =
+        document.activeElement instanceof Node &&
+        composerFormElement?.contains(document.activeElement);
+      const composerOwnedKeyboardNow = options.composerOwnsKeyboard();
+      const virtualKeyboardTransition =
+        visualViewport?.scale === 1
+          ? readVirtualKeyboardTransition('visual-viewport', composerOwnedKeyboardNow)
+          : { active: false, isVisible: false, ownedByComposer: composerOwnedKeyboardNow };
+      if ((event.type === 'resize' || event.type === 'scroll') && layoutKeyboardResizeActive) {
+        if (event.type === 'scroll' && layoutKeyboardScrollsSeen < 2) {
+          layoutKeyboardScrollsSeen += 1;
+          return;
+        }
+        if (event.type === 'resize') return;
+        layoutKeyboardResizeActive = false;
+      }
+      if (
+        (event.type === 'resize' || event.type === 'scroll') &&
+        virtualKeyboardTransition.active &&
+        (composerHasFocus || virtualKeyboardTransition.ownedByComposer)
+      ) {
+        return;
+      }
+      closeForMovement();
+    };
+    // A cancel/submit that only returns focus to the pre-open owner (or drops
+    // it entirely) still leaves the composer "in charge" of the in-flight
+    // keyboard close, so the latch above should survive it. But once focus
+    // lands on something outside this popover entirely, the interaction has
+    // genuinely moved on — drop the latch so a later keyboard-close resize is
+    // free to dismiss (see "an external visual-viewport keyboard close
+    // dismisses a collapsed popover").
+    const forgetComposerKeyboardOwnershipOnExternalFocus = (event: FocusEvent) => {
+      if (options.isRestoringFocus()) return;
+      const panel = options.panel();
+      if (event.target instanceof Node && panel?.contains(event.target)) {
+        // Focus genuinely returned to the composer (e.g. the user tapped
+        // away and back while the keyboard stayed up). A keyboard
+        // interaction it triggers from here should be able to establish
+        // ownership again, rather than staying forgotten until the whole
+        // transition settles.
+        keyboardOwnershipForgotten.delete('window');
+        keyboardOwnershipForgotten.delete('visual-viewport');
+        return;
+      }
+      // document.body is where the platform (and our own restoreFocus() calls)
+      // parks focus when the previously-focused element is removed or isn't
+      // focusable — it is never a real destination the user chose, so it
+      // isn't evidence the interaction moved on.
+      if (event.target === document.body) return;
+      // The user has deliberately moved focus to a real destination outside
+      // the popover (e.g. tabbing out to another control). A later movement
+      // dismissal's restoreFocus() must not steal focus back from it, so
+      // drop the saved restoration target along with the keyboard latches.
+      // Mark ownership forgotten (not just clear it) so `expanded` or a
+      // leftover draft can't immediately re-claim it as composer-owned on
+      // the very next event while the keyboard is still visible.
+      options.onFocusMovedOutside();
+      delete virtualKeyboardOwnedByComposer.window;
+      delete virtualKeyboardOwnedByComposer['visual-viewport'];
+      keyboardOwnershipForgotten.add('window');
+      keyboardOwnershipForgotten.add('visual-viewport');
+    };
+    const windowScrollOptions: AddEventListenerOptions = { capture: true, passive: true };
+    const visualViewportScrollOptions: AddEventListenerOptions = { passive: true };
+    window.addEventListener('scroll', dismiss, windowScrollOptions);
+    window.addEventListener('resize', dismiss);
+    window.addEventListener('focusin', forgetComposerKeyboardOwnershipOnExternalFocus);
+    visualViewport?.addEventListener('scroll', dismissVisualViewport, visualViewportScrollOptions);
+    visualViewport?.addEventListener('resize', dismissVisualViewport);
+    return () => {
+      for (const frame of Object.values(virtualKeyboardTransitionFrames)) {
+        if (frame !== undefined) window.cancelAnimationFrame(frame);
+      }
+      for (const frame of layoutKeyboardSettleFrames) window.cancelAnimationFrame(frame);
+      window.removeEventListener('scroll', dismiss, windowScrollOptions);
+      window.removeEventListener('resize', dismiss);
+      window.removeEventListener('focusin', forgetComposerKeyboardOwnershipOnExternalFocus);
+      visualViewport?.removeEventListener(
+        'scroll',
+        dismissVisualViewport,
+        visualViewportScrollOptions,
+      );
+      visualViewport?.removeEventListener('resize', dismissVisualViewport);
+    };
+  });
+}

--- a/packages/components/src/components/selection-popover/virtual-keyboard-dismissal.test.ts
+++ b/packages/components/src/components/selection-popover/virtual-keyboard-dismissal.test.ts
@@ -1,0 +1,121 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { cleanup, render, fireEvent } = await import('@testing-library/svelte');
+const { default: VirtualKeyboardDismissalFixture } =
+  await import('../../test/fixtures/virtual-keyboard-dismissal-fixture.svelte');
+
+afterEach(cleanup);
+
+/**
+ * Simulates the on-screen keyboard reporting itself open (`height > 0`) or
+ * closed (`height === 0`) via the `navigator.virtualKeyboard` API — the same
+ * deterministic signal `selection-popover.test.ts` uses for its full-mount
+ * equivalents of these scenarios.
+ */
+function setVirtualKeyboardHeight(height: number): void {
+  Object.defineProperty(navigator, 'virtualKeyboard', {
+    configurable: true,
+    value: { boundingRect: { height } },
+  });
+}
+
+describe('createVirtualKeyboardDismissal', () => {
+  test('fires the dismiss callback on a visualViewport resize/scroll sequence consistent with the on-screen keyboard opening then closing, when nothing owns it', async () => {
+    const originalVirtualKeyboard = Object.getOwnPropertyDescriptor(navigator, 'virtualKeyboard');
+    const originalVisualViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+    const visualViewport = new EventTarget() as EventTarget & { scale: number };
+    visualViewport.scale = 1;
+    Object.defineProperty(window, 'visualViewport', { configurable: true, value: visualViewport });
+
+    const dismissCalls: boolean[] = [];
+    render(VirtualKeyboardDismissalFixture, {
+      props: {
+        onDismiss: (preventScroll: boolean) => dismissCalls.push(preventScroll),
+      },
+    });
+
+    try {
+      // The textarea never receives focus in this test — the composer is
+      // not "in use," so a keyboard transition it didn't request should
+      // dismiss the popover, not be swallowed.
+      setVirtualKeyboardHeight(300);
+      visualViewport.dispatchEvent(new Event('resize'));
+      expect(dismissCalls).toEqual([true]);
+
+      setVirtualKeyboardHeight(0);
+      visualViewport.dispatchEvent(new Event('scroll'));
+      expect(dismissCalls).toEqual([true, true]);
+    } finally {
+      if (originalVirtualKeyboard) {
+        Object.defineProperty(navigator, 'virtualKeyboard', originalVirtualKeyboard);
+      } else {
+        Reflect.deleteProperty(navigator, 'virtualKeyboard');
+      }
+      if (originalVisualViewport) {
+        Object.defineProperty(window, 'visualViewport', originalVisualViewport);
+      } else {
+        Reflect.deleteProperty(window, 'visualViewport');
+      }
+    }
+  });
+
+  test('does not fire on a visualViewport resize/scroll sequence consistent with the composer itself owning the on-screen keyboard (real focus inside the panel)', async () => {
+    const originalVirtualKeyboard = Object.getOwnPropertyDescriptor(navigator, 'virtualKeyboard');
+    const originalVisualViewport = Object.getOwnPropertyDescriptor(window, 'visualViewport');
+    const visualViewport = new EventTarget() as EventTarget & { scale: number };
+    visualViewport.scale = 1;
+    Object.defineProperty(window, 'visualViewport', { configurable: true, value: visualViewport });
+
+    const dismissCalls: boolean[] = [];
+    const { getByTestId } = render(VirtualKeyboardDismissalFixture, {
+      props: {
+        onDismiss: (preventScroll: boolean) => dismissCalls.push(preventScroll),
+      },
+    });
+
+    try {
+      // Real DOM focus inside the panel is what `composerForm?.contains(document.activeElement)`
+      // reads — this is the "the user is actively typing" signal, distinct
+      // from an unrelated/external viewport movement.
+      const textarea = getByTestId('textarea');
+      (textarea as HTMLTextAreaElement).focus();
+
+      setVirtualKeyboardHeight(300);
+      visualViewport.dispatchEvent(new Event('resize'));
+      setVirtualKeyboardHeight(0);
+      visualViewport.dispatchEvent(new Event('scroll'));
+
+      expect(dismissCalls).toEqual([]);
+    } finally {
+      if (originalVirtualKeyboard) {
+        Object.defineProperty(navigator, 'virtualKeyboard', originalVirtualKeyboard);
+      } else {
+        Reflect.deleteProperty(navigator, 'virtualKeyboard');
+      }
+      if (originalVisualViewport) {
+        Object.defineProperty(window, 'visualViewport', originalVisualViewport);
+      } else {
+        Reflect.deleteProperty(window, 'visualViewport');
+      }
+    }
+  });
+
+  test('does nothing while disabled', async () => {
+    const dismissCalls: boolean[] = [];
+    render(VirtualKeyboardDismissalFixture, {
+      props: {
+        enabled: false,
+        onDismiss: (preventScroll: boolean) => dismissCalls.push(preventScroll),
+      },
+    });
+
+    await fireEvent(window, new Event('resize'));
+
+    expect(dismissCalls).toEqual([]);
+  });
+});

--- a/packages/components/src/components/source-diff-viewer/index.ts
+++ b/packages/components/src/components/source-diff-viewer/index.ts
@@ -2,6 +2,7 @@ import './source-diff-viewer.css';
 import SourceDiffViewer from './source-diff-viewer.svelte';
 
 export default SourceDiffViewer;
+export { getSourceDiffFileLabel, getSourceDiffLineLabel } from './source-diff-viewer.labels.ts';
 export type {
   SourceDiffFile,
   SourceDiffHunk,
@@ -10,9 +11,5 @@ export type {
   SourceDiffParseResult,
   SourceDiffViewerProps,
 } from './source-diff-viewer.types.ts';
-export {
-  getSourceDiffFileLabel,
-  getSourceDiffLineLabel,
-  parseUnifiedPatch,
-} from './source-diff-viewer.utilities.ts';
+export { parseUnifiedPatch } from './source-diff-viewer.utilities.ts';
 export { SourceDiffViewer };

--- a/packages/components/src/components/source-diff-viewer/source-diff-viewer.binary-notice.ts
+++ b/packages/components/src/components/source-diff-viewer/source-diff-viewer.binary-notice.ts
@@ -1,0 +1,116 @@
+import {
+  normalizeGitHeaderPaths,
+  parsePatchPath,
+} from './source-diff-viewer.path-normalization.ts';
+import type { SourceDiffFile } from './source-diff-viewer.types.ts';
+
+export function parseBinaryNoticePaths(
+  file: SourceDiffFile,
+  rawLine: string,
+): Pick<SourceDiffFile, 'oldPath' | 'newPath'> | null {
+  const payload = rawLine.match(/^Binary files (.+) differ$/)?.[1];
+  if (!payload) return null;
+
+  const candidates: (Pick<SourceDiffFile, 'oldPath' | 'newPath'> & {
+    hasKnownEndpoints: boolean;
+  })[] = [];
+  let delimiterIndex = payload.indexOf(' and ');
+  while (delimiterIndex !== -1) {
+    const rawOldPath = payload.slice(0, delimiterIndex);
+    const rawNewPath = payload.slice(delimiterIndex + ' and '.length);
+    const oldPath = parsePatchPath(rawOldPath, {
+      stripSyntheticPrefix: true,
+    });
+    const newPath = parsePatchPath(rawNewPath, {
+      stripSyntheticPrefix: true,
+    });
+    const normalizedPaths = normalizeGitHeaderPaths(oldPath, newPath);
+    const normalizedOldPath =
+      normalizedPaths.oldPath !== null &&
+      file.oldPath !== null &&
+      normalizedPaths.oldPath.endsWith(`/${file.oldPath}`)
+        ? file.oldPath
+        : normalizedPaths.oldPath;
+    const normalizedNewPath =
+      normalizedPaths.newPath !== null &&
+      file.newPath !== null &&
+      normalizedPaths.newPath.endsWith(`/${file.newPath}`)
+        ? file.newPath
+        : normalizedPaths.newPath;
+    candidates.push({
+      oldPath: normalizedOldPath,
+      newPath: normalizedNewPath,
+      hasKnownEndpoints:
+        (rawOldPath.startsWith('a/') || rawOldPath === '/dev/null') &&
+        (rawNewPath.startsWith('b/') || rawNewPath === '/dev/null'),
+    });
+    delimiterIndex = payload.indexOf(' and ', delimiterIndex + 1);
+  }
+
+  const preferredCandidates = candidates.some((candidate) => candidate.hasKnownEndpoints)
+    ? candidates.filter((candidate) => candidate.hasKnownEndpoints)
+    : candidates;
+
+  if (preferredCandidates.length === 1) return preferredCandidates[0] ?? null;
+
+  return (
+    preferredCandidates.find(
+      (candidate) => candidate.oldPath === file.oldPath && candidate.newPath === file.newPath,
+    ) ?? null
+  );
+}
+
+export function applyFileMetadata(file: SourceDiffFile, rawLine: string): void {
+  const binaryPaths = parseBinaryNoticePaths(file, rawLine);
+  if (binaryPaths) {
+    file.oldPath = binaryPaths.oldPath;
+    file.newPath = binaryPaths.newPath;
+    return;
+  }
+
+  if (rawLine.startsWith('new file mode ')) {
+    file.oldPath = null;
+    return;
+  }
+
+  if (rawLine.startsWith('deleted file mode ')) {
+    file.newPath = null;
+    return;
+  }
+
+  if (rawLine.startsWith('rename from ')) {
+    file.oldPath = parsePatchPath(rawLine.slice('rename from '.length), {
+      stripSyntheticPrefix: false,
+    });
+    return;
+  }
+
+  if (rawLine.startsWith('rename to ')) {
+    file.newPath = parsePatchPath(rawLine.slice('rename to '.length), {
+      stripSyntheticPrefix: false,
+    });
+    return;
+  }
+
+  if (rawLine.startsWith('copy from ')) {
+    file.oldPath = parsePatchPath(rawLine.slice('copy from '.length), {
+      stripSyntheticPrefix: false,
+    });
+    return;
+  }
+
+  if (rawLine.startsWith('copy to ')) {
+    file.newPath = parsePatchPath(rawLine.slice('copy to '.length), {
+      stripSyntheticPrefix: false,
+    });
+  }
+}
+
+export function isGitBinaryNoticeMetadata(file: SourceDiffFile, rawLine: string): boolean {
+  if (/^Binary files (?:a\/|\/dev\/null).+ and (?:b\/|\/dev\/null).+ differ$/.test(rawLine)) {
+    return true;
+  }
+
+  const binaryPaths = parseBinaryNoticePaths(file, rawLine);
+  return binaryPaths?.oldPath === file.oldPath && binaryPaths.newPath === file.newPath;
+}

--- a/packages/components/src/components/source-diff-viewer/source-diff-viewer.git-header-parser.ts
+++ b/packages/components/src/components/source-diff-viewer/source-diff-viewer.git-header-parser.ts
@@ -1,0 +1,85 @@
+import {
+  normalizeGitHeaderPaths,
+  parsePatchPath,
+} from './source-diff-viewer.path-normalization.ts';
+import type { SourceDiffFile } from './source-diff-viewer.types.ts';
+
+export function readQuotedGitToken(
+  payload: string,
+  startIndex: number,
+): { token: string; endIndex: number } | null {
+  if (payload[startIndex] !== '"') return null;
+
+  for (let index = startIndex + 1; index < payload.length; index += 1) {
+    if (payload[index] === '\\') {
+      index += 1;
+      continue;
+    }
+
+    if (payload[index] === '"') {
+      return {
+        token: payload.slice(startIndex, index + 1),
+        endIndex: index + 1,
+      };
+    }
+  }
+
+  return null;
+}
+
+export function parseQuotedDiffGitHeader(
+  payload: string,
+): Pick<SourceDiffFile, 'oldPath' | 'newPath'> | null {
+  const oldToken = readQuotedGitToken(payload, 0);
+  if (!oldToken) return null;
+
+  const separator = payload.slice(oldToken.endIndex).match(/^ +/);
+  if (!separator) return null;
+
+  const newToken = readQuotedGitToken(payload, oldToken.endIndex + separator[0].length);
+  if (!newToken || newToken.endIndex !== payload.length) return null;
+
+  return normalizeGitHeaderPaths(
+    parsePatchPath(oldToken.token, { stripSyntheticPrefix: false }),
+    parsePatchPath(newToken.token, { stripSyntheticPrefix: false }),
+  );
+}
+
+export function parseDiffGitHeader(
+  line: string,
+): Pick<SourceDiffFile, 'oldPath' | 'newPath' | 'header'> {
+  const payload = line.slice('diff --git '.length);
+  const quotedHeader = parseQuotedDiffGitHeader(payload);
+  if (quotedHeader) return { ...quotedHeader, header: line };
+
+  const separatorIndexes = [...payload.matchAll(/ /g)].map((match) => match.index ?? -1);
+  for (const separatorIndex of separatorIndexes) {
+    if (separatorIndex <= 0) continue;
+    const parsedPaths = normalizeGitHeaderPaths(
+      parsePatchPath(payload.slice(0, separatorIndex), { stripSyntheticPrefix: false }),
+      parsePatchPath(payload.slice(separatorIndex + 1), { stripSyntheticPrefix: false }),
+    );
+    if (parsedPaths.oldPath && parsedPaths.oldPath === parsedPaths.newPath) {
+      return { ...parsedPaths, header: line };
+    }
+  }
+
+  const separatorIndex = separatorIndexes[separatorIndexes.length - 1] ?? -1;
+  if (separatorIndex <= 0) return { oldPath: null, newPath: null, header: line };
+
+  return {
+    ...normalizeGitHeaderPaths(
+      parsePatchPath(payload.slice(0, separatorIndex), { stripSyntheticPrefix: false }),
+      parsePatchPath(payload.slice(separatorIndex + 1), { stripSyntheticPrefix: false }),
+    ),
+    header: line,
+  };
+}
+
+export function createParsedGitFile(rawLine: string): SourceDiffFile {
+  return {
+    ...parseDiffGitHeader(rawLine),
+    metadata: [],
+    hunks: [],
+  };
+}

--- a/packages/components/src/components/source-diff-viewer/source-diff-viewer.labels.ts
+++ b/packages/components/src/components/source-diff-viewer/source-diff-viewer.labels.ts
@@ -1,0 +1,34 @@
+import type { SourceDiffFile, SourceDiffLine } from './source-diff-viewer.types.ts';
+
+export function getSourceDiffFileLabel(file: SourceDiffFile): string {
+  if (file.newPath && file.oldPath && file.newPath !== file.oldPath) {
+    return `${file.oldPath} -> ${file.newPath}`;
+  }
+
+  return file.newPath ?? file.oldPath ?? file.header ?? 'Patch';
+}
+
+export function getSourceDiffLineLabel(line: SourceDiffLine): string {
+  if (line.kind === 'addition') {
+    return `Added line ${line.newLineNumber ?? 'unknown'}: ${line.content}`;
+  }
+
+  if (line.kind === 'removal') {
+    return `Removed line ${line.oldLineNumber ?? 'unknown'}: ${line.content}`;
+  }
+
+  if (line.kind === 'metadata') {
+    return `Diff metadata: ${line.content}`;
+  }
+
+  if (
+    line.oldLineNumber !== null &&
+    line.newLineNumber !== null &&
+    line.oldLineNumber !== line.newLineNumber
+  ) {
+    return `Context old line ${line.oldLineNumber}, new line ${line.newLineNumber}: ${line.content}`;
+  }
+
+  const lineNumber = line.newLineNumber ?? line.oldLineNumber ?? 'unknown';
+  return `Context line ${lineNumber}: ${line.content}`;
+}

--- a/packages/components/src/components/source-diff-viewer/source-diff-viewer.path-normalization.ts
+++ b/packages/components/src/components/source-diff-viewer/source-diff-viewer.path-normalization.ts
@@ -1,0 +1,145 @@
+import type { SourceDiffFile } from './source-diff-viewer.types.ts';
+
+const TEXT_ENCODER = new TextEncoder();
+
+export function stripSyntheticDiffPrefix(path: string): string {
+  return path.replace(/^[ab]\//, '');
+}
+
+export function stripLeadingPathSegmentPrefix(path: string): string {
+  return path.replace(/^[^/]+\//, '');
+}
+
+export function sharedPathSegmentSuffixSegments(firstPath: string, secondPath: string): string[] {
+  const firstSegments = firstPath.split('/');
+  const secondSegments = secondPath.split('/');
+  const sharedSegments: string[] = [];
+
+  while (firstSegments.length > 0 && secondSegments.length > 0) {
+    const firstSegment = firstSegments.pop();
+    const secondSegment = secondSegments.pop();
+    if (firstSegment !== secondSegment || firstSegment === undefined) break;
+    sharedSegments.unshift(firstSegment);
+  }
+
+  return sharedSegments;
+}
+
+export function sharedPathSegmentSuffix(firstPath: string, secondPath: string): string | null {
+  const sharedSegments = sharedPathSegmentSuffixSegments(firstPath, secondPath);
+  return sharedSegments.length > 0 ? sharedSegments.join('/') : null;
+}
+
+export function decodeGitQuotedPath(path: string): string {
+  if (!path.startsWith('"') || !path.endsWith('"')) return path;
+
+  const bytes: number[] = [];
+  const quoted = path.slice(1, -1);
+  for (let index = 0; index < quoted.length; index += 1) {
+    const character = quoted[index];
+    if (character !== '\\') {
+      const codePoint = quoted.codePointAt(index);
+      if (codePoint !== undefined) {
+        bytes.push(...TEXT_ENCODER.encode(String.fromCodePoint(codePoint)));
+        if (codePoint > 0xffff) index += 1;
+      }
+      continue;
+    }
+
+    const next = quoted[index + 1];
+    if (next && /[0-7]/.test(next)) {
+      const octal = quoted.slice(index + 1).match(/^[0-7]{1,3}/)?.[0] ?? '';
+      bytes.push(Number.parseInt(octal, 8));
+      index += octal.length;
+      continue;
+    }
+
+    const escapes: Record<string, number> = {
+      '"': 0x22,
+      '\\': 0x5c,
+      a: 0x07,
+      b: 0x08,
+      f: 0x0c,
+      n: 0x0a,
+      r: 0x0d,
+      t: 0x09,
+      v: 0x0b,
+    };
+    bytes.push(next ? (escapes[next] ?? next.charCodeAt(0)) : 0x5c);
+    if (next) index += 1;
+  }
+
+  return new TextDecoder().decode(new Uint8Array(bytes));
+}
+
+export function parsePatchPath(
+  path: string,
+  options: { stripSyntheticPrefix: boolean },
+): string | null {
+  const [pathWithoutTimestamp = path] = path.split('\t');
+  const trimmedPath = decodeGitQuotedPath(pathWithoutTimestamp);
+  const normalized = options.stripSyntheticPrefix
+    ? stripSyntheticDiffPrefix(trimmedPath)
+    : trimmedPath;
+  return normalized === '/dev/null' ? null : normalized;
+}
+
+export function normalizeGitHeaderPaths(
+  oldPath: string | null,
+  newPath: string | null,
+): Pick<SourceDiffFile, 'oldPath' | 'newPath'> {
+  if (!oldPath || !newPath) return { oldPath, newPath };
+  if (oldPath === newPath) return { oldPath, newPath };
+
+  const oldSegments = oldPath.split('/');
+  const newSegments = newPath.split('/');
+  const sharedSegments = sharedPathSegmentSuffixSegments(oldPath, newPath);
+  const [oldPrefix] = oldSegments;
+  const [newPrefix] = newSegments;
+  if (oldPrefix === 'a' && newPrefix === 'b') {
+    return {
+      oldPath: stripSyntheticDiffPrefix(oldPath),
+      newPath: stripSyntheticDiffPrefix(newPath),
+    };
+  }
+
+  if (oldPrefix === 'old' && newPrefix === 'new') {
+    if (
+      sharedSegments.length >= 2 &&
+      oldSegments.length === sharedSegments.length + 1 &&
+      newSegments.length === sharedSegments.length + 1
+    ) {
+      const sharedSuffix = sharedPathSegmentSuffix(oldPath, newPath);
+      return { oldPath: sharedSuffix, newPath: sharedSuffix };
+    }
+
+    return {
+      oldPath: stripLeadingPathSegmentPrefix(oldPath),
+      newPath: stripLeadingPathSegmentPrefix(newPath),
+    };
+  }
+
+  return { oldPath, newPath };
+}
+
+export function parseGitFileSidePath(
+  file: SourceDiffFile,
+  rawPath: string,
+  currentPath: string | null,
+): string | null {
+  const parsedPath = parsePatchPath(rawPath, { stripSyntheticPrefix: false });
+  if (!parsedPath || !file.header?.startsWith('diff --git ')) return parsedPath;
+  if (currentPath && parsedPath === currentPath) return currentPath;
+  const [prefix] = parsedPath.split('/');
+  const hasKnownDiffPrefix =
+    prefix === 'a' || prefix === 'b' || prefix === 'old' || prefix === 'new';
+  if (prefix === 'a' || prefix === 'b') return stripSyntheticDiffPrefix(parsedPath);
+  if (currentPath && hasKnownDiffPrefix && parsedPath.endsWith(`/${currentPath}`)) {
+    return currentPath;
+  }
+
+  const pathWithoutPrefix = stripLeadingPathSegmentPrefix(parsedPath);
+  return currentPath && hasKnownDiffPrefix && pathWithoutPrefix === currentPath
+    ? currentPath
+    : parsedPath;
+}

--- a/packages/components/src/components/source-diff-viewer/source-diff-viewer.svelte
+++ b/packages/components/src/components/source-diff-viewer/source-diff-viewer.svelte
@@ -21,20 +21,14 @@
     SourceDiffParseResult,
     SourceDiffViewerProps,
   } from './source-diff-viewer.types.ts';
-  export {
-    getSourceDiffFileLabel,
-    getSourceDiffLineLabel,
-    parseUnifiedPatch,
-  } from './source-diff-viewer.utilities.ts';
+  export { getSourceDiffFileLabel, getSourceDiffLineLabel } from './source-diff-viewer.labels.ts';
+  export { parseUnifiedPatch } from './source-diff-viewer.utilities.ts';
 </script>
 
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
-  import {
-    getSourceDiffFileLabel,
-    getSourceDiffLineLabel,
-    parseUnifiedPatch,
-  } from './source-diff-viewer.utilities.ts';
+  import { getSourceDiffFileLabel, getSourceDiffLineLabel } from './source-diff-viewer.labels.ts';
+  import { parseUnifiedPatch } from './source-diff-viewer.utilities.ts';
   import type { SourceDiffLine, SourceDiffViewerProps } from './source-diff-viewer.types.ts';
 
   let {

--- a/packages/components/src/components/source-diff-viewer/source-diff-viewer.utilities.ts
+++ b/packages/components/src/components/source-diff-viewer/source-diff-viewer.utilities.ts
@@ -1,3 +1,9 @@
+import {
+  applyFileMetadata,
+  isGitBinaryNoticeMetadata,
+} from './source-diff-viewer.binary-notice.ts';
+import { createParsedGitFile } from './source-diff-viewer.git-header-parser.ts';
+import { parseGitFileSidePath } from './source-diff-viewer.path-normalization.ts';
 import type {
   SourceDiffFile,
   SourceDiffHunk,
@@ -19,194 +25,6 @@ type HunkLineResult = {
 
 const DEFAULT_MAX_LINES = 1000;
 const HUNK_HEADER_PATTERN = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
-const TEXT_ENCODER = new TextEncoder();
-
-function stripSyntheticDiffPrefix(path: string): string {
-  return path.replace(/^[ab]\//, '');
-}
-
-function stripLeadingPathSegmentPrefix(path: string): string {
-  return path.replace(/^[^/]+\//, '');
-}
-
-function sharedPathSegmentSuffixSegments(firstPath: string, secondPath: string): string[] {
-  const firstSegments = firstPath.split('/');
-  const secondSegments = secondPath.split('/');
-  const sharedSegments: string[] = [];
-
-  while (firstSegments.length > 0 && secondSegments.length > 0) {
-    const firstSegment = firstSegments.pop();
-    const secondSegment = secondSegments.pop();
-    if (firstSegment !== secondSegment || firstSegment === undefined) break;
-    sharedSegments.unshift(firstSegment);
-  }
-
-  return sharedSegments;
-}
-
-function sharedPathSegmentSuffix(firstPath: string, secondPath: string): string | null {
-  const sharedSegments = sharedPathSegmentSuffixSegments(firstPath, secondPath);
-  return sharedSegments.length > 0 ? sharedSegments.join('/') : null;
-}
-
-function decodeGitQuotedPath(path: string): string {
-  if (!path.startsWith('"') || !path.endsWith('"')) return path;
-
-  const bytes: number[] = [];
-  const quoted = path.slice(1, -1);
-  for (let index = 0; index < quoted.length; index += 1) {
-    const character = quoted[index];
-    if (character !== '\\') {
-      const codePoint = quoted.codePointAt(index);
-      if (codePoint !== undefined) {
-        bytes.push(...TEXT_ENCODER.encode(String.fromCodePoint(codePoint)));
-        if (codePoint > 0xffff) index += 1;
-      }
-      continue;
-    }
-
-    const next = quoted[index + 1];
-    if (next && /[0-7]/.test(next)) {
-      const octal = quoted.slice(index + 1).match(/^[0-7]{1,3}/)?.[0] ?? '';
-      bytes.push(Number.parseInt(octal, 8));
-      index += octal.length;
-      continue;
-    }
-
-    const escapes: Record<string, number> = {
-      '"': 0x22,
-      '\\': 0x5c,
-      a: 0x07,
-      b: 0x08,
-      f: 0x0c,
-      n: 0x0a,
-      r: 0x0d,
-      t: 0x09,
-      v: 0x0b,
-    };
-    bytes.push(next ? (escapes[next] ?? next.charCodeAt(0)) : 0x5c);
-    if (next) index += 1;
-  }
-
-  return new TextDecoder().decode(new Uint8Array(bytes));
-}
-
-function parsePatchPath(path: string, options: { stripSyntheticPrefix: boolean }): string | null {
-  const [pathWithoutTimestamp = path] = path.split('\t');
-  const trimmedPath = decodeGitQuotedPath(pathWithoutTimestamp);
-  const normalized = options.stripSyntheticPrefix
-    ? stripSyntheticDiffPrefix(trimmedPath)
-    : trimmedPath;
-  return normalized === '/dev/null' ? null : normalized;
-}
-
-function normalizeGitHeaderPaths(
-  oldPath: string | null,
-  newPath: string | null,
-): Pick<SourceDiffFile, 'oldPath' | 'newPath'> {
-  if (!oldPath || !newPath) return { oldPath, newPath };
-  if (oldPath === newPath) return { oldPath, newPath };
-
-  const oldSegments = oldPath.split('/');
-  const newSegments = newPath.split('/');
-  const sharedSegments = sharedPathSegmentSuffixSegments(oldPath, newPath);
-  const [oldPrefix] = oldSegments;
-  const [newPrefix] = newSegments;
-  if (oldPrefix === 'a' && newPrefix === 'b') {
-    return {
-      oldPath: stripSyntheticDiffPrefix(oldPath),
-      newPath: stripSyntheticDiffPrefix(newPath),
-    };
-  }
-
-  if (oldPrefix === 'old' && newPrefix === 'new') {
-    if (
-      sharedSegments.length >= 2 &&
-      oldSegments.length === sharedSegments.length + 1 &&
-      newSegments.length === sharedSegments.length + 1
-    ) {
-      const sharedSuffix = sharedPathSegmentSuffix(oldPath, newPath);
-      return { oldPath: sharedSuffix, newPath: sharedSuffix };
-    }
-
-    return {
-      oldPath: stripLeadingPathSegmentPrefix(oldPath),
-      newPath: stripLeadingPathSegmentPrefix(newPath),
-    };
-  }
-
-  return { oldPath, newPath };
-}
-
-function readQuotedGitToken(
-  payload: string,
-  startIndex: number,
-): { token: string; endIndex: number } | null {
-  if (payload[startIndex] !== '"') return null;
-
-  for (let index = startIndex + 1; index < payload.length; index += 1) {
-    if (payload[index] === '\\') {
-      index += 1;
-      continue;
-    }
-
-    if (payload[index] === '"') {
-      return {
-        token: payload.slice(startIndex, index + 1),
-        endIndex: index + 1,
-      };
-    }
-  }
-
-  return null;
-}
-
-function parseQuotedDiffGitHeader(
-  payload: string,
-): Pick<SourceDiffFile, 'oldPath' | 'newPath'> | null {
-  const oldToken = readQuotedGitToken(payload, 0);
-  if (!oldToken) return null;
-
-  const separator = payload.slice(oldToken.endIndex).match(/^ +/);
-  if (!separator) return null;
-
-  const newToken = readQuotedGitToken(payload, oldToken.endIndex + separator[0].length);
-  if (!newToken || newToken.endIndex !== payload.length) return null;
-
-  return normalizeGitHeaderPaths(
-    parsePatchPath(oldToken.token, { stripSyntheticPrefix: false }),
-    parsePatchPath(newToken.token, { stripSyntheticPrefix: false }),
-  );
-}
-
-function parseDiffGitHeader(line: string): Pick<SourceDiffFile, 'oldPath' | 'newPath' | 'header'> {
-  const payload = line.slice('diff --git '.length);
-  const quotedHeader = parseQuotedDiffGitHeader(payload);
-  if (quotedHeader) return { ...quotedHeader, header: line };
-
-  const separatorIndexes = [...payload.matchAll(/ /g)].map((match) => match.index ?? -1);
-  for (const separatorIndex of separatorIndexes) {
-    if (separatorIndex <= 0) continue;
-    const parsedPaths = normalizeGitHeaderPaths(
-      parsePatchPath(payload.slice(0, separatorIndex), { stripSyntheticPrefix: false }),
-      parsePatchPath(payload.slice(separatorIndex + 1), { stripSyntheticPrefix: false }),
-    );
-    if (parsedPaths.oldPath && parsedPaths.oldPath === parsedPaths.newPath) {
-      return { ...parsedPaths, header: line };
-    }
-  }
-
-  const separatorIndex = separatorIndexes[separatorIndexes.length - 1] ?? -1;
-  if (separatorIndex <= 0) return { oldPath: null, newPath: null, header: line };
-
-  return {
-    ...normalizeGitHeaderPaths(
-      parsePatchPath(payload.slice(0, separatorIndex), { stripSyntheticPrefix: false }),
-      parsePatchPath(payload.slice(separatorIndex + 1), { stripSyntheticPrefix: false }),
-    ),
-    header: line,
-  };
-}
 
 function createFile(header: string | null = null): SourceDiffFile {
   return {
@@ -317,108 +135,6 @@ function createHunkMetadataLine(
   return line;
 }
 
-function parseBinaryNoticePaths(
-  file: SourceDiffFile,
-  rawLine: string,
-): Pick<SourceDiffFile, 'oldPath' | 'newPath'> | null {
-  const payload = rawLine.match(/^Binary files (.+) differ$/)?.[1];
-  if (!payload) return null;
-
-  const candidates: (Pick<SourceDiffFile, 'oldPath' | 'newPath'> & {
-    hasKnownEndpoints: boolean;
-  })[] = [];
-  let delimiterIndex = payload.indexOf(' and ');
-  while (delimiterIndex !== -1) {
-    const rawOldPath = payload.slice(0, delimiterIndex);
-    const rawNewPath = payload.slice(delimiterIndex + ' and '.length);
-    const oldPath = parsePatchPath(rawOldPath, {
-      stripSyntheticPrefix: true,
-    });
-    const newPath = parsePatchPath(rawNewPath, {
-      stripSyntheticPrefix: true,
-    });
-    const normalizedPaths = normalizeGitHeaderPaths(oldPath, newPath);
-    const normalizedOldPath =
-      normalizedPaths.oldPath !== null &&
-      file.oldPath !== null &&
-      normalizedPaths.oldPath.endsWith(`/${file.oldPath}`)
-        ? file.oldPath
-        : normalizedPaths.oldPath;
-    const normalizedNewPath =
-      normalizedPaths.newPath !== null &&
-      file.newPath !== null &&
-      normalizedPaths.newPath.endsWith(`/${file.newPath}`)
-        ? file.newPath
-        : normalizedPaths.newPath;
-    candidates.push({
-      oldPath: normalizedOldPath,
-      newPath: normalizedNewPath,
-      hasKnownEndpoints:
-        (rawOldPath.startsWith('a/') || rawOldPath === '/dev/null') &&
-        (rawNewPath.startsWith('b/') || rawNewPath === '/dev/null'),
-    });
-    delimiterIndex = payload.indexOf(' and ', delimiterIndex + 1);
-  }
-
-  const preferredCandidates = candidates.some((candidate) => candidate.hasKnownEndpoints)
-    ? candidates.filter((candidate) => candidate.hasKnownEndpoints)
-    : candidates;
-
-  if (preferredCandidates.length === 1) return preferredCandidates[0] ?? null;
-
-  return (
-    preferredCandidates.find(
-      (candidate) => candidate.oldPath === file.oldPath && candidate.newPath === file.newPath,
-    ) ?? null
-  );
-}
-
-function applyFileMetadata(file: SourceDiffFile, rawLine: string): void {
-  const binaryPaths = parseBinaryNoticePaths(file, rawLine);
-  if (binaryPaths) {
-    file.oldPath = binaryPaths.oldPath;
-    file.newPath = binaryPaths.newPath;
-    return;
-  }
-
-  if (rawLine.startsWith('new file mode ')) {
-    file.oldPath = null;
-    return;
-  }
-
-  if (rawLine.startsWith('deleted file mode ')) {
-    file.newPath = null;
-    return;
-  }
-
-  if (rawLine.startsWith('rename from ')) {
-    file.oldPath = parsePatchPath(rawLine.slice('rename from '.length), {
-      stripSyntheticPrefix: false,
-    });
-    return;
-  }
-
-  if (rawLine.startsWith('rename to ')) {
-    file.newPath = parsePatchPath(rawLine.slice('rename to '.length), {
-      stripSyntheticPrefix: false,
-    });
-    return;
-  }
-
-  if (rawLine.startsWith('copy from ')) {
-    file.oldPath = parsePatchPath(rawLine.slice('copy from '.length), {
-      stripSyntheticPrefix: false,
-    });
-    return;
-  }
-
-  if (rawLine.startsWith('copy to ')) {
-    file.newPath = parsePatchPath(rawLine.slice('copy to '.length), {
-      stripSyntheticPrefix: false,
-    });
-  }
-}
-
 function pushMetadata(
   files: SourceDiffFile[],
   rawLine: string,
@@ -505,36 +221,6 @@ function readHunkLine(
   return { renderedLineCount, lineWasRead: true, lineWasRendered: false };
 }
 
-function createParsedGitFile(rawLine: string): SourceDiffFile {
-  return {
-    ...parseDiffGitHeader(rawLine),
-    metadata: [],
-    hunks: [],
-  };
-}
-
-function parseGitFileSidePath(
-  file: SourceDiffFile,
-  rawPath: string,
-  currentPath: string | null,
-): string | null {
-  const parsedPath = parsePatchPath(rawPath, { stripSyntheticPrefix: false });
-  if (!parsedPath || !file.header?.startsWith('diff --git ')) return parsedPath;
-  if (currentPath && parsedPath === currentPath) return currentPath;
-  const [prefix] = parsedPath.split('/');
-  const hasKnownDiffPrefix =
-    prefix === 'a' || prefix === 'b' || prefix === 'old' || prefix === 'new';
-  if (prefix === 'a' || prefix === 'b') return stripSyntheticDiffPrefix(parsedPath);
-  if (currentPath && hasKnownDiffPrefix && parsedPath.endsWith(`/${currentPath}`)) {
-    return currentPath;
-  }
-
-  const pathWithoutPrefix = stripLeadingPathSegmentPrefix(parsedPath);
-  return currentPath && hasKnownDiffPrefix && pathWithoutPrefix === currentPath
-    ? currentPath
-    : parsedPath;
-}
-
 function createEmptyParseResult(): SourceDiffParseResult {
   return {
     files: [],
@@ -579,15 +265,6 @@ function isStandaloneRecursiveDiffMetadata(rawLine: string): boolean {
     (rawLine.startsWith('Symbolic links ') && rawLine.endsWith(' differ')) ||
     (rawLine.startsWith('File ') && rawLine.includes(' is a ') && rawLine.includes(' while file '))
   );
-}
-
-function isGitBinaryNoticeMetadata(file: SourceDiffFile, rawLine: string): boolean {
-  if (/^Binary files (?:a\/|\/dev\/null).+ and (?:b\/|\/dev\/null).+ differ$/.test(rawLine)) {
-    return true;
-  }
-
-  const binaryPaths = parseBinaryNoticePaths(file, rawLine);
-  return binaryPaths?.oldPath === file.oldPath && binaryPaths.newPath === file.newPath;
 }
 
 function isIndexedUnifiedFilePrelude(
@@ -644,39 +321,6 @@ function readLine(kind: SourceDiffLineKind, content: string, cursor: HunkCursor)
 function positiveInteger(value: number | undefined): number {
   if (value === undefined || !Number.isFinite(value)) return DEFAULT_MAX_LINES;
   return Math.max(0, Math.floor(value));
-}
-
-export function getSourceDiffFileLabel(file: SourceDiffFile): string {
-  if (file.newPath && file.oldPath && file.newPath !== file.oldPath) {
-    return `${file.oldPath} -> ${file.newPath}`;
-  }
-
-  return file.newPath ?? file.oldPath ?? file.header ?? 'Patch';
-}
-
-export function getSourceDiffLineLabel(line: SourceDiffLine): string {
-  if (line.kind === 'addition') {
-    return `Added line ${line.newLineNumber ?? 'unknown'}: ${line.content}`;
-  }
-
-  if (line.kind === 'removal') {
-    return `Removed line ${line.oldLineNumber ?? 'unknown'}: ${line.content}`;
-  }
-
-  if (line.kind === 'metadata') {
-    return `Diff metadata: ${line.content}`;
-  }
-
-  if (
-    line.oldLineNumber !== null &&
-    line.newLineNumber !== null &&
-    line.oldLineNumber !== line.newLineNumber
-  ) {
-    return `Context old line ${line.oldLineNumber}, new line ${line.newLineNumber}: ${line.content}`;
-  }
-
-  const lineNumber = line.newLineNumber ?? line.oldLineNumber ?? 'unknown';
-  return `Context line ${lineNumber}: ${line.content}`;
 }
 
 export function parseUnifiedPatch(

--- a/packages/components/src/components/table-of-contents/table-of-contents-active-heading.svelte.ts
+++ b/packages/components/src/components/table-of-contents/table-of-contents-active-heading.svelte.ts
@@ -1,0 +1,199 @@
+import type { TableOfContentsItem } from './table-of-contents.types.ts';
+
+export function flattenIds(source: TableOfContentsItem[]): string[] {
+  const ids: string[] = [];
+
+  const visit = (entries: TableOfContentsItem[]) => {
+    for (const entry of entries) {
+      ids.push(entry.id);
+      if ((entry.children?.length ?? 0) > 0) {
+        visit(entry.children ?? []);
+      }
+    }
+  };
+
+  visit(source);
+  return ids;
+}
+
+export function parseRootMarginToken(token: string, viewportHeight: number): number {
+  if (token.endsWith('px')) {
+    const value = Number.parseFloat(token);
+    return Number.isFinite(value) ? value : 0;
+  }
+  if (token.endsWith('%')) {
+    const percent = Number.parseFloat(token);
+    return Number.isFinite(percent) ? (viewportHeight * percent) / 100 : 0;
+  }
+  return 0;
+}
+
+export function parseActivationOffset(rootMargin: string, viewportHeight: number): number {
+  const tokens = rootMargin
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0);
+  const [topToken, rightToken = topToken, bottomToken = topToken] = tokens;
+  const resolvedTopToken = topToken ?? '0px';
+  const resolvedBottomToken = bottomToken ?? rightToken ?? resolvedTopToken;
+  const bottom = parseRootMarginToken(resolvedBottomToken, viewportHeight);
+  return viewportHeight + bottom;
+}
+
+export function pickActiveId(
+  orderedElements: HTMLElement[],
+  activationOffset: number,
+): string | null {
+  let lastPassed: { id: string; top: number } | null = null;
+  let firstUpcoming: { id: string; top: number } | null = null;
+
+  for (const element of orderedElements) {
+    const top = element.getBoundingClientRect().top;
+    if (top <= activationOffset) {
+      lastPassed = { id: element.id, top };
+      continue;
+    }
+
+    if (firstUpcoming === null || top < firstUpcoming.top) {
+      firstUpcoming = { id: element.id, top };
+    }
+  }
+
+  return lastPassed?.id ?? firstUpcoming?.id ?? null;
+}
+
+/**
+ * Tracks which heading id is "active" (i.e. currently in view per the
+ * scroll-spy heuristic) via an IntersectionObserver plus a scroll/resize
+ * fallback. `sync()` is called from a thin `$effect` in
+ * table-of-contents.svelte — this class creates no `$effect` of its own.
+ */
+export class TableOfContentsActiveHeadingTracker {
+  activeId = $state<string | null>(null);
+
+  setActiveId(id: string): void {
+    this.activeId = id;
+  }
+
+  sync(items: TableOfContentsItem[], rootMargin: string): () => void {
+    if (typeof window === 'undefined') {
+      return () => {};
+    }
+
+    const observedIds = flattenIds(items);
+
+    if (observedIds.length === 0 || typeof IntersectionObserver === 'undefined') {
+      this.activeId = null;
+      return () => {};
+    }
+
+    const collectObservedElements = () =>
+      observedIds
+        .map((id) => document.getElementById(id))
+        .filter((element): element is HTMLElement => element instanceof HTMLElement);
+
+    let observedElements = collectObservedElements();
+
+    let pendingAnimationFrame: number | null = null;
+
+    const updateActiveId = () => {
+      if (observedElements.length === 0) {
+        this.activeId = null;
+        return;
+      }
+
+      const elementsInDocumentOrder = [...observedElements].sort((a, b) => {
+        if (a === b) {
+          return 0;
+        }
+        const relation = a.compareDocumentPosition(b);
+        if ((relation & Node.DOCUMENT_POSITION_FOLLOWING) !== 0) {
+          return -1;
+        }
+        if ((relation & Node.DOCUMENT_POSITION_PRECEDING) !== 0) {
+          return 1;
+        }
+        return 0;
+      });
+
+      this.activeId = pickActiveId(
+        elementsInDocumentOrder,
+        parseActivationOffset(rootMargin, window.innerHeight),
+      );
+    };
+
+    const scheduleActiveIdUpdate = () => {
+      if (typeof window.requestAnimationFrame !== 'function') {
+        updateActiveId();
+        return;
+      }
+      if (pendingAnimationFrame !== null) {
+        return;
+      }
+      pendingAnimationFrame = window.requestAnimationFrame(() => {
+        pendingAnimationFrame = null;
+        updateActiveId();
+      });
+    };
+
+    const observer = new IntersectionObserver(
+      () => {
+        scheduleActiveIdUpdate();
+      },
+      {
+        root: null,
+        rootMargin,
+        threshold: [0, 1],
+      },
+    );
+
+    for (const element of observedElements) {
+      observer.observe(element);
+    }
+
+    const syncObservedElements = () => {
+      const nextObservedElements = collectObservedElements();
+      const unchanged =
+        observedElements.length === nextObservedElements.length &&
+        observedElements.every((element, index) => element === nextObservedElements[index]);
+      if (unchanged) {
+        return;
+      }
+
+      observedElements = nextObservedElements;
+      observer.disconnect();
+      for (const element of observedElements) {
+        observer.observe(element);
+      }
+      scheduleActiveIdUpdate();
+    };
+
+    window.addEventListener('scroll', scheduleActiveIdUpdate, { passive: true });
+    window.addEventListener('resize', scheduleActiveIdUpdate);
+
+    let domObserver: MutationObserver | null = null;
+    if (typeof MutationObserver !== 'undefined' && document.body !== null) {
+      domObserver = new MutationObserver(() => {
+        syncObservedElements();
+      });
+      domObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['id'],
+      });
+    }
+
+    updateActiveId();
+
+    return () => {
+      if (pendingAnimationFrame !== null && typeof window.cancelAnimationFrame === 'function') {
+        window.cancelAnimationFrame(pendingAnimationFrame);
+      }
+      window.removeEventListener('scroll', scheduleActiveIdUpdate);
+      window.removeEventListener('resize', scheduleActiveIdUpdate);
+      domObserver?.disconnect();
+      observer.disconnect();
+    };
+  }
+}

--- a/packages/components/src/components/table-of-contents/table-of-contents-active-heading.test.ts
+++ b/packages/components/src/components/table-of-contents/table-of-contents-active-heading.test.ts
@@ -1,0 +1,90 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { TableOfContentsActiveHeadingTracker, pickActiveId } =
+  await import('./table-of-contents-active-heading.svelte.ts');
+
+function headingAt(id: string, top: number): HTMLElement {
+  const element = document.createElement('h2');
+  element.id = id;
+  element.getBoundingClientRect = () =>
+    ({
+      top,
+      bottom: top,
+      left: 0,
+      right: 0,
+      width: 0,
+      height: 0,
+      x: 0,
+      y: top,
+      toJSON() {
+        return {};
+      },
+    }) as DOMRect;
+  return element;
+}
+
+describe('pickActiveId', () => {
+  test('picks the last heading that has scrolled past the activation offset', () => {
+    const headings = [headingAt('intro', -400), headingAt('usage', -50), headingAt('api', 300)];
+
+    expect(pickActiveId(headings, 0)).toBe('usage');
+  });
+
+  test('falls back to the first upcoming heading when none has passed the offset', () => {
+    const headings = [headingAt('intro', 200), headingAt('usage', 500)];
+
+    expect(pickActiveId(headings, 0)).toBe('intro');
+  });
+
+  test('returns null for an empty set of elements', () => {
+    expect(pickActiveId([], 0)).toBeNull();
+  });
+});
+
+describe('TableOfContentsActiveHeadingTracker', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  test('setActiveId writes activeId synchronously', () => {
+    const tracker = new TableOfContentsActiveHeadingTracker();
+    expect(tracker.activeId).toBeNull();
+
+    tracker.setActiveId('usage');
+
+    expect(tracker.activeId).toBe('usage');
+  });
+
+  test('sync() reports no active id when the item list is empty', () => {
+    const tracker = new TableOfContentsActiveHeadingTracker();
+    const cleanup = tracker.sync([], '0% 0% -70% 0%');
+
+    expect(tracker.activeId).toBeNull();
+
+    cleanup();
+  });
+
+  test('sync() picks the active id among the mounted, observed headings', () => {
+    const intro = headingAt('intro', -400);
+    const usage = headingAt('usage', -50);
+    document.body.append(intro, usage);
+
+    const tracker = new TableOfContentsActiveHeadingTracker();
+    const cleanup = tracker.sync(
+      [
+        { id: 'intro', label: 'Intro', children: [] },
+        { id: 'usage', label: 'Usage', children: [] },
+      ],
+      '0% 0% 0% 0%',
+    );
+
+    expect(tracker.activeId).toBe('usage');
+
+    cleanup();
+  });
+});

--- a/packages/components/src/components/table-of-contents/table-of-contents-heading-registry.svelte.ts
+++ b/packages/components/src/components/table-of-contents/table-of-contents-heading-registry.svelte.ts
@@ -1,0 +1,321 @@
+import type { TableOfContentsItem, TableOfContentsProps } from './table-of-contents.types.ts';
+
+type ParsedHeading = {
+  id: string;
+  label: string;
+  level: number;
+};
+
+function isNonNullable<TValue>(value: TValue | null | undefined): value is TValue {
+  return value != null;
+}
+
+export function slugifyHeading(text: string): string {
+  return text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-');
+}
+
+export function resolveTargetElement(
+  targetProp: TableOfContentsProps['target'],
+): HTMLElement | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+
+  if (typeof targetProp === 'string') {
+    const selector = targetProp.trim();
+    if (selector === '') {
+      return null;
+    }
+    return document.querySelector<HTMLElement>(selector);
+  }
+
+  if (targetProp instanceof HTMLElement) {
+    return targetProp.isConnected ? targetProp : null;
+  }
+
+  return null;
+}
+
+function parseHeadingLevel(heading: HTMLElement): number | null {
+  const match = /^H([1-6])$/.exec(heading.tagName);
+  if (!match) {
+    return null;
+  }
+
+  return Number(match[1]);
+}
+
+function ensureHeadingId(
+  heading: HTMLElement,
+  fallbackLabel: string,
+  index: number,
+  seenIds: Set<string>,
+): string {
+  const rawId = heading.id.trim();
+  const baseId =
+    rawId !== '' ? rawId : slugifyHeading(fallbackLabel) || `section-${Math.max(index + 1, 1)}`;
+
+  let candidate = baseId;
+  let suffix = 2;
+
+  while (
+    seenIds.has(candidate) ||
+    (document.getElementById(candidate) !== null && document.getElementById(candidate) !== heading)
+  ) {
+    candidate = `${baseId}-${suffix}`;
+    suffix += 1;
+  }
+
+  if (heading.id !== candidate) {
+    heading.id = candidate;
+  }
+
+  seenIds.add(candidate);
+  return candidate;
+}
+
+export function deriveItemsFromHeadings(
+  targetElement: HTMLElement | null,
+  selector: string,
+): TableOfContentsItem[] {
+  if (targetElement === null) {
+    return [];
+  }
+
+  const selectorToUse = selector.trim() === '' ? 'h2, h3, h4' : selector;
+  const headings = [...targetElement.querySelectorAll<HTMLElement>(selectorToUse)];
+  const seenIds = new Set<string>();
+
+  const parsed: ParsedHeading[] = headings
+    .map((heading, index) => {
+      const label = heading.textContent?.trim() ?? '';
+      if (label === '') {
+        return null;
+      }
+
+      const level = parseHeadingLevel(heading);
+      if (level === null) {
+        return null;
+      }
+
+      const id = ensureHeadingId(heading, label, index, seenIds);
+      return { id, label, level };
+    })
+    .filter(isNonNullable);
+
+  const nested: TableOfContentsItem[] = [];
+  const stack: Array<{ level: number; item: TableOfContentsItem }> = [];
+
+  for (const heading of parsed) {
+    const item: TableOfContentsItem = {
+      id: heading.id,
+      label: heading.label,
+      level: heading.level,
+      children: [],
+    };
+
+    while (stack.length > 0 && heading.level <= stack[stack.length - 1]!.level) {
+      stack.pop();
+    }
+
+    if (stack.length === 0) {
+      nested.push(item);
+    } else {
+      stack[stack.length - 1]!.item.children?.push(item);
+    }
+
+    stack.push({ level: heading.level, item });
+  }
+
+  return nested;
+}
+
+/**
+ * Derives `items` from live DOM headings under `target`, matching on
+ * `headingSelector`. Owns the MutationObserver retry state machine that
+ * re-derives when the target's heading content changes, when the target
+ * itself appears/disappears (selector-based targets), or when a watched
+ * `HTMLElement` target is disconnected/reconnected.
+ *
+ * `sync()` is called from a thin `$effect` in table-of-contents.svelte —
+ * this class itself creates no `$effect`; it only owns `$state` and
+ * imperative DOM observer bookkeeping.
+ */
+export class TableOfContentsHeadingRegistry {
+  items = $state<TableOfContentsItem[]>([]);
+
+  sync(target: TableOfContentsProps['target'], headingSelector: string): () => void {
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+      this.items = [];
+      return () => {};
+    }
+
+    let targetObserver: MutationObserver | null = null;
+    let targetParentObserver: MutationObserver | null = null;
+    let documentObserver: MutationObserver | null = null;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
+    let pendingDocumentRefresh: ReturnType<typeof setTimeout> | null = null;
+    let observedTarget: HTMLElement | null = null;
+    let observedTargetParent: HTMLElement | null = null;
+
+    const clearRetryTimer = () => {
+      if (retryTimer !== null) {
+        clearTimeout(retryTimer);
+        retryTimer = null;
+      }
+    };
+
+    const clearPendingDocumentRefresh = () => {
+      if (pendingDocumentRefresh !== null) {
+        clearTimeout(pendingDocumentRefresh);
+        pendingDocumentRefresh = null;
+      }
+    };
+
+    const scheduleRetry = () => {
+      if (retryTimer !== null) {
+        return;
+      }
+
+      retryTimer = setTimeout(() => {
+        retryTimer = null;
+        refreshDerived();
+      }, 50);
+    };
+
+    const syncTargetObserver = (nextTarget: HTMLElement | null) => {
+      if (observedTarget !== nextTarget) {
+        targetObserver?.disconnect();
+        targetObserver = null;
+        targetParentObserver?.disconnect();
+        targetParentObserver = null;
+        observedTarget = nextTarget;
+        observedTargetParent = nextTarget?.parentElement ?? null;
+      }
+
+      if (
+        nextTarget !== null &&
+        targetObserver === null &&
+        typeof MutationObserver !== 'undefined'
+      ) {
+        targetObserver = new MutationObserver(() => {
+          refreshDerived();
+        });
+        targetObserver.observe(nextTarget, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+          attributes: true,
+          // ensureHeadingId is the only attribute-driven reason to
+          // recompute — an author's own attribute churn elsewhere inside
+          // the target (class/style/data-*) must not re-trigger derivation.
+          attributeFilter: ['id'],
+        });
+      }
+
+      if (
+        observedTargetParent !== null &&
+        targetParentObserver === null &&
+        typeof MutationObserver !== 'undefined'
+      ) {
+        targetParentObserver = new MutationObserver(() => {
+          refreshDerived();
+        });
+        targetParentObserver.observe(observedTargetParent, {
+          childList: true,
+        });
+      }
+    };
+
+    const shouldDeriveFromTarget =
+      (typeof target === 'string' && target.trim() !== '') || target instanceof HTMLElement;
+    const shouldWatchForTargetBySelector = typeof target === 'string' && target.trim() !== '';
+    const shouldWatchTargetConnection = target instanceof HTMLElement;
+
+    if (!shouldDeriveFromTarget) {
+      this.items = [];
+      return () => {};
+    }
+
+    const refreshDerived = () => {
+      const targetElement = resolveTargetElement(target);
+      syncTargetObserver(targetElement);
+      this.items = deriveItemsFromHeadings(targetElement, headingSelector);
+
+      if (targetElement !== null) {
+        clearRetryTimer();
+      } else if (shouldWatchForTargetBySelector && typeof MutationObserver === 'undefined') {
+        scheduleRetry();
+      } else {
+        clearRetryTimer();
+      }
+    };
+
+    const scheduleDocumentRefreshCheck = () => {
+      if (
+        (!shouldWatchForTargetBySelector && !shouldWatchTargetConnection) ||
+        pendingDocumentRefresh !== null
+      ) {
+        return;
+      }
+      if (observedTarget !== null && !document.contains(observedTarget)) {
+        refreshDerived();
+        return;
+      }
+      if (!shouldWatchForTargetBySelector) {
+        return;
+      }
+      if (observedTarget !== null && document.contains(observedTarget)) {
+        const latestTarget = resolveTargetElement(target);
+        if (latestTarget === observedTarget) {
+          return;
+        }
+      } else if (observedTarget !== null) {
+        refreshDerived();
+        return;
+      }
+
+      pendingDocumentRefresh = setTimeout(() => {
+        pendingDocumentRefresh = null;
+        const latestTarget = resolveTargetElement(target);
+        if (latestTarget !== observedTarget) {
+          refreshDerived();
+        }
+      }, 50);
+    };
+
+    if (
+      (shouldWatchForTargetBySelector || shouldWatchTargetConnection) &&
+      typeof MutationObserver !== 'undefined' &&
+      document.body !== null
+    ) {
+      documentObserver = new MutationObserver(() => {
+        scheduleDocumentRefreshCheck();
+      });
+      documentObserver.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        // scheduleDocumentRefreshCheck only cares about the watched target
+        // appearing, disappearing, or a selector re-matching — which
+        // depends only on id/class attribute changes plus childList.
+        attributeFilter: ['id', 'class'],
+      });
+    }
+
+    refreshDerived();
+
+    return () => {
+      clearRetryTimer();
+      clearPendingDocumentRefresh();
+      targetObserver?.disconnect();
+      targetParentObserver?.disconnect();
+      documentObserver?.disconnect();
+    };
+  }
+}

--- a/packages/components/src/components/table-of-contents/table-of-contents-heading-registry.test.ts
+++ b/packages/components/src/components/table-of-contents/table-of-contents-heading-registry.test.ts
@@ -1,0 +1,96 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { TableOfContentsHeadingRegistry } =
+  await import('./table-of-contents-heading-registry.svelte.ts');
+
+function mountFixture(html: string): HTMLElement {
+  const container = document.createElement('div');
+  container.innerHTML = html;
+  document.body.append(container);
+  return container;
+}
+
+describe('TableOfContentsHeadingRegistry', () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  test('derives items from headings under the target, slugifying missing ids', () => {
+    const target = mountFixture(`
+      <h2>Getting Started</h2>
+      <h2>API Reference</h2>
+    `);
+
+    const registry = new TableOfContentsHeadingRegistry();
+    const cleanup = registry.sync(target, 'h2, h3, h4');
+
+    expect(registry.items).toEqual([
+      { id: 'getting-started', label: 'Getting Started', level: 2, children: [] },
+      { id: 'api-reference', label: 'API Reference', level: 2, children: [] },
+    ]);
+    expect(target.querySelector('h2')?.id).toBe('getting-started');
+
+    cleanup();
+  });
+
+  test('dedupes headings that already share an id by suffixing later ones', () => {
+    const target = mountFixture(`
+      <h2 id="overview">Overview</h2>
+      <h2 id="overview">Overview</h2>
+    `);
+
+    const registry = new TableOfContentsHeadingRegistry();
+    const cleanup = registry.sync(target, 'h2');
+
+    expect(registry.items.map((item) => item.id)).toEqual(['overview', 'overview-2']);
+
+    cleanup();
+  });
+
+  test('nests headings under their nearest preceding shallower-level heading', () => {
+    const target = mountFixture(`
+      <h2>Guides</h2>
+      <h3>Install</h3>
+      <h3>Configure</h3>
+      <h2>Reference</h2>
+    `);
+
+    const registry = new TableOfContentsHeadingRegistry();
+    const cleanup = registry.sync(target, 'h2, h3');
+
+    expect(registry.items).toHaveLength(2);
+    expect(registry.items[0]?.id).toBe('guides');
+    expect(registry.items[0]?.children?.map((child) => child.id)).toEqual(['install', 'configure']);
+    expect(registry.items[1]?.id).toBe('reference');
+
+    cleanup();
+  });
+
+  test('skips headings with empty text content', () => {
+    const target = mountFixture(`
+      <h2>   </h2>
+      <h2>Real Heading</h2>
+    `);
+
+    const registry = new TableOfContentsHeadingRegistry();
+    const cleanup = registry.sync(target, 'h2');
+
+    expect(registry.items.map((item) => item.label)).toEqual(['Real Heading']);
+
+    cleanup();
+  });
+
+  test('reports no items when the target resolves to null', () => {
+    const registry = new TableOfContentsHeadingRegistry();
+    const cleanup = registry.sync('#does-not-exist', 'h2');
+
+    expect(registry.items).toEqual([]);
+
+    cleanup();
+  });
+});

--- a/packages/components/src/components/table-of-contents/table-of-contents.svelte
+++ b/packages/components/src/components/table-of-contents/table-of-contents.svelte
@@ -21,6 +21,8 @@
 <script lang="ts">
   import { classNames } from '../../utilities/class-names.ts';
   import { useReducedMotion } from '../../utilities/use-reduced-motion.svelte.ts';
+  import { TableOfContentsHeadingRegistry } from './table-of-contents-heading-registry.svelte.ts';
+  import { TableOfContentsActiveHeadingTracker } from './table-of-contents-active-heading.svelte.ts';
   import type { TableOfContentsItem, TableOfContentsProps } from './table-of-contents.types.ts';
 
   type RuntimeProps = TableOfContentsProps & {
@@ -41,10 +43,10 @@
   }: RuntimeProps = $props();
 
   const reducedMotion = useReducedMotion();
-  let activeId = $state<string | null>(null);
-  let derivedHeadingItems = $state<TableOfContentsItem[]>([]);
+  const registry = new TableOfContentsHeadingRegistry();
+  const tracker = new TableOfContentsActiveHeadingTracker();
   const normalizedItems = $derived(
-    items === undefined ? derivedHeadingItems : normalizeExplicitItems(items),
+    items === undefined ? registry.items : normalizeExplicitItems(items),
   );
 
   const validatedAriaLabel = $derived.by(() => {
@@ -88,491 +90,15 @@
     return value != null;
   }
 
-  function slugifyHeading(text: string): string {
-    return text
-      .toLowerCase()
-      .trim()
-      .replace(/[^\w\s-]/g, '')
-      .replace(/\s+/g, '-')
-      .replace(/-+/g, '-');
-  }
-
-  function resolveTargetElement(targetProp: TableOfContentsProps['target']): HTMLElement | null {
-    if (typeof document === 'undefined') {
-      return null;
-    }
-
-    if (typeof targetProp === 'string') {
-      const selector = targetProp.trim();
-      if (selector === '') {
-        return null;
-      }
-      return document.querySelector<HTMLElement>(selector);
-    }
-
-    if (targetProp instanceof HTMLElement) {
-      return targetProp.isConnected ? targetProp : null;
-    }
-
-    return null;
-  }
-
-  type ParsedHeading = {
-    id: string;
-    label: string;
-    level: number;
-  };
-
-  function parseHeadingLevel(heading: HTMLElement): number | null {
-    const match = /^H([1-6])$/.exec(heading.tagName);
-    if (!match) {
-      return null;
-    }
-
-    return Number(match[1]);
-  }
-
-  function ensureHeadingId(
-    heading: HTMLElement,
-    fallbackLabel: string,
-    index: number,
-    seenIds: Set<string>,
-  ): string {
-    const rawId = heading.id.trim();
-    const baseId =
-      rawId !== '' ? rawId : slugifyHeading(fallbackLabel) || `section-${Math.max(index + 1, 1)}`;
-
-    let candidate = baseId;
-    let suffix = 2;
-
-    while (
-      seenIds.has(candidate) ||
-      (document.getElementById(candidate) !== null &&
-        document.getElementById(candidate) !== heading)
-    ) {
-      candidate = `${baseId}-${suffix}`;
-      suffix += 1;
-    }
-
-    if (heading.id !== candidate) {
-      heading.id = candidate;
-    }
-
-    seenIds.add(candidate);
-    return candidate;
-  }
-
-  function deriveItemsFromHeadings(
-    targetElement: HTMLElement | null,
-    selector: string,
-  ): TableOfContentsItem[] {
-    if (targetElement === null) {
-      return [];
-    }
-
-    const selectorToUse = selector.trim() === '' ? 'h2, h3, h4' : selector;
-    const headings = [...targetElement.querySelectorAll<HTMLElement>(selectorToUse)];
-    const seenIds = new Set<string>();
-
-    const parsed: ParsedHeading[] = headings
-      .map((heading, index) => {
-        const label = heading.textContent?.trim() ?? '';
-        if (label === '') {
-          return null;
-        }
-
-        const level = parseHeadingLevel(heading);
-        if (level === null) {
-          return null;
-        }
-
-        const id = ensureHeadingId(heading, label, index, seenIds);
-        return { id, label, level };
-      })
-      .filter(isNonNullable);
-
-    const nested: TableOfContentsItem[] = [];
-    const stack: Array<{ level: number; item: TableOfContentsItem }> = [];
-
-    for (const heading of parsed) {
-      const item: TableOfContentsItem = {
-        id: heading.id,
-        label: heading.label,
-        level: heading.level,
-        children: [],
-      };
-
-      while (stack.length > 0 && heading.level <= stack[stack.length - 1]!.level) {
-        stack.pop();
-      }
-
-      if (stack.length === 0) {
-        nested.push(item);
-      } else {
-        stack[stack.length - 1]!.item.children?.push(item);
-      }
-
-      stack.push({ level: heading.level, item });
-    }
-
-    return nested;
-  }
-
   $effect(() => {
     if (items !== undefined) {
-      derivedHeadingItems = [];
+      registry.items = [];
       return;
     }
-
-    if (typeof window === 'undefined' || typeof document === 'undefined') {
-      derivedHeadingItems = [];
-      return;
-    }
-
-    let targetObserver: MutationObserver | null = null;
-    let targetParentObserver: MutationObserver | null = null;
-    let documentObserver: MutationObserver | null = null;
-    let retryTimer: ReturnType<typeof setTimeout> | null = null;
-    let pendingDocumentRefresh: ReturnType<typeof setTimeout> | null = null;
-    let observedTarget: HTMLElement | null = null;
-    let observedTargetParent: HTMLElement | null = null;
-
-    const clearRetryTimer = () => {
-      if (retryTimer !== null) {
-        clearTimeout(retryTimer);
-        retryTimer = null;
-      }
-    };
-
-    const clearPendingDocumentRefresh = () => {
-      if (pendingDocumentRefresh !== null) {
-        clearTimeout(pendingDocumentRefresh);
-        pendingDocumentRefresh = null;
-      }
-    };
-
-    const scheduleRetry = () => {
-      if (retryTimer !== null) {
-        return;
-      }
-
-      retryTimer = setTimeout(() => {
-        retryTimer = null;
-        refreshDerived();
-      }, 50);
-    };
-
-    const syncTargetObserver = (nextTarget: HTMLElement | null) => {
-      if (observedTarget !== nextTarget) {
-        targetObserver?.disconnect();
-        targetObserver = null;
-        targetParentObserver?.disconnect();
-        targetParentObserver = null;
-        observedTarget = nextTarget;
-        observedTargetParent = nextTarget?.parentElement ?? null;
-      }
-
-      if (
-        nextTarget !== null &&
-        targetObserver === null &&
-        typeof MutationObserver !== 'undefined'
-      ) {
-        targetObserver = new MutationObserver(() => {
-          refreshDerived();
-        });
-        targetObserver.observe(nextTarget, {
-          childList: true,
-          subtree: true,
-          characterData: true,
-          attributes: true,
-          // ensureHeadingId is the only attribute-driven reason to
-          // recompute — an author's own attribute churn elsewhere inside
-          // the target (class/style/data-*) must not re-trigger derivation.
-          attributeFilter: ['id'],
-        });
-      }
-
-      if (
-        observedTargetParent !== null &&
-        targetParentObserver === null &&
-        typeof MutationObserver !== 'undefined'
-      ) {
-        targetParentObserver = new MutationObserver(() => {
-          refreshDerived();
-        });
-        targetParentObserver.observe(observedTargetParent, {
-          childList: true,
-        });
-      }
-    };
-
-    const shouldDeriveFromTarget =
-      (typeof target === 'string' && target.trim() !== '') || target instanceof HTMLElement;
-    const shouldWatchForTargetBySelector = typeof target === 'string' && target.trim() !== '';
-    const shouldWatchTargetConnection = target instanceof HTMLElement;
-
-    if (!shouldDeriveFromTarget) {
-      derivedHeadingItems = [];
-      return;
-    }
-
-    const refreshDerived = () => {
-      const targetElement = resolveTargetElement(target);
-      syncTargetObserver(targetElement);
-      derivedHeadingItems = deriveItemsFromHeadings(targetElement, headingSelector);
-
-      if (targetElement !== null) {
-        clearRetryTimer();
-      } else if (shouldWatchForTargetBySelector && typeof MutationObserver === 'undefined') {
-        scheduleRetry();
-      } else {
-        clearRetryTimer();
-      }
-    };
-
-    const scheduleDocumentRefreshCheck = () => {
-      if (
-        (!shouldWatchForTargetBySelector && !shouldWatchTargetConnection) ||
-        pendingDocumentRefresh !== null
-      ) {
-        return;
-      }
-      if (observedTarget !== null && !document.contains(observedTarget)) {
-        refreshDerived();
-        return;
-      }
-      if (!shouldWatchForTargetBySelector) {
-        return;
-      }
-      if (observedTarget !== null && document.contains(observedTarget)) {
-        const latestTarget = resolveTargetElement(target);
-        if (latestTarget === observedTarget) {
-          return;
-        }
-      } else if (observedTarget !== null) {
-        refreshDerived();
-        return;
-      }
-
-      pendingDocumentRefresh = setTimeout(() => {
-        pendingDocumentRefresh = null;
-        const latestTarget = resolveTargetElement(target);
-        if (latestTarget !== observedTarget) {
-          refreshDerived();
-        }
-      }, 50);
-    };
-
-    if (
-      (shouldWatchForTargetBySelector || shouldWatchTargetConnection) &&
-      typeof MutationObserver !== 'undefined' &&
-      document.body !== null
-    ) {
-      documentObserver = new MutationObserver(() => {
-        scheduleDocumentRefreshCheck();
-      });
-      documentObserver.observe(document.body, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        // scheduleDocumentRefreshCheck only cares about the watched target
-        // appearing, disappearing, or a selector re-matching — which
-        // depends only on id/class attribute changes plus childList.
-        attributeFilter: ['id', 'class'],
-      });
-    }
-
-    refreshDerived();
-
-    return () => {
-      clearRetryTimer();
-      clearPendingDocumentRefresh();
-      targetObserver?.disconnect();
-      targetParentObserver?.disconnect();
-      documentObserver?.disconnect();
-    };
+    return registry.sync(target, headingSelector);
   });
 
-  function flattenIds(source: TableOfContentsItem[]): string[] {
-    const ids: string[] = [];
-
-    const visit = (entries: TableOfContentsItem[]) => {
-      for (const entry of entries) {
-        ids.push(entry.id);
-        if ((entry.children?.length ?? 0) > 0) {
-          visit(entry.children ?? []);
-        }
-      }
-    };
-
-    visit(source);
-    return ids;
-  }
-
-  const observedIds = $derived.by(() => flattenIds(normalizedItems));
-
-  function parseRootMarginToken(token: string, viewportHeight: number): number {
-    if (token.endsWith('px')) {
-      const value = Number.parseFloat(token);
-      return Number.isFinite(value) ? value : 0;
-    }
-    if (token.endsWith('%')) {
-      const percent = Number.parseFloat(token);
-      return Number.isFinite(percent) ? (viewportHeight * percent) / 100 : 0;
-    }
-    return 0;
-  }
-
-  function parseActivationOffset(rootMargin: string, viewportHeight: number): number {
-    const tokens = rootMargin
-      .trim()
-      .split(/\s+/)
-      .filter((token) => token.length > 0);
-    const [topToken, rightToken = topToken, bottomToken = topToken] = tokens;
-    const resolvedTopToken = topToken ?? '0px';
-    const resolvedBottomToken = bottomToken ?? rightToken ?? resolvedTopToken;
-    const bottom = parseRootMarginToken(resolvedBottomToken, viewportHeight);
-    return viewportHeight + bottom;
-  }
-
-  function pickActiveId(orderedElements: HTMLElement[], activationOffset: number): string | null {
-    let lastPassed: { id: string; top: number } | null = null;
-    let firstUpcoming: { id: string; top: number } | null = null;
-
-    for (const element of orderedElements) {
-      const top = element.getBoundingClientRect().top;
-      if (top <= activationOffset) {
-        lastPassed = { id: element.id, top };
-        continue;
-      }
-
-      if (firstUpcoming === null || top < firstUpcoming.top) {
-        firstUpcoming = { id: element.id, top };
-      }
-    }
-
-    return lastPassed?.id ?? firstUpcoming?.id ?? null;
-  }
-
-  $effect(() => {
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    if (observedIds.length === 0 || typeof IntersectionObserver === 'undefined') {
-      activeId = null;
-      return;
-    }
-
-    const collectObservedElements = () =>
-      observedIds
-        .map((id) => document.getElementById(id))
-        .filter((element): element is HTMLElement => element instanceof HTMLElement);
-
-    let observedElements = collectObservedElements();
-
-    let pendingAnimationFrame: number | null = null;
-
-    const updateActiveId = () => {
-      if (observedElements.length === 0) {
-        activeId = null;
-        return;
-      }
-
-      const elementsInDocumentOrder = [...observedElements].sort((a, b) => {
-        if (a === b) {
-          return 0;
-        }
-        const relation = a.compareDocumentPosition(b);
-        if ((relation & Node.DOCUMENT_POSITION_FOLLOWING) !== 0) {
-          return -1;
-        }
-        if ((relation & Node.DOCUMENT_POSITION_PRECEDING) !== 0) {
-          return 1;
-        }
-        return 0;
-      });
-
-      activeId = pickActiveId(
-        elementsInDocumentOrder,
-        parseActivationOffset(observeRootMargin, window.innerHeight),
-      );
-    };
-
-    function scheduleActiveIdUpdate() {
-      if (typeof window.requestAnimationFrame !== 'function') {
-        updateActiveId();
-        return;
-      }
-      if (pendingAnimationFrame !== null) {
-        return;
-      }
-      pendingAnimationFrame = window.requestAnimationFrame(() => {
-        pendingAnimationFrame = null;
-        updateActiveId();
-      });
-    }
-
-    const observer = new IntersectionObserver(
-      () => {
-        scheduleActiveIdUpdate();
-      },
-      {
-        root: null,
-        rootMargin: observeRootMargin,
-        threshold: [0, 1],
-      },
-    );
-
-    for (const element of observedElements) {
-      observer.observe(element);
-    }
-
-    function syncObservedElements() {
-      const nextObservedElements = collectObservedElements();
-      const unchanged =
-        observedElements.length === nextObservedElements.length &&
-        observedElements.every((element, index) => element === nextObservedElements[index]);
-      if (unchanged) {
-        return;
-      }
-
-      observedElements = nextObservedElements;
-      observer.disconnect();
-      for (const element of observedElements) {
-        observer.observe(element);
-      }
-      scheduleActiveIdUpdate();
-    }
-
-    window.addEventListener('scroll', scheduleActiveIdUpdate, { passive: true });
-    window.addEventListener('resize', scheduleActiveIdUpdate);
-
-    let domObserver: MutationObserver | null = null;
-    if (typeof MutationObserver !== 'undefined' && document.body !== null) {
-      domObserver = new MutationObserver(() => {
-        syncObservedElements();
-      });
-      domObserver.observe(document.body, {
-        childList: true,
-        subtree: true,
-        attributes: true,
-        attributeFilter: ['id'],
-      });
-    }
-
-    updateActiveId();
-
-    return () => {
-      if (pendingAnimationFrame !== null && typeof window.cancelAnimationFrame === 'function') {
-        window.cancelAnimationFrame(pendingAnimationFrame);
-      }
-      window.removeEventListener('scroll', scheduleActiveIdUpdate);
-      window.removeEventListener('resize', scheduleActiveIdUpdate);
-      domObserver?.disconnect();
-      observer.disconnect();
-    };
-  });
+  $effect(() => tracker.sync(normalizedItems, observeRootMargin));
 
   function handleItemClick(event: MouseEvent, id: string) {
     const element = document.getElementById(id);
@@ -592,7 +118,7 @@
     }
 
     event.preventDefault();
-    activeId = id;
+    tracker.setActiveId(id);
     element.scrollIntoView({
       behavior: reducedMotion.current ? 'auto' : 'smooth',
       block: 'start',
@@ -622,10 +148,10 @@
             <a
               class={classNames(
                 'cinder-table-of-contents__link',
-                activeId === entry.id && 'cinder-table-of-contents__link--active',
+                tracker.activeId === entry.id && 'cinder-table-of-contents__link--active',
               )}
               href={'#' + entry.id}
-              aria-current={activeId === entry.id ? 'location' : undefined}
+              aria-current={tracker.activeId === entry.id ? 'location' : undefined}
               onclick={(event) => handleItemClick(event, entry.id)}
             >
               {entry.label}

--- a/packages/components/src/components/tree-item/tree-item-async-load.svelte.ts
+++ b/packages/components/src/components/tree-item/tree-item-async-load.svelte.ts
@@ -1,0 +1,76 @@
+import type { TreeItemProps } from './tree-item.types.ts';
+
+export type TreeItemAsyncLoaderOptions = {
+  getId: () => string;
+  getLoadChildren: () => TreeItemProps['loadChildren'];
+  getOnLoadError: () => TreeItemProps['onLoadError'];
+  setExpanded: (id: string, expanded: boolean) => void;
+};
+
+/**
+ * Owns the async `loadChildren` lifecycle for a single tree item: at most one
+ * in-flight load at a time, aborted on collapse or unmount, with the branch
+ * collapsed and `onLoadError` (or a console fallback) invoked on a genuine
+ * failure. Callers drive it from the reactive `isExpanded`-watching effects
+ * that stay in `tree-item.svelte` — this class has no `$effect` of its own.
+ */
+export class TreeItemAsyncLoader {
+  busy = $state(false);
+  loaded = $state(false);
+
+  #activeController: AbortController | null = null;
+  readonly #options: TreeItemAsyncLoaderOptions;
+
+  constructor(options: TreeItemAsyncLoaderOptions) {
+    this.#options = options;
+  }
+
+  async trigger(): Promise<void> {
+    const loadChildren = this.#options.getLoadChildren();
+    if (!loadChildren || this.loaded || this.busy) return;
+
+    this.#activeController?.abort();
+    const controller = new AbortController();
+    this.#activeController = controller;
+    this.busy = true;
+
+    const id = this.#options.getId();
+    try {
+      await loadChildren({ id, signal: controller.signal });
+      if (!controller.signal.aborted) {
+        this.loaded = true;
+        this.busy = false;
+      }
+    } catch (error) {
+      if (
+        controller.signal.aborted ||
+        (error instanceof DOMException && error.name === 'AbortError')
+      ) {
+        // Only clear busy if this is still the active load. If a newer load
+        // has already started (expand→collapse→expand race), clearing busy
+        // here would cause the watching effect to re-fire and start a load
+        // cascade.
+        if (this.#activeController === controller) this.busy = false;
+        return;
+      }
+      this.busy = false;
+      this.loaded = false;
+      // Collapse the branch on error
+      this.#options.setExpanded(id, false);
+      const onLoadError = this.#options.getOnLoadError();
+      if (onLoadError) {
+        onLoadError(error, id);
+      } else {
+        console.error('[cinder-tree] loadChildren failed for item', id, error);
+      }
+    }
+  }
+
+  /** No-op if there is no in-flight load. Safe to call from an unmount cleanup. */
+  abort(): void {
+    if (!this.#activeController) return;
+    this.#activeController.abort();
+    this.#activeController = null;
+    this.busy = false;
+  }
+}

--- a/packages/components/src/components/tree-item/tree-item-drag.svelte.ts
+++ b/packages/components/src/components/tree-item/tree-item-drag.svelte.ts
@@ -1,0 +1,161 @@
+import type { TreeDragController } from '../../_internal/tree-drag-controller.svelte.ts';
+
+export type TreeItemDragHandlersOptions = {
+  getDragController: () => TreeDragController | null;
+  getId: () => string;
+  getLabel: () => string;
+  /**
+   * `canDrag` depends on the `draggable` prop and the `disabled` prop, both
+   * component-level concerns this class has no reason to know about — the
+   * component computes the boolean and hands it in.
+   */
+  getCanDrag: () => boolean;
+  getDragHandleElement: () => HTMLButtonElement | undefined;
+  getOuterElement: () => HTMLElement | undefined;
+};
+
+/**
+ * Drag/reorder interaction for a single tree item: keyboard lift-and-move,
+ * pointer lift, and the derived drag/drop-target booleans the template reads.
+ * Modeled on the `$state`-fields-plus-`#options`-object shape of
+ * `TreeDragController` — this class does not own drag STATE itself (that
+ * lives on the shared `TreeDragController` from tree context), it only
+ * translates this item's DOM events into calls against it.
+ */
+export class TreeItemDragHandlers {
+  #dragKeyboardReturnTarget: HTMLElement | undefined;
+  readonly #options: TreeItemDragHandlersOptions;
+
+  constructor(options: TreeItemDragHandlersOptions) {
+    this.#options = options;
+  }
+
+  get canDrag(): boolean {
+    return this.#options.getCanDrag();
+  }
+
+  get isDraggingItem(): boolean {
+    return this.#options.getDragController()?.isDragging(this.#options.getId()) ?? false;
+  }
+
+  get isDropBefore(): boolean {
+    return (
+      this.#options.getDragController()?.isDropTarget(this.#options.getId(), 'before') ?? false
+    );
+  }
+
+  get isDropAfter(): boolean {
+    return this.#options.getDragController()?.isDropTarget(this.#options.getId(), 'after') ?? false;
+  }
+
+  get isDropInto(): boolean {
+    return this.#options.getDragController()?.isDropTarget(this.#options.getId(), 'child') ?? false;
+  }
+
+  get dragHandleLabel(): string {
+    return `Reorder ${this.#options.getLabel()}`;
+  }
+
+  #restoreDragKeyboardFocus(): void {
+    const target =
+      this.#dragKeyboardReturnTarget ??
+      this.#options.getDragHandleElement() ??
+      this.#options.getOuterElement();
+    queueMicrotask(() => target?.focus());
+  }
+
+  #canLiftWithKeyboard(event: KeyboardEvent): boolean {
+    const fromDragHandle = event.currentTarget === this.#options.getDragHandleElement();
+    const treeItemShortcut =
+      event.key === ' ' && event.ctrlKey && event.shiftKey && !event.altKey && !event.metaKey;
+    return (fromDragHandle && (event.key === ' ' || event.key === 'Enter')) || treeItemShortcut;
+  }
+
+  handleKeyboard = (event: KeyboardEvent): boolean => {
+    const controller = this.#options.getDragController();
+    if (!this.canDrag || !controller) return false;
+
+    if (!controller.dragging && this.#canLiftWithKeyboard(event)) {
+      event.preventDefault();
+      event.stopPropagation();
+      this.#dragKeyboardReturnTarget =
+        event.currentTarget instanceof HTMLElement ? event.currentTarget : undefined;
+      controller.lift(this.#options.getId(), 'keyboard');
+      this.#restoreDragKeyboardFocus();
+      return true;
+    }
+
+    if (!controller.isDragging(this.#options.getId())) return false;
+
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.moveBy(1);
+        return true;
+      case 'ArrowUp':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.moveBy(-1);
+        return true;
+      case 'ArrowRight':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.moveIntoPreviousBranch();
+        return true;
+      case 'ArrowLeft':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.moveOut();
+        return true;
+      case 'Home':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.moveToEdge('first');
+        return true;
+      case 'End':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.moveToEdge('last');
+        return true;
+      case 'F2':
+        event.preventDefault();
+        event.stopPropagation();
+        return true;
+      case 'Tab':
+        event.stopPropagation();
+        controller.cancel();
+        return true;
+      case ' ':
+      case 'Enter':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.drop();
+        this.#restoreDragKeyboardFocus();
+        return true;
+      case 'Escape':
+        event.preventDefault();
+        event.stopPropagation();
+        controller.cancel();
+        this.#restoreDragKeyboardFocus();
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  handlePointerDown = (event: PointerEvent): void => {
+    const controller = this.#options.getDragController();
+    if (!this.canDrag || !controller || event.button !== 0) return;
+    event.preventDefault();
+    event.stopPropagation();
+    const dragHandleElement = this.#options.getDragHandleElement();
+    dragHandleElement?.focus();
+    dragHandleElement?.setPointerCapture(event.pointerId);
+    controller.lift(this.#options.getId(), 'pointer');
+  };
+
+  handleClick = (event: MouseEvent): void => {
+    event.stopPropagation();
+  };
+}

--- a/packages/components/src/components/tree-item/tree-item-label-highlight.ts
+++ b/packages/components/src/components/tree-item/tree-item-label-highlight.ts
@@ -1,0 +1,32 @@
+export type LabelSegment = {
+  text: string;
+  highlighted: boolean;
+  start: number;
+};
+
+/**
+ * Splits `value` into highlight segments around the first case-insensitive
+ * match of `query`. An empty `query` (no active filter) or no match returns
+ * the whole label as a single, non-highlighted segment.
+ */
+export function splitLabelForHighlight(value: string, query: string): LabelSegment[] {
+  if (query.length === 0) return [{ text: value, highlighted: false, start: 0 }];
+
+  const matchIndex = value.toLowerCase().indexOf(query.toLowerCase());
+  if (matchIndex === -1) return [{ text: value, highlighted: false, start: 0 }];
+
+  const matchEnd = matchIndex + query.length;
+  const segments: LabelSegment[] = [];
+  if (matchIndex > 0) {
+    segments.push({ text: value.slice(0, matchIndex), highlighted: false, start: 0 });
+  }
+  segments.push({
+    text: value.slice(matchIndex, matchEnd),
+    highlighted: true,
+    start: matchIndex,
+  });
+  if (matchEnd < value.length) {
+    segments.push({ text: value.slice(matchEnd), highlighted: false, start: matchEnd });
+  }
+  return segments;
+}

--- a/packages/components/src/components/tree-item/tree-item-rename.svelte.ts
+++ b/packages/components/src/components/tree-item/tree-item-rename.svelte.ts
@@ -1,0 +1,192 @@
+import type { Attachment } from 'svelte/attachments';
+
+import type { TreeItemProps } from './tree-item.types.ts';
+
+export type TreeItemRenameControllerOptions = {
+  getId: () => string;
+  getLabel: () => string;
+  getOnRename: () => TreeItemProps['onRename'];
+  /**
+   * Not in the extraction's original sketch, but load-bearing: `canRename`
+   * gates F2/double-click/Enter entry into edit mode, and the existing
+   * "disabled items do not enter edit mode" coverage
+   * (tree/tree-rename.test.ts) requires it to keep gating after the move.
+   */
+  getDisabled: () => boolean;
+  getOuterElement: () => HTMLElement | undefined;
+  getElementId: () => string;
+  canFocusVisibleDelta: (direction: 1 | -1) => boolean;
+  focusVisibleDelta: (direction: 1 | -1) => void;
+};
+
+/**
+ * Inline-rename state machine for a single tree item: begin/cancel/commit
+ * editing, the async `onRename` round-trip (pending/error), and the
+ * live-region announcements that accompany each transition. Modeled on the
+ * `$state`-fields-plus-`#options`-object shape of `TreeDragController`.
+ */
+export class TreeItemRenameController {
+  editing = $state(false);
+  editValue = $state('');
+  renamePending = $state(false);
+  renameError = $state('');
+  renameAnnouncement = $state('');
+  renameAnnouncementSequence = $state(0);
+
+  #inputElement: HTMLInputElement | undefined;
+  #owningTreeElement: HTMLElement | undefined;
+  readonly #options: TreeItemRenameControllerOptions;
+
+  constructor(options: TreeItemRenameControllerOptions) {
+    this.#options = options;
+  }
+
+  get canRename(): boolean {
+    return !this.#options.getDisabled() && this.#options.getOnRename() != null;
+  }
+
+  get editingLabel(): string {
+    return `Editing: ${this.#options.getLabel()}`;
+  }
+
+  get messageId(): string {
+    return `${this.#options.getElementId()}-rename-message`;
+  }
+
+  attachInput: Attachment<HTMLInputElement> = (node) => {
+    this.#inputElement = node;
+    queueMicrotask(() => {
+      if (!this.editing || this.#inputElement !== node) return;
+      node.focus();
+      node.select();
+    });
+    return () => {
+      if (this.#inputElement === node) this.#inputElement = undefined;
+    };
+  };
+
+  #announce(message: string): void {
+    this.renameAnnouncement = message;
+    this.renameAnnouncementSequence += 1;
+  }
+
+  #renameFailureMessage(error: unknown): string {
+    if (error instanceof Error && error.message) return error.message;
+    if (typeof error === 'string' && error) return error;
+    return 'Unknown error';
+  }
+
+  #focusCurrentTreeItem(): void {
+    const outerElement = this.#options.getOuterElement();
+    if (outerElement?.isConnected) {
+      outerElement.focus();
+      this.#owningTreeElement = undefined;
+      return;
+    }
+
+    if (typeof document === 'undefined') return;
+    const root: ParentNode =
+      this.#owningTreeElement?.isConnected === true ? this.#owningTreeElement : document;
+    const id = this.#options.getId();
+    const current = [...root.querySelectorAll<HTMLElement>('[data-cinder-tree-item-id]')].find(
+      (element) => element.dataset['cinderTreeItemId'] === id,
+    );
+    current?.focus();
+    this.#owningTreeElement = undefined;
+  }
+
+  beginEdit(): void {
+    if (!this.canRename || this.editing) return;
+    const label = this.#options.getLabel();
+    this.editValue = label;
+    this.renameError = '';
+    this.renamePending = false;
+    this.#owningTreeElement =
+      this.#options.getOuterElement()?.closest<HTMLElement>('[role="tree"]') ?? undefined;
+    this.editing = true;
+    this.#announce(`Editing ${label}. Press Enter to confirm, Escape to cancel.`);
+  }
+
+  #finishEdit(afterFocus: (() => void) | undefined = undefined): void {
+    this.editing = false;
+    this.renameError = '';
+    this.renamePending = false;
+    queueMicrotask(() => {
+      this.#focusCurrentTreeItem();
+      afterFocus?.();
+    });
+  }
+
+  cancelEdit(): void {
+    this.editValue = this.#options.getLabel();
+    this.#announce('Rename cancelled.');
+    this.#finishEdit();
+  }
+
+  async commitEdit(afterFocus: (() => void) | undefined = undefined): Promise<boolean> {
+    if (!this.editing || this.renamePending) return false;
+
+    if (this.editValue.trim().length === 0) {
+      this.renameError = 'Label is required.';
+      this.#announce(this.renameError);
+      queueMicrotask(() => this.#inputElement?.focus());
+      return false;
+    }
+
+    const onRename = this.#options.getOnRename();
+    if (!onRename) {
+      this.#finishEdit(afterFocus);
+      return true;
+    }
+
+    this.renamePending = true;
+    this.renameError = '';
+    try {
+      await onRename(this.#options.getId(), this.editValue);
+      this.#announce(`${this.editValue}, renamed.`);
+      this.#finishEdit(afterFocus);
+      return true;
+    } catch (error) {
+      const message = `Rename failed: ${this.#renameFailureMessage(error)}.`;
+      this.renamePending = false;
+      this.renameError = message;
+      this.#announce(message);
+      queueMicrotask(() => this.#inputElement?.focus());
+      return false;
+    }
+  }
+
+  async #commitEditAndMove(direction: 1 | -1): Promise<void> {
+    await this.commitEdit(() => this.#options.focusVisibleDelta(direction));
+  }
+
+  handleInputKeydown = (event: KeyboardEvent): void => {
+    event.stopPropagation();
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      void this.commitEdit();
+      return;
+    }
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.cancelEdit();
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      const direction = event.shiftKey ? -1 : 1;
+      if (this.#options.canFocusVisibleDelta(direction)) {
+        event.preventDefault();
+        void this.#commitEditAndMove(direction);
+      } else {
+        void this.commitEdit();
+      }
+    }
+  };
+
+  handleInputBlur = (): void => {
+    void this.commitEdit();
+  };
+}

--- a/packages/components/src/components/tree-item/tree-item-rename.test.ts
+++ b/packages/components/src/components/tree-item/tree-item-rename.test.ts
@@ -1,0 +1,55 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { TreeItemRenameController } = await import('./tree-item-rename.svelte.ts');
+
+type RenameCall = { id: string; value: string };
+
+function createController(onRename: (id: string, value: string) => Promise<void>) {
+  const controller = new TreeItemRenameController({
+    getId: () => 'alpha',
+    getLabel: () => 'Alpha',
+    getOnRename: () => onRename,
+    getDisabled: () => false,
+    getOuterElement: () => undefined,
+    getElementId: () => 'tree-item-alpha',
+    canFocusVisibleDelta: () => false,
+    focusVisibleDelta: () => {},
+  });
+  return controller;
+}
+
+describe('TreeItemRenameController', () => {
+  test('commitEdit calls onRename with the edited value and clears editing on success', async () => {
+    const calls: RenameCall[] = [];
+    const controller = createController(async (id, value) => {
+      calls.push({ id, value });
+    });
+
+    controller.beginEdit();
+    controller.editValue = 'Beta';
+    const result = await controller.commitEdit();
+
+    expect(result).toBe(true);
+    expect(calls).toEqual([{ id: 'alpha', value: 'Beta' }]);
+    expect(controller.editing).toBe(false);
+  });
+
+  test('commitEdit sets renameError and stays editing when onRename rejects', async () => {
+    const controller = createController(async () => {
+      throw new Error('Name already exists');
+    });
+
+    controller.beginEdit();
+    controller.editValue = 'Beta';
+    const result = await controller.commitEdit();
+
+    expect(result).toBe(false);
+    expect(controller.editing).toBe(true);
+    expect(controller.renameError).toBe('Rename failed: Name already exists.');
+  });
+});

--- a/packages/components/src/components/tree-item/tree-item.svelte
+++ b/packages/components/src/components/tree-item/tree-item.svelte
@@ -27,12 +27,10 @@
   } from '../../_internal/tree-context.ts';
   import { classNames } from '../../utilities/class-names.ts';
   import VisuallyHiddenLiveRegion from '../_visually-hidden-live-region.svelte';
-
-  type LabelSegment = {
-    text: string;
-    highlighted: boolean;
-    start: number;
-  };
+  import { TreeItemAsyncLoader } from './tree-item-async-load.svelte.ts';
+  import { TreeItemDragHandlers } from './tree-item-drag.svelte.ts';
+  import { splitLabelForHighlight } from './tree-item-label-highlight.ts';
+  import { TreeItemRenameController } from './tree-item-rename.svelte.ts';
 
   // ---------------------------------------------------------------------------
   // Props
@@ -79,23 +77,29 @@
 
   const isBranch = $derived(branch || loadChildren != null);
 
-  let busy = $state(false);
-  let loaded = $state(false);
-  let activeController: AbortController | null = null;
-  let editing = $state(false);
-  let editValue = $state('');
-  let renamePending = $state(false);
-  let renameError = $state('');
-  let renameAnnouncement = $state('');
-  let renameAnnouncementSequence = $state(0);
   let probedFilterValue = $state<string | null>(null);
 
   let outerElement: HTMLElement | undefined = $state();
-  let renameInputElement: HTMLInputElement | undefined = $state();
   let dragHandleElement: HTMLButtonElement | undefined = $state();
-  let renameOwningTreeElement: HTMLElement | undefined;
   const treeItemElementId = $props.id();
-  const renameMessageId = $derived(`${treeItemElementId}-rename-message`);
+
+  const asyncLoader = new TreeItemAsyncLoader({
+    getId: () => id,
+    getLoadChildren: () => loadChildren,
+    getOnLoadError: () => onLoadError,
+    setExpanded: (itemId, expanded) => context.setExpanded(itemId, expanded),
+  });
+
+  const renameController = new TreeItemRenameController({
+    getId: () => id,
+    getLabel: () => label,
+    getOnRename: () => onRename,
+    getDisabled: () => disabled,
+    getOuterElement: () => outerElement,
+    getElementId: () => treeItemElementId,
+    canFocusVisibleDelta: (direction) => context.canFocusVisibleDelta(id, direction),
+    focusVisibleDelta: (direction) => context.focusVisibleDelta(id, direction),
+  });
 
   // ---------------------------------------------------------------------------
   // Derived state from context
@@ -125,15 +129,18 @@
   const checkboxSelectionActive = $derived(context.checkboxSelectionActive());
   const selectionState = $derived(context.selectionStateFor(id));
   const labelSegments = $derived.by(() => splitLabelForHighlight(label, context.filterValue));
-  const canRename = $derived(!disabled && onRename != null);
-  const editingLabel = $derived(`Editing: ${label}`);
   const dragController = $derived(context.dragController);
   const canDrag = $derived(draggable && !disabled && dragController != null);
-  const isDraggingItem = $derived(dragController?.isDragging(id) ?? false);
-  const isDropBefore = $derived(dragController?.isDropTarget(id, 'before') ?? false);
-  const isDropAfter = $derived(dragController?.isDropTarget(id, 'after') ?? false);
-  const isDropInto = $derived(dragController?.isDropTarget(id, 'child') ?? false);
-  const dragHandleLabel = $derived(`Reorder ${label}`);
+
+  const dragHandlers = new TreeItemDragHandlers({
+    getDragController: () => dragController,
+    getId: () => id,
+    getLabel: () => label,
+    getCanDrag: () => canDrag,
+    getDragHandleElement: () => dragHandleElement,
+    getOuterElement: () => outerElement,
+  });
+
   const ariaChecked = $derived.by(() => {
     if (!checkboxSelectionActive) return undefined;
     if (selectionState.indeterminate) return 'mixed';
@@ -209,10 +216,7 @@
 
       return () => {
         // Abort any in-flight async load when the item unmounts
-        if (activeController) {
-          activeController.abort();
-          activeController = null;
-        }
+        asyncLoader.abort();
         unregister();
       };
     });
@@ -222,56 +226,17 @@
   // Async loading
   // ---------------------------------------------------------------------------
 
-  async function triggerLoad(): Promise<void> {
-    if (!loadChildren || loaded || busy) return;
-
-    activeController?.abort();
-    const controller = new AbortController();
-    activeController = controller;
-    busy = true;
-
-    try {
-      await loadChildren({ id, signal: controller.signal });
-      if (!controller.signal.aborted) {
-        loaded = true;
-        busy = false;
-      }
-    } catch (error) {
-      if (
-        controller.signal.aborted ||
-        (error instanceof DOMException && error.name === 'AbortError')
-      ) {
-        // Only clear busy if this is still the active load. If a newer load
-        // has already started (expand→collapse→expand race), clearing busy
-        // here would cause the $effect to re-fire and start a load cascade.
-        if (activeController === controller) busy = false;
-        return;
-      }
-      busy = false;
-      loaded = false;
-      // Collapse the branch on error
-      context.setExpanded(id, false);
-      if (onLoadError) {
-        onLoadError(error, id);
-      } else {
-        console.error('[cinder-tree] loadChildren failed for item', id, error);
-      }
-    }
-  }
-
   // When expanded for the first time with a loadChildren, trigger the load
   $effect(() => {
-    if (isExpanded && loadChildren && !loaded && !busy) {
-      triggerLoad();
+    if (isExpanded && loadChildren && !asyncLoader.loaded && !asyncLoader.busy) {
+      asyncLoader.trigger();
     }
   });
 
   // Abort in-flight load when collapsing
   $effect(() => {
-    if (!isExpanded && busy && activeController) {
-      activeController.abort();
-      activeController = null;
-      busy = false;
+    if (!isExpanded && asyncLoader.busy) {
+      asyncLoader.abort();
     }
   });
 
@@ -305,239 +270,6 @@
   // Keyboard handler
   // ---------------------------------------------------------------------------
 
-  const focusRenameInput: Attachment<HTMLInputElement> = (node) => {
-    renameInputElement = node;
-    queueMicrotask(() => {
-      if (!editing || renameInputElement !== node) return;
-      node.focus();
-      node.select();
-    });
-    return () => {
-      if (renameInputElement === node) renameInputElement = undefined;
-    };
-  };
-
-  function announceRename(message: string): void {
-    renameAnnouncement = message;
-    renameAnnouncementSequence += 1;
-  }
-
-  function renameFailureMessage(error: unknown): string {
-    if (error instanceof Error && error.message) return error.message;
-    if (typeof error === 'string' && error) return error;
-    return 'Unknown error';
-  }
-
-  function focusCurrentTreeItem(): void {
-    if (outerElement?.isConnected) {
-      outerElement.focus();
-      renameOwningTreeElement = undefined;
-      return;
-    }
-
-    if (typeof document === 'undefined') return;
-    const root: ParentNode =
-      renameOwningTreeElement?.isConnected === true ? renameOwningTreeElement : document;
-    const current = [...root.querySelectorAll<HTMLElement>('[data-cinder-tree-item-id]')].find(
-      (element) => element.dataset['cinderTreeItemId'] === id,
-    );
-    current?.focus();
-    renameOwningTreeElement = undefined;
-  }
-
-  function beginEdit(): void {
-    if (!canRename || editing) return;
-    editValue = label;
-    renameError = '';
-    renamePending = false;
-    renameOwningTreeElement = outerElement?.closest<HTMLElement>('[role="tree"]') ?? undefined;
-    editing = true;
-    announceRename(`Editing ${label}. Press Enter to confirm, Escape to cancel.`);
-  }
-
-  function finishEdit(afterFocus: (() => void) | undefined = undefined): void {
-    editing = false;
-    renameError = '';
-    renamePending = false;
-    queueMicrotask(() => {
-      focusCurrentTreeItem();
-      afterFocus?.();
-    });
-  }
-
-  function cancelEdit(): void {
-    editValue = label;
-    announceRename('Rename cancelled.');
-    finishEdit();
-  }
-
-  async function commitEdit(afterFocus: (() => void) | undefined = undefined): Promise<boolean> {
-    if (!editing || renamePending) return false;
-
-    if (editValue.trim().length === 0) {
-      renameError = 'Label is required.';
-      announceRename(renameError);
-      queueMicrotask(() => renameInputElement?.focus());
-      return false;
-    }
-
-    if (!onRename) {
-      finishEdit(afterFocus);
-      return true;
-    }
-
-    renamePending = true;
-    renameError = '';
-    try {
-      await onRename(id, editValue);
-      announceRename(`${editValue}, renamed.`);
-      finishEdit(afterFocus);
-      return true;
-    } catch (error) {
-      const message = `Rename failed: ${renameFailureMessage(error)}.`;
-      renamePending = false;
-      renameError = message;
-      announceRename(message);
-      queueMicrotask(() => renameInputElement?.focus());
-      return false;
-    }
-  }
-
-  async function commitEditAndMove(direction: 1 | -1): Promise<void> {
-    await commitEdit(() => context.focusVisibleDelta(id, direction));
-  }
-
-  function handleRenameInputKeydown(event: KeyboardEvent): void {
-    event.stopPropagation();
-
-    if (event.key === 'Enter') {
-      event.preventDefault();
-      void commitEdit();
-      return;
-    }
-
-    if (event.key === 'Escape') {
-      event.preventDefault();
-      void cancelEdit();
-      return;
-    }
-
-    if (event.key === 'Tab') {
-      const direction = event.shiftKey ? -1 : 1;
-      if (context.canFocusVisibleDelta(id, direction)) {
-        event.preventDefault();
-        void commitEditAndMove(direction);
-      } else {
-        void commitEdit();
-      }
-    }
-  }
-
-  function handleRenameInputBlur(): void {
-    void commitEdit();
-  }
-
-  let dragKeyboardReturnTarget: HTMLElement | undefined;
-
-  function restoreDragKeyboardFocus(): void {
-    const target = dragKeyboardReturnTarget ?? dragHandleElement ?? outerElement;
-    queueMicrotask(() => target?.focus());
-  }
-
-  function canLiftWithKeyboard(event: KeyboardEvent): boolean {
-    const fromDragHandle = event.currentTarget === dragHandleElement;
-    const treeItemShortcut =
-      event.key === ' ' && event.ctrlKey && event.shiftKey && !event.altKey && !event.metaKey;
-    return (fromDragHandle && (event.key === ' ' || event.key === 'Enter')) || treeItemShortcut;
-  }
-
-  function handleDragKeyboard(event: KeyboardEvent): boolean {
-    const controller = dragController;
-    if (!canDrag || !controller) return false;
-
-    if (!controller.dragging && canLiftWithKeyboard(event)) {
-      event.preventDefault();
-      event.stopPropagation();
-      dragKeyboardReturnTarget =
-        event.currentTarget instanceof HTMLElement ? event.currentTarget : undefined;
-      controller.lift(id, 'keyboard');
-      restoreDragKeyboardFocus();
-      return true;
-    }
-
-    if (!controller.isDragging(id)) return false;
-
-    switch (event.key) {
-      case 'ArrowDown':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.moveBy(1);
-        return true;
-      case 'ArrowUp':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.moveBy(-1);
-        return true;
-      case 'ArrowRight':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.moveIntoPreviousBranch();
-        return true;
-      case 'ArrowLeft':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.moveOut();
-        return true;
-      case 'Home':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.moveToEdge('first');
-        return true;
-      case 'End':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.moveToEdge('last');
-        return true;
-      case 'F2':
-        event.preventDefault();
-        event.stopPropagation();
-        return true;
-      case 'Tab':
-        event.stopPropagation();
-        controller.cancel();
-        return true;
-      case ' ':
-      case 'Enter':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.drop();
-        restoreDragKeyboardFocus();
-        return true;
-      case 'Escape':
-        event.preventDefault();
-        event.stopPropagation();
-        controller.cancel();
-        restoreDragKeyboardFocus();
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  function handleDragPointerDown(event: PointerEvent): void {
-    const controller = dragController;
-    if (!canDrag || !controller || event.button !== 0) return;
-    event.preventDefault();
-    event.stopPropagation();
-    dragHandleElement?.focus();
-    dragHandleElement?.setPointerCapture(event.pointerId);
-    controller.lift(id, 'pointer');
-  }
-
-  function handleDragClick(event: MouseEvent): void {
-    event.stopPropagation();
-  }
-
   function toggleKeyboardSelection(event: KeyboardEvent): void {
     if (disabled) return;
     if (checkboxSelectionActive) {
@@ -555,11 +287,11 @@
 
     const key = event.key;
 
-    if (handleDragKeyboard(event)) return;
+    if (dragHandlers.handleKeyboard(event)) return;
 
     if (key === 'F2') {
       event.preventDefault();
-      beginEdit();
+      renameController.beginEdit();
       return;
     }
 
@@ -615,8 +347,8 @@
 
       case 'Enter':
         event.preventDefault();
-        if (context.selectionMode === 'none' && canRename) {
-          beginEdit();
+        if (context.selectionMode === 'none' && renameController.canRename) {
+          renameController.beginEdit();
           break;
         }
         if (checkboxSelectionActive) {
@@ -695,7 +427,7 @@
   function handleLabelDoubleClick(event: MouseEvent): void {
     event.preventDefault();
     event.stopPropagation();
-    beginEdit();
+    renameController.beginEdit();
   }
 
   function handleCheckboxActivation(event: Event): void {
@@ -723,28 +455,6 @@
   function toggleSelectionFromRow(): void {
     if (!disabled) context.toggleSelectionScope(id);
   }
-
-  function splitLabelForHighlight(value: string, query: string): LabelSegment[] {
-    if (query.length === 0) return [{ text: value, highlighted: false, start: 0 }];
-
-    const matchIndex = value.toLowerCase().indexOf(query.toLowerCase());
-    if (matchIndex === -1) return [{ text: value, highlighted: false, start: 0 }];
-
-    const matchEnd = matchIndex + query.length;
-    const segments: LabelSegment[] = [];
-    if (matchIndex > 0) {
-      segments.push({ text: value.slice(0, matchIndex), highlighted: false, start: 0 });
-    }
-    segments.push({
-      text: value.slice(matchIndex, matchEnd),
-      highlighted: true,
-      start: matchIndex,
-    });
-    if (matchEnd < value.length) {
-      segments.push({ text: value.slice(matchEnd), highlighted: false, start: matchEnd });
-    }
-    return segments;
-  }
 </script>
 
 {#snippet visibleLabel()}
@@ -763,8 +473,8 @@
   role="treeitem"
   id={treeItemElementId}
   class={classNames('cinder-tree-item', className)}
-  aria-label={editing ? editingLabel : undefined}
-  aria-labelledby={editing ? undefined : `${treeItemElementId}-label`}
+  aria-label={renameController.editing ? renameController.editingLabel : undefined}
+  aria-labelledby={renameController.editing ? undefined : `${treeItemElementId}-label`}
   aria-level={level}
   aria-expanded={isBranch ? renderedExpanded : undefined}
   aria-posinset={positionInSet}
@@ -773,20 +483,24 @@
     ? undefined
     : isSelected}
   aria-checked={ariaChecked}
-  aria-busy={busy || undefined}
+  aria-busy={asyncLoader.busy || undefined}
   aria-disabled={disabled || undefined}
   aria-describedby={canDrag ? context.dragInstructionsId : undefined}
   tabindex={isFocused ? 0 : -1}
   data-cinder-expanded={isBranch && isExpanded ? '' : undefined}
   data-cinder-selected={isSelected ? '' : undefined}
   data-cinder-disabled={disabled ? '' : undefined}
-  data-cinder-busy={busy ? '' : undefined}
+  data-cinder-busy={asyncLoader.busy ? '' : undefined}
   data-cinder-hidden={!isVisible ? '' : undefined}
-  data-cinder-editing={editing ? '' : undefined}
+  data-cinder-editing={renameController.editing ? '' : undefined}
   data-cinder-tree-item-id={id}
-  data-cinder-dragging={isDraggingItem ? '' : undefined}
-  data-cinder-drop-target={isDropBefore ? 'before' : isDropAfter ? 'after' : undefined}
-  data-cinder-drop-into={isDropInto ? '' : undefined}
+  data-cinder-dragging={dragHandlers.isDraggingItem ? '' : undefined}
+  data-cinder-drop-target={dragHandlers.isDropBefore
+    ? 'before'
+    : dragHandlers.isDropAfter
+      ? 'after'
+      : undefined}
+  data-cinder-drop-into={dragHandlers.isDropInto ? '' : undefined}
   onfocus={handleFocus}
   onkeydown={handleKeydown}
   onclick={handleClick}
@@ -813,13 +527,13 @@
         bind:this={dragHandleElement}
         type="button"
         class="cinder-tree-item__drag-handle"
-        aria-label={dragHandleLabel}
-        aria-pressed={isDraggingItem}
+        aria-label={dragHandlers.dragHandleLabel}
+        aria-pressed={dragHandlers.isDraggingItem}
         aria-describedby={context.dragInstructionsId}
         tabindex="-1"
-        onpointerdown={handleDragPointerDown}
-        onclickcapture={handleDragClick}
-        onkeydown={handleDragKeyboard}
+        onpointerdown={dragHandlers.handlePointerDown}
+        onclickcapture={dragHandlers.handleClick}
+        onkeydown={dragHandlers.handleKeyboard}
       >
         <span aria-hidden="true">::</span>
       </button>
@@ -829,26 +543,26 @@
       {@render row({
         expanded: isExpanded,
         selected: isSelected,
-        busy,
+        busy: asyncLoader.busy,
         level,
         checkboxSelection: checkboxSelectionActive,
         selectionState,
-        editing,
-        beginEdit,
+        editing: renameController.editing,
+        beginEdit: () => renameController.beginEdit(),
         toggleSelection: toggleSelectionFromRow,
       })}
-    {:else if editing}
+    {:else if renameController.editing}
       <input
-        {@attach focusRenameInput}
+        {@attach renameController.attachInput}
         type="text"
         class="cinder-tree-item__rename-input"
-        bind:value={editValue}
-        aria-label={editingLabel}
-        aria-invalid={renameError ? 'true' : undefined}
-        aria-describedby={renameError ? renameMessageId : undefined}
-        disabled={renamePending}
-        onkeydown={handleRenameInputKeydown}
-        onblur={handleRenameInputBlur}
+        bind:value={renameController.editValue}
+        aria-label={renameController.editingLabel}
+        aria-invalid={renameController.renameError ? 'true' : undefined}
+        aria-describedby={renameController.renameError ? renameController.messageId : undefined}
+        disabled={renameController.renamePending}
+        onkeydown={renameController.handleInputKeydown}
+        onblur={renameController.handleInputBlur}
       />
     {:else if checkboxSelectionActive}
       <!--
@@ -907,8 +621,10 @@
       >
     {/if}
   </div>
-  {#if renameError}
-    <span id={renameMessageId} class="cinder-sr-only">{renameError}</span>
+  {#if renameController.renameError}
+    <span id={renameController.messageId} class="cinder-sr-only"
+      >{renameController.renameError}</span
+    >
   {/if}
   {#if shouldRenderChildren}
     <div role="group" aria-labelledby={treeItemElementId} class="cinder-tree-item__children">
@@ -917,8 +633,8 @@
   {/if}
   {#if onRename}
     <VisuallyHiddenLiveRegion
-      message={renameAnnouncement}
-      announcementSequence={renameAnnouncementSequence}
+      message={renameController.renameAnnouncement}
+      announcementSequence={renameController.renameAnnouncementSequence}
       priority="assertive"
     />
   {/if}

--- a/packages/components/src/components/tree/tree.svelte
+++ b/packages/components/src/components/tree/tree.svelte
@@ -29,6 +29,7 @@
   import { SvelteSet } from 'svelte/reactivity';
   import type { TreeProps, TreeRef } from './tree.types.ts';
 
+  import { TreeAutoscrollController } from '../../_internal/tree-autoscroll.svelte.ts';
   import type { TreeContext } from '../../_internal/tree-context.ts';
   import { setTreeContext, setTreeItemParentContext } from '../../_internal/tree-context.ts';
   import {
@@ -38,6 +39,7 @@
     type FlattenedTreeDataItem,
   } from '../../_internal/tree-data.ts';
   import { TreeDragController } from '../../_internal/tree-drag-controller.svelte.ts';
+  import { TreeFilterController } from '../../_internal/tree-filter.svelte.ts';
   import type { TreeVisibilityPredicate } from '../../_internal/tree-registry.svelte.ts';
   import { TreeRegistry } from '../../_internal/tree-registry.svelte.ts';
   import { TreeVirtualizer } from '../../_internal/use-virtualizer.svelte.ts';
@@ -110,26 +112,34 @@
   const registry = new TreeRegistry();
   let focusedId = $state<string | null>(null);
   let treeElement = $state<HTMLElement | null>(null);
-  let filterInputElement = $state<HTMLInputElement | null>(null);
-  let uncontrolledFilterValue = $state(untrack(() => filterValue ?? ''));
-  let filterStatusAnnouncement = $state('');
-  let filterStatusAnnouncementSequence = $state(0);
-  let filterStatusBusy = $state(false);
-  let filterStatusTimer: ReturnType<typeof setTimeout> | null = null;
   let expansionAnnouncement = $state('');
   let expansionAnnouncementSequence = $state(0);
   let dragAnnouncement = $state('');
   let dragAnnouncementSequence = $state(0);
   let dragController: TreeDragController | null = $state(null);
-  let latestDragPointerX = 0;
-  let latestDragPointerY = 0;
-  let dragScrollElement: HTMLElement | null = null;
-  let dragScrollAnimationFrame: number | null = null;
 
   // Anchor for shift-select range
   let selectionAnchorId = $state<string | null>(null);
 
   const typeaheadBuffer = new TypeaheadBuffer();
+
+  const filterController = new TreeFilterController({
+    getFilterValue: () => filterValue,
+    isControlled: () => isFilterControlled,
+    onFilterChange: (next) => onFilterChange?.(next),
+    focusFirstVisible: () => {
+      const firstVisibleId = visibleIds[0];
+      if (firstVisibleId) focusNode(firstVisibleId);
+    },
+  });
+
+  const autoscroll = new TreeAutoscrollController({
+    isPointerDragging: () => dragController?.pointerDragging ?? false,
+    setDropTarget: (_clientX, clientY, target) => {
+      if (!(target instanceof HTMLElement)) return;
+      dragController?.setDropTarget(dragController.targetFromPointer(clientY, target));
+    },
+  });
 
   // Warn once when no accessible label is provided
   let hasWarnedNoLabel = false;
@@ -167,11 +177,8 @@
   $effect(() => {
     return () => {
       typeaheadBuffer.reset();
-      if (filterStatusTimer !== null) {
-        clearTimeout(filterStatusTimer);
-        filterStatusTimer = null;
-      }
-      stopDragAutoscroll();
+      filterController.destroy();
+      autoscroll.stop();
     };
   });
 
@@ -180,11 +187,6 @@
   // ---------------------------------------------------------------------------
 
   const isFilterControlled = $derived(filterValue !== undefined);
-  const currentFilterValue = $derived(
-    isFilterControlled ? (filterValue ?? '') : uncontrolledFilterValue,
-  );
-  const normalizedFilterValue = $derived(currentFilterValue.trim());
-  const filtering = $derived(normalizedFilterValue.length > 0);
   const treeId = $derived(idAttribute ?? `${generatedId}-tree`);
   const filterInputId = $derived(`${generatedId}-filter`);
   const dragInstructionsId = $derived(`${generatedId}-drag-instructions`);
@@ -194,22 +196,22 @@
     () => new Map(flattenedDataItems.map((item) => [item.id, item])),
   );
   const hasTreeChrome = $derived(
-    selectionControls != null || searchVisible || filtering || onReorder != null,
+    selectionControls != null || searchVisible || filterController.filtering || onReorder != null,
   );
   const hasRegisteredItems = $derived(
     isVirtualizedTree ? flattenedDataItems.length > 0 : registry.size > 0,
   );
   const activeVisibilityPredicate = $derived.by<TreeVisibilityPredicate | undefined>(() => {
-    if (!filtering) return undefined;
-    const query = normalizedFilterValue;
+    if (!filterController.filtering) return undefined;
+    const query = filterController.normalizedValue;
     const predicate = filterPredicate;
     return ({ id, label }) => predicate(label, id, query);
   });
   const activeDataVisibilityPredicate = $derived.by<
     ((item: FlattenedTreeDataItem) => boolean) | undefined
   >(() => {
-    if (!filtering) return undefined;
-    const query = normalizedFilterValue;
+    if (!filterController.filtering) return undefined;
+    const query = filterController.normalizedValue;
     const predicate = filterPredicate;
     return (item) => predicate(item.label, item.id, query);
   });
@@ -222,7 +224,9 @@
   const visibleIds = $derived.by(() =>
     isVirtualizedTree ? visibleDataItems.map((item) => item.id) : registryVisibleIds,
   );
-  const hasNoFilterResults = $derived(filtering && hasRegisteredItems && visibleIds.length === 0);
+  const hasNoFilterResults = $derived(
+    filterController.filtering && hasRegisteredItems && visibleIds.length === 0,
+  );
   const visibleIdSet = $derived.by(() => new SvelteSet(visibleIds));
   const expandableBranchIds = $derived.by(() =>
     isVirtualizedTree
@@ -233,29 +237,7 @@
   const hasExpandedItems = $derived(expandedIds.length > 0);
 
   $effect(() => {
-    if (filterStatusTimer !== null) {
-      clearTimeout(filterStatusTimer);
-      filterStatusTimer = null;
-    }
-
-    if (!filtering) {
-      filterStatusBusy = false;
-      filterStatusAnnouncement = '';
-      return;
-    }
-
-    const query = normalizedFilterValue;
-    const resultCount = visibleIds.length;
-    filterStatusBusy = true;
-    filterStatusTimer = setTimeout(() => {
-      filterStatusAnnouncement =
-        resultCount === 0
-          ? `No results for ${query}.`
-          : `${resultCount} result${resultCount === 1 ? '' : 's'} found.`;
-      filterStatusAnnouncementSequence += 1;
-      filterStatusBusy = false;
-      filterStatusTimer = null;
-    }, 500);
+    filterController.scheduleStatusAnnouncement(visibleIds.length);
   });
 
   // Initial roving tabindex: first selected visible item, or first visible item
@@ -380,7 +362,7 @@
   function virtualizedItemExpanded(item: FlattenedTreeDataItem): boolean {
     return (
       expandedIds.includes(item.id) ||
-      (filtering &&
+      (filterController.filtering &&
         item.branch &&
         visibleDataItems.some(
           (visibleItem) => visibleItem.id !== item.id && visibleItem.ancestorIds.includes(item.id),
@@ -391,7 +373,7 @@
   function virtualizedFilterForcedOpen(item: FlattenedTreeDataItem): boolean {
     return (
       item.branch &&
-      filtering &&
+      filterController.filtering &&
       !expandedIds.includes(item.id) &&
       visibleDataItems.some(
         (visibleItem) => visibleItem.id !== item.id && visibleItem.ancestorIds.includes(item.id),
@@ -789,10 +771,10 @@
       return effectiveFocusedId;
     },
     get filtering() {
-      return filtering;
+      return filterController.filtering;
     },
     get filterValue() {
-      return normalizedFilterValue;
+      return filterController.normalizedValue;
     },
     get hasRegisteredItems() {
       return hasRegisteredItems;
@@ -834,7 +816,9 @@
       return registry.descendantsOf(id).some((descendantId) => visibleIdSet.has(descendantId));
     },
     matchesFilter(label, id) {
-      return filtering && filterPredicate(label, id, normalizedFilterValue);
+      return (
+        filterController.filtering && filterPredicate(label, id, filterController.normalizedValue)
+      );
     },
     checkboxSelectionActive,
     selectionStateFor: selectionStateForId,
@@ -1053,113 +1037,20 @@
     return true;
   }
 
-  function updateFilterValue(next: string): void {
-    if (!isFilterControlled) uncontrolledFilterValue = next;
-    onFilterChange?.(next);
-  }
-
-  function handleFilterInput(event: Event): void {
-    const target = event.currentTarget as HTMLInputElement;
-    updateFilterValue(target.value);
-  }
-
-  function handleFilterKeydown(event: KeyboardEvent): void {
-    if (event.key === 'ArrowDown') {
-      event.preventDefault();
-      const firstVisibleId = visibleIds[0];
-      if (firstVisibleId) focusNode(firstVisibleId);
-      return;
-    }
-
-    if (event.key === 'Escape' && currentFilterValue.length > 0) {
-      event.preventDefault();
-      event.stopPropagation();
-      updateFilterValue('');
-      filterInputElement?.focus();
-    }
-  }
-
-  function pointerTargetElement(
-    clientX: number,
-    clientY: number,
-    fallbackTarget: EventTarget | null,
-  ): HTMLElement | null {
-    if (typeof document !== 'undefined') {
-      const element = document.elementFromPoint(clientX, clientY);
-      if (element instanceof HTMLElement) return element;
-    }
-    return fallbackTarget instanceof HTMLElement ? fallbackTarget : null;
-  }
-
-  function updateDragTargetFromPointer(
-    clientX: number,
-    clientY: number,
-    fallbackTarget: EventTarget | null,
-  ): void {
-    const element = pointerTargetElement(clientX, clientY, fallbackTarget);
-    if (!element) return;
-    dragController?.setDropTarget(dragController.targetFromPointer(clientY, element));
-  }
-
-  function stopDragAutoscroll(): void {
-    if (dragScrollAnimationFrame !== null && typeof cancelAnimationFrame === 'function') {
-      cancelAnimationFrame(dragScrollAnimationFrame);
-    }
-    dragScrollAnimationFrame = null;
-    dragScrollElement = null;
-  }
-
-  function scheduleDragAutoscroll(): void {
-    if (
-      dragScrollAnimationFrame !== null ||
-      !dragController?.pointerDragging ||
-      !dragScrollElement ||
-      typeof requestAnimationFrame !== 'function'
-    ) {
-      return;
-    }
-
-    dragScrollAnimationFrame = requestAnimationFrame(() => {
-      dragScrollAnimationFrame = null;
-      const tree = dragScrollElement;
-      if (!dragController?.pointerDragging || !tree) return;
-
-      const rect = tree.getBoundingClientRect();
-      const edge = 32;
-      const speed = 8;
-      const previousScrollTop = tree.scrollTop;
-      if (latestDragPointerY - rect.top < edge) {
-        tree.scrollTop -= speed;
-      } else if (rect.bottom - latestDragPointerY < edge) {
-        tree.scrollTop += speed;
-      }
-
-      if (tree.scrollTop === previousScrollTop) return;
-      updateDragTargetFromPointer(latestDragPointerX, latestDragPointerY, tree);
-      scheduleDragAutoscroll();
-    });
-  }
-
   function handlePointerMove(event: PointerEvent): void {
-    if (!dragController?.pointerDragging) return;
-    event.preventDefault();
-    latestDragPointerX = event.clientX;
-    latestDragPointerY = event.clientY;
-    dragScrollElement = event.currentTarget as HTMLElement;
-    updateDragTargetFromPointer(event.clientX, event.clientY, event.target);
-    scheduleDragAutoscroll();
+    autoscroll.handlePointerMove(event, event.currentTarget as HTMLElement);
   }
 
   function handlePointerUp(event: PointerEvent): void {
     if (!dragController?.pointerDragging) return;
     event.preventDefault();
-    stopDragAutoscroll();
+    autoscroll.stop();
     dragController.drop();
   }
 
   function handlePointerCancel(): void {
     if (!dragController?.pointerDragging) return;
-    stopDragAutoscroll();
+    autoscroll.stop();
     dragController.cancel();
   }
 
@@ -1319,7 +1210,7 @@
     aria-labelledby={resolvedAriaLabelledBy}
     aria-activedescendant={virtualizedActiveDescendantId}
     aria-multiselectable={selectionMode === 'multiple' ? true : undefined}
-    aria-busy={filterStatusBusy || undefined}
+    aria-busy={filterController.statusBusy || undefined}
     data-cinder-checkbox-selection={checkboxSelectionActive() ? '' : undefined}
     data-cinder-virtualized={isVirtualizedTree ? '' : undefined}
     onkeydown={handleKeydown}
@@ -1341,19 +1232,19 @@
       <div class="cinder-tree__filter">
         <label class="cinder-sr-only" for={filterInputId}>{resolvedFilterPlaceholder}</label>
         <input
-          bind:this={filterInputElement}
+          bind:this={filterController.filterInputElement}
           id={filterInputId}
           class="cinder-tree__filter-input"
           type="search"
-          value={currentFilterValue}
+          value={filterController.currentValue}
           placeholder={resolvedFilterPlaceholder}
           aria-label={resolvedFilterPlaceholder}
           aria-controls={treeId}
           autocomplete="off"
           autocorrect="off"
           spellcheck={false}
-          oninput={handleFilterInput}
-          onkeydown={handleFilterKeydown}
+          oninput={filterController.handleInput}
+          onkeydown={filterController.handleKeydown}
         />
       </div>
     {/if}
@@ -1378,8 +1269,8 @@
     {/if}
 
     <VisuallyHiddenLiveRegion
-      message={filterStatusAnnouncement}
-      announcementSequence={filterStatusAnnouncementSequence}
+      message={filterController.statusAnnouncement}
+      announcementSequence={filterController.statusAnnouncementSequence}
       priority="polite"
     />
 

--- a/packages/components/src/test/fixtures/virtual-keyboard-dismissal-fixture.svelte
+++ b/packages/components/src/test/fixtures/virtual-keyboard-dismissal-fixture.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { createVirtualKeyboardDismissal } from '../../components/selection-popover/virtual-keyboard-dismissal.svelte.ts';
+
+  interface Props {
+    enabled?: boolean;
+    onDismiss?: (preventScroll: boolean) => void;
+    onFocusMovedOutside?: () => void;
+  }
+
+  let { enabled = true, onDismiss, onFocusMovedOutside }: Props = $props();
+
+  let panel = $state<HTMLDivElement | null>(null);
+  let composerForm = $state<HTMLDivElement | null>(null);
+
+  createVirtualKeyboardDismissal({
+    enabled: () => enabled,
+    panel: () => panel,
+    composerForm: () => composerForm,
+    // Ownership in this fixture is driven purely by real DOM focus
+    // (composerForm.contains(document.activeElement)) rather than a
+    // separate "composer has a draft" flag — that's the mechanism this
+    // test exercises directly.
+    composerOwnsKeyboard: () => false,
+    isRestoringFocus: () => false,
+    onDismiss: (preventScroll) => onDismiss?.(preventScroll),
+    onFocusMovedOutside: () => onFocusMovedOutside?.(),
+  });
+</script>
+
+<div bind:this={panel} data-testid="panel">
+  <div bind:this={composerForm} data-testid="composer-form">
+    <textarea data-testid="textarea"></textarea>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

Extracts independently-testable modules from the eight oversized component files named in #1179, one commit per file, in the issue's prescribed order (smallest/lowest-risk first). Every extraction is script/logic-level only — no template markup, CSS class, or public API changes. Each component's existing test suite passes unmodified; new unit tests were added only where the issue's Acceptance criteria call for them (previously-untestable logic that becomes directly testable once extracted).

Two files (`schedule-builder.svelte`, `tree-item.svelte`) get the narrower fix the issue prescribes rather than forced full compliance, and four files land honestly over the 500-line cap by design (`kanban-board.svelte`, `schedule-builder.svelte`, `tree-item.svelte`, `tree.svelte`) — each "Do NOT" boundary from the issue (no forced subcomponent splits, no state-shape unification) was followed as written.

## Per-file line-count evidence

Literal `wc -l` output, run from the repository root, before (parent commit) and after (this branch) each file's split:

### 1. `source-diff-viewer.utilities.ts` — split into 4 concern files, no re-export barrel

| File | Before | After |
|---|---|---|
| `source-diff-viewer.utilities.ts` | 898 | 542 |
| `source-diff-viewer.path-normalization.ts` (new) | — | 145 |
| `source-diff-viewer.git-header-parser.ts` (new) | — | 85 |
| `source-diff-viewer.binary-notice.ts` (new) | — | 116 |
| `source-diff-viewer.labels.ts` (new) | — | 34 |

### 2. `table-of-contents.svelte` — heading-registry and active-heading state machines

| File | Before | After |
|---|---|---|
| `table-of-contents.svelte` | 643 | 169 |
| `table-of-contents-heading-registry.svelte.ts` (new) | — | 321 |
| `table-of-contents-active-heading.svelte.ts` (new) | — | 199 |

### 3. `selection-popover.svelte` — virtual-keyboard-dismissal factory

| File | Before | After |
|---|---|---|
| `selection-popover.svelte` | 557 | 313 |
| `virtual-keyboard-dismissal.svelte.ts` (new) | — | 282 |

### 4. `kanban-board.svelte` — hit-testing helpers and column-reorder state

| File | Before | After |
|---|---|---|
| `kanban-board.svelte` | 692 | 536 |
| `kanban-board-helpers.ts` (existing, gained hit-testing helpers) | 210 | 301 |
| `kanban-board-column-reorder.svelte.ts` (new) | — | 149 |

Still ~36 lines over the 500-line cap by design — the issue explicitly rejects extracting a `_kanban-column.svelte` subcomponent (would need ~24 props/snippets/callbacks threaded through a single call site) and rejects chasing the remainder via the card-DnD `setSortableContext` block.

### 5. `schema-form-body.svelte` — path-keyed editing state into `SchemaFormState`

| File | Before | After |
|---|---|---|
| `schema-form-body.svelte` | 725 | 414 |
| `schema-form-state.svelte.ts` (new) | — | 438 |

The six state maps (`errors`, `rawDrafts`, `parsedRawDrafts`, `numericDrafts`, `touchedValidationSequences`, `arrayKeys`) stay as six separate private fields, not unified into one `Record<string, FieldState>`, per the issue's explicit rejection of that redesign.

### 6. `schedule-builder.svelte` — deduplicate the triplicated reseed block

| File | Before | After |
|---|---|---|
| `schedule-builder.svelte` | 821 | 834 |

No new file. `applySeedToFields`/`applyPresetSeedToFields` replace three copies of the same 8-12-line assignment block, but the two new helpers' documentation (explaining why `applyPresetSeedToFields` — not the full helper — is load-bearing in `handleAuthoringModeChange`'s presets branch) adds more lines than the dedup removed. The issue explicitly states its own "~796 lines" figure is a non-binding estimate, not a threshold; the actual fix (eliminating the three-way duplication that risked silent field-by-field desync) is done. The 11 flat `$state` field declarations and the three authoring-mode panels are untouched, per the issue's explicit rejection of both.

### 7. `tree-item.svelte` — rename, drag, async-load, label-highlight

| File | Before | After |
|---|---|---|
| `tree-item.svelte` | 925 | 641 |
| `tree-item-rename.svelte.ts` (new) | — | 192 |
| `tree-item-drag.svelte.ts` (new) | — | 161 |
| `tree-item-async-load.svelte.ts` (new) | — | 76 |
| `tree-item-label-highlight.ts` (new) | — | 32 |

Checkbox-selection reconciliation and `registerWithTree` stay inline, per the issue's explicit rejection — both depend on same-file, same-tick ordering guarantees documented in the component's own comments.

### 8. `tree.svelte` — filter state and drag autoscroll

| File | Before | After |
|---|---|---|
| `tree.svelte` | 1402 | 1293 |
| `_internal/tree-filter.svelte.ts` (new) | — | 110 |
| `_internal/tree-autoscroll.svelte.ts` (new) | — | 105 |

Typeahead dispatch stays inline (moving it would leak virtualization internals into the filter controller). Both render paths (DOM-registry and virtualized) are untouched.

## Deviations from the issue's illustrative constructor sketches

Every extraction follows the issue's prescribed module boundary and "Do NOT" list exactly. A few constructor option objects needed one or two additional getters beyond the issue's illustrative sketch to preserve behavior exactly — each is called out in its commit message:

- `SchemaFormState` takes `getSubmitting()` and `onDraftChange` (beyond the sketch's two-arg factory) — several moved methods guard on the component-owned `submitting` flag and report through the component-owned `onDraftChange` prop; proven necessary by `schema-form-async.fixture.ts`'s "freezes edits until it resolves" test.
- `TreeItemRenameController` takes `getDisabled()` and `getElementId()` — `canRename` gates F2/double-click/Enter entry into edit mode, and `tree/tree-rename.test.ts`'s "disabled items do not enter edit mode" case depends on that gate surviving the move.
- `TreeItemDragHandlers` takes `getLabel()` — needed for `dragHandleLabel` (`Reorder ${label}`).
- `TreeFilterController.scheduleStatusAnnouncement(resultCount)` takes an explicit parameter rather than reading a `getVisibleCount()` getter, so the `$effect` watching `visibleIds.length` stays owned by `tree.svelte`.

## New unit tests (per Acceptance criteria)

- `table-of-contents-heading-registry.test.ts`, `table-of-contents-active-heading.test.ts`
- `virtual-keyboard-dismissal.test.ts`
- `tree-item-rename.test.ts`
- `tree-autoscroll.test.ts`, `tree-filter.test.ts`

Files 1, 4, 5, 6 are pure code-motion/mechanical dedup with no new testable seam, per the issue — no new tests required there.

## Validation

Per file: `bun run test <component>`, `bun run typecheck`, `bun run lint`, `bun run check:primitive-composition`, `bun run components:check`. Once at the end, from `packages/components`: `bun run lint:invariants` (including the component-graph/unmodellable-imports guard — every new module uses static imports only, confirmed via `component-graph.test.ts`, 68/68 pass) and the full package `bun run test` — **10037 pass, 1 skip, 0 fail, 23300 expect() calls, 424 files** (exit code 0). The 1 skip is a pre-existing `describe.skipIf` guard unrelated to this branch.

Markup safety: diffed the template section (everything after the last `</script>` tag) of every touched `.svelte` file against its pre-extraction version. Every diff is an expression-level substitution (reading from a new controller object instead of a local variable) except one explicitly-issue-prescribed change: `kanban-board.svelte`'s two byte-identical placeholder `<li>` blocks deduped into a `{#snippet dropPlaceholder()}`, which renders identical markup. No CSS class, attribute, or element-structure changes anywhere — Playwright's pinned `.cinder-*` selectors (`focus-family-rings`, `selection-popover-positioning`, `schema-form`, `sortable-list-layout`, `tree-checkbox-selection`, `tree-dnd`, `tree-virtualized`) are unaffected.

## Out of scope, correctly not fixed here

A pre-existing, unrelated Svelte compiler warning surfaces during `schema-form.test.ts` and `schedule-builder.test.ts` runs: `_internal/form-field-provider.svelte:14:22` — `state_referenced_locally` on a `context` reference. Confirmed via `git log`/`git diff` that this file is untouched by this branch (last touched by an unrelated commit, PR #1120). Per the issue's "Out of scope" instruction, this is flagged here rather than fixed in these PRs.

Closes #1179
