### PR TITLE
test(mega-menu): stop racing the ancestor-mutation restamp test against its own rAF contract

### DIFF
--- a/packages/components/src/components/mega-menu/mega-menu.test.ts
+++ b/packages/components/src/components/mega-menu/mega-menu.test.ts
@@ -631,7 +631,19 @@ describe('MegaMenu', () => {
     if (!nav || !ancestor) throw new Error('Missing menu ancestor.');
     expect(nav.getAttribute('dir')).toBe('rtl');
     ancestor.setAttribute('dir', 'ltr');
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // observeTextDirection's MutationObserver delivers records through
+    // happy-dom's own `window.setTimeout(fn)` (a macrotask, not a spec
+    // microtask — see MutationObserverListener#report), and the
+    // direction-chain effect now coalesces its directionRevision bump onto
+    // requestAnimationFrame (#1186 row 4a). A bare `setTimeout(resolve, N)`
+    // races the MutationObserver's own timer instead of waiting for it: under
+    // load, both timers can become due in the same timers-phase pass, and a
+    // `requestAnimationFrame` callback registered mid-pass can't run until
+    // that pass finishes — letting this assertion fire before the restamp
+    // lands (#1204). Wait for both real hops of the scheduling contract
+    // instead of guessing a wall-clock delay.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
     expect(nav.getAttribute('dir')).toBe('ltr');
   });
 


### PR DESCRIPTION
## Summary

Root-causes the recurring red on `main`: `MegaMenu > restamps inherited direction after an ancestor mutation` (main-green run [31018506505](https://github.com/stevekinney/cinder/actions/runs/31018506505), `component-tests (1/4)`; filed as #1204).

**Winning hypothesis: (A) test-timing.** The component's restamp still happens every time — the test just wasn't awaiting the real scheduling contract the component now uses.

## Discrimination: how A won over B

Two live hypotheses going in:
- **(A)** test-timing — the restamp still happens, just inside a coalesced rAF frame the test doesn't await.
- **(B)** real race — #1202's coalescing drops a restamp under some ordering/load.

**Proof A, not B:**

1. **Reproduced the failure against the unmodified component** (no source changes) under CPU contention — a foreground `bun test` loop racing against 12–16 parallel busy-loops mimicking chunk-parallelism/noisy-neighbor scheduling jitter. Unmodified `main`: **6/20 failures**, always with `Received: "rtl"` (the pre-mutation value) — the assertion firing *before* the restamp landed, never a case of the restamp never landing.
2. **Traced the exact race.** `observeTextDirection`'s `MutationObserver` is delivered through happy-dom's own `window.setTimeout(fn)` (`MutationObserverListener#report` — a macrotask, *not* a spec microtask), and #1202 now coalesces the resulting `directionRevision` bump onto `requestAnimationFrame` (`scheduleIndicatorRecompute`). The test waited on a bare `setTimeout(resolve, 10)`. Under a stalled event loop, both timers (the MutationObserver's and the test's) can become simultaneously due in the same Node `timers` phase pass; a `requestAnimationFrame`/`setImmediate` callback registered mid-pass can't run until that pass finishes and the loop reaches `check` — so the test's timer (and its assertion) can fire first even though it was scheduled *after* the MutationObserver's.
3. **Fixed the test to await the two real hops** (`setTimeout(resolve, 0)` to clear the MutationObserver's own macrotask, then an actual `requestAnimationFrame` to clear the coalesced frame) and reran the same contention harness: **0 failures across 280+ runs** (160 on the fixed test alone at increasing contention, 120 more at higher intensity, plus 40 full-file runs covering all 36 tests in the file, including the sibling media-query-driven direction test — checked independently under its own 200-run contention pass since it shares the same coalescing mechanism but turned out *not* to race, because its trigger fires synchronously rather than through a second deferred timer).
4. **Corroborated against the actual CI failure log**: the failing run shows the test taking 251ms (vs. its normal few-ms baseline) — consistent with a stalled event loop, not a deterministic drop.
5. **Ruled out B on the merits, not just by elimination**: `scheduleIndicatorRecompute` clears `pendingIndicatorFrame` *before* running the frame body (a trigger arriving mid-callback reschedules rather than being swallowed), and `directionRevision` is a cache-buster read fresh by `resolvedDirection`'s `$derived.by` — not an accumulated delta — so N coalesced triggers still resolve to the same final DOM state. The coalescing is structurally incapable of dropping a restamp.

## Fix

Test-only. `restamps inherited direction after an ancestor mutation` now awaits `setTimeout(resolve, 0)` (letting happy-dom's MutationObserver macrotask deliver) followed by an actual `requestAnimationFrame` (letting the coalesced recompute run) before asserting — matching the pattern the sibling `re-resolves responsive CSS direction after resize` test already used for the `resize`-triggered path.

No component code changed. No changeset (test-only).

## Test plan

- [x] Reproduced red under CPU contention against unmodified `main` (6/20 failures, `Received: "rtl"`)
- [x] Fix green under the same contention harness (0/280+ across two contention passes + a full-file pass)
- [x] `mega-menu.test.ts` + `text-direction.test.ts` (174 tests) — pass
- [x] `dropdown-menu`, `slider`, `context-menu`, `menu-bar` (other `observeTextDirection` consumers, 133 tests) — pass
- [x] `bun run typecheck` (`tsc --noEmit` + `svelte-check`) — 0 errors
- [x] `oxlint --type-aware` on the changed file — 0 warnings/errors
- [x] `prettier --check` — pass
- [x] `bun run lint:invariants` — all 13 gates pass

Closes #1204