### PR TITLE
test(popover,menu-bar): await the async floating-ui pass instead of a single tick

### DIFF
--- a/packages/components/src/components/menu-bar/menu-bar.test.ts
+++ b/packages/components/src/components/menu-bar/menu-bar.test.ts
@@ -27,7 +27,7 @@ mock.module('@floating-ui/dom', () => ({
   shift: (options: unknown) => ({ name: 'shift', options, fn: () => ({}) }),
 }));
 
-const { cleanup, fireEvent, render } = await import('@testing-library/svelte');
+const { cleanup, fireEvent, render, waitFor } = await import('@testing-library/svelte');
 const { prepareServerRenderSource, renderToServerHtml } =
   await import('../../test/server-render.ts');
 const { tick } = await import('svelte');
@@ -266,13 +266,18 @@ describe('MenuBar', () => {
 
     const submenuTrigger = getByRole('menuitem', { name: 'Open Recent' });
     await fireEvent.keyDown(submenuTrigger, { key: 'ArrowLeft' });
-    await tick();
 
-    const submenuCall = computePositionSpy.mock.calls.find((call) => {
-      const options = call.at(2) as { placement?: string } | undefined;
-      return options?.placement === 'left-start';
+    // `computePosition` is awaited inside the anchored-overlay effect, so the call
+    // does not land within a single `tick()`. Poll for it rather than sampling once.
+    // This does not weaken the assertion: a genuinely broken RTL placement never
+    // produces a `left-start` call, so `waitFor` would time out and still fail.
+    await waitFor(() => {
+      const submenuCall = computePositionSpy.mock.calls.find((call) => {
+        const options = call.at(2) as { placement?: string } | undefined;
+        return options?.placement === 'left-start';
+      });
+      expect(submenuCall).toBeDefined();
     });
-    expect(submenuCall).toBeDefined();
     expect(getByRole('menu', { name: 'Open Recent' }).getAttribute('dir')).toBe('rtl');
   });
 

--- a/packages/components/src/components/popover/popover.test.ts
+++ b/packages/components/src/components/popover/popover.test.ts
@@ -953,7 +953,12 @@ describe('Popover — floating-ui wiring', () => {
         children: textSnippet('content'),
       },
     });
-    await tick();
+    // Wait for positioning to actually RUN before asserting the middleware was not
+    // added. Asserting after a bare `tick()` passed for the wrong reason: nothing had
+    // been computed yet, so the negative held vacuously and the test could not fail.
+    await waitFor(() => {
+      expect(computePositionSpy).toHaveBeenCalled();
+    });
     expect(arrowSpy).not.toHaveBeenCalled();
   });
 
@@ -966,8 +971,15 @@ describe('Popover — floating-ui wiring', () => {
         children: textSnippet('content'),
       },
     });
-    await tick();
-    expect(arrowSpy).toHaveBeenCalled();
+    // The arrow element is `bind:this` on a span inside `{#if arrowVisible}`, so it
+    // is still undefined on the first positioning pass — `anchored-overlay` only
+    // pushes the arrow middleware once BOTH `arrowVisible` and the bound element are
+    // truthy, which happens on the re-run triggered by that binding. A single
+    // `tick()` samples one microtask too early and lands before the re-run. Await the
+    // real contract instead, the same way the offset-middleware tests above do.
+    await waitFor(() => {
+      expect(arrowSpy).toHaveBeenCalled();
+    });
   });
 
   test('autoUpdate teardown invoked on close', async () => {


### PR DESCRIPTION
`main` is red. Two tests fail deterministically — individually, in isolation, and on a pristine checkout of current `main` (638579f5):

- `Popover — floating-ui wiring > arrow middleware IS called when arrowVisible=true`
- `MenuBar > right-to-left submenus fall back to the inline-start side`

Both are test-timing bugs, not product bugs.

## Root cause

Both assert on floating-ui positioning after `await tick()` — a single microtask. `computePosition` is `await`ed inside the `anchored-overlay` effect, so the call has not landed yet when the assertion samples the spy.

**Popover** has a second layer: `arrowElement` is `bind:this` on a span inside `{#if arrowVisible}`, so it is still `undefined` on the first positioning pass. `anchored-overlay.svelte.ts:213` pushes the arrow middleware only when **both** `arrowVisible` and the bound element are truthy — which happens on the re-run that binding triggers. `tick()` lands before that re-run.

The sibling offset-middleware tests in the same file already use `waitFor`; these now match that idiom.

## Also fixed: a test that could never fail

`arrow middleware is NOT called when arrowVisible=false` asserted the middleware had not been called after a bare `tick()` — when nothing had been computed yet. The negative held vacuously, so the test was passing for the wrong reason and could not have caught a regression. It now waits for positioning to actually run before asserting.

## This does not weaken the assertions

Verified by mutation: forcing `submenuPlacement` (`menu-bar.svelte:333`) to always return `'right-start'` makes the RTL test fail through the `waitFor` timeout. A genuinely broken placement is still caught — `waitFor` waits for the real contract, it does not accept a wrong one.

No timeouts, retries, or polling caps were raised.

## Verification

`bun run test src/components/popover src/components/menu-bar` → 80 pass, 0 fail (was 78/2).

Split out of #1208 so the token-palette change can be reviewed against a green baseline.
