### PR TITLE
fix(playground): stop the docs harness misreporting broken previews

### DIFF
--- a/.changeset/tidy-pugs-invite.md
+++ b/.changeset/tidy-pugs-invite.md
@@ -1,0 +1,10 @@
+---
+'@lostgradient/markdown': minor
+---
+
+Render GitHub alert blockquotes (`> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`, `[!CAUTION]`) as Cinder Callout markup, and stop emitting a phantom blank line under every highlighted code fence.
+
+- New `remarkGithubCallouts` plugin, registered after `remark-gfm` in both the sync and math-aware pipelines. GitHub alerts are a GitHub extension rather than part of GFM, so `remark-gfm` left the marker in the output as literal text. Blockquotes that open with a marker now become `<div role="note" data-cinder-variant="…" class="cinder-callout …">`, which picks up `callout.css` from `@lostgradient/cinder`. Text after the marker on the same line becomes the callout title; without it, the alert type supplies the title. Blockquotes with no marker are untouched.
+- The sanitize schema now allows `role` (value-restricted to `note`), `data-cinder-variant` (restricted to the four Cinder variants), and `aria-label` on `div`. The schema's `'*': ['className']` entry replaces `hast-util-sanitize`'s default wildcard allowlist, so without this the callout attributes were silently stripped. Scoped to `div` with value allowlists rather than widened globally, so no document can put an arbitrary `role` on an arbitrary element.
+- `rehype-shiki-sync` now strips the single trailing newline `mdast-util-to-hast` appends to every fence before handing the code to Shiki. Shiki was treating it as the start of another line and emitting a trailing empty `<span class="line">`. Exactly one newline is removed, so fences that deliberately end in blank lines keep them.
+- `renderMarkdown` / `renderMarkdownWithMath` now run the processor's mdast transformers (`runSync`) in addition to parsing. Previously only `parse()` ran, which was invisible while every registered remark plugin contributed micromark extensions only.

--- a/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.test.ts
@@ -429,6 +429,54 @@ describe('rehype-shiki-sync', () => {
       expect(pre.properties?.style).toBeDefined();
     });
 
+    it('emits no phantom empty trailing line span', () => {
+      // `mdast-util-to-hast` appends a trailing "\n" to every fence's text.
+      // Passed to Shiki verbatim, that newline starts one more line and yields
+      // a final `<span class="line"></span>` with no content — a stray blank
+      // row under every code block.
+      const tree = createCodeBlockTree('const x = 1;\nconst y = 2;\n', 'javascript');
+      rehypeShikiSync()(tree);
+
+      const pre = tree.children[0] as Element;
+      const code = pre.children.find(
+        (child): child is Element => child.type === 'element' && child.tagName === 'code',
+      );
+      const lines = (code?.children ?? []).filter(
+        (child): child is Element =>
+          child.type === 'element' &&
+          Array.isArray(child.properties?.className) &&
+          child.properties.className.includes('line'),
+      );
+
+      expect(lines).toHaveLength(2);
+      expect(collectAllText(lines[0]!)).toBe('const x = 1;');
+      expect(collectAllText(lines[1]!)).toBe('const y = 2;');
+      expect(lines.some((line) => collectAllText(line) === '')).toBe(false);
+    });
+
+    it('strips exactly one trailing newline, preserving deliberate blank lines', () => {
+      // Only the serializer's own artifact goes. A fence is whitespace
+      // significant, so `.trimEnd()` here would silently delete content the
+      // author meant to keep.
+      const tree = createCodeBlockTree('const x = 1;\n\n\n', 'javascript');
+      rehypeShikiSync()(tree);
+
+      const pre = tree.children[0] as Element;
+      const code = pre.children.find(
+        (child): child is Element => child.type === 'element' && child.tagName === 'code',
+      );
+      const lines = (code?.children ?? []).filter(
+        (child): child is Element =>
+          child.type === 'element' &&
+          Array.isArray(child.properties?.className) &&
+          child.properties.className.includes('line'),
+      );
+
+      // "const x = 1;" plus the two blank lines the author wrote.
+      expect(lines).toHaveLength(3);
+      expect(collectAllText(lines[0]!)).toBe('const x = 1;');
+    });
+
     it('adds dataLanguage attribute', () => {
       const tree = createCodeBlockTree('const x = 1;', 'typescript');
       rehypeShikiSync()(tree);

--- a/packages/markdown/src/rendering/rehype-shiki-sync.ts
+++ b/packages/markdown/src/rendering/rehype-shiki-sync.ts
@@ -376,7 +376,18 @@ export function rehypeShikiSync(options: RehypeShikiSyncOptions = {}) {
       // Extract language and code
       const rawLanguage = extractLanguage(codeChild);
       const language = rawLanguage ? normalizeLanguage(rawLanguage) : defaultLanguage;
-      const code = extractText(codeChild);
+      // `mdast-util-to-hast` terminates every fence's text node with a
+      // trailing "\n" (it is what makes the serialized `<pre>` end on its own
+      // line). Shiki treats that newline as starting one more line and emits a
+      // phantom `<span class="line"></span>` at the end of every block, which
+      // renders as a stray blank row.
+      //
+      // Exactly one newline, via an anchored replace — NOT `.trimEnd()`. A
+      // fence is whitespace-significant (think a `diff` fence, or a snippet
+      // that deliberately ends in blank lines), and `trimEnd()` would eat all
+      // of that meaningful trailing whitespace, not just the serializer's
+      // artifact.
+      const code = extractText(codeChild).replace(/\n$/, '');
 
       // Skip empty code blocks
       if (!code.trim()) return;

--- a/packages/markdown/src/rendering/remark-github-callouts.test.ts
+++ b/packages/markdown/src/rendering/remark-github-callouts.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for the GitHub-alert → Cinder Callout rewrite.
+ *
+ * These deliberately go through `renderMarkdown` / `renderMarkdownWithMath`
+ * rather than driving the plugin in isolation. Two failure modes only show up
+ * end-to-end:
+ *
+ *   1. The plugin is registered on a processor whose `.parse()` never runs
+ *      transformers, so it is wired up but never called.
+ *   2. The markup is produced correctly and then quietly dismantled by
+ *      `rehype-sanitize`, whose `'*': ['className']` entry REPLACES the
+ *      default wildcard allowlist. A stripped `data-cinder-variant` renders an
+ *      un-themed callout, which looks exactly like the plugin not matching.
+ */
+
+import { describe, expect, it } from 'bun:test';
+import type { Element, Root } from 'hast';
+import { sanitize } from 'hast-util-sanitize';
+
+import { clearRenderCache, renderMarkdown, renderMarkdownWithMath } from './render.js';
+import { createSanitizeSchema } from './sanitize-schema.js';
+
+describe('GitHub callouts through the full render pipeline', () => {
+  it('survives sanitization with its variant, role, and label intact', () => {
+    clearRenderCache();
+    const { html } = renderMarkdown('> [!WARNING]\n> Do not do this.');
+
+    // The attribute this test exists for. `data-cinder-variant` is what
+    // selects the color treatment in callout.css; without the sanitizer
+    // widening it is dropped and the callout renders un-themed.
+    expect(html).toContain('data-cinder-variant="warning"');
+    expect(html).toContain('role="note"');
+    expect(html).toContain('aria-label="Warning"');
+    expect(html).toContain('class="cinder-callout');
+    expect(html).toContain('cinder-callout__title');
+    expect(html).toContain('cinder-callout__content');
+    expect(html).toContain('Do not do this.');
+
+    // The marker itself must be gone — leaking it is the bug being fixed.
+    expect(html).not.toContain('[!WARNING]');
+  });
+
+  it('maps all five GitHub alert types onto Cinder variants', () => {
+    const cases: ReadonlyArray<[string, string, string]> = [
+      ['NOTE', 'info', 'Note'],
+      ['TIP', 'success', 'Tip'],
+      ['IMPORTANT', 'info', 'Important'],
+      ['WARNING', 'warning', 'Warning'],
+      ['CAUTION', 'danger', 'Caution'],
+    ];
+
+    for (const [marker, variant, title] of cases) {
+      clearRenderCache();
+      const { html } = renderMarkdown(`> [!${marker}]\n> Body text.`);
+      expect(html).toContain(`data-cinder-variant="${variant}"`);
+      expect(html).toContain(`<p class="cinder-callout__title">${title}</p>`);
+      expect(html).not.toContain(`[!${marker}]`);
+    }
+  });
+
+  it('accepts the lowercase spelling GitHub also accepts', () => {
+    clearRenderCache();
+    const { html } = renderMarkdown('> [!caution]\n> Careful.');
+    expect(html).toContain('data-cinder-variant="danger"');
+  });
+
+  it('uses same-line trailing text as the callout title', () => {
+    clearRenderCache();
+    const { html } = renderMarkdown(
+      '> [!IMPORTANT] Chat needs a definite-height ancestor\n> Body.',
+    );
+    expect(html).toContain(
+      '<p class="cinder-callout__title">Chat needs a definite-height ancestor</p>',
+    );
+    expect(html).toContain('aria-label="Chat needs a definite-height ancestor"');
+    expect(html).toContain('data-cinder-variant="info"');
+  });
+
+  it('falls back to the default title when the rest of the line is inline markup', () => {
+    // `\`someApi\`` parses into a separate inlineCode node, so the marker's own
+    // text run ends right after the bracket. The styled remainder belongs to
+    // the body rather than being flattened into a plain-text title.
+    clearRenderCache();
+    const { html } = renderMarkdown('> [!WARNING] `subscribe` runs inside an effect\n> Body.');
+    expect(html).toContain('<p class="cinder-callout__title">Warning</p>');
+    expect(html).toContain('<code>subscribe</code>');
+  });
+
+  it('leaves ordinary blockquotes alone', () => {
+    clearRenderCache();
+    const { html } = renderMarkdown('> Just a quotation.');
+    expect(html).toContain('<blockquote>');
+    expect(html).not.toContain('cinder-callout');
+  });
+
+  it('does not promote a marker that appears mid-sentence', () => {
+    clearRenderCache();
+    const { html } = renderMarkdown('> See the [!NOTE] convention below.');
+    expect(html).toContain('<blockquote>');
+    expect(html).not.toContain('cinder-callout');
+  });
+
+  it('runs on the math-aware pipeline too', async () => {
+    // Both processors have to carry the plugin; the math pipeline is a
+    // separate `unified()` chain that is easy to forget.
+    clearRenderCache();
+    const { html } = await renderMarkdownWithMath('> [!TIP]\n> Inline math $x = 1$ here.');
+    expect(html).toContain('data-cinder-variant="success"');
+    expect(html).toContain('katex');
+  });
+});
+
+describe('sanitize schema: div attribute allowlist', () => {
+  /** Sanitize a single-element hast tree and return the surviving properties. */
+  function sanitizeProperties(properties: Element['properties']): Element['properties'] {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'element', tagName: 'div', properties, children: [] }],
+    };
+    const cleaned = sanitize(tree, createSanitizeSchema()) as Root;
+    const element = cleaned.children[0];
+    return element?.type === 'element' ? element.properties : undefined;
+  }
+
+  it('keeps the callout attributes', () => {
+    const properties = sanitizeProperties({
+      className: ['cinder-callout'],
+      dataCinderVariant: 'warning',
+      role: 'note',
+      ariaLabel: 'Warning',
+    });
+
+    expect(properties?.['dataCinderVariant']).toBe('warning');
+    expect(properties?.['role']).toBe('note');
+    expect(properties?.['ariaLabel']).toBe('Warning');
+  });
+
+  it('drops a role other than note, so div cannot claim an arbitrary role', () => {
+    // The reason `role` is scoped to `div` with a value allowlist rather than
+    // added to the `'*'` entry: a global `role` would let any document spoof
+    // any element's semantics.
+    expect(sanitizeProperties({ role: 'button' })?.['role']).toBeUndefined();
+    expect(sanitizeProperties({ role: 'alert' })?.['role']).toBeUndefined();
+  });
+
+  it('drops a variant outside the four Cinder ships', () => {
+    expect(
+      sanitizeProperties({ dataCinderVariant: 'evil' })?.['dataCinderVariant'],
+    ).toBeUndefined();
+  });
+
+  it('does not grant role to other elements', () => {
+    const tree: Root = {
+      type: 'root',
+      children: [{ type: 'element', tagName: 'p', properties: { role: 'note' }, children: [] }],
+    };
+    const cleaned = sanitize(tree, createSanitizeSchema()) as Root;
+    const element = cleaned.children[0];
+    expect(element?.type === 'element' ? element.properties['role'] : undefined).toBeUndefined();
+  });
+});

--- a/packages/markdown/src/rendering/remark-github-callouts.ts
+++ b/packages/markdown/src/rendering/remark-github-callouts.ts
@@ -1,0 +1,195 @@
+/**
+ * Remark plugin: GitHub alert syntax → Cinder Callout markup.
+ *
+ * GitHub renders
+ *
+ * ```md
+ * > [!WARNING]
+ * > This API is deprecated.
+ * ```
+ *
+ * as a colored admonition. That syntax is a GitHub extension, not GFM —
+ * `remark-gfm` does not implement it — so without this plugin the marker
+ * survives as literal text and the reader sees a plain blockquote whose first
+ * line is a stray `[!WARNING]`.
+ *
+ * The rewrite targets Cinder's `<Callout>` markup (see
+ * `packages/components/src/components/callout/callout.svelte`) so the result
+ * picks up `callout.css` and re-themes with the rest of the design system,
+ * rather than needing a parallel set of styles.
+ *
+ * Two deliberate narrowings versus the Svelte component:
+ *
+ *   - The `semantic: 'note'` form (`<div role="note">`) is emitted rather than
+ *     the default `<aside>`. `div` is already in the sanitizer's tag
+ *     allowlist; `aside` would have to be added, and an `<aside>` at
+ *     top level is a `complementary` landmark, which is a heavier promise than
+ *     an inline admonition should make.
+ *   - The icon channel is skipped. Icons mean inline `<svg>`, and allowing
+ *     `<svg>` through the sanitizer widens the XSS surface substantially for
+ *     a purely decorative gain — the visible title already carries the
+ *     meaning, and the component marks the icon `aria-hidden` anyway.
+ *
+ * Emitted markup is produced through mdast `data.hName` / `data.hProperties`
+ * (which `mdast-util-to-hast` applies during the remark→rehype step) rather
+ * than raw `html` nodes, because `render.ts` strips every `html` node before
+ * conversion as an injection guard — a raw-HTML implementation would be
+ * silently deleted.
+ *
+ * @module
+ */
+
+import type { Blockquote, Paragraph, PhrasingContent, Root, Text } from 'mdast';
+import type { Plugin } from 'unified';
+import { SKIP, visit } from 'unist-util-visit';
+
+/** Cinder Callout variants reachable from GitHub's five alert types. */
+type CalloutVariant = 'info' | 'success' | 'warning' | 'danger';
+
+type AlertKind = {
+  /** `data-cinder-variant` value, which selects the color treatment. */
+  variant: CalloutVariant;
+  /** Visible title. Also becomes the root's accessible name. */
+  title: string;
+};
+
+/**
+ * Default titles, keyed by GitHub alert type.
+ *
+ * NOTE and IMPORTANT both land on the `info` variant — Cinder has no separate
+ * "elevated neutral" — so the title is what keeps them distinguishable.
+ */
+const DEFAULT_TITLES: Readonly<Record<string, string>> = {
+  NOTE: 'Note',
+  TIP: 'Tip',
+  IMPORTANT: 'Important',
+  WARNING: 'Warning',
+  CAUTION: 'Caution',
+};
+
+/** GitHub's five alert types, mapped onto Cinder's four variants. */
+const VARIANTS: Readonly<Record<string, CalloutVariant>> = {
+  NOTE: 'info',
+  TIP: 'success',
+  IMPORTANT: 'info',
+  WARNING: 'warning',
+  CAUTION: 'danger',
+};
+
+/**
+ * The marker opens the blockquote's first line. Anything else on that line is
+ * captured as a custom title.
+ *
+ * The custom-title capture is a deliberate superset of GitHub, which requires
+ * the marker to sit alone and renders `> [!NOTE] Heads up` as a literal
+ * blockquote. Cinder's Callout takes a `title` prop, so the trailing text has
+ * an obvious home, and the repo's own docs already write alerts this way (see
+ * `packages/chat/src/lib/components/chat/README.md`). Anchoring to the start
+ * of the line still keeps prose that merely mentions `[!NOTE]` mid-sentence
+ * from being promoted.
+ *
+ * Only a plain-text title is picked up. If the rest of the line carries inline
+ * markup (`[!WARNING] \`someApi\` is deprecated`), markdown has already split
+ * it into separate inline nodes, so the marker consumes just its own text run
+ * and the styled remainder stays in the body under the default title.
+ *
+ * Case-insensitive, matching GitHub's acceptance of `[!note]`.
+ */
+const MARKER = /^\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][^\S\r\n]*([^\r\n]*)(?:\r?\n|$)/i;
+
+/** Class list mirroring callout.svelte's root element. */
+const ROOT_CLASSES = [
+  'cinder-callout',
+  'cinder-_status-surface',
+  'cinder-_status-surface-border',
+  'cinder-_status-surface-stripe',
+];
+
+/**
+ * Read the alert marker off a blockquote, consuming it from the tree.
+ *
+ * Returns `null` — leaving the node untouched — unless the blockquote opens
+ * with a paragraph whose first text run is exactly a marker line.
+ */
+function takeMarker(blockquote: Blockquote): AlertKind | null {
+  const firstChild = blockquote.children[0];
+  if (firstChild?.type !== 'paragraph') return null;
+
+  const firstInline = firstChild.children[0];
+  // Only a literal text run can carry the marker. If markdown parsed the
+  // brackets into something else (a link reference resolved by a matching
+  // definition, say), the author wrote a link, not an alert.
+  if (firstInline?.type !== 'text') return null;
+
+  const match = MARKER.exec(firstInline.value);
+  if (!match) return null;
+
+  const type = (match[1] ?? '').toUpperCase();
+  const variant = VARIANTS[type];
+  const defaultTitle = DEFAULT_TITLES[type];
+  if (!variant || !defaultTitle) return null;
+
+  // Consume the marker line. Everything after it on the same paragraph is
+  // real content and stays.
+  const remainder = firstInline.value.slice(match[0].length);
+  if (remainder === '') {
+    firstChild.children.shift();
+    // `> [!NOTE]` with the body on following blocks leaves an empty paragraph
+    // behind; drop it so the callout does not open with a blank line.
+    if (firstChild.children.length === 0) blockquote.children.shift();
+  } else {
+    firstInline.value = remainder;
+  }
+
+  const customTitle = (match[2] ?? '').trim();
+  return { variant, title: customTitle === '' ? defaultTitle : customTitle };
+}
+
+/** Build the `<p class="cinder-callout__title">` node. */
+function titleParagraph(title: string): Paragraph {
+  const text: Text = { type: 'text', value: title };
+  return {
+    type: 'paragraph',
+    children: [text satisfies PhrasingContent],
+    data: { hProperties: { className: ['cinder-callout__title'] } },
+  };
+}
+
+/**
+ * Rewrite GitHub alert blockquotes into Cinder Callout markup.
+ *
+ * Registered immediately after `remarkGfm` in `render.ts` so it sees the same
+ * mdast GFM produces.
+ */
+export const remarkGithubCallouts: Plugin<[], Root> = () => {
+  return (tree: Root): undefined => {
+    visit(tree, 'blockquote', (node: Blockquote) => {
+      const kind = takeMarker(node);
+      if (!kind) return;
+
+      // The content wrapper. Modeled as a blockquote (a block container, so
+      // the mdast types stay honest about its children) that renders as a
+      // plain `div` via `hName`.
+      const content: Blockquote = {
+        type: 'blockquote',
+        children: node.children,
+        data: { hName: 'div', hProperties: { className: ['cinder-callout__content'] } },
+      };
+
+      node.children = [titleParagraph(kind.title), content];
+      node.data = {
+        hName: 'div',
+        hProperties: {
+          className: ROOT_CLASSES,
+          dataCinderVariant: kind.variant,
+          role: 'note',
+          ariaLabel: kind.title,
+        },
+      };
+
+      // Do not descend. The subtree we just built contains a blockquote of our
+      // own making, and GitHub does not nest alerts either.
+      return SKIP;
+    });
+  };
+};

--- a/packages/markdown/src/rendering/render.ts
+++ b/packages/markdown/src/rendering/render.ts
@@ -53,6 +53,7 @@ import { visit } from 'unist-util-visit';
 import { extractCodeBlocks } from './extract-code-blocks.js';
 import { getHighlighterSync } from './highlighter.js';
 import { rehypeShikiSync } from './rehype-shiki-sync.js';
+import { remarkGithubCallouts } from './remark-github-callouts.js';
 import { createSanitizeSchema } from './sanitize-schema.js';
 import { transformUrls } from './transform-urls.js';
 import type { RenderOptions, RenderResult } from './types.js';
@@ -68,7 +69,8 @@ import type { RenderOptions, RenderResult } from './types.js';
  */
 let baseProcessor: unknown = null;
 function getBaseProcessor(): Processor {
-  if (!baseProcessor) baseProcessor = unified().use(remarkParse).use(remarkGfm);
+  if (!baseProcessor)
+    baseProcessor = unified().use(remarkParse).use(remarkGfm).use(remarkGithubCallouts);
   // eslint-disable-next-line no-unsafe-type-assertion -- unified's `.use()` returns a narrowly-parameterised `Processor<...>` that doesn't structurally extend the zero-arg `Processor`; see the `baseProcessor` doc comment above.
   return baseProcessor as Processor;
 }
@@ -124,7 +126,11 @@ async function ensureMathPipeline(): Promise<{
   }
   const { remarkMath, rehypeKatex } = await mathPluginsPromise;
   if (!mathProcessor) {
-    mathProcessor = unified().use(remarkParse).use(remarkGfm).use(remarkMath);
+    mathProcessor = unified()
+      .use(remarkParse)
+      .use(remarkGfm)
+      .use(remarkGithubCallouts)
+      .use(remarkMath);
   }
   // eslint-disable-next-line no-unsafe-type-assertion -- same Processor variance constraint as getBaseProcessor; see the `baseProcessor` doc comment above.
   return { processor: mathProcessor as Processor, rehypeKatex };
@@ -155,6 +161,25 @@ export function __setMathPluginLoaderForTests(loader: MathPluginLoader): () => v
     mathPluginsPromise = null;
     mathProcessor = null;
   };
+}
+
+/**
+ * Parse markdown AND run the processor's mdast transformers.
+ *
+ * `processor.parse()` alone runs only the parser — unified never invokes
+ * transformers during `parse`, they belong to the `run` phase. Both entry
+ * points used to call bare `parse()`, which was harmless while every remark
+ * plugin in these pipelines (`remark-gfm`, `remark-math`) contributed nothing
+ * but micromark extensions. `remarkGithubCallouts` is a real transformer, so
+ * the `run` phase has to happen or the plugin is registered-but-never-called —
+ * a failure mode that looks exactly like the plugin not matching.
+ *
+ * `runSync` is safe here: these processors hold only synchronous transformers,
+ * and none of them is a compiler, so no stringification is triggered.
+ */
+function parseMarkdown(processor: Processor, markdown: string): MdastRoot {
+  // eslint-disable-next-line no-unsafe-type-assertion -- unified's `parse()`/`runSync()` are typed against the broad unist `Node`; a remark-parse processor always yields an mdast `Root`.
+  return processor.runSync(processor.parse(markdown)) as MdastRoot;
 }
 
 /**
@@ -468,8 +493,7 @@ export function renderMarkdown(markdown: string, options: RenderOptions = {}): R
   }
 
   // Parse markdown to mdast (no math).
-  // eslint-disable-next-line no-unsafe-type-assertion -- unified's `parse()` is typed as the broad unist `Node`; a remark-parse processor always yields an mdast `Root`.
-  const mdast = getBaseProcessor().parse(markdown) as MdastRoot;
+  const mdast = parseMarkdown(getBaseProcessor(), markdown);
   const result = renderFromMdast(markdown, options, mdast, null);
 
   // Add to cache (with LRU eviction)
@@ -545,8 +569,7 @@ export async function renderMarkdownWithMath(
     return cloneResult(cached);
   }
 
-  // eslint-disable-next-line no-unsafe-type-assertion -- unified's `parse()` is typed as the broad unist `Node`; a remark-parse processor always yields an mdast `Root`.
-  const mdast = processor.parse(markdown) as MdastRoot;
+  const mdast = parseMarkdown(processor, markdown);
   const result = renderFromMdast(markdown, options, mdast, rehypeKatex);
 
   if (cache.size >= CACHE_SIZE) {

--- a/packages/markdown/src/rendering/sanitize-schema.ts
+++ b/packages/markdown/src/rendering/sanitize-schema.ts
@@ -89,6 +89,24 @@ export function createSanitizeSchema(options: { allowDataImages?: boolean } = {}
       pre: ['className', 'style', 'dataLanguage', 'tabIndex'],
       // Spans: allow style for Shiki token colors and KaTeX sizing/spacing
       span: ['className', 'style'],
+      // GitHub alerts (`> [!WARNING]`) are rewritten into Cinder Callout
+      // markup by `remark-github-callouts`. The `'*': ['className']` entry
+      // above REPLACES hast-util-sanitize's default `*` allowlist rather than
+      // extending it, so without these three the variant/role/label are all
+      // silently dropped and every callout renders un-themed and unnamed — a
+      // failure indistinguishable from the plugin never having run.
+      //
+      // Scoped to `div` rather than added to `*`: widening `*` to include
+      // `role` would let any element in any document claim any role, which is
+      // a real accessibility-spoofing vector. The value allowlists narrow it
+      // further — `role` may only ever be `note`, and the variant may only be
+      // one of the four Cinder ships — so this grants exactly the callout's
+      // markup and nothing beyond it.
+      div: [
+        ['role', 'note'],
+        ['dataCinderVariant', 'info', 'success', 'warning', 'danger'],
+        'ariaLabel',
+      ],
       // Tables
       table: ['className'],
       th: ['align', 'valign', 'scope'],

--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -84,11 +84,11 @@ describe('static export', () => {
       expect(indexHtml).toContain('id="cinder-initial"');
       expect(indexHtml).toContain('readmeHtml');
       expect(indexHtml).toContain('/shell-bundle/shell.js');
-      expect(indexHtml).toContain('/styles/shell.css');
+      expect(indexHtml).toContain('/styles/all.css');
       expect(indexHtml).not.toContain('http-equiv="refresh"');
       expect(rendered.has('/shell-bundle/shell.js')).toBe(true);
       expect(indexHtml).not.toContain('data-canonical-documentation');
-      expect(rendered.has('/styles/shell.css')).toBe(true);
+      expect(rendered.has('/styles/all.css')).toBe(true);
     } finally {
       await rm(outputDirectory, { recursive: true, force: true });
     }

--- a/packages/playground/src/analyze.ts
+++ b/packages/playground/src/analyze.ts
@@ -49,6 +49,17 @@ export type { ComponentManifest, ControlKind, ObjectShape, PropManifest, ValueSh
 function inferControlKindFromTypeNode(
   typeNode: TypeNode | undefined,
   typeText: string,
+  /**
+   * How deep to expand array/object SHAPES. `0` means "describe the type, don't
+   * walk it": the control still reports `kind: 'array'` and its `rawType` (which
+   * is all the props table renders), but the element shape comes back opaque.
+   *
+   * Threaded rather than fixed because the shape has exactly one consumer —
+   * seeding a REQUIRED prop with no default. Expanding it for every optional
+   * array prop in the library tripled a cold manifest build (7.4s -> 26.7s),
+   * paid on every dev-server start, for a value nothing reads.
+   */
+  shapeDepthBudget: number = MAX_SHAPE_DEPTH,
 ): ControlKind {
   if (typeNode === undefined) return { kind: 'unknown', rawType: typeText };
 
@@ -93,7 +104,7 @@ function inferControlKindFromTypeNode(
     // what it holds.
     for (const member of members) {
       if (isNullishTypeNode(member)) continue;
-      const control = inferControlKindFromTypeNode(member, member.getText());
+      const control = inferControlKindFromTypeNode(member, member.getText(), shapeDepthBudget);
       if (control.kind !== 'unknown' && control.kind !== 'snippet') return control;
     }
     return { kind: 'unknown', rawType: typeText };
@@ -104,7 +115,7 @@ function inferControlKindFromTypeNode(
     const operator = typeNode.asKindOrThrow(SyntaxKind.TypeOperator);
     if (operator.getOperator() === SyntaxKind.ReadonlyKeyword) {
       const inner = operator.getTypeNode();
-      return inferControlKindFromTypeNode(inner, inner.getText());
+      return inferControlKindFromTypeNode(inner, inner.getText(), shapeDepthBudget);
     }
   }
 
@@ -112,7 +123,7 @@ function inferControlKindFromTypeNode(
     const element = typeNode.asKindOrThrow(SyntaxKind.ArrayType).getElementTypeNode();
     return {
       kind: 'array',
-      element: shapeFromType(element.getType(), element, 0),
+      element: shapeFromType(element.getType(), element, MAX_SHAPE_DEPTH - shapeDepthBudget),
       rawType: typeText,
     };
   }
@@ -120,7 +131,7 @@ function inferControlKindFromTypeNode(
   if (kind === SyntaxKind.TypeLiteral) {
     return {
       kind: 'object',
-      shape: objectShapeFromType(typeNode.getType(), typeNode, 0),
+      shape: objectShapeFromType(typeNode.getType(), typeNode, MAX_SHAPE_DEPTH - shapeDepthBudget),
       rawType: typeText,
     };
   }
@@ -138,7 +149,7 @@ function inferControlKindFromTypeNode(
       if (argument !== undefined) {
         return {
           kind: 'array',
-          element: shapeFromType(argument.getType(), argument, 0),
+          element: shapeFromType(argument.getType(), argument, MAX_SHAPE_DEPTH - shapeDepthBudget),
           rawType: typeText,
         };
       }
@@ -149,7 +160,11 @@ function inferControlKindFromTypeNode(
     const alias = sf.getTypeAlias(name);
     if (alias !== undefined) {
       const resolvedNode = alias.getTypeNode();
-      return inferControlKindFromTypeNode(resolvedNode, resolvedNode?.getText() ?? typeText);
+      return inferControlKindFromTypeNode(
+        resolvedNode,
+        resolvedNode?.getText() ?? typeText,
+        shapeDepthBudget,
+      );
     }
 
     const importedControl = inferControlKindFromImportedAlias(sf, name, typeText);
@@ -185,12 +200,13 @@ function isNullishTypeNode(typeNode: TypeNode): boolean {
 /**
  * How deep a synthesized shape may nest before fields become opaque.
  *
- * Two is enough for every real case in the library (the deepest is
- * `KeyboardShortcutGroup.shortcuts[].keys[]`) and is what makes recursive types
- * terminate — `MegaMenuItem.submenu?: MegaMenuItem[]` would otherwise expand
- * forever.
+ * Three, because the deepest real case in the library is
+ * `groups[] -> shortcuts[] -> keys[]` — each array hop costs a level, so a cap
+ * of two truncated `KeyboardShortcuts.groups` to `[{ shortcuts: [{}, {}] }]`.
+ * The cap is what makes recursive types terminate at all:
+ * `MegaMenuItem.submenu?: MegaMenuItem[]` would otherwise expand forever.
  */
-const MAX_SHAPE_DEPTH = 2;
+const MAX_SHAPE_DEPTH = 3;
 
 /** True for a resolved type the generator cannot invent a value for. */
 function isOpaqueType(type: Type): boolean {
@@ -207,9 +223,29 @@ function isOpaqueType(type: Type): boolean {
  * the `string` arm, since `Statistic.value: string | number` reads better as
  * text than as a number.
  */
+/**
+ * Memoizes {@link shapeFromType} by resolved type text and depth.
+ *
+ * The same element types recur constantly — `string`, an enum alias, a shared
+ * `Item` — both within one component and across the ~194 analyzed per build.
+ * Recursing into array element types without this made a cold manifest build
+ * roughly five times slower (5.9s -> 26s), which is paid on every dev-server
+ * start. Cleared by `resetProject()` along with the other analyzer caches,
+ * because a stale entry would outlive the source it was derived from.
+ */
+const shapeCache = new Map<string, ValueShape | ObjectShape>();
+
 function shapeFromType(type: Type, at: Node, depth: number): ValueShape | ObjectShape {
   const bare = type.getNonNullableType();
+  const cacheKey = `${depth}:${bare.getText()}`;
+  const cached = shapeCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+  const shape = computeShapeFromType(bare, at, depth);
+  shapeCache.set(cacheKey, shape);
+  return shape;
+}
 
+function computeShapeFromType(bare: Type, at: Node, depth: number): ValueShape | ObjectShape {
   if (isOpaqueType(bare)) return { kind: 'opaque', rawType: bare.getText() };
   if (bare.isString()) return { kind: 'string' };
   if (bare.isNumber()) return { kind: 'number' };
@@ -237,6 +273,17 @@ function shapeFromType(type: Type, at: Node, depth: number): ValueShape | Object
       return shapeFromType(resolved, at, depth + 1);
     }
     return { kind: 'opaque', rawType: bare.getText() };
+  }
+
+  // Arrays BEFORE the object branch: an array is an object to the checker, so
+  // reaching `objectShapeFromType` with `string[]` synthesizes the array's own
+  // internals (`length`, `__@unscopables@…`) as if they were data fields.
+  if (bare.isArray() || bare.isReadonlyArray()) {
+    const element = bare.getArrayElementType();
+    if (element === undefined || depth >= MAX_SHAPE_DEPTH) {
+      return { kind: 'opaque', rawType: bare.getText() };
+    }
+    return { kind: 'array', element: shapeFromType(element, at, depth + 1) };
   }
 
   if (bare.isObject()) return objectShapeFromType(bare, at, depth);
@@ -830,7 +877,13 @@ function descriptionFromSymbol(symbol: TsSymbol): string | undefined {
  */
 function controlKindFromResolvedSymbol(symbol: TsSymbol, at: Node): ControlKind {
   const typeNode = propertySignatureOf(symbol)?.getTypeNode();
-  if (typeNode !== undefined) return inferControlKindFromTypeNode(typeNode, typeNode.getText());
+  if (typeNode !== undefined) {
+    return inferControlKindFromTypeNode(
+      typeNode,
+      typeNode.getText(),
+      symbol.hasFlags(SymbolFlags.Optional) ? 0 : MAX_SHAPE_DEPTH,
+    );
+  }
   // No declaration node (a mapped or synthesized property) — the checker is the
   // only way to see it. Deliberately NOT used as a fallback when the node walk
   // returns `unknown`: instantiating these types is the expensive path, and
@@ -950,6 +1003,7 @@ export function resetProject(): void {
   sharedProject = undefined;
   analyzeAllCache.clear();
   importedLiteralUnionCache.clear();
+  shapeCache.clear();
 }
 
 /**
@@ -1088,7 +1142,11 @@ function extractTypeInfo(
         const uniqueTexts = [...new Set(typeTexts)];
         let control: ControlKind;
         if (uniqueTexts.length === 1 && firstProp !== undefined) {
-          control = inferControlKindFromTypeNode(firstProp.getTypeNode(), uniqueTexts[0] ?? '?');
+          control = inferControlKindFromTypeNode(
+            firstProp.getTypeNode(),
+            uniqueTexts[0] ?? '?',
+            optional ? 0 : MAX_SHAPE_DEPTH,
+          );
         } else {
           control = { kind: 'unknown', rawType: 'discriminated-union' };
         }
@@ -1106,8 +1164,12 @@ function extractTypeInfo(
     for (const [name, prop] of propMap) {
       const typeNodeForProp = prop.getTypeNode();
       const typeText = typeNodeForProp?.getText() ?? '?';
-      const control = inferControlKindFromTypeNode(typeNodeForProp, typeText);
       const optional = prop.hasQuestionToken();
+      const control = inferControlKindFromTypeNode(
+        typeNodeForProp,
+        typeText,
+        optional ? 0 : MAX_SHAPE_DEPTH,
+      );
       const description =
         prop
           .getJsDocs()

--- a/packages/playground/src/analyze.ts
+++ b/packages/playground/src/analyze.ts
@@ -17,18 +17,27 @@ import { basename, dirname, join, resolve } from 'node:path';
 import type { Expression, Pattern, Property, SpreadElement } from 'estree';
 import { type AST, parse } from 'svelte/compiler';
 import {
+  type Node,
   Project,
   type PropertySignature,
   type SourceFile,
+  SymbolFlags,
   SyntaxKind,
+  type Symbol as TsSymbol,
   type Type,
   type TypeNode,
 } from 'ts-morph';
 
 import { discoverComponentFilePaths } from './discover.ts';
-import type { ComponentManifest, ControlKind, PropManifest } from './types.ts';
+import type {
+  ComponentManifest,
+  ControlKind,
+  ObjectShape,
+  PropManifest,
+  ValueShape,
+} from './types.ts';
 
-export type { ComponentManifest, ControlKind, PropManifest };
+export type { ComponentManifest, ControlKind, ObjectShape, PropManifest, ValueShape };
 
 // ---------------------------------------------------------------------------
 // Control kind inference from ts-morph TypeNode
@@ -71,7 +80,49 @@ function inferControlKindFromTypeNode(
     if (allStringLiterals && stringLiterals.length > 0) {
       return { kind: 'select', options: stringLiterals };
     }
+
+    // A MIXED union (`string | Snippet`, `Date | number | string`) is not a
+    // select, but it is not unclassifiable either. If one arm is a primitive the
+    // reader can actually type, offer a control for THAT arm — the component
+    // accepts it, so the control and the generated snippet are both valid.
+    //
+    // Without this, `PageHeader`'s entirely ordinary `title: string | Snippet`
+    // came out `unknown`, and because it is required with no default it counted
+    // as unsynthesizable and suppressed the component's whole Playground
+    // section. Nullish arms are skipped: they say the prop may be omitted, not
+    // what it holds.
+    for (const member of members) {
+      if (isNullishTypeNode(member)) continue;
+      const control = inferControlKindFromTypeNode(member, member.getText());
+      if (control.kind !== 'unknown' && control.kind !== 'snippet') return control;
+    }
     return { kind: 'unknown', rawType: typeText };
+  }
+
+  // `readonly T[]` wraps the array in a TypeOperator; unwrap and re-enter.
+  if (kind === SyntaxKind.TypeOperator) {
+    const operator = typeNode.asKindOrThrow(SyntaxKind.TypeOperator);
+    if (operator.getOperator() === SyntaxKind.ReadonlyKeyword) {
+      const inner = operator.getTypeNode();
+      return inferControlKindFromTypeNode(inner, inner.getText());
+    }
+  }
+
+  if (kind === SyntaxKind.ArrayType) {
+    const element = typeNode.asKindOrThrow(SyntaxKind.ArrayType).getElementTypeNode();
+    return {
+      kind: 'array',
+      element: shapeFromType(element.getType(), element, 0),
+      rawType: typeText,
+    };
+  }
+
+  if (kind === SyntaxKind.TypeLiteral) {
+    return {
+      kind: 'object',
+      shape: objectShapeFromType(typeNode.getType(), typeNode, 0),
+      rawType: typeText,
+    };
   }
 
   if (kind === SyntaxKind.TypeReference) {
@@ -80,6 +131,18 @@ function inferControlKindFromTypeNode(
 
     // Snippet or Snippet<[...]> â snippet control
     if (name === 'Snippet') return { kind: 'snippet' };
+
+    // `ReadonlyArray<T>` / `Array<T>` are the generic spellings of `T[]`.
+    if (name === 'Array' || name === 'ReadonlyArray') {
+      const argument = ref.getTypeArguments()[0];
+      if (argument !== undefined) {
+        return {
+          kind: 'array',
+          element: shapeFromType(argument.getType(), argument, 0),
+          rawType: typeText,
+        };
+      }
+    }
 
     // Try to resolve the referenced alias in the same source file
     const sf = typeNode.getSourceFile();
@@ -99,6 +162,110 @@ function inferControlKindFromTypeNode(
   }
 
   return { kind: 'unknown', rawType: typeText };
+}
+
+/**
+ * True for the `null` / `undefined` arms of a union. They carry optionality, not
+ * a value shape, so {@link inferControlKindFromTypeNode} skips them when picking
+ * a typeable arm out of a mixed union.
+ */
+function isNullishTypeNode(typeNode: TypeNode): boolean {
+  const kind = typeNode.getKind();
+  if (kind === SyntaxKind.UndefinedKeyword) return true;
+  if (kind !== SyntaxKind.LiteralType) return false;
+  return (
+    typeNode.asKindOrThrow(SyntaxKind.LiteralType).getLiteral().getKind() === SyntaxKind.NullKeyword
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Structural shapes — what a synthesized array/object placeholder is built from
+// ---------------------------------------------------------------------------
+
+/**
+ * How deep a synthesized shape may nest before fields become opaque.
+ *
+ * Two is enough for every real case in the library (the deepest is
+ * `KeyboardShortcutGroup.shortcuts[].keys[]`) and is what makes recursive types
+ * terminate — `MegaMenuItem.submenu?: MegaMenuItem[]` would otherwise expand
+ * forever.
+ */
+const MAX_SHAPE_DEPTH = 2;
+
+/** True for a resolved type the generator cannot invent a value for. */
+function isOpaqueType(type: Type): boolean {
+  return type.getCallSignatures().length > 0 || isSnippetType(type);
+}
+
+/**
+ * Describe a resolved type structurally, for value synthesis.
+ *
+ * Union handling is ordered by what produces a usable placeholder: an
+ * all-string-literal union becomes an `enum`; a union with an object arm takes
+ * the FIRST object arm (`MegaMenuItem`, `EventStreamEntry` and
+ * `RunStepTimelineEntry` are all shaped that way); a union of primitives prefers
+ * the `string` arm, since `Statistic.value: string | number` reads better as
+ * text than as a number.
+ */
+function shapeFromType(type: Type, at: Node, depth: number): ValueShape | ObjectShape {
+  const bare = type.getNonNullableType();
+
+  if (isOpaqueType(bare)) return { kind: 'opaque', rawType: bare.getText() };
+  if (bare.isString()) return { kind: 'string' };
+  if (bare.isNumber()) return { kind: 'number' };
+  if (bare.isBoolean() || bare.isBooleanLiteral()) return { kind: 'boolean' };
+
+  const literalUnion = inferControlKindFromResolvedType(bare);
+  if (literalUnion !== undefined && literalUnion.kind === 'select') {
+    return { kind: 'enum', options: literalUnion.options };
+  }
+
+  if (bare.isUnion()) {
+    const arms = bare.getUnionTypes().filter((arm) => !arm.isNull() && !arm.isUndefined());
+    const objectArm = arms.find((arm) => arm.isObject() && !isOpaqueType(arm));
+    if (objectArm !== undefined) return objectShapeFromType(objectArm, at, depth);
+    if (arms.some((arm) => arm.isString() || arm.isStringLiteral())) return { kind: 'string' };
+    if (arms.some((arm) => arm.isNumber() || arm.isNumberLiteral())) return { kind: 'number' };
+    return { kind: 'opaque', rawType: bare.getText() };
+  }
+
+  // A type PARAMETER (`Row extends DataTableRow = Record<string, unknown>`)
+  // carries its shape on its default or constraint.
+  if (bare.isTypeParameter()) {
+    const resolved = bare.getDefault() ?? bare.getConstraint();
+    if (resolved !== undefined && depth < MAX_SHAPE_DEPTH) {
+      return shapeFromType(resolved, at, depth + 1);
+    }
+    return { kind: 'opaque', rawType: bare.getText() };
+  }
+
+  if (bare.isObject()) return objectShapeFromType(bare, at, depth);
+
+  return { kind: 'opaque', rawType: bare.getText() };
+}
+
+/**
+ * The required, named, synthesizable fields of an object type.
+ *
+ * An object with no named properties is `degenerate` — an index-signature-only
+ * record such as `MatrixChartDatum = Record<string, string | number | null>`.
+ * That seeds to `{}` / `[]`, never an invented member: those components' sibling
+ * props name KEYS of the datum, so any datum invented here would contradict them.
+ */
+function objectShapeFromType(type: Type, at: Node, depth: number): ObjectShape {
+  if (depth >= MAX_SHAPE_DEPTH) return { fields: [], degenerate: true };
+
+  const fields: ObjectShape['fields'] = [];
+  for (const symbol of type.getProperties()) {
+    // Optional fields are dropped: the target is the MINIMAL literal.
+    if (symbol.hasFlags(SymbolFlags.Optional)) continue;
+    const shape = shapeFromType(symbol.getTypeAtLocation(at), at, depth + 1);
+    // Never fake an opaque field — omit it and let the reader supply it.
+    if ('kind' in shape && shape.kind === 'opaque') continue;
+    fields.push({ name: symbol.getName(), shape });
+  }
+
+  return { fields, degenerate: fields.length === 0 };
 }
 
 const importedLiteralUnionCache = new Map<string, ControlKind | null>();
@@ -205,9 +372,37 @@ function controlKindFromTypeAliasSource(source: string, typeName: string): Contr
 
 type RawPropEntry = {
   name: string;
+  /**
+   * The identifier the prop is destructured INTO, which is not always the prop
+   * name: `role: _role` binds `role` to a local called `_role`. The underscore
+   * is the codebase's marker for a prop the component deliberately accepts and
+   * swallows (so a spread consumer can pass it without it reaching the DOM) —
+   * internal plumbing, not public API. Recorded here so
+   * {@link isSwallowedProp} can keep those out of the manifest; the old code
+   * discarded the binding name and shipped them as public required props.
+   */
+  localName: string | undefined;
   defaultValue?: unknown;
   bindable: boolean;
 };
+
+/**
+ * Resolve the local binding identifier of a destructured property, unwrapping a
+ * default (`role: _role = 'toolbar'` binds `_role`). Returns `undefined` for
+ * nested destructuring patterns, which Svelte components don't use for props.
+ */
+function localBindingName(value: Pattern): string | undefined {
+  const target = value.type === 'AssignmentPattern' ? value.left : value;
+  return target.type === 'Identifier' ? target.name : undefined;
+}
+
+/**
+ * True when a prop is destructured into an underscore-prefixed local, e.g.
+ * `role: _role`. See {@link RawPropEntry.localName}.
+ */
+function isSwallowedProp(entry: RawPropEntry): boolean {
+  return entry.localName !== undefined && entry.localName.startsWith('_');
+}
 
 /**
  * Returns the literal value of an array element, or `undefined` for holes,
@@ -392,13 +587,14 @@ function extractPropsFromSvelteAst(source: string): RawPropEntry[] {
 
         // class, aria-* and other non-standard names â will be filtered later
         const value = property.value;
+        const localName = localBindingName(value);
 
         if (value.type === 'AssignmentPattern') {
           const { defaultValue, bindable } = parseDefaultExpression(value.right, source);
-          entries.push({ name: rawName, defaultValue, bindable });
+          entries.push({ name: rawName, localName, defaultValue, bindable });
         } else {
           // No default value
-          entries.push({ name: rawName, defaultValue: undefined, bindable: false });
+          entries.push({ name: rawName, localName, defaultValue: undefined, bindable: false });
         }
       }
 
@@ -485,6 +681,227 @@ type TypeInfo = {
 };
 
 // ---------------------------------------------------------------------------
+// Semantic fallback — filling the gaps the syntactic walk cannot reach
+// ---------------------------------------------------------------------------
+//
+// `collectPropertiesFromTypeNode` walks type NODES: TypeLiteral, Intersection,
+// a same-file TypeAlias, Parenthesized. That is fast and preserves source-order
+// detail (a string-literal union keeps its authored option order), but it is
+// blind to anything the TypeScript CHECKER would have to resolve:
+//
+//   - properties inherited from an IMPORTED base (`ChartSharedProps & { … }`),
+//   - properties behind a mapped type (`Omit<HTMLAttributes<HTMLElement>, …>`),
+//   - properties inside a UNION nested in an intersection
+//     (`SharedBase & (WithLabel | WithChildren | WithIconOnly)` — the node walker
+//     has no UnionType branch at this level, so every arm's props vanish).
+//
+// A prop missing from the type map got `{ kind: 'unknown', rawType: '?' }` AND
+// `optional: false` (see `analyzeComponent`), i.e. "we could not type it" was
+// reported as "it is required". That single default is what blocked Button — the
+// most-visited page in the library — along with ~20 others whose only "required"
+// props were optional DOM handlers all along.
+//
+// So: after the syntactic pass, ask the checker about the props it missed. The
+// syntactic result always wins where it exists; this only fills gaps.
+
+/** One arm's view of a prop, as both the syntactic and semantic paths report it. */
+type ArmMembership = { never: boolean; optional: boolean };
+
+/**
+ * Decide whether a union expresses "exactly one of these props", and if so which
+ * alternative the playground should commit to.
+ *
+ * The idiom is `{ a: string; b?: never } | { a?: never; b: string }`. Merged
+ * naively both `a` and `b` come out optional — each is absent-or-`never` in one
+ * arm — so the playground seeded both to `''` and supplied either both or
+ * neither. DropdownGroup, which enforces "exactly one accessible naming
+ * strategy", threw on its own generated preview.
+ *
+ * Two guards keep this narrow:
+ *
+ *  - Only a `?: never` member marks an exclusive alternative. `href?: undefined`
+ *    on Button's non-link arm is not one — `href` is genuinely omittable, and
+ *    treating it as exclusive reported a plain `<Button label="…" />` as missing
+ *    a required prop.
+ *  - If ANY arm requires none of the exclusive props, that arm is a legal
+ *    "neither" and nothing is committed. Card's basic variant is exactly this:
+ *    it needs no `header` and no `title`, so committing to the header arm would
+ *    have turned a component that previews fine into one blocked on a required
+ *    Snippet.
+ *
+ * @returns The chosen arm index (`-1` for "do not commit") and, per prop, the
+ *   first arm that requires it.
+ */
+function chooseExclusiveArm(arms: ReadonlyArray<ReadonlyMap<string, ArmMembership>>): {
+  requiredInArm: ReadonlyMap<string, number>;
+  chosenArm: number;
+} {
+  const exclusive = new Set<string>();
+  for (const arm of arms) {
+    for (const [name, membership] of arm) {
+      if (membership.never) exclusive.add(name);
+    }
+  }
+
+  const requiredInArm = new Map<string, number>();
+  const armRequiresOne = arms.map((arm, armIndex) => {
+    let requiresOne = false;
+    for (const name of exclusive) {
+      const membership = arm.get(name);
+      if (membership === undefined || membership.never || membership.optional) continue;
+      requiresOne = true;
+      if (!requiredInArm.has(name)) requiredInArm.set(name, armIndex);
+    }
+    return requiresOne;
+  });
+
+  if (arms.length === 0 || !armRequiresOne.every(Boolean) || requiredInArm.size === 0) {
+    return { requiredInArm: new Map(), chosenArm: -1 };
+  }
+  return { requiredInArm, chosenArm: Math.min(...requiredInArm.values()) };
+}
+
+/**
+ * True for the `prop?: never` member an exclusive-union arm uses to say "not
+ * this alternative". Semantically the prop is ABSENT from that arm.
+ */
+function isNeverProperty(prop: PropertySignature): boolean {
+  return prop.getTypeNode()?.getKind() === SyntaxKind.NeverKeyword;
+}
+
+/**
+ * True when a resolved type is Svelte's `Snippet` (or `Snippet<[…]>`). Checked
+ * via the ALIAS symbol because `Snippet` resolves to a call signature — without
+ * this it would classify as an opaque function type.
+ */
+function isSnippetType(type: Type): boolean {
+  return type.getAliasSymbol()?.getName() === 'Snippet';
+}
+
+/**
+ * Classify a checker-resolved property type. `null`/`undefined` arms are
+ * stripped first: an optional `string` prop resolves to `string | undefined`,
+ * which would otherwise fall through every branch and land back on `unknown`.
+ */
+function controlKindFromResolvedPropertyType(type: Type): ControlKind {
+  const bare = type.getNonNullableType();
+  if (isSnippetType(bare)) return { kind: 'snippet' };
+  return inferControlKindFromResolvedType(bare) ?? { kind: 'unknown', rawType: bare.getText() };
+}
+
+/**
+ * True for the `prop?: never` member an exclusive-union arm uses to say "not
+ * this alternative".
+ */
+function isNeverSymbol(symbol: TsSymbol): boolean {
+  const declaration = propertySignatureOf(symbol);
+  return declaration?.getTypeNode()?.getKind() === SyntaxKind.NeverKeyword;
+}
+
+/** The `PropertySignature` a resolved symbol was declared by, if it has one. */
+function propertySignatureOf(symbol: TsSymbol): PropertySignature | undefined {
+  for (const declaration of symbol.getDeclarations()) {
+    if (declaration.getKind() === SyntaxKind.PropertySignature) {
+      return declaration.asKindOrThrow(SyntaxKind.PropertySignature);
+    }
+  }
+  return undefined;
+}
+
+/** The JSDoc description attached to a resolved property's declaration. */
+function descriptionFromSymbol(symbol: TsSymbol): string | undefined {
+  const text =
+    propertySignatureOf(symbol)
+      ?.getJsDocs()
+      .map((doc) => doc.getDescription().trim())
+      .join('') ?? '';
+  return text === '' ? undefined : text;
+}
+
+/**
+ * Classify a resolved property, preferring its DECLARATION's type node over
+ * asking the checker for the property's type.
+ *
+ * Both give the same answer, but `getTypeAtLocation` instantiates the type,
+ * which for props inherited from `HTMLAttributes<…>` is the expensive path and
+ * is paid once per prop per union arm. The node walk is also higher fidelity: a
+ * string-literal union keeps its authored option order, which the checker does
+ * not promise.
+ */
+function controlKindFromResolvedSymbol(symbol: TsSymbol, at: Node): ControlKind {
+  const typeNode = propertySignatureOf(symbol)?.getTypeNode();
+  if (typeNode !== undefined) return inferControlKindFromTypeNode(typeNode, typeNode.getText());
+  // No declaration node (a mapped or synthesized property) — the checker is the
+  // only way to see it. Deliberately NOT used as a fallback when the node walk
+  // returns `unknown`: instantiating these types is the expensive path, and
+  // paying it to re-derive the same `unknown` roughly doubled the cost of a cold
+  // manifest build. What this pass exists to recover is OPTIONALITY, which is
+  // read off the symbol either way.
+  return controlKindFromResolvedPropertyType(symbol.getTypeAtLocation(at));
+}
+
+/**
+ * Resolve one prop against the checker, merging across the arms of a top-level
+ * union.
+ *
+ * Optionality merges the SAME way the syntactic union path does: a prop that is
+ * absent from any arm, or optional in any arm, is optional overall. That is the
+ * conservative direction — a prop the caller may legally omit must never be
+ * reported as required, because "required" is what suppresses the generated
+ * preview.
+ *
+ * Returns `undefined` when no arm declares the prop, leaving it to the existing
+ * `{ kind: 'unknown', rawType: '?' }` default.
+ */
+function resolvePropTypeInfo(
+  armProperties: ReadonlyArray<ReadonlyMap<string, TsSymbol>>,
+  at: Node,
+  name: string,
+  chosenArm: number,
+  requiredInArm: ReadonlyMap<string, number>,
+): TypeInfo | undefined {
+  let found = false;
+  let optional = false;
+  let description: string | undefined;
+  const controls: ControlKind[] = [];
+
+  for (const properties of armProperties) {
+    const symbol = properties.get(name);
+    // A `never`-typed member is how an exclusive arm says "not this
+    // alternative" — semantically absent, exactly like a missing symbol. Without
+    // this, arm B's `label?: never` contributed an `unknown` control that
+    // disagreed with arm A's `string`, and the merged result was `unknown`.
+    if (symbol === undefined || isNeverSymbol(symbol)) {
+      // Absent from this arm — a caller picking this arm omits it.
+      optional = true;
+      continue;
+    }
+    found = true;
+    if (symbol.hasFlags(SymbolFlags.Optional)) optional = true;
+    description ??= descriptionFromSymbol(symbol);
+    controls.push(controlKindFromResolvedSymbol(symbol, at));
+  }
+
+  if (!found) return undefined;
+
+  // Arms that disagree on the control kind can't drive one control. Keep the
+  // resolved optionality though — that is the half that unblocks the preview.
+  const first = controls[0] ?? { kind: 'unknown', rawType: '?' };
+  const allAgree = controls.every((control) => control.kind === first.kind);
+
+  return {
+    control: allAgree ? first : { kind: 'unknown', rawType: 'discriminated-union' },
+    // Exclusive alternatives (`{ a: string } | { b: string }`) are each optional
+    // across the union as a whole, so seeding every one of them to `''` supplies
+    // either all or none — and a component enforcing "exactly one" rejects both.
+    // Commit to the first arm's required props; the rest stay optional, seed to
+    // `''`, and are dropped from the snippet and the mount alike.
+    optional: requiredInArm.get(name) === chosenArm ? false : optional,
+    description,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Shared ts-morph Project
 // ---------------------------------------------------------------------------
 //
@@ -553,6 +970,7 @@ function buildTypeInfoMap(
   moduleScriptContent: string,
   componentName: string,
   sourceDirectory: string,
+  propNames: readonly string[],
 ): Map<string, TypeInfo> {
   const project = getSharedProject();
 
@@ -567,7 +985,7 @@ function buildTypeInfoMap(
   const sf = project.createSourceFile(syntheticPath, moduleScriptContent);
 
   try {
-    return extractTypeInfo(sf, componentName);
+    return extractTypeInfo(sf, componentName, propNames);
   } finally {
     // Remove the synthetic source file so the shared project doesn't accumulate
     // stale sources or leak memory across the ~100 components analyzed per build.
@@ -584,6 +1002,7 @@ function buildTypeInfoMap(
 function extractTypeInfo(
   sf: ReturnType<Project['createSourceFile']>,
   componentName: string,
+  propNames: readonly string[],
 ): Map<string, TypeInfo> {
   const propsAliasName = `${componentName}Props`;
   const propsAlias = sf.getTypeAlias(propsAliasName);
@@ -615,6 +1034,21 @@ function extractTypeInfo(
         for (const name of armMap.keys()) allNames.add(name);
       }
 
+      // Commit to one alternative of an `exactly one of` union — see
+      // `chooseExclusiveArm` for the idiom and the two guards that keep it from
+      // firing on ordinary unions.
+      const { requiredInArm, chosenArm } = chooseExclusiveArm(
+        perArmMaps.map(
+          (armMap) =>
+            new Map(
+              [...armMap].map(([name, prop]) => [
+                name,
+                { never: isNeverProperty(prop), optional: prop.hasQuestionToken() },
+              ]),
+            ),
+        ),
+      );
+
       for (const name of allNames) {
         // Gather all type texts from arms that have this prop
         const typeTexts: string[] = [];
@@ -624,7 +1058,9 @@ function extractTypeInfo(
 
         for (const armMap of perArmMaps) {
           const prop = armMap.get(name);
-          if (prop !== undefined) {
+          // `b?: never` is how an arm says "not this alternative" — semantically
+          // the prop is ABSENT from that arm, not present with type `never`.
+          if (prop !== undefined && !isNeverProperty(prop)) {
             const tn = prop.getTypeNode();
             typeTexts.push(tn?.getText() ?? '?');
             if (firstProp === undefined) {
@@ -643,6 +1079,10 @@ function extractTypeInfo(
         }
 
         if (firstProp === undefined) continue;
+
+        // …except the chosen arm's own required prop: the playground commits to
+        // that alternative so exactly one of the group is supplied.
+        if (requiredInArm.get(name) === chosenArm) optional = false;
 
         // If all arms agree on type text, use that; otherwise unknown
         const uniqueTexts = [...new Set(typeTexts)];
@@ -679,6 +1119,54 @@ function extractTypeInfo(
   }
 
   processTypeNode(typeNode);
+
+  // Gap-fill from the checker. Only props the syntactic walk MISSED are looked
+  // up — where it produced an answer, that answer stands.
+  //
+  // The checker work is gated on there BEING a gap, and each arm's property list
+  // is materialized once rather than per prop name. Both matter: resolving these
+  // types pulls in the whole of `svelte/elements`, and doing it per name per arm
+  // made a cold manifest build several times slower.
+  const missing = propNames.filter((name) => !result.has(name));
+  if (missing.length > 0) {
+    const aliasType = propsAlias.getType();
+    const arms = aliasType.isUnion() ? aliasType.getUnionTypes() : [aliasType];
+    const armProperties = arms.map(
+      (arm) => new Map(arm.getProperties().map((symbol) => [symbol.getName(), symbol])),
+    );
+    // Which arm first REQUIRES each missing prop — see the exclusive-union note
+    // in `resolvePropTypeInfo`. Computed once over the whole missing set so the
+    // choice is consistent across the alternatives of one group.
+    const { requiredInArm, chosenArm } = chooseExclusiveArm(
+      armProperties.map(
+        (properties) =>
+          new Map(
+            missing.flatMap((name) => {
+              const symbol = properties.get(name);
+              if (symbol === undefined) return [];
+              return [
+                [
+                  name,
+                  { never: isNeverSymbol(symbol), optional: symbol.hasFlags(SymbolFlags.Optional) },
+                ] as const,
+              ];
+            }),
+          ),
+      ),
+    );
+
+    for (const name of missing) {
+      const resolved = resolvePropTypeInfo(
+        armProperties,
+        propsAlias,
+        name,
+        chosenArm,
+        requiredInArm,
+      );
+      if (resolved !== undefined) result.set(name, resolved);
+    }
+  }
+
   return result;
 }
 
@@ -752,12 +1240,19 @@ export async function analyzeComponent(
   const componentName = toPascalCase(fileBaseName);
 
   const rawProps = extractPropsFromSvelteAst(source);
-  const publicRawProps = rawProps.filter((prop) => isPublicPropName(prop.name));
+  const publicRawProps = rawProps.filter(
+    (prop) => isPublicPropName(prop.name) && !isSwallowedProp(prop),
+  );
   let moduleScriptContent = extractModuleScriptContent(source);
 
   const typeInfoMap =
     publicRawProps.length > 0
-      ? await buildComponentTypeInfoMap(filePath, moduleScriptContent, componentName)
+      ? await buildComponentTypeInfoMap(
+          filePath,
+          moduleScriptContent,
+          componentName,
+          publicRawProps.map((prop) => prop.name),
+        )
       : new Map<string, TypeInfo>();
 
   const props: PropManifest[] = [];
@@ -799,6 +1294,7 @@ async function buildComponentTypeInfoMap(
   filePath: string,
   moduleScriptContent: string,
   componentName: string,
+  propNames: readonly string[],
 ): Promise<Map<string, TypeInfo>> {
   // After the per-directory migration, the .svelte module script may only
   // re-export types from <name>.types.ts. Concatenate the types-file content
@@ -810,7 +1306,7 @@ async function buildComponentTypeInfoMap(
     moduleScriptContent = `${moduleScriptContent}\n${typesSource}`;
   }
 
-  return buildTypeInfoMap(moduleScriptContent, componentName, dirname(filePath));
+  return buildTypeInfoMap(moduleScriptContent, componentName, dirname(filePath), propNames);
 }
 
 /**

--- a/packages/playground/src/component-page-children-seed.test.ts
+++ b/packages/playground/src/component-page-children-seed.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { allowsPlainTextChildren, NO_TEXT_CHILDREN } from './component-page-children-seed.ts';
+import { CINDER_COMPONENT_SOURCE } from './component-sources.ts';
+import {
+  COMPOUND_COMPONENT_FAMILIES,
+  COMPOUND_COMPONENT_PARENTS,
+} from './shell-app/compound-families.ts';
+import type { ComponentManifest } from './types.ts';
+
+function manifest(kebabName: string, isCompound = false): ComponentManifest {
+  return {
+    name: 'X',
+    kebabName,
+    file: `${kebabName}.svelte`,
+    importPath: kebabName,
+    props: [],
+    ...(isCompound ? { isCompound: true } : {}),
+  };
+}
+
+describe('allowsPlainTextChildren', () => {
+  test('allows the ordinary case', () => {
+    // Badge, Button, Chip and friends render plain text children — that is the
+    // whole reason the seed exists, and the common path must stay allowed.
+    expect(allowsPlainTextChildren(manifest('badge'))).toBe(true);
+    expect(allowsPlainTextChildren(manifest('card'))).toBe(true);
+    expect(allowsPlainTextChildren(manifest('callout'))).toBe(true);
+  });
+
+  test('rejects compound roots and every family member', () => {
+    expect(allowsPlainTextChildren(manifest('accordion', true))).toBe(false);
+    // A leaf: `<td>` with no `<tr>` ancestor.
+    expect(allowsPlainTextChildren(manifest('table-cell'))).toBe(false);
+    // A family ROOT whose index.ts re-exports rather than `Object.assign`-ing,
+    // so `isCompound` is false and only the family table catches it.
+    expect(allowsPlainTextChildren(manifest('segmented-control'))).toBe(false);
+  });
+
+  test('rejects the layout, overlay, and behavior-wrapper cases', () => {
+    expect(allowsPlainTextChildren(manifest('masonry'))).toBe(false);
+    expect(allowsPlainTextChildren(manifest('modal'))).toBe(false);
+    expect(allowsPlainTextChildren(manifest('focus-trap'))).toBe(false);
+    expect(allowsPlainTextChildren(manifest('checkbox-group'))).toBe(false);
+  });
+});
+
+describe('NO_TEXT_CHILDREN drift guards', () => {
+  test('every entry names a real component', () => {
+    for (const slug of NO_TEXT_CHILDREN) {
+      const path = join(CINDER_COMPONENT_SOURCE.componentsRoot, slug, `${slug}.svelte`);
+      expect({ slug, exists: existsSync(path) }).toEqual({ slug, exists: true });
+    }
+  });
+
+  test('no entry is redundant with the compound-family rules', () => {
+    // The family rules are derived and maintained elsewhere; a slug listed here
+    // as well would be a second, silently-drifting source of truth.
+    for (const slug of NO_TEXT_CHILDREN) {
+      expect({ slug, inFamilyTable: slug in COMPOUND_COMPONENT_PARENTS }).toEqual({
+        slug,
+        inFamilyTable: false,
+      });
+      expect({ slug, isFamilyRoot: slug in COMPOUND_COMPONENT_FAMILIES }).toEqual({
+        slug,
+        isFamilyRoot: false,
+      });
+    }
+  });
+});

--- a/packages/playground/src/component-page-children-seed.ts
+++ b/packages/playground/src/component-page-children-seed.ts
@@ -1,0 +1,97 @@
+/**
+ * Whether the docs playground may seed a component's `children` with plain text.
+ *
+ * The playground synthesizes an editable text `children` control seeded with the
+ * component's own display name, so a Badge previews as a Badge reading "Badge"
+ * rather than an empty shell. That is right for most components and actively
+ * wrong for a few: a `CheckboxGroup` whose only content is the literal string
+ * "CheckboxGroup" is worse than an empty preview, and a bare `<td>` mounted with
+ * no `<tr>` ancestor is not a preview of anything.
+ *
+ * Three rules decide it, two of them derived from data that already exists so
+ * they cost nothing to maintain. Only the third is a list, and it is a list
+ * because the judgement it encodes — `Card` reads fine with text, `Masonry` does
+ * not, and both are boxes — is a design call no source artifact records.
+ */
+import type { ComponentManifest } from './types.ts';
+
+import {
+  COMPOUND_COMPONENT_FAMILIES,
+  COMPOUND_COMPONENT_PARENTS,
+} from './shell-app/compound-families.ts';
+
+/**
+ * Components whose `children` need structure, an ancestor, or interactive state
+ * that plain text cannot stand in for.
+ *
+ * Kept deliberately small. Anything covered by the compound-family rules below
+ * is NOT listed here — `compound-families.test.ts` guards that, so a slug added
+ * out of habit fails rather than silently overlapping.
+ *
+ * Grouped by why:
+ *
+ *  - LAYOUT primitives render a box whose whole job is arranging children. One
+ *    text run shows no columns, no tracks, and no gutters, so the preview says
+ *    nothing about the component. These get a preview recipe instead — see
+ *    `component-page-preview-recipes.ts`.
+ *  - OVERLAYS need open/trigger state before anything is visible. Seeding text
+ *    into a closed overlay renders nothing at all.
+ *  - BEHAVIOR wrappers render their children and nothing else, so the text is
+ *    the entire preview and the component is invisible in it.
+ *  - STRUCTURED containers document, in their own schema, that children must be
+ *    particular elements or sub-components.
+ */
+export const NO_TEXT_CHILDREN: ReadonlySet<string> = new Set([
+  // Layout primitives
+  'container',
+  'masonry',
+  'aspect-ratio',
+  'scroll-area',
+  'marquee',
+  'surface',
+  // Overlays and gates
+  'backdrop',
+  'drawer',
+  'modal',
+  'sheet',
+  'popover',
+  'tooltip',
+  'toast-region',
+  'access-gate',
+  'capability-gate',
+  // Behavior-only wrappers
+  'focus-trap',
+  'click-away-listener',
+  'locale-provider',
+  'portal',
+  // Structured containers
+  'checkbox-group',
+  'form-field',
+  'form-section',
+  'button-group',
+  'navigation-bar',
+]);
+
+/**
+ * True when seeding `children` with the component's display name produces a
+ * preview worth showing.
+ *
+ * Rejects, in order:
+ *
+ *  1. A compound ROOT — its children are `<Accordion.Item>`-shaped, so loose
+ *     text renders a semantically broken instance.
+ *  2. Any member of a compound FAMILY, root or leaf. `table-cell` is a `<td>`
+ *     with no table; `dropdown-label` is an unstyled orphan outside its
+ *     `role="menu"`; `side-navigation-group` renders a bare `<li>`. The mapping
+ *     is already maintained and drift-guarded in `compound-families.ts`, so this
+ *     rule costs nothing. Both directions are checked because a family root does
+ *     not always assemble its parts with `Object.assign` — `segmented-control`
+ *     re-exports `Segment` instead, so `isCompound` is false for it.
+ *  3. {@link NO_TEXT_CHILDREN}.
+ */
+export function allowsPlainTextChildren(manifest: ComponentManifest): boolean {
+  if (manifest.isCompound === true) return false;
+  if (manifest.kebabName in COMPOUND_COMPONENT_PARENTS) return false;
+  if (manifest.kebabName in COMPOUND_COMPONENT_FAMILIES) return false;
+  return !NO_TEXT_CHILDREN.has(manifest.kebabName);
+}

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -174,13 +174,34 @@ afterEach(() => {
   }
 });
 
+/**
+ * Switch the page to the Playground view and settle.
+ *
+ * The Playground is one of two VIEWS now (decision 2) rather than a rail pinned
+ * beside the prose — the rail took a fixed 38rem out of every page width and
+ * starved the documentation column. So a test asserting on playground markup has
+ * to select the view first, exactly as a reader does.
+ */
+async function showPlayground(): Promise<void> {
+  await fireEvent.click(screen.getByRole('tab', { name: 'Playground' }));
+  await tick();
+}
+
 describe('component-page single-scroll layout', () => {
   test('groups standalone page actions and exposes focus-visible tooltips', async () => {
-    const { container, unmount } = render(ComponentPage);
+    // The page controls live in the SIDEBAR footer now, not a top bar — the band
+    // they came from restated the sidebar brand, the hero eyebrow, and the page
+    // `<h1>`. So this renders with sidebar entries, as both real render paths do.
+    const { container, unmount } = render(ComponentPage, {
+      props: { sidebarComponents: ['button', 'badge'] },
+    });
     await tick();
 
     const toolbar = container.querySelector('[role="toolbar"][aria-label="Page controls"]');
     expect(toolbar).not.toBeNull();
+    // Specifically in the sidebar, which renders on the landing page too — so
+    // the theme toggle stays reachable there.
+    expect(container.querySelector('nav.dx-nav .dx-nav__footer')).not.toBeNull();
     expect(toolbar?.querySelector('[data-tooltip="View source on GitHub"]')).not.toBeNull();
     expect(toolbar?.querySelector('[data-tooltip="Preview theme: switch to dark"]')).not.toBeNull();
     expect(toolbar?.querySelectorAll('button[aria-label^="Preview theme: switch to"]').length).toBe(
@@ -235,8 +256,9 @@ describe('component-page single-scroll layout', () => {
     expect(screen.getByText('Triggering a fixture action.')).toBeTruthy();
     expect(screen.getByText('Selecting from a fixed set.')).toBeTruthy();
     // The avoidWhen alternative links to that component's page. The link text is
-    // the humanized id ("Segmented control"); the href keeps the kebab id.
-    const altLink = screen.getByRole('link', { name: /Segmented control/ });
+    // the humanized id, Title Case via the shared acronym-aware humanizer
+    // ("Segmented Control"); the href keeps the kebab id.
+    const altLink = screen.getByRole('link', { name: /Segmented Control/ });
     expect(altLink.getAttribute('href')).toBe('/page/segmented-control');
 
     unmount();
@@ -416,14 +438,61 @@ describe('component-page single-scroll layout', () => {
     await tick();
   });
 
+  test('defaults to the documentation view and switches to the playground on demand', async () => {
+    const { unmount } = render(ComponentPage);
+    await screen.findByRole('heading', { level: 1, name: 'Button' });
+
+    // Documentation is the default: the prose column gets the full width, which
+    // is the whole point of the split.
+    expect(document.querySelector('.dx-layout')).toBeTruthy();
+    expect(document.querySelector('.dx-playground')).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Documentation' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+
+    await showPlayground();
+
+    // …and the two views are genuinely exclusive, rather than a rail pinned
+    // beside the prose taking a fixed 38rem out of every page.
+    expect(document.querySelector('.dx-playground')).toBeTruthy();
+    expect(document.querySelector('.dx-layout')).toBeNull();
+    expect(screen.getByRole('tab', { name: 'Playground' }).getAttribute('aria-selected')).toBe(
+      'true',
+    );
+
+    unmount();
+    await tick();
+  });
+
+  test('makes the active view linkable through the URL', async () => {
+    const { unmount } = render(ComponentPage);
+    await screen.findByRole('heading', { level: 1, name: 'Button' });
+
+    await showPlayground();
+    expect(window.location.search).toContain('view=playground');
+
+    // The default view is expressed by DROPPING the parameter, so the canonical
+    // documentation URL stays clean.
+    await fireEvent.click(screen.getByRole('tab', { name: 'Documentation' }));
+    await tick();
+    expect(window.location.search).not.toContain('view=');
+
+    unmount();
+    await tick();
+  });
+
   test('shows the Playground with a control derived from a select prop', async () => {
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
 
+    // The documentation view does NOT carry the playground — that is the point
+    // of the split.
+    expect(document.querySelector('.dx-playground')).toBeNull();
+
+    await showPlayground();
+
     // `variant` is a select prop with a default → a control is generated.
-    // The controls live in the persistent preview pane beside the prose, not in
-    // a `#playground` section you scroll to.
-    expect(document.querySelector('.dx-preview')).toBeTruthy();
+    expect(document.querySelector('.dx-playground')).toBeTruthy();
     const select = await screen.findByLabelText('variant');
     expect(select.tagName).toBe('SELECT');
 
@@ -431,10 +500,14 @@ describe('component-page single-scroll layout', () => {
     await tick();
   });
 
-  test('omits the Playground when a required non-snippet prop has no default', async () => {
+  test('withholds only the generated snippet when a required non-snippet prop has no default', async () => {
     const required = baseFixture();
     // A required `unknown` prop with no default can't be synthesized, so the
-    // generated interactive playground is suppressed entirely.
+    // COPYABLE SNIPPET is withheld — it would not compile if pasted. Everything
+    // else the playground block offers survives, and the reader is told which
+    // prop was the problem. Suppressing the whole block here is what made ~20
+    // components report "no adjustable props" when the real cause was a
+    // synthesis failure.
     required.propsManifest.props = [
       {
         name: 'value',
@@ -448,17 +521,44 @@ describe('component-page single-scroll layout', () => {
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
 
-    expect(document.getElementById('playground')).toBeNull();
+    await showPlayground();
+    const play = document.querySelector('.dx-playground');
+    expect(play).not.toBeNull();
 
-    const nav = screen.getByRole('navigation', { name: 'On this page' });
-    const labels = Array.from(nav.querySelectorAll('a')).map((a) => a.textContent?.trim() ?? '');
-    expect(labels.some((label) => label.includes('Playground'))).toBe(false);
+    // No generated snippet: a `<CodeBlock>` inside the playground block would be
+    // uncompilable Svelte for a component with an unsatisfiable required prop.
+    expect(play?.querySelector('pre[data-language="svelte"]')).toBeNull();
+
+    // …and the reader is told why, by name.
+    const note = play?.querySelector('.dx-play__note');
+    expect(note).not.toBeNull();
+    const noteText = note?.textContent ?? '';
+    expect(noteText).toContain('value');
+    expect(noteText).toContain('required prop');
+    // The old blanket line was a lie in exactly this case.
+    expect(noteText).not.toContain('no adjustable props');
 
     unmount();
     await tick();
   });
 
-  test('omits the Playground for components that require authored examples', async () => {
+  test('says a component has no adjustable props only when that is true', async () => {
+    const bare = baseFixture();
+    bare.propsManifest.props = [];
+    installDocumentationDataIsland(bare);
+
+    const { unmount } = render(ComponentPage);
+    await screen.findByRole('heading', { level: 1, name: 'Button' });
+
+    await showPlayground();
+    const note = document.querySelector('.dx-play__note');
+    expect(note?.textContent).toContain('no adjustable props');
+
+    unmount();
+    await tick();
+  });
+
+  test('keeps the props panel for components that require authored examples', async () => {
     const exampleOnly = baseFixture();
     exampleOnly.component.id = 'autocomplete';
     exampleOnly.component.name = 'Autocomplete';
@@ -495,17 +595,23 @@ describe('component-page single-scroll layout', () => {
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Autocomplete' });
 
-    expect(document.getElementById('playground')).toBeNull();
-
-    const nav = screen.getByRole('navigation', { name: 'On this page' });
-    const labels = Array.from(nav.querySelectorAll('a')).map((a) => a.textContent?.trim() ?? '');
-    expect(labels.some((label) => label.includes('Playground'))).toBe(false);
+    await showPlayground();
+    const play = document.querySelector('.dx-playground');
+    expect(play).not.toBeNull();
+    // No generated snippet — the component is documented through its examples…
+    expect(play?.querySelector('pre[data-language="svelte"]')).toBeNull();
+    // …and it says so, rather than claiming there is nothing to adjust.
+    const noteText = play?.querySelector('.dx-play__note')?.textContent ?? '';
+    expect(noteText).toContain('documented through its examples');
+    expect(noteText).not.toContain('no adjustable props');
+    // The adjustable props it DOES have keep their controls.
+    expect(play?.querySelector('.dx-play__controls')).not.toBeNull();
 
     unmount();
     await tick();
   });
 
-  test('omits the Playground when a required non-children snippet has no default', async () => {
+  test('withholds only the generated snippet when a required non-children snippet has no default', async () => {
     const required = baseFixture();
     required.propsManifest.props = [
       {
@@ -520,7 +626,11 @@ describe('component-page single-scroll layout', () => {
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });
 
-    expect(document.getElementById('playground')).toBeNull();
+    await showPlayground();
+    const play = document.querySelector('.dx-playground');
+    expect(play).not.toBeNull();
+    expect(play?.querySelector('pre[data-language="svelte"]')).toBeNull();
+    expect(play?.querySelector('.dx-play__note')?.textContent).toContain('items');
 
     unmount();
     await tick();

--- a/packages/playground/src/component-page-live-preview.ts
+++ b/packages/playground/src/component-page-live-preview.ts
@@ -18,8 +18,14 @@
  */
 import { createRawSnippet, mount, unmount } from 'svelte';
 
-import type { PlaygroundControl, PlaygroundValue } from './component-page-playground.ts';
+import type {
+  PlaygroundControl,
+  PlaygroundSeed,
+  PlaygroundValue,
+} from './component-page-playground.ts';
+import type { PreviewRecipe } from './component-page-preview-recipes.ts';
 import { toMountErrorDetail, type MountErrorDetail } from './example-error.ts';
+import { CONTEXT_REQUIRED_PARTS } from './shell-app/compound-families.ts';
 
 /**
  * Escape a string for an HTML text-content context: `&` and `<` only. Used for
@@ -51,11 +57,28 @@ function escapeHtmlText(text: string): string {
 export function toMountProps(
   controls: PlaygroundControl[],
   values: Record<string, PlaygroundValue>,
+  seeds: readonly PlaygroundSeed[] = [],
+  recipe?: PreviewRecipe,
 ): Record<string, unknown> {
   const props: Record<string, unknown> = {};
+  // A recipe's children are a repo constant (placeholder boxes for a layout
+  // primitive, a padded block for Surface), so they are inserted as MARKUP —
+  // that is the point, since the whole failure being fixed is that one text run
+  // shows nothing about a component whose job is arranging elements. Reader
+  // input still goes through `escapeHtmlText` below; these two paths never mix.
+  if (recipe?.childrenHtml !== undefined) {
+    const html = recipe.childrenHtml;
+    props['children'] = createRawSnippet(() => ({ render: () => html }));
+  }
+  // Synthesized structural values (a required `items: Item[]`, say). These are
+  // live objects, not strings, so nothing is parsed at mount time.
+  for (const seed of seeds) props[seed.name] = seed.value;
   for (const control of controls) {
     const value = values[control.name] ?? control.value;
     if (control.kind === 'text' && control.isChildren === true) {
+      // A recipe already supplied structured children; the name-as-text seed
+      // must not overwrite them.
+      if (recipe?.childrenHtml !== undefined) continue;
       const text = String(value);
       if (text === '') continue;
       const escaped = escapeHtmlText(text);
@@ -64,6 +87,20 @@ export function toMountProps(
       }));
       continue;
     }
+    // A SYNTHESIZED empty string — a prop with no manifest default, seeded to
+    // `''` — is not passed to the mount, mirroring `shouldEmit`, which already
+    // drops it from the copyable snippet.
+    //
+    // Two reasons. The preview must render the code it tells you to copy: with a
+    // seeded `''` passed here but omitted there, `<DropdownGroup />` was the
+    // published snippet while the live mount was really
+    // `<DropdownGroup label="" labelledBy="" />`. And a component that validates
+    // its own inputs is entitled to reject `''` — DropdownGroup throws
+    // "requires a non-empty label value", so the seed did not just differ from
+    // the snippet, it painted an error callout over a component that works.
+    // A synthesized `0` is dropped for the same reason (and matters for `Image`,
+    // where `width={0} height={0}` collapses the element regardless of `src`).
+    if (!control.hasDefault && (value === '' || value === 0)) continue;
     props[control.name] = value;
   }
   return props;
@@ -116,6 +153,35 @@ export function isMountableComponent(value: unknown): value is MountableComponen
 function readProperty(value: unknown, key: string): unknown {
   if (value === null || typeof value !== 'object') return undefined;
   return Reflect.get(value, key);
+}
+
+/**
+ * Whether the playground may mount this component BARE with synthesized props.
+ *
+ * Two structural exclusions, both about children the playground cannot invent:
+ *
+ *  - A compound ROOT (`isCompound`, from the manifest) expects structured
+ *    sub-components (`<Accordion.Item>`); a bare mount renders an empty shell or
+ *    throws on `{@render children()}`.
+ *  - A context-requiring PART (see {@link CONTEXT_REQUIRED_PARTS}) reads a strict
+ *    context getter during init, so a mount with no provider ancestor throws
+ *    `missing_context` — which the page then paints as a red error callout on a
+ *    component whose only sin is being designed for composition.
+ *
+ * Auto-wrapping the parts in a synthesized `<Root><Part/></Root>` was considered
+ * and rejected: several need a nesting depth greater than two
+ * (`Table > Table.Header > Table.Row > Table.HeaderCell`), the roots have their
+ * own required props, and `tab`/`segment`/`choice-grid-item` need registration
+ * values that match the root's selection state. A generic wrapper renders blank
+ * or misleading for most of them, and the root's own page already shows the real
+ * composition.
+ *
+ * Deliberately NOT gated on compound-family membership as a whole: most family
+ * members read context through the optional `tryGet*` accessors and bare-mount
+ * fine today.
+ */
+export function canBareMount(kebabName: string, isCompound: boolean | undefined): boolean {
+  return isCompound !== true && !CONTEXT_REQUIRED_PARTS.has(kebabName);
 }
 
 /**

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -333,6 +333,47 @@ describe('structural seeds', () => {
     ]);
   });
 
+  test('synthesizes a NESTED array as an array, not as its own internals', () => {
+    // Arrays are objects to the type checker, so a nested `shortcuts: Entry[]`
+    // used to fall through to the object branch and serialize the ARRAY's own
+    // members as if they were data — `shortcuts: { length: 10, '__@unscopables@38': {} }`
+    // reached the copyable snippet for KeyboardShortcuts.
+    const model = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'groups',
+          control: {
+            kind: 'array',
+            rawType: 'Group[]',
+            element: {
+              fields: [
+                { name: 'label', shape: { kind: 'string' } },
+                {
+                  name: 'shortcuts',
+                  shape: {
+                    kind: 'array',
+                    element: {
+                      fields: [{ name: 'action', shape: { kind: 'string' } }],
+                      degenerate: false,
+                    },
+                  },
+                },
+              ],
+              degenerate: false,
+            },
+          },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+    );
+    const seeded = model.seeds[0]?.value as Array<Record<string, unknown>> | undefined;
+    const first = seeded?.[0];
+    expect(Array.isArray(first?.['shortcuts'])).toBe(true);
+    expect(first?.['shortcuts']).toEqual([{ action: 'Action one' }, { action: 'Action two' }]);
+    expect(model.seeds[0]?.source).toContain("shortcuts: [{ action: 'Action one' }");
+  });
+
   test('never invents a member for an index-signature-only record', () => {
     // `MatrixChartDatum = Record<string, string | number>` has no named field,
     // and the component's sibling props name KEYS of the datum — so any datum

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 
 import { buildPlaygroundModel, buildSnippet } from './component-page-playground.ts';
-import type { ComponentManifest, PropManifest } from './types.ts';
+import type { ComponentManifest, ObjectShape, PropManifest } from './types.ts';
 
 function manifest(props: PropManifest[]): ComponentManifest {
   return { name: 'Demo', kebabName: 'demo', file: 'demo.svelte', importPath: 'demo', props };
@@ -372,6 +372,46 @@ describe('structural seeds', () => {
     expect(Array.isArray(first?.['shortcuts'])).toBe(true);
     expect(first?.['shortcuts']).toEqual([{ action: 'Action one' }, { action: 'Action two' }]);
     expect(model.seeds[0]?.source).toContain("shortcuts: [{ action: 'Action one' }");
+  });
+
+  test('never seeds an optional or defaulted structural prop', () => {
+    // `buildSnippet` always emits seeds and `toMountProps` always passes them,
+    // so seeding a prop the component did not require OVERWRITES its own
+    // behavior: `ChoiceGrid.values` (optional, defaults to `[]`) got invented
+    // data, and `PhoneInput.countries` (optional) had its full 245-country list
+    // replaced by three. Same rule as the synthesized `''`/`0` control values.
+    const element: ObjectShape = {
+      fields: [{ name: 'label', shape: { kind: 'string' } }],
+      degenerate: false,
+    };
+    const model = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'optionalItems',
+          control: { kind: 'array', rawType: 'Item[]', element },
+          bindable: false,
+          optional: true,
+        },
+        {
+          name: 'defaultedItems',
+          control: { kind: 'array', rawType: 'Item[]', element },
+          bindable: false,
+          optional: false,
+          defaultValue: [],
+        },
+        {
+          name: 'requiredItems',
+          control: { kind: 'array', rawType: 'Item[]', element },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+    );
+    // Only the prop that would otherwise BLOCK the preview is seeded.
+    expect(model.seeds.map((seed) => seed.name)).toEqual(['requiredItems']);
+    // The other two are surfaced as non-adjustable rather than silently faked.
+    expect(model.skipped).toEqual(['optionalItems', 'defaultedItems']);
+    expect(model.hasUnsatisfiedRequired).toBe(false);
   });
 
   test('never invents a member for an index-signature-only record', () => {

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -53,7 +53,43 @@ describe('buildPlaygroundModel', () => {
     ]);
     expect(model.skipped).toEqual([]);
     expect(model.hasUnsatisfiedRequired).toBe(false);
+    expect(model.unsatisfiedRequired).toEqual([]);
     expect(model.requiresExamplePlayground).toBe(false);
+  });
+
+  test('names every required prop it could not synthesize', () => {
+    // The page has to tell the reader WHY a generated snippet is missing, so the
+    // model reports the blocking prop NAMES, not just that there were some. A
+    // bare boolean left the page with nothing honest to say, and it printed
+    // "This component has no adjustable props" — false here, since `label` is
+    // adjustable and present.
+    const model = buildPlaygroundModel(
+      manifest([
+        { name: 'label', control: { kind: 'text' }, bindable: false, optional: true },
+        {
+          name: 'items',
+          control: { kind: 'unknown', rawType: 'Item[]' },
+          bindable: false,
+          optional: false,
+        },
+        {
+          name: 'row',
+          control: { kind: 'snippet' },
+          bindable: false,
+          optional: false,
+        },
+        // Optional and defaulted props never block, however exotic their type.
+        {
+          name: 'formatter',
+          control: { kind: 'unknown', rawType: '(value: number) => string' },
+          bindable: false,
+          optional: true,
+        },
+      ]),
+    );
+    expect(model.unsatisfiedRequired).toEqual(['items', 'row']);
+    expect(model.hasUnsatisfiedRequired).toBe(true);
+    expect(model.controls.map((control) => control.name)).toEqual(['label']);
   });
 
   test('skips snippet/unknown props and lists them', () => {
@@ -257,6 +293,108 @@ describe('buildPlaygroundModel', () => {
       { name: 'id', hasDefault: false, kind: 'text', value: 'demo-example' },
       { name: 'label', hasDefault: false, kind: 'text', value: 'Demo' },
     ]);
+  });
+});
+
+describe('structural seeds', () => {
+  test('satisfies a required array-of-object prop instead of blocking on it', () => {
+    // The motivating case: a required `items: Item[]` used to be `unknown`, which
+    // counted as unsynthesizable and deleted the component's whole Playground
+    // section. It is now satisfied by a synthesized placeholder.
+    const model = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'items',
+          control: {
+            kind: 'array',
+            rawType: 'Item[]',
+            element: {
+              fields: [
+                { name: 'id', shape: { kind: 'string' } },
+                { name: 'label', shape: { kind: 'string' } },
+              ],
+              degenerate: false,
+            },
+          },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+    );
+    expect(model.hasUnsatisfiedRequired).toBe(false);
+    expect(model.unsatisfiedRequired).toEqual([]);
+    expect(model.skipped).toEqual([]);
+    // Three elements, so a list renders as a real multi-item instance.
+    expect(model.seeds).toHaveLength(1);
+    expect(model.seeds[0]?.value).toEqual([
+      { id: 'one', label: 'Label one' },
+      { id: 'two', label: 'Label two' },
+      { id: 'three', label: 'Label three' },
+    ]);
+  });
+
+  test('never invents a member for an index-signature-only record', () => {
+    // `MatrixChartDatum = Record<string, string | number>` has no named field,
+    // and the component's sibling props name KEYS of the datum — so any datum
+    // invented here would contradict them. Seed the empty array instead and let
+    // the component show its real empty state.
+    const model = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'data',
+          control: {
+            kind: 'array',
+            rawType: 'Datum[]',
+            element: { fields: [], degenerate: true },
+          },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+    );
+    expect(model.seeds[0]?.value).toEqual([{}, {}, {}]);
+    expect(model.seeds[0]?.source).toBe('[{}, {}, {}]');
+  });
+
+  test('emits seeds as Svelte source, inline when short and as a preamble when long', () => {
+    const shortSeed = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'keys',
+          control: { kind: 'array', rawType: 'string[]', element: { kind: 'string' } },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+    );
+    // Short enough to read inline as an expression attribute.
+    expect(buildSnippet('Widget', shortSeed.controls, {}, shortSeed.seeds)).toContain('keys={[');
+
+    const longSeed = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'items',
+          control: {
+            kind: 'array',
+            rawType: 'Item[]',
+            element: {
+              fields: [
+                { name: 'identifier', shape: { kind: 'string' } },
+                { name: 'description', shape: { kind: 'string' } },
+              ],
+              degenerate: false,
+            },
+          },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+    );
+    const snippet = buildSnippet('Widget', longSeed.controls, {}, longSeed.seeds, 'pkg/widget');
+    // A nine-field object array inline is not how anyone writes this.
+    expect(snippet).toContain("import { Widget } from 'pkg/widget';");
+    expect(snippet).toContain('const items = [');
+    expect(snippet).toContain('<Widget {items} />');
   });
 });
 
@@ -485,11 +623,16 @@ describe('buildSnippet', () => {
         },
       ]),
     ).controls;
-    // The seeded values (first option / `false` / `0`) are surfaced explicitly,
-    // because we cannot prove they match the component's own defaults.
+    // The seeded values are surfaced explicitly, because we cannot prove they
+    // match the component's own defaults — EXCEPT the empty placeholders `''`
+    // and `0`, which the generator invented for props that declared no default
+    // at all. Emitting those claims the reader asked for them: `Image` seeded
+    // `width={0} height={0}` and collapsed the element to nothing however good
+    // its `src` was. `toMountProps` drops the same two, so the live preview and
+    // the copyable snippet stay in agreement.
     expect(
       buildSnippet('Widget', noDefault, { variant: 'primary', disabled: false, count: 0 }),
-    ).toBe('<Widget\n  variant="primary"\n  disabled={false}\n  count={0}\n/>');
+    ).toBe('<Widget\n  variant="primary"\n  disabled={false}\n/>');
   });
 
   test('renders a children control as element content, not an attribute', () => {

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -380,10 +380,22 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
         break;
       case 'array':
       case 'object': {
-        // Structural props are satisfied by a synthesized literal rather than a
-        // control — see `PlaygroundSeed`. They are NOT `skipped` and do NOT
-        // block: the whole point is that a required `items: Item[]` should stop
-        // deleting the component's Playground section.
+        // ONLY a required prop with no default is seeded, matching exactly the
+        // condition that would otherwise block the preview (see
+        // `blocksGeneratedPreview`) — which is the entire reason seeds exist.
+        //
+        // Seeding an optional or defaulted structural prop actively breaks the
+        // component: `buildSnippet` always emits seeds and `toMountProps` always
+        // passes them, so `ChoiceGrid.values` (optional, defaults to `[]`) had
+        // its own default overwritten with invented data, and
+        // `PhoneInput.countries` (optional) had its full 245-country list
+        // replaced by three. Same reasoning as the synthesized `''`/`0` values
+        // that `shouldEmit` and `toMountProps` already drop: never supply a
+        // value the component did not ask for.
+        if (prop.optional || prop.defaultValue !== undefined) {
+          skipped.push(prop.name);
+          break;
+        }
         const scoped = COMPONENT_VALUE_SEEDS[manifest.kebabName]?.[prop.name];
         const value =
           scoped !== undefined

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -8,7 +8,8 @@
  * component with an exotic prop degrades gracefully instead of emitting a
  * broken control or invalid snippet.
  */
-import type { ComponentManifest, PropManifest } from './types.ts';
+import { allowsPlainTextChildren } from './component-page-children-seed.ts';
+import type { ComponentManifest, ObjectShape, PropManifest, ValueShape } from './types.ts';
 
 /**
  * Fields common to every {@link PlaygroundControl}, regardless of kind.
@@ -34,17 +35,139 @@ export type PlaygroundControl = PlaygroundControlBase &
 export type PlaygroundValue = boolean | string | number;
 
 /**
+ * A required prop the generator cannot make ADJUSTABLE, but CAN satisfy with a
+ * synthesized literal so the preview mounts and the snippet compiles.
+ *
+ * Seeds exist because the alternative was worse: an array-of-object prop like
+ * `Breadcrumbs.items` is not something a text input can edit, so the analyzer
+ * used to report it unsynthesizable and the page deleted the whole Playground
+ * section. A read-only placeholder renders a real, multi-item instance and
+ * copies as valid Svelte.
+ *
+ * Not a `PlaygroundControl`: `PlaygroundValue` is `boolean | string | number`
+ * and is threaded through the snippet builder, the mount, and the page's
+ * `$state`. Widening it to `unknown` to carry an object would touch all of that,
+ * and a JSON textarea would remount the component with a parse failure on most
+ * keystrokes.
+ */
+export type PlaygroundSeed = {
+  name: string;
+  description?: string;
+  /** The literal handed to `mount`. */
+  value: unknown;
+  /** The same literal as copy-pasteable Svelte source. */
+  source: string;
+};
+
+/**
+ * Three elements — enough that a list, chart, or carousel renders as a real
+ * multi-item instance rather than a degenerate single-row case.
+ */
+const SYNTHESIZED_ARRAY_LENGTH = 3;
+
+/** Ordinal words for placeholder text, so items read as content, not as `item0`. */
+const ORDINALS = ['one', 'two', 'three', 'four', 'five'] as const;
+
+function ordinal(index: number): string {
+  return ORDINALS[index] ?? String(index + 1);
+}
+
+/** True when a shape is an {@link ObjectShape} rather than a leaf {@link ValueShape}. */
+function isObjectShape(shape: ValueShape | ObjectShape): shape is ObjectShape {
+  return 'fields' in shape;
+}
+
+/**
+ * Invent the minimal value satisfying a shape. `index` varies the placeholders
+ * across the elements of an array so the preview shows distinguishable items.
+ */
+function synthesizeValue(
+  shape: ValueShape | ObjectShape,
+  index: number,
+  propName: string,
+): unknown {
+  if (isObjectShape(shape)) {
+    if (shape.degenerate) return {};
+    const value: Record<string, unknown> = {};
+    for (const field of shape.fields) {
+      value[field.name] = synthesizeValue(field.shape, index, field.name);
+    }
+    return value;
+  }
+
+  switch (shape.kind) {
+    case 'string':
+      // Identifier-ish fields get a slug, prose fields a readable label — an
+      // `id` of "Item one" would be a strange thing to show a reader.
+      return /^(id|key|value|slug|name)$/i.test(propName)
+        ? ordinal(index)
+        : `${sentenceCase(propName)} ${ordinal(index)}`;
+    case 'number':
+      return (index + 1) * 10;
+    case 'boolean':
+      return false;
+    case 'enum':
+      return shape.options[index % shape.options.length] ?? shape.options[0] ?? '';
+    default:
+      // Opaque — never faked. Callers drop these fields entirely.
+      return undefined;
+  }
+}
+
+/** `datetime` -> `Datetime`, `firstName` -> `First name`. */
+function sentenceCase(name: string): string {
+  const spaced = name.replace(/([a-z0-9])([A-Z])/g, '$1 $2').toLowerCase();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+/**
+ * Serialize a synthesized value as Svelte SOURCE, not JSON: unquoted
+ * identifier-safe keys and single-quoted strings, because `{"label":"Item one"}`
+ * is valid but reads as JSON rather than as code a reader would have written.
+ */
+export function formatValueLiteral(value: unknown): string {
+  if (typeof value === 'string') return `'${value.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (value === null || value === undefined) return 'null';
+  if (Array.isArray(value)) return `[${value.map(formatValueLiteral).join(', ')}]`;
+  const entries = Object.entries(value as Record<string, unknown>).map(
+    ([key, entry]) =>
+      `${/^[A-Za-z_$][\w$]*$/.test(key) ? key : `'${key}'`}: ${formatValueLiteral(entry)}`,
+  );
+  return entries.length === 0 ? '{}' : `{ ${entries.join(', ')} }`;
+}
+
+/**
  * The result of classifying a component's props for the Playground: the
  * controls we can render, and the names of props we deliberately skipped
  * (shown to the reader so the omission is explicit, not silent).
  */
 export type PlaygroundModel = {
   controls: PlaygroundControl[];
+  /**
+   * Props satisfied by a synthesized literal rather than a control. See
+   * {@link PlaygroundSeed}.
+   */
+  seeds: PlaygroundSeed[];
   skipped: string[];
+  /**
+   * Names of the required props with no default that we cannot supply a
+   * baseline for — the props that make a GENERATED preview invalid by
+   * construction (see {@link blocksGeneratedPreview}).
+   *
+   * Carried as names rather than a bare flag because the page has to tell the
+   * reader WHY the generated snippet is missing. The previous boolean-only
+   * shape left the page with nothing honest to say, so it printed "This
+   * component has no adjustable props" — false whenever the component had
+   * plenty of adjustable props and merely one unsynthesizable required one.
+   */
+  unsatisfiedRequired: string[];
   /**
    * True when the component has a required prop with no default that we cannot
    * supply a baseline for. The page should then omit the generated preview +
-   * snippet rather than emit an invalid one.
+   * snippet rather than emit an invalid one. Equivalent to
+   * `unsatisfiedRequired.length > 0`; kept as a named field because it is the
+   * question every call site actually asks.
    */
   hasUnsatisfiedRequired: boolean;
   /**
@@ -56,7 +179,27 @@ export type PlaygroundModel = {
   requiresExamplePlayground: boolean;
 };
 
-const EXAMPLE_ONLY_PLAYGROUND_COMPONENTS = new Set(['autocomplete', 'spectrogram']);
+/**
+ * Components documented through their authored examples rather than the generic
+ * prop playground.
+ *
+ * The overlays are here for a specific reason: `Modal`, `Drawer`, `Sheet` and
+ * `CommandPalette` all call `showModal()`, so seeding `open: true` would not put
+ * a preview in the stage — it would blanket the entire documentation page in the
+ * top layer and take the body scroll lock with it. `Popover` cannot be opened at
+ * all without a `trigger` snippet to anchor against, which the generator has no
+ * way to synthesize as focusable markup. Each of them ships a trigger-based
+ * example that demonstrates the real interaction, which is what the stage shows
+ * instead of an empty box.
+ */
+const EXAMPLE_ONLY_PLAYGROUND_COMPONENTS = new Set([
+  'autocomplete',
+  'spectrogram',
+  'modal',
+  'drawer',
+  'sheet',
+  'popover',
+]);
 
 /**
  * True when a prop would make the generated preview invalid by construction: it
@@ -91,7 +234,58 @@ function stringDefault(value: unknown): string {
  * optional text controls, but a required label/id/title seeded to `''` makes the
  * live playground look broken before the reader changes anything.
  */
+/**
+ * Per-component seeds for required text props whose value has to be a REAL
+ * instance of something, not a label.
+ *
+ * `requiredTextSeed` keys only on the prop name and falls back to the name
+ * itself, which is fine for a `label` but produced the two most visibly broken
+ * previews in the library: `Image` rendered a broken-image glyph because `src`
+ * was the literal string "src", and `SourceDiffViewer` rendered a fake one-line
+ * diff because `patch` was the literal string "patch".
+ */
+const COMPONENT_TEXT_SEEDS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  image: {
+    // An inline SVG data URI rather than a remote placeholder service: the docs
+    // site ships no image assets, and the examples already use this pattern
+    // (see `examples/carousel/basic.example.svelte`) precisely to avoid a
+    // third-party network dependency that breaks offline dev and snapshots.
+    src:
+      "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='600' height='338'%3E" +
+      "%3Crect width='600' height='338' fill='%23b8c4d4'/%3E%3C/svg%3E",
+    alt: 'A muted grey placeholder rectangle',
+  },
+  'source-diff-viewer': {
+    // Deliberately a Markdown diff, not a code diff: no braces, quotes,
+    // ampersands, or angle brackets, so it survives every attribute-escaping
+    // path unchanged.
+    patch: [
+      'diff --git a/README.md b/README.md',
+      '--- a/README.md',
+      '+++ b/README.md',
+      '@@ -1,3 +1,3 @@',
+      ' # Cinder',
+      '-A component library.',
+      '+A Svelte component library for building fast UIs.',
+      ' Read the docs to get started.',
+    ].join('\n'),
+  },
+};
+
+/**
+ * Per-component seeds for STRUCTURAL props whose generic placeholder is
+ * technically valid but reads as nonsense. `ShortcutHint.keys` is the clear
+ * case: the generic array-of-string synthesis yields
+ * `['Keys one', 'Keys two', 'Keys three']`, and rendering those as keycaps is
+ * exactly the sort of thing a reader would screenshot as a bug.
+ */
+const COMPONENT_VALUE_SEEDS: Readonly<Record<string, Readonly<Record<string, unknown>>>> = {
+  'shortcut-hint': { keys: ['Meta', 'Shift', 'P'] },
+};
+
 function requiredTextSeed(prop: PropManifest, manifest: ComponentManifest): string {
+  const scoped = COMPONENT_TEXT_SEEDS[manifest.kebabName]?.[prop.name];
+  if (scoped !== undefined) return scoped;
   switch (prop.name) {
     case 'id':
       return `${manifest.kebabName}-example`;
@@ -145,8 +339,9 @@ function childrenSeed(manifest: ComponentManifest): string {
  */
 export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundModel {
   const controls: PlaygroundControl[] = [];
+  const seeds: PlaygroundSeed[] = [];
   const skipped: string[] = [];
-  let hasUnsatisfiedRequired = false;
+  const unsatisfiedRequired: string[] = [];
 
   for (const prop of manifest.props) {
     // Spread description only when present — the control type uses an optional
@@ -174,6 +369,33 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
       case 'number':
         controls.push({ ...base, kind: 'number', value: numberDefault(prop.defaultValue) });
         break;
+      case 'array':
+      case 'object': {
+        // Structural props are satisfied by a synthesized literal rather than a
+        // control — see `PlaygroundSeed`. They are NOT `skipped` and do NOT
+        // block: the whole point is that a required `items: Item[]` should stop
+        // deleting the component's Playground section.
+        const scoped = COMPONENT_VALUE_SEEDS[manifest.kebabName]?.[prop.name];
+        const value =
+          scoped !== undefined
+            ? scoped
+            : prop.control.kind === 'array'
+              ? Array.from({ length: SYNTHESIZED_ARRAY_LENGTH }, (_unused, index) =>
+                  synthesizeValue(
+                    prop.control.kind === 'array'
+                      ? prop.control.element
+                      : {
+                          fields: [],
+                          degenerate: true,
+                        },
+                    index,
+                    prop.name,
+                  ),
+                )
+              : synthesizeValue(prop.control.shape, 0, prop.name);
+        seeds.push({ ...base, value, source: formatValueLiteral(value) });
+        break;
+      }
       default:
         // snippet / unknown — not adjustable as an attribute. The one exception
         // is the ubiquitous `children` snippet: many components (Badge, Button,
@@ -189,7 +411,11 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
         // a semantically broken preview (loose text in an empty `.cinder-accordion`
         // shell). They skip the control and fall back to the featured-example
         // mount instead — see {@link ComponentManifest.isCompound}.
-        if (prop.name === 'children' && prop.control.kind === 'snippet' && !manifest.isCompound) {
+        if (
+          prop.name === 'children' &&
+          prop.control.kind === 'snippet' &&
+          allowsPlainTextChildren(manifest)
+        ) {
           controls.push({
             ...base,
             kind: 'text',
@@ -202,15 +428,17 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
         // non-snippet value the generator can't synthesize means we can't build
         // a valid preview at all.
         skipped.push(prop.name);
-        if (blocksGeneratedPreview(prop)) hasUnsatisfiedRequired = true;
+        if (blocksGeneratedPreview(prop)) unsatisfiedRequired.push(prop.name);
         break;
     }
   }
 
   return {
     controls,
+    seeds,
     skipped,
-    hasUnsatisfiedRequired,
+    unsatisfiedRequired,
+    hasUnsatisfiedRequired: unsatisfiedRequired.length > 0,
     requiresExamplePlayground: EXAMPLE_ONLY_PLAYGROUND_COMPONENTS.has(manifest.kebabName),
   };
 }
@@ -230,7 +458,12 @@ export function buildPlaygroundModel(manifest: ComponentManifest): PlaygroundMod
 function attributeFor(name: string, value: PlaygroundValue): string {
   if (typeof value === 'boolean') return value ? name : `${name}={false}`;
   if (typeof value === 'number') return `${name}={${value}}`;
-  if (/["&<>]/.test(value)) return `${name}={${JSON.stringify(value)}}`;
+  // `{` and `}` are NOT safe in a double-quoted Svelte attribute — `{expr}` is
+  // interpolated there, so a value containing braces pastes as different (or
+  // invalid) Svelte than the preview shows. `\n` is legal but emits literal
+  // newlines inside the quotes, wrecking the snippet's formatting and
+  // highlighting. All of them route to the JSON-escaped expression form.
+  if (/["&<>{}\n]/.test(value)) return `${name}={${JSON.stringify(value)}}`;
   return `${name}="${value}"`;
 }
 
@@ -250,7 +483,11 @@ function attributeFor(name: string, value: PlaygroundValue): string {
  */
 function shouldEmit(control: PlaygroundControl, current: PlaygroundValue): boolean {
   if (control.hasDefault) return current !== control.value;
-  return current !== '';
+  // A synthesized `0` is noise for the same reason a synthesized `''` is: the
+  // component never declared it. It is also actively wrong for `Image`, where
+  // `width={0} height={0}` collapses the element to nothing however good the
+  // `src` is.
+  return current !== '' && current !== 0;
 }
 
 /**
@@ -285,10 +522,19 @@ function escapeSnippetText(text: string): string {
   return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/\{/g, '&lbrace;');
 }
 
+/**
+ * Serialized seed literals longer than this move out of the attribute list and
+ * into a `<script>` preamble. An inline nine-field object array is not how
+ * anyone writes this, and the snippet is meant to be copied.
+ */
+const INLINE_SEED_MAX_CHARS = 60;
+
 export function buildSnippet(
   exportName: string,
   controls: PlaygroundControl[],
   values: Record<string, PlaygroundValue>,
+  seeds: readonly PlaygroundSeed[] = [],
+  importPath?: string,
 ): string {
   // The synthesized `children` control renders as element CONTENT, not an
   // attribute, so it is partitioned out of the attribute list.
@@ -298,10 +544,21 @@ export function buildSnippet(
       ? String(values[childrenControl.name] ?? childrenControl.value)
       : '';
 
-  const attributes = controls
-    .filter((control) => !(control.kind === 'text' && control.isChildren))
-    .filter((control) => shouldEmit(control, values[control.name] ?? control.value))
-    .map((control) => attributeFor(control.name, values[control.name] ?? control.value));
+  // Seeds are ALWAYS emitted — a synthesized value for a required prop can never
+  // be omitted without the snippet failing to compile. Short ones inline as an
+  // expression attribute; long ones become `const` bindings in a preamble and
+  // are referenced by the `{name}` shorthand.
+  const inlineSeeds = seeds.filter((seed) => seed.source.length <= INLINE_SEED_MAX_CHARS);
+  const preambleSeeds = seeds.filter((seed) => seed.source.length > INLINE_SEED_MAX_CHARS);
+
+  const attributes = [
+    ...controls
+      .filter((control) => !(control.kind === 'text' && control.isChildren))
+      .filter((control) => shouldEmit(control, values[control.name] ?? control.value))
+      .map((control) => attributeFor(control.name, values[control.name] ?? control.value)),
+    ...inlineSeeds.map((seed) => `${seed.name}={${seed.source}}`),
+    ...preambleSeeds.map((seed) => `{${seed.name}}`),
+  ];
 
   // One attribute fragment shared by both the self-closing and open/close forms,
   // so children is a single suffix concern rather than a parallel set of paths.
@@ -314,10 +571,19 @@ export function buildSnippet(
 
   // With children content, emit an open/close pair so the snippet copy-pastes as
   // a real labelled instance; otherwise keep the minimal self-closing form.
-  if (childrenText !== '') {
-    return `<${exportName}${attributePart}>${escapeSnippetText(childrenText)}</${exportName}>`;
-  }
-  return attributes.length > 1
-    ? `<${exportName}${attributePart}/>`
-    : `<${exportName}${attributePart} />`;
+  const element =
+    childrenText !== ''
+      ? `<${exportName}${attributePart}>${escapeSnippetText(childrenText)}</${exportName}>`
+      : attributes.length > 1
+        ? `<${exportName}${attributePart}/>`
+        : `<${exportName}${attributePart} />`;
+
+  if (preambleSeeds.length === 0) return element;
+
+  const importLine =
+    importPath === undefined ? '' : `  import { ${exportName} } from '${importPath}';\n\n`;
+  const declarations = preambleSeeds
+    .map((seed) => `  const ${seed.name} = ${seed.source};`)
+    .join('\n');
+  return `<script lang="ts">\n${importLine}${declarations}\n</script>\n\n${element}`;
 }

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -108,6 +108,10 @@ function synthesizeValue(
       return false;
     case 'enum':
       return shape.options[index % shape.options.length] ?? shape.options[0] ?? '';
+    case 'array':
+      // Two elements for a NESTED array — enough to read as a list without
+      // making the outer literal unwieldy.
+      return [0, 1].map((nested) => synthesizeValue(shape.element, nested, propName));
     default:
       // Opaque — never faked. Callers drop these fields entirely.
       return undefined;
@@ -199,6 +203,11 @@ const EXAMPLE_ONLY_PLAYGROUND_COMPONENTS = new Set([
   'drawer',
   'sheet',
   'popover',
+  // Listed defensively. CommandPalette is currently blocked anyway by its
+  // required `items` snippet, so no `open` control is generated today — but it
+  // is a `showModal()` dialog like the four above, so if that snippet ever
+  // becomes synthesizable the blanket-the-page failure would come back silently.
+  'command-palette',
 ]);
 
 /**

--- a/packages/playground/src/component-page-preview-recipes.ts
+++ b/packages/playground/src/component-page-preview-recipes.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-component preview scaffolding for the classes of component that no amount
+ * of prop seeding can make legible.
+ *
+ * Three of them:
+ *
+ *  - LAYOUT primitives (`Container`, `Grid`, `BentoCell`, `Masonry`) render a box
+ *    whose entire job is arranging children. With one text run there are no
+ *    columns, no tracks, and no gutters to see — and unlike a static example,
+ *    placeholder children re-flow live as `columns` / `minItemWidth` / `maxWidth`
+ *    change, which is exactly what the reader came to the playground for.
+ *  - STYLING primitives (`Surface`) are invisible in isolation: with no reference
+ *    surface beside it, a tone is just "the page", and `surface.css` sets no
+ *    padding so text sits flush against the border.
+ *  - BEHAVIOR-only wrappers (`FocusTrap`, `ClickAwayListener`, `LocaleProvider`,
+ *    `Portal`) render their children and nothing else. There is no visual state a
+ *    recipe could make legible, so they route to their authored example instead,
+ *    which demonstrates the behavior interactively.
+ *
+ * The markup here is a repo constant, never reader input, which is why it is
+ * inserted raw rather than through the escaping path `toMountProps` uses for the
+ * editable `children` text control.
+ */
+
+/** Scaffolding for one component's live-preview stage. */
+export type PreviewRecipe = {
+  /**
+   * Raw HTML mounted as the component's `children`, replacing the synthesized
+   * name-as-text seed.
+   */
+  childrenHtml?: string;
+  /**
+   * Raw HTML rendered as a SIBLING of the component inside the stage, before it.
+   * Used to give a styling primitive something to be compared against.
+   */
+  referenceHtml?: string;
+  /**
+   * True when the component has no useful bare preview at all and should fall
+   * through to its authored example.
+   *
+   * Deliberately separate from `requiresExamplePlayground`, which additionally
+   * suppresses the prop CONTROLS. A reader on `Portal` still wants to see
+   * `target` / `disabled` / `inheritAttributes` listed.
+   */
+  prefersFeaturedExample?: boolean;
+};
+
+/** Three numbered placeholder boxes, so a layout's tracks and gutters are visible. */
+const PLACEHOLDER_BOXES = [1, 2, 3]
+  .map(
+    (n) =>
+      `<div class="dx-recipe-box" style="padding:var(--cinder-space-4);border:1px dashed var(--cinder-border);border-radius:var(--cinder-radius-sm);background:var(--cinder-surface-inset);color:var(--cinder-text-muted);font-family:var(--cinder-font-mono);font-size:var(--cinder-text-xs)">Item ${n}</div>`,
+  )
+  .join('');
+
+const LAYOUT_RECIPE: PreviewRecipe = { childrenHtml: PLACEHOLDER_BOXES };
+
+export const PREVIEW_RECIPES: Readonly<Record<string, PreviewRecipe>> = {
+  container: LAYOUT_RECIPE,
+  grid: LAYOUT_RECIPE,
+  'grid-item': LAYOUT_RECIPE,
+  'bento-cell': LAYOUT_RECIPE,
+  masonry: LAYOUT_RECIPE,
+  'aspect-ratio': {
+    childrenHtml:
+      '<div style="display:grid;place-items:center;block-size:100%;background:var(--cinder-surface-inset);color:var(--cinder-text-muted);font-family:var(--cinder-font-mono);font-size:var(--cinder-text-xs)">Aspect-ratio content</div>',
+  },
+  surface: {
+    // A tone is only readable against another tone, and the component itself
+    // supplies no padding — so the recipe supplies both the reference and the
+    // inner spacing.
+    referenceHtml:
+      '<div style="padding:var(--cinder-space-4);border-radius:var(--cinder-radius-md);background:var(--cinder-surface);color:var(--cinder-text-muted);font-size:var(--cinder-text-sm)">Reference surface (default tone)</div>',
+    childrenHtml:
+      '<div style="padding:var(--cinder-space-4);color:var(--cinder-text);font-size:var(--cinder-text-sm)">This Surface, at the selected tone</div>',
+  },
+  'focus-trap': { prefersFeaturedExample: true },
+  'click-away-listener': { prefersFeaturedExample: true },
+  portal: { prefersFeaturedExample: true },
+  // LocaleProvider renders a bare `{@render children?.()}` and ships no example,
+  // so there is nothing to show either way. Marking it keeps the stage from
+  // reserving a frame that never fills.
+  'locale-provider': { prefersFeaturedExample: true },
+};
+
+/** The recipe for a component, or `undefined` when it needs no scaffolding. */
+export function previewRecipeFor(kebabName: string): PreviewRecipe | undefined {
+  return PREVIEW_RECIPES[kebabName];
+}

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -25,7 +25,14 @@
   import Sun from 'lucide-svelte/icons/sun';
   import X from 'lucide-svelte/icons/x';
   import { COMPOUND_COMPONENT_PARENTS } from './shell-app/compound-families.ts';
-  import { buildComponentHref, readFocusModeFromSearch } from './shell-app/routing.ts';
+  import { humanizeComponentName } from './shell-app/humanize.ts';
+  import {
+    buildComponentHref,
+    readFocusModeFromSearch,
+    readViewFromSearch,
+    searchForView,
+    type ComponentPageView,
+  } from './shell-app/routing.ts';
   import { persistScrollPosition } from './shell-app/sidebar-scroll.ts';
   import { createEventSource } from './shell-app/event-source.svelte.ts';
   import { splitReadmeHtml } from './split-readme-html.ts';
@@ -46,7 +53,10 @@
     buildSnippet,
     type PlaygroundValue,
   } from './component-page-playground.ts';
+  import { depictHighlighter } from './depict-highlighter.ts';
+  import { previewRecipeFor } from './component-page-preview-recipes.ts';
   import {
+    canBareMount,
     createLivePreviewMount,
     LIVE_MOUNT_CONTAINER_ID,
     resolveBareComponent,
@@ -146,7 +156,9 @@
 
   // Height of the sticky top bar, in pixels — used for scroll-spy activation
   // and smooth-scroll offset so anchored sections clear the bar.
-  const TOP_BAR_HEIGHT = 52;
+  // The sticky top bar was removed; its height stays as a named zero so the
+  // scroll-spy and smooth-scroll offsets keep reading as deliberate.
+  const TOP_BAR_HEIGHT = 0;
 
   function readExamples(): CinderExampleDescriptor[] {
     if (typeof window === 'undefined') return [];
@@ -235,8 +247,30 @@
     // Adopted after hydration, not during init: the server cannot read the URL's
     // toolbar state without the two trees disagreeing.
     previewWidth = readInitialPreviewWidth();
-    isFocusMode = readFocusModeFromSearch(new URLSearchParams(window.location.search));
+    const search = new URLSearchParams(window.location.search);
+    isFocusMode = readFocusModeFromSearch(search);
+    activeView = readViewFromSearch(search);
   });
+
+  /**
+   * Which of the two views the page is showing (decision 2).
+   *
+   * Seeded to `documentation` on BOTH server and client so the first render
+   * agrees, then adopted from the URL after hydration — the same discipline the
+   * theme and focus-mode state already use. Reading `location.search` during
+   * init would render the docs view on the server and the playground view on
+   * the client for anyone following a `?view=playground` link.
+   */
+  let activeView = $state<ComponentPageView>('documentation');
+
+  function selectView(view: ComponentPageView): void {
+    activeView = view;
+    if (typeof window === 'undefined') return;
+    // `replaceState`, not `pushState`: flipping a view is not a navigation the
+    // Back button should have to walk through, but the URL must stay shareable.
+    const search = searchForView(new URLSearchParams(window.location.search), view);
+    window.history.replaceState(null, '', `${window.location.pathname}${search}`);
+  }
 
   let previewWidth = $state<number | null>(null);
 
@@ -272,7 +306,7 @@
     const query = navFilter.trim().toLowerCase();
     if (query === '') return sidebarComponents;
     return sidebarComponents.filter(
-      (name) => name.includes(query) || humanizeId(name).toLowerCase().includes(query),
+      (name) => name.includes(query) || humanizeComponentName(name).toLowerCase().includes(query),
     );
   });
 
@@ -413,6 +447,46 @@
     return members.length <= 4 && members.every((member) => member.length <= 20);
   }
 
+  /**
+   * The props table's columns, in render order.
+   *
+   * The header cells, each body cell's `data-label`, and the stacked-layout
+   * `::before` labels all read from this one list. They used to be three
+   * independent things, with the stacked labels positioned by `nth-child` — so
+   * dropping the Required and Bindable columns would have silently relabelled
+   * Description as "Required" and left the real Description rule matching
+   * nothing. Nothing errors; the narrow-container card just lies, and only below
+   * a 34rem CONTAINER width where a desktop check never looks.
+   */
+  const PROP_COLUMNS = [
+    { key: 'name', label: 'Name' },
+    { key: 'type', label: 'Type' },
+    { key: 'default', label: 'Default' },
+    { key: 'description', label: 'Description' },
+  ] as const;
+
+  /**
+   * Union members rendered before the remainder moves behind a disclosure.
+   *
+   * `PhoneInput.country` is a 245-member union — an unbounded vertical wall of
+   * country codes in a table cell, at every width. There was already an
+   * `isShortUnion` threshold on the short side and nothing on the long side.
+   * Nothing is discarded: a reader checking whether `'GB'` is in the list can
+   * still open it, and for a union there is no alias name to fall back on (the
+   * analyzer resolves it to its options before the manifest is written).
+   */
+  const UNION_PREVIEW_COUNT = 8;
+
+  /**
+   * Characters of a single (non-union) type rendered before it is truncated.
+   *
+   * The long-side twin of the union cap, for structural types: `Statistic.change`
+   * is a 540-character inline object type — JSDoc comments and all — and
+   * `DateRangeField.value` and `ApprovalCard.sandbox` are the same shape. One
+   * policy for type complexity, not two.
+   */
+  const SINGLE_TYPE_PREVIEW_CHARS = 160;
+
   function statusDotStatus(status: string): StatusDotStatus {
     switch (status) {
       case 'stable':
@@ -473,7 +547,9 @@
     documentation === null
       ? {
           controls: [],
+          seeds: [],
           skipped: [],
+          unsatisfiedRequired: [],
           hasUnsatisfiedRequired: false,
           requiresExamplePlayground: false,
         }
@@ -498,13 +574,55 @@
           documentation.component.exportName,
           playgroundModel.controls,
           playgroundValues,
+          playgroundModel.seeds,
+          documentation.propsManifest.importPath,
         ),
   );
-  const showGeneratedPlayground = $derived(
-    playgroundModel.controls.length > 0 &&
-      !playgroundModel.hasUnsatisfiedRequired &&
-      !playgroundModel.requiresExamplePlayground,
+  /**
+   * Whether the GENERATED artifacts — the live bare mount and the copyable
+   * snippet — can be trusted for this component. False when a required prop has
+   * no synthesizable value (the snippet would not compile) or when the component
+   * is documented through its examples instead.
+   *
+   * This gates ONLY the generated pieces. It deliberately does NOT gate the
+   * section: the featured example, the prop controls, and the surrounding chrome
+   * stay. Gating the whole `.dx-play` block on this is what made a synthesis
+   * failure indistinguishable from a component that genuinely has no props —
+   * ~20 components lost their entire Playground section and were told, falsely,
+   * that they had nothing to adjust.
+   */
+  const canGenerateFromProps = $derived(
+    !playgroundModel.hasUnsatisfiedRequired && !playgroundModel.requiresExamplePlayground,
   );
+
+  /**
+   * The reader-facing explanation for a missing generated preview, or `null`
+   * when there is nothing to explain. Three distinct states the old single line
+   * collapsed into one (usually untrue) sentence:
+   *
+   *  - `example-only`  — the component is documented through its examples.
+   *  - `unsatisfied`   — a required prop can't be synthesized, so the generated
+   *                      snippet is withheld. Names the props, because "we
+   *                      couldn't" is only useful if the reader can see what.
+   *  - `no-props`      — the honest original: there really is nothing to adjust.
+   */
+  type PlaygroundNote =
+    | { kind: 'example-only' }
+    | { kind: 'unsatisfied'; props: string[]; hasFallback: boolean }
+    | { kind: 'no-props' };
+
+  const playgroundNote = $derived.by<PlaygroundNote | null>(() => {
+    if (playgroundModel.requiresExamplePlayground) return { kind: 'example-only' };
+    if (playgroundModel.unsatisfiedRequired.length > 0) {
+      return {
+        kind: 'unsatisfied',
+        props: playgroundModel.unsatisfiedRequired,
+        hasFallback: overviewExample !== undefined,
+      };
+    }
+    if (playgroundModel.controls.length === 0) return { kind: 'no-props' };
+    return null;
+  });
 
   // The bare component constructor for the Playground section's LIVE preview
   // (#405): resolved from the module namespace passed in as a prop by the page
@@ -512,16 +630,42 @@
   // `undefined` when the module wasn't provided or the export isn't a component,
   // in which case the section degrades to the static featured-example mount.
   //
-  // Compound components (Accordion, Tabs, …) resolve to `undefined` here on
-  // purpose: their `children` are structured sub-components the playground can't
-  // synthesize, so a bare mount with no children would throw
-  // (`{@render children()}` on `undefined`). They take the featured-example
-  // fallback, whose mount renders a real composed instance — see
-  // `documentation.propsManifest.isCompound`.
+  // Compound ROOTS (Accordion, Tabs, …) and context-requiring PARTS
+  // (accordion-item, tab, table-header-cell, …) both resolve to `undefined` here
+  // on purpose — see `canBareMount` for why neither can be mounted alone. Roots
+  // take the featured-example fallback; parts have no examples of their own and
+  // take the compose-guidance branch below.
+  const canMountBare = $derived(
+    documentation !== null &&
+      canBareMount(documentation.propsManifest.kebabName, documentation.propsManifest.isCompound),
+  );
+
+  /**
+   * Stage scaffolding for components no amount of prop seeding makes legible —
+   * layout primitives, Surface, and the behavior-only wrappers. See
+   * `component-page-preview-recipes.ts`.
+   */
+  const previewRecipe = $derived(
+    documentation === null ? undefined : previewRecipeFor(documentation.propsManifest.kebabName),
+  );
+
   const bareComponent = $derived(
-    documentation === null || documentation.propsManifest.isCompound === true
+    documentation === null || !canMountBare || previewRecipe?.prefersFeaturedExample === true
       ? undefined
       : resolveBareComponent(bareComponentModule, documentation.component.exportName),
+  );
+
+  /**
+   * The compound root a part composes into, or `undefined` for anything that is
+   * not a part. Drives the stage's compose-guidance branch: a part has no live
+   * mount and no examples of its own, so without this its stage is a permanently
+   * empty frame. Pointing at the root — which documents the real composition — is
+   * the useful thing to put there.
+   */
+  const composesInto = $derived(
+    documentation === null
+      ? undefined
+      : COMPOUND_COMPONENT_PARENTS[documentation.propsManifest.kebabName],
   );
 
   // The `{@attach …}` factory that mounts the bare component live. The props are
@@ -646,16 +790,6 @@
   function jsonBlock(value: JsonValue | null): string {
     return JSON.stringify(value, null, 2);
   }
-
-  // Turn a kebab-case component id into sentence-case display text, e.g.
-  // `segmented-control` → `Segmented control`. The href keeps the raw id.
-  // Callers pass an `avoidWhen.alternative`, which the manifest generator
-  // validates as a non-empty kebab id, so the empty-string case can't arrive
-  // from real data (it returns `''` harmlessly if it ever does).
-  function humanizeId(id: string): string {
-    const spaced = id.replace(/-/g, ' ');
-    return spaced.charAt(0).toUpperCase() + spaced.slice(1);
-  }
 </script>
 
 {#if previewOnly}
@@ -668,7 +802,7 @@
     })}
   >
     {#if overviewExample === undefined}
-      <h1 class="snapshot-empty-heading">{humanizeId(componentName)}</h1>
+      <h1 class="snapshot-empty-heading">{humanizeComponentName(componentName)}</h1>
     {:else}
       <div
         class="example-preview"
@@ -698,7 +832,7 @@
            before running axe, so an empty container would resolve to `hidden`
            and time out. Render a visible, axe-clean heading so the snapshot has
            deterministic, contrast-safe content. -->
-      <h1 class="snapshot-empty-heading">{humanizeId(componentName)}</h1>
+      <h1 class="snapshot-empty-heading">{humanizeComponentName(componentName)}</h1>
     {:else}
       {#each examples as { scenario } (scenario)}
         <div
@@ -736,56 +870,6 @@
       data-component-page
     >
       <!-- ===== Top bar ===== -->
-      <header class="dx-topbar">
-        <div class="dx-topbar__inner">
-          <nav class="dx-crumbs" aria-label="Breadcrumb">
-            <span class="dx-crumbs__mark">CINDER</span>
-            <!-- The separator only renders when a crumb follows it. A bare
-                 "CINDER /" reads as a truncated trail to a screen reader. -->
-            {#if isLanding}
-              <span class="dx-crumbs__sep" aria-hidden="true">/</span>
-              <span class="dx-crumbs__current" aria-current="page">Overview</span>
-            {:else if documentation !== null}
-              <span class="dx-crumbs__sep" aria-hidden="true">/</span>
-            {/if}
-            {#if documentation !== null}
-              <span>{documentation.component.categoryLabel}</span>
-              <span class="dx-crumbs__sep" aria-hidden="true">/</span>
-              <span class="dx-crumbs__current" aria-current="page"
-                >{documentation.component.name}</span
-              >
-            {/if}
-          </nav>
-          <div class="dx-topbar__actions" role="toolbar" aria-label="Page controls">
-            <Tooltip text="View source on GitHub" placement="bottom">
-              <a
-                class="dx-iconbtn"
-                href="https://github.com/stevekinney/cinder"
-                target="_blank"
-                rel="noreferrer"
-                aria-label="View source on GitHub"
-              >
-                <Github size={17} strokeWidth={1.5} aria-hidden="true" />
-              </a>
-            </Tooltip>
-            <Tooltip text={themeToggleLabel} placement="bottom">
-              <button
-                type="button"
-                class="dx-iconbtn"
-                onclick={toggleTheme}
-                aria-label={themeToggleLabel}
-              >
-                {#if theme === 'dark'}
-                  <Sun size={17} strokeWidth={1.5} aria-hidden="true" />
-                {:else}
-                  <Moon size={17} strokeWidth={1.5} aria-hidden="true" />
-                {/if}
-              </button>
-            </Tooltip>
-            {@render toolbarActions?.()}
-          </div>
-        </div>
-      </header>
 
       {#if isLanding}
         <!-- Landing: the README in the prose column, same chrome as every
@@ -904,478 +988,50 @@
           </div>
         </div>
 
-        <!-- ===== Layout: TOC + content ===== -->
+        <!-- ===== Layout: Documentation / Playground ===== -->
         <div class="dx__inner">
-          <div class="dx-layout">
-            <nav class="dx-toc" aria-label="On this page">
-              <div class="dx-toc__label">On this page</div>
-              <ul class="dx-toc__list">
-                {#each sections as section (section.id)}
-                  <li>
-                    <a
-                      class="dx-toc__link"
-                      href="#{section.id}"
-                      data-active={activeSection === section.id ? '' : undefined}
-                      aria-current={activeSection === section.id ? 'location' : undefined}
-                      onclick={goToSection(section.id)}
-                    >
-                      <span class="dx-toc__num">{section.num}</span>
-                      <span>{section.label}</span>
-                    </a>
-                  </li>
-                {/each}
-              </ul>
-            </nav>
-
-            <main class="dx-content">
-              <!-- -- Overview -- -->
-              <section id="overview" class="dx-section">
-                <div class="dx-section__head">
-                  <span class="dx-section__num">01</span>
-                  <h2 class="dx-section__title">Overview</h2>
-                  <span class="dx-section__rule" aria-hidden="true"></span>
-                </div>
-                <div class="dx-prose readme-content">
-                  {#each splitReadmeHtml(documentation.readme.html) as segment, i (i)}
-                    {#if segment.type === 'html'}
-                      {@html segment.content}
-                    {:else}
-                      {@const block = documentation.readme.codeBlocks[segment.index]}
-                      {#if block !== undefined}
-                        <CodeBlock
-                          code={block.value}
-                          language={block.language ?? 'plaintext'}
-                          copyable
-                        />
-                      {:else}
-                        <div class="readme-pre-fallback">{@html segment.fallbackHtml}</div>
-                      {/if}
-                    {/if}
-                  {/each}
-                </div>
-                {#if overviewExample !== undefined}
-                  <div class="dx-stage">
-                    <div class="dx-stage__bar">
-                      <span class="dx-stage__dot" aria-hidden="true"></span>
-                      <span class="dx-stage__label">Live preview</span>
-                    </div>
-                    <div class="dx-stage__canvas">
-                      {#if mountErrors[`overview-mount-${overviewExample.scenario}`] !== undefined}
-                        {@const error = mountErrors[`overview-mount-${overviewExample.scenario}`]}
-                        <Callout variant="danger" title="This preview failed to render">
-                          <p>{error?.message}</p>
-                        </Callout>
-                      {/if}
-                      <div
-                        class="example-preview"
-                        id="overview-mount-{overviewExample.scenario}"
-                        {@attach mountScenario(overviewExample.scenario)}
-                      ></div>
-                    </div>
-                  </div>
-                {/if}
-              </section>
-
-              <!-- -- Guidance -- -->
-              {#if component.useWhen.length > 0 || component.avoidWhen.length > 0}
-                <section id="guidance" class="dx-section">
-                  <div class="dx-section__head">
-                    <span class="dx-section__num">{sectionNumber.get('guidance') ?? ''}</span>
-                    <h2 class="dx-section__title">When to use</h2>
-                    <span class="dx-section__rule" aria-hidden="true"></span>
-                  </div>
-                  <div class="dx-guide">
-                    {#if component.useWhen.length > 0}
-                      <div class="dx-guide__card">
-                        <div class="dx-guide__head">
-                          <span class="dx-guide__icon dx-guide__icon--use">
-                            <Check size={16} strokeWidth={1.5} aria-hidden="true" />
-                          </span>
-                          Use when
-                        </div>
-                        <ul class="dx-guide__list dx-guide__list--use">
-                          {#each component.useWhen as item, index (index)}
-                            <li>
-                              <Check size={15} strokeWidth={1.5} aria-hidden="true" />
-                              <span>{item}</span>
-                            </li>
-                          {/each}
-                        </ul>
-                      </div>
-                    {/if}
-                    {#if component.avoidWhen.length > 0}
-                      <div class="dx-guide__card">
-                        <div class="dx-guide__head">
-                          <span class="dx-guide__icon dx-guide__icon--avoid">
-                            <X size={16} strokeWidth={1.5} aria-hidden="true" />
-                          </span>
-                          Avoid when
-                        </div>
-                        <ul class="dx-guide__list dx-guide__list--avoid">
-                          {#each component.avoidWhen as item, index (index)}
-                            <li>
-                              <X size={15} strokeWidth={1.5} aria-hidden="true" />
-                              <span>
-                                {item.reason}
-                                {#if item.alternative !== undefined}
-                                  <a
-                                    class="dx-guide__alt"
-                                    href={buildComponentHref(item.alternative)}
-                                    target="_top"
-                                  >
-                                    Use {humanizeId(item.alternative)} instead
-                                  </a>
-                                {/if}
-                              </span>
-                            </li>
-                          {/each}
-                        </ul>
-                      </div>
-                    {/if}
-                  </div>
-                </section>
-              {/if}
-
-              <!-- -- Examples -- -->
-              {#if examples.length > 0}
-                <section id="examples" class="dx-section">
-                  <div class="dx-section__head">
-                    <span class="dx-section__num">{sectionNumber.get('examples') ?? ''}</span>
-                    <h2 class="dx-section__title">Examples</h2>
-                    <span class="dx-section__rule" aria-hidden="true"></span>
-                  </div>
-                  <div class="dx-examples">
-                    {#each examples as { scenario, title, description } (scenario)}
-                      {@const disclosure = disclosureFor(exampleDisclosures, scenario)}
-                      {@const source = fetchedSource[scenario]}
-                      {@const mountError = mountErrors[`example-mount-${scenario}`]}
-                      {@const sourceError = sourceErrors[scenario]}
-                      {#if disclosure}
-                        <section id="example-card-{scenario}" class="dx-example">
-                          <div class="dx-example__head">
-                            <div>
-                              <h3 class="dx-example__title">{title}</h3>
-                              {#if description !== undefined}
-                                <p class="dx-example__desc">{description}</p>
-                              {/if}
-                            </div>
-                          </div>
-                          <div class="dx-example__body">
-                            <div class="dx-stage">
-                              <div class="dx-stage__canvas">
-                                <div
-                                  class="example-preview"
-                                  id="example-mount-{scenario}"
-                                  {@attach mountScenario(scenario)}
-                                ></div>
-                              </div>
-                            </div>
-
-                            {#if mountError !== undefined}
-                              <Callout variant="danger" title="This example failed to render">
-                                <p class="example-error__message">{mountError.message}</p>
-                                {#if mountError.stack !== undefined}
-                                  <pre
-                                    class="example-error__stack"
-                                    aria-label="Stack trace">{mountError.stack}</pre>
-                                {/if}
-                                <div class="example-error__actions">
-                                  <Button
-                                    size="sm"
-                                    variant="secondary"
-                                    aria-label="Copy error for {title}"
-                                    onclick={() => copyErrorToClipboard(mountError)}
-                                  >
-                                    Copy error
-                                  </Button>
-                                </div>
-                              </Callout>
-                            {/if}
-
-                            <Accordion bind:expandedIds={disclosure.expandedIds}>
-                              <AccordionItem id={`source-${scenario}`} title="Show code">
-                                {#if loadingSource[scenario]}
-                                  <p class="source-loading">Loading…</p>
-                                {:else if source === null}
-                                  <Callout variant="danger" title="Could not load source">
-                                    <dl class="example-error__detail">
-                                      <dt>Requested</dt>
-                                      <dd>
-                                        <code>
-                                          {sourceError?.url ??
-                                            `/example-src/${componentName}/${scenario}`}
-                                        </code>
-                                      </dd>
-                                      <dt>Reason</dt>
-                                      <dd>{sourceError?.detail ?? 'Unknown error'}</dd>
-                                    </dl>
-                                    <div class="example-error__actions">
-                                      <Button
-                                        size="sm"
-                                        variant="secondary"
-                                        aria-label="Retry loading source for {title}"
-                                        onclick={() =>
-                                          fetchExampleSource(componentName, scenario, {
-                                            fetchedSource,
-                                            loadingSource,
-                                            sourceErrors,
-                                          })}
-                                      >
-                                        Retry
-                                      </Button>
-                                    </div>
-                                  </Callout>
-                                {:else if source !== undefined}
-                                  <CodeBlock code={source} language="svelte" copyable />
-                                {/if}
-                              </AccordionItem>
-                            </Accordion>
-                          </div>
-                        </section>
-                      {/if}
-                    {/each}
-                  </div>
-                </section>
-              {/if}
-
-              <!-- -- Props -- -->
-              {#if propRows.length > 0}
-                <section id="props" class="dx-section props-section">
-                  <div class="dx-section__head">
-                    <span class="dx-section__num">{sectionNumber.get('props') ?? ''}</span>
-                    <h2 class="dx-section__title">Props</h2>
-                    <span class="dx-section__rule" aria-hidden="true"></span>
-                  </div>
-                  <!-- tabindex makes the scroll region keyboard-accessible (WCAG 2.1.1). -->
-                  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
-                  <div
-                    class={['props-table-scroll', { 'is-scrollable': propsTableOverflows }]}
-                    role="region"
-                    aria-label="Props for {componentName}"
-                    tabindex="0"
-                    {@attach (element) =>
-                      scrollOverflowSentinel(
-                        element,
-                        (overflows) => (propsTableOverflows = overflows),
-                      )}
-                  >
-                    <Table caption={`Props for ${componentName}`} density="condensed">
-                      <Table.Header>
-                        <Table.Row>
-                          <Table.HeaderCell scope="col">Name</Table.HeaderCell>
-                          <Table.HeaderCell scope="col">Type</Table.HeaderCell>
-                          <Table.HeaderCell scope="col">Default</Table.HeaderCell>
-                          <Table.HeaderCell scope="col" align="center">Required</Table.HeaderCell>
-                          <Table.HeaderCell scope="col" align="center">Bindable</Table.HeaderCell>
-                          <Table.HeaderCell scope="col">Description</Table.HeaderCell>
-                        </Table.Row>
-                      </Table.Header>
-                      <Table.Body>
-                        {#each propRows as prop (prop.name)}
-                          <Table.Row>
-                            <Table.Cell>
-                              <code class="props-name">{prop.name}</code>
-                            </Table.Cell>
-                            <Table.Cell>
-                              {@const typeMembers = splitUnionType(prop.type)}
-                              {#if typeMembers.length === 1 || isShortUnion(typeMembers)}
-                                <code class="props-type">{typeMembers.join(' | ')}</code>
-                              {:else}
-                                <code class="props-type props-type--union">
-                                  {#each typeMembers as member, index (index)}
-                                    <span class="props-type__member"
-                                      >{#if index > 0}<span
-                                          class="props-type__sep"
-                                          aria-hidden="true">|</span
-                                        >{/if}<span class="props-type__value">{member}</span></span
-                                    >
-                                  {/each}
-                                </code>
-                              {/if}
-                            </Table.Cell>
-                            <Table.Cell>
-                              {#if prop.defaultValue !== undefined}
-                                <code class="props-default">{prop.defaultValue}</code>
-                              {:else}
-                                <span class="props-dash" aria-hidden="true">—</span>
-                              {/if}
-                            </Table.Cell>
-                            <Table.Cell align="center">
-                              {#if prop.required}
-                                <span class="dx-prop-flag dx-prop-flag--req">req</span>
-                              {:else}
-                                <span class="props-dash" aria-hidden="true">—</span>
-                              {/if}
-                            </Table.Cell>
-                            <Table.Cell align="center">
-                              {#if prop.bindable}
-                                <span class="dx-prop-flag dx-prop-flag--bind">bind</span>
-                              {:else}
-                                <span class="props-dash" aria-hidden="true">—</span>
-                              {/if}
-                            </Table.Cell>
-                            <Table.Cell>
-                              {#if prop.description !== undefined}
-                                <span class="props-description"
-                                  >{@html renderPropDescription(prop.description)}</span
-                                >
-                              {:else}
-                                <span class="props-dash" aria-hidden="true">—</span>
-                              {/if}
-                            </Table.Cell>
-                          </Table.Row>
-                        {/each}
-                      </Table.Body>
-                    </Table>
-                  </div>
-                </section>
-              {/if}
-
-              <!-- -- Accessibility -- -->
-              {#if component.a11y !== undefined}
-                {@const a11y = component.a11y}
-                <section id="accessibility" class="dx-section">
-                  <div class="dx-section__head">
-                    <span class="dx-section__num">{sectionNumber.get('accessibility') ?? ''}</span>
-                    <h2 class="dx-section__title">Accessibility</h2>
-                    <span class="dx-section__rule" aria-hidden="true"></span>
-                  </div>
-                  {#if a11y.pattern !== undefined}
-                    <div class="dx-a11y-alert">
-                      <Alert variant="info">
-                        {#snippet icon()}
-                          <Accessibility size={18} strokeWidth={1.5} aria-hidden="true" />
-                        {/snippet}
-                        Implements the {a11y.pattern} pattern.
-                      </Alert>
-                    </div>
-                  {/if}
-                  <div class="dx-a11y">
-                    {#if a11y.keyboard !== undefined && a11y.keyboard.length > 0}
-                      <div class="dx-keys">
-                        {#each a11y.keyboard as shortcut, index (index)}
-                          <div class="dx-keys__row">
-                            <div class="dx-keys__key-list">
-                              {#each shortcut.keys.split(/\s+\/\s+/) as key, keyIndex (keyIndex)}
-                                {#if keyIndex === 0}
-                                  <Kbd label={key} />
-                                {:else}
-                                  <span class="dx-keys__alternative">
-                                    <span class="dx-keys__separator">/</span>
-                                    <Kbd label={key} />
-                                  </span>
-                                {/if}
-                              {/each}
-                            </div>
-                            <div class="dx-keys__action">{shortcut.action}</div>
-                          </div>
-                        {/each}
-                      </div>
-                    {/if}
-                    {#if a11y.notes !== undefined && a11y.notes.length > 0}
-                      <div class="dx-notes">
-                        {#each a11y.notes as note, index (index)}
-                          <div class="dx-note">
-                            <ShieldCheck size={15} strokeWidth={1.5} aria-hidden="true" />
-                            <span>{note}</span>
-                          </div>
-                        {/each}
-                      </div>
-                    {/if}
-                  </div>
-                </section>
-              {/if}
-
-              <!-- -- Related -- -->
-              {#if component.related.length > 0}
-                <section id="related" class="dx-section">
-                  <div class="dx-section__head">
-                    <span class="dx-section__num">{sectionNumber.get('related') ?? ''}</span>
-                    <h2 class="dx-section__title">Related</h2>
-                    <span class="dx-section__rule" aria-hidden="true"></span>
-                  </div>
-                  <div class="dx-related">
-                    {#each component.related as related (related)}
-                      <a class="dx-rel" href={buildComponentHref(related)} target="_top">
-                        <span class="dx-rel__top">
-                          <span class="dx-rel__name">{related}</span>
-                          <ArrowUpRight
-                            class="dx-rel__arrow"
-                            size={16}
-                            strokeWidth={1.5}
-                            aria-hidden="true"
-                          />
-                        </span>
-                      </a>
-                    {/each}
-                  </div>
-                </section>
-              {/if}
-
-              <!-- -- Raw artifacts (demoted from a primary tab) -- -->
-              <section class="dx-section dx-raw">
-                <Collapsible
-                  trigger="Raw artifacts"
-                  onToggle={(open) => {
-                    if (open) hasOpenedRawArtifacts = true;
-                  }}
-                >
-                  {#if hasOpenedRawArtifacts}
-                    <div class="dx-raw__grid">
-                      <div class="dx-raw__panel">
-                        <h3>Manifest entry</h3>
-                        <CodeBlock
-                          code={jsonBlock(documentation.rawArtifacts.manifestEntry)}
-                          language="json"
-                          copyable
-                        />
-                      </div>
-                      <div class="dx-raw__panel">
-                        <h3>Schema</h3>
-                        <CodeBlock
-                          code={jsonBlock(documentation.rawArtifacts.schema)}
-                          language="json"
-                          copyable
-                        />
-                      </div>
-                      <div class="dx-raw__panel">
-                        <h3>Variables</h3>
-                        <CodeBlock
-                          code={jsonBlock(documentation.rawArtifacts.variables)}
-                          language="json"
-                          copyable
-                        />
-                      </div>
-                      <div class="dx-raw__panel">
-                        <h3>Constraints</h3>
-                        <CodeBlock
-                          code={jsonBlock(documentation.rawArtifacts.constraints)}
-                          language="json"
-                          copyable
-                        />
-                      </div>
-                      <div class="dx-raw__panel">
-                        <h3>Examples</h3>
-                        <CodeBlock
-                          code={jsonBlock(documentation.rawArtifacts.examples)}
-                          language="json"
-                          copyable
-                        />
-                      </div>
-                    </div>
-                  {/if}
-                </Collapsible>
-              </section>
-            </main>
-            <aside class="dx-preview" aria-label="Live preview">
-              <div
-                class="dx-preview__sticky"
-                style:--dx-stage-w={previewWidth === null ? '100%' : `${previewWidth}px`}
-              >
+          <div class="dx-views" role="tablist" aria-label="Component views">
+            <button
+              type="button"
+              class="dx-views__tab"
+              role="tab"
+              id="view-tab-documentation"
+              aria-selected={activeView === 'documentation'}
+              aria-controls="view-panel-documentation"
+              tabindex={activeView === 'documentation' ? 0 : -1}
+              onclick={() => selectView('documentation')}
+            >
+              Documentation
+            </button>
+            <button
+              type="button"
+              class="dx-views__tab"
+              role="tab"
+              id="view-tab-playground"
+              aria-selected={activeView === 'playground'}
+              aria-controls="view-panel-playground"
+              tabindex={activeView === 'playground' ? 0 : -1}
+              onclick={() => selectView('playground')}
+            >
+              Playground
+            </button>
+          </div>
+          {#if activeView === 'playground'}
+            <!-- Playground view: a real stage with room beside it for the props
+                 panel. Previously this lived in a 38rem rail pinned next to the
+                 prose, which starved both — the stage was too narrow to show a
+                 wide component and the prose column was too narrow to read. -->
+            <div
+              class="dx-playground"
+              role="tabpanel"
+              id="view-panel-playground"
+              aria-labelledby="view-tab-playground"
+            >
+              <div class="dx-playground__stage">
                 <!-- Stage controls. Width simulation and focus mode used to live on
                      the shell's top bar and act on an iframe; they now sit with the
                      stage they resize, and work by constraining a plain container. -->
-                <div class="dx-viewport" role="group" aria-label="Preview viewport">
+                <div class="dx-viewport" role="group" aria-label="Stage width">
                   <div class="dx-viewport__sizes">
                     {#each PREVIEW_WIDTHS as option (option.label)}
                       <button
@@ -1384,7 +1040,7 @@
                         aria-pressed={previewWidth === option.width}
                         onclick={() => (previewWidth = option.width)}
                       >
-                        {option.label}
+                        {option.width === null ? 'Full' : `${option.width}`}
                       </button>
                     {/each}
                   </div>
@@ -1400,11 +1056,17 @@
                     {isFocusMode ? 'Exit' : 'Expand'}
                   </button>
                 </div>
-                {#if showGeneratedPlayground}
-                  <!-- Single wrapper: a branch with several top-level children trips
-                       happy-dom's fragment handling in the documentation tests. -->
-                  <div class="dx-play">
-                    <!-- When the bare component resolves from the page bundle, mount it
+                <!-- Single wrapper: a branch with several top-level children trips
+                       happy-dom's fragment handling in the documentation tests.
+
+                       Rendered UNCONDITIONALLY. Whether a snippet can be
+                       synthesized from the props is a question about the
+                       SNIPPET — it is not a reason to withhold the preview, the
+                       featured example, or the controls. Gating the whole block
+                       on it is what deleted the entire Playground section for
+                       ~20 components and told each of them, falsely, that it had
+                       no adjustable props. See `canGenerateFromProps`. -->
+                <!-- When the bare component resolves from the page bundle, mount it
                directly with the synthesized prop values so the preview
                re-renders as the controls change — a genuine "Live preview"
                (#405). `mountLivePreview` re-runs its attachment on every
@@ -1418,175 +1080,764 @@
                rather than show an error callout over what would otherwise be
                a working preview. With no featured fallback, the live branch
                stays and surfaces the error — better than a blank section. -->
-                    <!-- `isHydrated` keeps the live mount off the server's tree: it
+                <!-- `isHydrated` keeps the live mount off the server's tree: it
                needs `bareComponentModule`, which only the client bundle
                supplies. Without the gate the server would render the
                featured-example branch and the client the live branch on
                its hydration pass — a mismatch. The live preview swaps in
                immediately after mount. -->
-                    {#if isHydrated && bareComponent !== undefined && !snapshotMode && (!liveMountFailed || overviewExample === undefined)}
-                      <div class="dx-stage">
-                        <div class="dx-stage__bar">
-                          <span class="dx-stage__dot" aria-hidden="true"></span>
-                          <span class="dx-stage__label">Live preview</span>
-                        </div>
-                        <div class="dx-stage__canvas">
-                          {#if mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined}
-                            {@const error = mountErrors[LIVE_MOUNT_CONTAINER_ID]}
-                            <Callout variant="danger" title="This preview failed to render">
-                              <p>{error?.message}</p>
-                            </Callout>
-                          {/if}
-                          <div
-                            class="example-preview"
-                            id={LIVE_MOUNT_CONTAINER_ID}
-                            {@attach mountLivePreview(
-                              bareComponent,
-                              toMountProps(
-                                playgroundModel.controls,
-                                $state.snapshot(playgroundValues),
-                              ),
-                            )}
-                          ></div>
-                        </div>
-                        <p class="dx-stage__note">
-                          Renders with the props below. Adjust the controls to update it live.
-                        </p>
-                      </div>
-                    {:else if overviewExample !== undefined && !snapshotMode}
-                      <!-- Fallback when the bare component can't be resolved (older
+                {#if isHydrated && bareComponent !== undefined && !snapshotMode && canGenerateFromProps && (!liveMountFailed || overviewExample === undefined)}
+                  <div class="dx-stage">
+                    <div class="dx-stage__bar">
+                      <span class="dx-stage__dot" aria-hidden="true"></span>
+                      <span class="dx-stage__label">Live preview</span>
+                    </div>
+                    <div class="dx-stage__canvas">
+                      {#if previewRecipe?.referenceHtml !== undefined}
+                        <!-- A styling primitive is invisible without something to
+                               be compared against. -->
+                        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+                        {@html previewRecipe.referenceHtml}
+                      {/if}
+                      {#if mountErrors[LIVE_MOUNT_CONTAINER_ID] !== undefined}
+                        {@const error = mountErrors[LIVE_MOUNT_CONTAINER_ID]}
+                        <Callout variant="danger" title="This preview failed to render">
+                          <p>{error?.message}</p>
+                        </Callout>
+                      {/if}
+                      <div
+                        class="example-preview"
+                        id={LIVE_MOUNT_CONTAINER_ID}
+                        {@attach mountLivePreview(
+                          bareComponent,
+                          toMountProps(
+                            playgroundModel.controls,
+                            $state.snapshot(playgroundValues),
+                            playgroundModel.seeds,
+                            previewRecipe,
+                          ),
+                        )}
+                      ></div>
+                    </div>
+                    <p class="dx-stage__note">
+                      Renders with the props below. Adjust the controls to update it live.
+                    </p>
+                  </div>
+                {:else if overviewExample !== undefined && !snapshotMode}
+                  <!-- Fallback when the bare component can't be resolved (older
                  page bundle, or a component whose default/named export isn't
                  a constructor): mount the static featured example so the
                  section still shows a rendered instance (#374), labelled
                  honestly since only the snippet is prop-driven here. -->
-                      <div class="dx-stage">
-                        <div class="dx-stage__bar">
-                          <span class="dx-stage__dot" aria-hidden="true"></span>
-                          <span class="dx-stage__label">Featured example</span>
-                        </div>
-                        <div class="dx-stage__canvas">
-                          {#if mountErrors[`playground-mount-${overviewExample.scenario}`] !== undefined}
-                            {@const error =
-                              mountErrors[`playground-mount-${overviewExample.scenario}`]}
-                            <Callout variant="danger" title="This preview failed to render">
-                              <p>{error?.message}</p>
-                            </Callout>
-                          {/if}
-                          <div
-                            class="example-preview"
-                            id="playground-mount-{overviewExample.scenario}"
-                            {@attach mountScenario(overviewExample.scenario)}
-                          ></div>
-                        </div>
-                        <p class="dx-stage__note">
-                          Shows the featured example. Adjust the controls to update the snippet.
-                        </p>
-                      </div>
-                    {:else if !snapshotMode && !documentation.propsManifest.isCompound}
-                      <!-- Reserve the stage for components with NO examples (label,
-                 statistic, accordion-item, …). Without this branch the
-                 server renders nothing here, and hydration then INSERTS
-                 the whole live stage into an already-painted page — a
-                 layout shift, and the opposite of the reservation the
-                 server entry promises.
-
-                 A non-compound component is one whose bare mount the
-                 client can resolve, so a live stage is what will appear.
-                 Compound components keep `bareComponent` undefined on
-                 purpose, so reserving a box they never fill would leave
-                 an empty frame. `isCompound` comes from the manifest, so
-                 the server can make this call. -->
-                      <div class="dx-stage" data-stage-reserved>
-                        <div class="dx-stage__bar">
-                          <span class="dx-stage__dot" aria-hidden="true"></span>
-                          <span class="dx-stage__label">Live preview</span>
-                        </div>
-                        <div class="dx-stage__canvas"></div>
-                        <p class="dx-stage__note">
-                          Renders with the props below. Adjust the controls to update it live.
-                        </p>
-                      </div>
-                    {/if}
-                    <CodeBlock code={playgroundSnippet} language="svelte" copyable />
-                    {#if playgroundModel.skipped.length > 0}
-                      <p class="dx-play__skipped">
-                        Not adjustable here: {playgroundModel.skipped.join(', ')}.
+                  <div class="dx-stage">
+                    <div class="dx-stage__bar">
+                      <span class="dx-stage__dot" aria-hidden="true"></span>
+                      <span class="dx-stage__label">Featured example</span>
+                    </div>
+                    <div class="dx-stage__canvas">
+                      {#if mountErrors[`playground-mount-${overviewExample.scenario}`] !== undefined}
+                        {@const error = mountErrors[`playground-mount-${overviewExample.scenario}`]}
+                        <Callout variant="danger" title="This preview failed to render">
+                          <p>{error?.message}</p>
+                        </Callout>
+                      {/if}
+                      <div
+                        class="example-preview"
+                        id="playground-mount-{overviewExample.scenario}"
+                        {@attach mountScenario(overviewExample.scenario)}
+                      ></div>
+                    </div>
+                    <p class="dx-stage__note">
+                      Shows the featured example. Adjust the controls to update the snippet.
+                    </p>
+                  </div>
+                {:else if !snapshotMode && composesInto !== undefined}
+                  <!-- Compound PARTS have no live mount (they throw without
+                 their provider) and ship no examples of their own, so
+                 every other branch leaves them a permanently empty
+                 frame. Point at the root instead: that page documents
+                 the composition this component exists for. -->
+                  <div class="dx-stage" data-stage-composed>
+                    <div class="dx-stage__bar">
+                      <span class="dx-stage__dot" aria-hidden="true"></span>
+                      <span class="dx-stage__label">Composed component</span>
+                    </div>
+                    <div class="dx-stage__canvas">
+                      <p class="dx-stage__compose">
+                        {documentation.component.name} is composed inside
+                        <a href={buildComponentHref(composesInto)} target="_top">
+                          {humanizeComponentName(composesInto)}
+                        </a>, which supplies the context it reads. Its page shows the whole
+                        composition running.
                       </p>
-                    {/if}
-                    <div class="dx-play__controls">
-                      <div class="dx-play__controls-head">
-                        <Sliders size={13} strokeWidth={1.5} aria-hidden="true" />
-                        Props
-                      </div>
-                      {#each playgroundModel.controls as control (control.name)}
-                        <div class={['dx-ctl', control.kind === 'boolean' && 'dx-ctl--inline']}>
-                          <div class="dx-ctl__text">
-                            <div class="dx-ctl__name" title={control.name}>{control.name}</div>
-                            {#if control.description !== undefined}
-                              <div class="dx-ctl__desc">
-                                {@html renderPropDescription(control.description)}
-                              </div>
-                            {/if}
-                          </div>
-                          {#if control.kind === 'boolean'}
-                            <Toggle
-                              id="pg-{control.name}"
-                              label={control.name}
-                              hideLabel
-                              bind:checked={
-                                () => Boolean(playgroundValues[control.name]),
-                                (next) => (playgroundValues[control.name] = next)
-                              }
-                            />
-                          {:else if control.kind === 'select'}
-                            <select
-                              class="dx-ctl__select"
-                              aria-label={control.name}
-                              value={String(playgroundValues[control.name] ?? control.value)}
-                              onchange={(event) =>
-                                (playgroundValues[control.name] = (
-                                  event.currentTarget as HTMLSelectElement
-                                ).value)}
-                            >
-                              {#each control.options as option (option)}
-                                <option value={option}>{option}</option>
-                              {/each}
-                            </select>
-                          {:else if control.kind === 'number'}
-                            <input
-                              class="dx-ctl__input"
-                              type="number"
-                              aria-label={control.name}
-                              value={Number(playgroundValues[control.name] ?? control.value)}
-                              oninput={(event) =>
-                                (playgroundValues[control.name] = Number(
-                                  (event.currentTarget as HTMLInputElement).value,
-                                ))}
-                            />
-                          {:else}
-                            <input
-                              class="dx-ctl__input"
-                              type="text"
-                              aria-label={control.name}
-                              value={String(playgroundValues[control.name] ?? control.value)}
-                              oninput={(event) =>
-                                (playgroundValues[control.name] = (
-                                  event.currentTarget as HTMLInputElement
-                                ).value)}
-                            />
-                          {/if}
-                        </div>
-                      {/each}
                     </div>
                   </div>
-                {:else}
-                  <p class="dx-preview__empty">
-                    This component has no adjustable props. See the examples for usage.
-                  </p>
+                {:else if !snapshotMode && canGenerateFromProps && canMountBare}
+                  <!-- Reserve the stage for components with NO examples (label,
+                 statistic, …). Without this branch the server renders
+                 nothing here, and hydration then INSERTS the whole live
+                 stage into an already-painted page — a layout shift, and
+                 the opposite of the reservation the server entry
+                 promises.
+
+                 Gated on `canMountBare`, which is exactly the set whose
+                 bare mount the client will resolve. Compound roots and
+                 context-requiring parts keep `bareComponent` undefined on
+                 purpose, so reserving a box they never fill would leave
+                 an empty frame. Both inputs come from the manifest, so
+                 the server can make this call. -->
+                  <div class="dx-stage" data-stage-reserved>
+                    <div class="dx-stage__bar">
+                      <span class="dx-stage__dot" aria-hidden="true"></span>
+                      <span class="dx-stage__label">Live preview</span>
+                    </div>
+                    <div class="dx-stage__canvas"></div>
+                    <p class="dx-stage__note">
+                      Renders with the props below. Adjust the controls to update it live.
+                    </p>
+                  </div>
                 {/if}
               </div>
-            </aside>
-          </div>
+              <aside class="dx-playground__panel" aria-label="Props">
+                <!-- The snippet is the one piece a synthesis failure really
+                         does invalidate: with an unsatisfiable required prop it
+                         would not compile if pasted. Withhold IT, and say why
+                         below — rather than withholding the whole section. -->
+                {#if canGenerateFromProps}
+                  <CodeBlock
+                    highlighter={depictHighlighter}
+                    code={playgroundSnippet}
+                    language="svelte"
+                    copyable
+                  />
+                {/if}
+                {#if playgroundNote !== null}
+                  <p class="dx-play__note">
+                    {#if playgroundNote.kind === 'example-only'}
+                      This component is documented through its examples — its behavior depends on
+                      data and callbacks the playground can't synthesize.
+                    {:else if playgroundNote.kind === 'unsatisfied'}
+                      No generated snippet:
+                      <code>{playgroundNote.props.join(', ')}</code>
+                      {playgroundNote.props.length === 1
+                        ? "is a required prop the playground can't synthesize a value for."
+                        : "are required props the playground can't synthesize values for."}
+                      {playgroundNote.hasFallback
+                        ? 'The featured example above is a real, working instance.'
+                        : ''}
+                    {:else}
+                      This component has no adjustable props. See the examples for usage.
+                    {/if}
+                  </p>
+                {/if}
+                {#if playgroundModel.skipped.length > 0}
+                  <p class="dx-play__skipped">
+                    Not adjustable here: {playgroundModel.skipped.join(', ')}.
+                  </p>
+                {/if}
+                {#if playgroundModel.seeds.length > 0}
+                  <div class="dx-play__seeds">
+                    <div class="dx-play__controls-head">Supplied values</div>
+                    {#each playgroundModel.seeds as seed (seed.name)}
+                      <div class="dx-seed">
+                        <div class="dx-seed__name">{seed.name}</div>
+                        <code class="dx-seed__value">{seed.source}</code>
+                      </div>
+                    {/each}
+                    <p class="dx-play__note">
+                      Placeholder data, so the preview renders a real instance. Not adjustable here
+                      — the snippet above copies with these values.
+                    </p>
+                  </div>
+                {/if}
+                {#if playgroundModel.controls.length > 0}
+                  <div class="dx-play__controls">
+                    <div class="dx-play__controls-head">
+                      <Sliders size={13} strokeWidth={1.5} aria-hidden="true" />
+                      Props
+                    </div>
+                    {#each playgroundModel.controls as control (control.name)}
+                      <div class={['dx-ctl', control.kind === 'boolean' && 'dx-ctl--inline']}>
+                        <div class="dx-ctl__text">
+                          <div class="dx-ctl__name" title={control.name}>{control.name}</div>
+                          {#if control.description !== undefined}
+                            <div class="dx-ctl__desc">
+                              {@html renderPropDescription(control.description)}
+                            </div>
+                          {/if}
+                        </div>
+                        {#if control.kind === 'boolean'}
+                          <Toggle
+                            id="pg-{control.name}"
+                            label={control.name}
+                            hideLabel
+                            bind:checked={
+                              () => Boolean(playgroundValues[control.name]),
+                              (next) => (playgroundValues[control.name] = next)
+                            }
+                          />
+                        {:else if control.kind === 'select'}
+                          <select
+                            class="dx-ctl__select"
+                            aria-label={control.name}
+                            value={String(playgroundValues[control.name] ?? control.value)}
+                            onchange={(event) =>
+                              (playgroundValues[control.name] = (
+                                event.currentTarget as HTMLSelectElement
+                              ).value)}
+                          >
+                            {#each control.options as option (option)}
+                              <option value={option}>{option}</option>
+                            {/each}
+                          </select>
+                        {:else if control.kind === 'number'}
+                          <input
+                            class="dx-ctl__input"
+                            type="number"
+                            aria-label={control.name}
+                            value={Number(playgroundValues[control.name] ?? control.value)}
+                            oninput={(event) =>
+                              (playgroundValues[control.name] = Number(
+                                (event.currentTarget as HTMLInputElement).value,
+                              ))}
+                          />
+                        {:else}
+                          <input
+                            class="dx-ctl__input"
+                            type="text"
+                            aria-label={control.name}
+                            value={String(playgroundValues[control.name] ?? control.value)}
+                            oninput={(event) =>
+                              (playgroundValues[control.name] = (
+                                event.currentTarget as HTMLInputElement
+                              ).value)}
+                          />
+                        {/if}
+                      </div>
+                    {/each}
+                  </div>
+                {/if}
+              </aside>
+            </div>
+          {:else}
+            <div
+              class="dx-layout"
+              role="tabpanel"
+              id="view-panel-documentation"
+              aria-labelledby="view-tab-documentation"
+            >
+              <nav class="dx-toc" aria-label="On this page">
+                <ul class="dx-toc__list">
+                  {#each sections as section (section.id)}
+                    <li>
+                      <a
+                        class="dx-toc__link"
+                        href="#{section.id}"
+                        data-active={activeSection === section.id ? '' : undefined}
+                        aria-current={activeSection === section.id ? 'location' : undefined}
+                        onclick={goToSection(section.id)}
+                      >
+                        <span class="dx-toc__num">{section.num}</span>
+                        <span>{section.label}</span>
+                      </a>
+                    </li>
+                  {/each}
+                </ul>
+              </nav>
+
+              <main class="dx-content">
+                <!-- -- Overview -- -->
+                <section id="overview" class="dx-section">
+                  <div class="dx-section__head">
+                    <span class="dx-section__num">01</span>
+                    <h2 class="dx-section__title">Overview</h2>
+                    <span class="dx-section__rule" aria-hidden="true"></span>
+                  </div>
+                  <div class="dx-prose readme-content">
+                    {#each splitReadmeHtml(documentation.readme.html) as segment, i (i)}
+                      {#if segment.type === 'html'}
+                        {@html segment.content}
+                      {:else}
+                        {@const block = documentation.readme.codeBlocks[segment.index]}
+                        {#if block !== undefined}
+                          <CodeBlock
+                            highlighter={depictHighlighter}
+                            code={block.value}
+                            language={block.language ?? 'plaintext'}
+                            copyable
+                          />
+                        {:else}
+                          <div class="readme-pre-fallback">{@html segment.fallbackHtml}</div>
+                        {/if}
+                      {/if}
+                    {/each}
+                  </div>
+                  {#if overviewExample !== undefined}
+                    <div class="dx-stage">
+                      <div class="dx-stage__bar">
+                        <span class="dx-stage__dot" aria-hidden="true"></span>
+                        <span class="dx-stage__label">Live preview</span>
+                      </div>
+                      <div class="dx-stage__canvas">
+                        {#if mountErrors[`overview-mount-${overviewExample.scenario}`] !== undefined}
+                          {@const error = mountErrors[`overview-mount-${overviewExample.scenario}`]}
+                          <Callout variant="danger" title="This preview failed to render">
+                            <p>{error?.message}</p>
+                          </Callout>
+                        {/if}
+                        <div
+                          class="example-preview"
+                          id="overview-mount-{overviewExample.scenario}"
+                          {@attach mountScenario(overviewExample.scenario)}
+                        ></div>
+                      </div>
+                    </div>
+                  {/if}
+                </section>
+
+                <!-- -- Guidance -- -->
+                {#if component.useWhen.length > 0 || component.avoidWhen.length > 0}
+                  <section id="guidance" class="dx-section">
+                    <div class="dx-section__head">
+                      <span class="dx-section__num">{sectionNumber.get('guidance') ?? ''}</span>
+                      <h2 class="dx-section__title">When to use</h2>
+                      <span class="dx-section__rule" aria-hidden="true"></span>
+                    </div>
+                    <div class="dx-guide">
+                      {#if component.useWhen.length > 0}
+                        <div class="dx-guide__card">
+                          <div class="dx-guide__head">
+                            <span class="dx-guide__icon dx-guide__icon--use">
+                              <Check size={16} strokeWidth={1.5} aria-hidden="true" />
+                            </span>
+                            Use when
+                          </div>
+                          <ul class="dx-guide__list dx-guide__list--use">
+                            {#each component.useWhen as item, index (index)}
+                              <li>
+                                <Check size={15} strokeWidth={1.5} aria-hidden="true" />
+                                <span>{item}</span>
+                              </li>
+                            {/each}
+                          </ul>
+                        </div>
+                      {/if}
+                      {#if component.avoidWhen.length > 0}
+                        <div class="dx-guide__card">
+                          <div class="dx-guide__head">
+                            <span class="dx-guide__icon dx-guide__icon--avoid">
+                              <X size={16} strokeWidth={1.5} aria-hidden="true" />
+                            </span>
+                            Avoid when
+                          </div>
+                          <ul class="dx-guide__list dx-guide__list--avoid">
+                            {#each component.avoidWhen as item, index (index)}
+                              <li>
+                                <X size={15} strokeWidth={1.5} aria-hidden="true" />
+                                <span>
+                                  {item.reason}
+                                  {#if item.alternative !== undefined}
+                                    <a
+                                      class="dx-guide__alt"
+                                      href={buildComponentHref(item.alternative)}
+                                      target="_top"
+                                    >
+                                      Use {humanizeComponentName(item.alternative)} instead
+                                    </a>
+                                  {/if}
+                                </span>
+                              </li>
+                            {/each}
+                          </ul>
+                        </div>
+                      {/if}
+                    </div>
+                  </section>
+                {/if}
+
+                <!-- -- Examples -- -->
+                {#if examples.length > 0}
+                  <section id="examples" class="dx-section">
+                    <div class="dx-section__head">
+                      <span class="dx-section__num">{sectionNumber.get('examples') ?? ''}</span>
+                      <h2 class="dx-section__title">Examples</h2>
+                      <span class="dx-section__rule" aria-hidden="true"></span>
+                    </div>
+                    <div class="dx-examples">
+                      {#each examples as { scenario, title, description } (scenario)}
+                        {@const disclosure = disclosureFor(exampleDisclosures, scenario)}
+                        {@const source = fetchedSource[scenario]}
+                        {@const mountError = mountErrors[`example-mount-${scenario}`]}
+                        {@const sourceError = sourceErrors[scenario]}
+                        {#if disclosure}
+                          <section id="example-card-{scenario}" class="dx-example">
+                            <div class="dx-example__head">
+                              <div>
+                                <h3 class="dx-example__title">{title}</h3>
+                                {#if description !== undefined}
+                                  <p class="dx-example__desc">{description}</p>
+                                {/if}
+                              </div>
+                            </div>
+                            <div class="dx-example__body">
+                              <div class="dx-stage">
+                                <div class="dx-stage__canvas">
+                                  <div
+                                    class="example-preview"
+                                    id="example-mount-{scenario}"
+                                    {@attach mountScenario(scenario)}
+                                  ></div>
+                                </div>
+                              </div>
+
+                              {#if mountError !== undefined}
+                                <Callout variant="danger" title="This example failed to render">
+                                  <p class="example-error__message">{mountError.message}</p>
+                                  {#if mountError.stack !== undefined}
+                                    <pre
+                                      class="example-error__stack"
+                                      aria-label="Stack trace">{mountError.stack}</pre>
+                                  {/if}
+                                  <div class="example-error__actions">
+                                    <Button
+                                      size="sm"
+                                      variant="secondary"
+                                      aria-label="Copy error for {title}"
+                                      onclick={() => copyErrorToClipboard(mountError)}
+                                    >
+                                      Copy error
+                                    </Button>
+                                  </div>
+                                </Callout>
+                              {/if}
+
+                              <Accordion bind:expandedIds={disclosure.expandedIds}>
+                                <AccordionItem id={`source-${scenario}`} title="Show code">
+                                  {#if loadingSource[scenario]}
+                                    <p class="source-loading">Loading…</p>
+                                  {:else if source === null}
+                                    <Callout variant="danger" title="Could not load source">
+                                      <dl class="example-error__detail">
+                                        <dt>Requested</dt>
+                                        <dd>
+                                          <code>
+                                            {sourceError?.url ??
+                                              `/example-src/${componentName}/${scenario}`}
+                                          </code>
+                                        </dd>
+                                        <dt>Reason</dt>
+                                        <dd>{sourceError?.detail ?? 'Unknown error'}</dd>
+                                      </dl>
+                                      <div class="example-error__actions">
+                                        <Button
+                                          size="sm"
+                                          variant="secondary"
+                                          aria-label="Retry loading source for {title}"
+                                          onclick={() =>
+                                            fetchExampleSource(componentName, scenario, {
+                                              fetchedSource,
+                                              loadingSource,
+                                              sourceErrors,
+                                            })}
+                                        >
+                                          Retry
+                                        </Button>
+                                      </div>
+                                    </Callout>
+                                  {:else if source !== undefined}
+                                    <CodeBlock
+                                      highlighter={depictHighlighter}
+                                      code={source}
+                                      language="svelte"
+                                      copyable
+                                    />
+                                  {/if}
+                                </AccordionItem>
+                              </Accordion>
+                            </div>
+                          </section>
+                        {/if}
+                      {/each}
+                    </div>
+                  </section>
+                {/if}
+
+                <!-- -- Props -- -->
+                {#if propRows.length > 0}
+                  <section id="props" class="dx-section props-section">
+                    <div class="dx-section__head">
+                      <span class="dx-section__num">{sectionNumber.get('props') ?? ''}</span>
+                      <h2 class="dx-section__title">Props</h2>
+                      <span class="dx-section__rule" aria-hidden="true"></span>
+                    </div>
+                    <!-- tabindex makes the scroll region keyboard-accessible (WCAG 2.1.1). -->
+                    <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+                    <div
+                      class={['props-table-scroll', { 'is-scrollable': propsTableOverflows }]}
+                      role="region"
+                      aria-label="Props for {componentName}"
+                      tabindex="0"
+                      {@attach (element) =>
+                        scrollOverflowSentinel(
+                          element,
+                          (overflows) => (propsTableOverflows = overflows),
+                        )}
+                    >
+                      <Table caption={`Props for ${componentName}`} density="condensed">
+                        <Table.Header>
+                          <Table.Row>
+                            {#each PROP_COLUMNS as column (column.key)}
+                              <Table.HeaderCell scope="col">{column.label}</Table.HeaderCell>
+                            {/each}
+                          </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                          {#each propRows as prop (prop.name)}
+                            <Table.Row>
+                              <Table.Cell data-label="Name">
+                                <span class="props-name-cell">
+                                  <code class="props-name">{prop.name}</code>
+                                  <!-- `required` and `bindable` are BADGES on the
+                                       name now, not columns. As columns they cost
+                                       two of six columns to say "no" with an
+                                       em-dash on most rows, and in the stacked
+                                       layout they became two more labelled lines
+                                       per prop. Spelled in full because the
+                                       column header that used to name them is
+                                       gone — an unexplained "req" is a worse
+                                       trade than four extra characters. -->
+                                  {#if prop.required}
+                                    <span class="dx-prop-flag dx-prop-flag--req">required</span>
+                                  {/if}
+                                  {#if prop.bindable}
+                                    <span class="dx-prop-flag dx-prop-flag--bind">bindable</span>
+                                  {/if}
+                                </span>
+                              </Table.Cell>
+                              <Table.Cell data-label="Type">
+                                {@const typeMembers = splitUnionType(prop.type)}
+                                {#if typeMembers.length === 1 || isShortUnion(typeMembers)}
+                                  {@const full = typeMembers.join(' | ')}
+                                  {#if full.length > SINGLE_TYPE_PREVIEW_CHARS}
+                                    <code class="props-type"
+                                      >{full.slice(0, SINGLE_TYPE_PREVIEW_CHARS)}…</code
+                                    >
+                                    <details class="props-type__more">
+                                      <summary>Show full type</summary>
+                                      <code class="props-type">{full}</code>
+                                    </details>
+                                  {:else}
+                                    <code class="props-type">{full}</code>
+                                  {/if}
+                                {:else}
+                                  {@const compact = typeMembers.every((m) => m.length <= 12)}
+                                  <code
+                                    class={[
+                                      'props-type',
+                                      'props-type--union',
+                                      compact && 'props-type--union-compact',
+                                    ]}
+                                  >
+                                    {#each typeMembers.slice(0, UNION_PREVIEW_COUNT) as member, index (index)}
+                                      <span class="props-type__member"
+                                        >{#if index > 0}<span
+                                            class="props-type__sep"
+                                            aria-hidden="true">|</span
+                                          >{/if}<span class="props-type__value">{member}</span
+                                        ></span
+                                      >
+                                    {/each}
+                                  </code>
+                                  {#if typeMembers.length > UNION_PREVIEW_COUNT}
+                                    <!-- A `<details>` SIBLING, never a child of
+                                         `<code>`: `code` is phrasing content and
+                                         `details` is flow content, so nesting it
+                                         makes the parser reflow the tree. -->
+                                    <details class="props-type__more">
+                                      <summary
+                                        >{typeMembers.length - UNION_PREVIEW_COUNT} more members</summary
+                                      >
+                                      <code class="props-type props-type--union">
+                                        {#each typeMembers.slice(UNION_PREVIEW_COUNT) as member, index (index)}
+                                          <span class="props-type__member"
+                                            ><span class="props-type__sep" aria-hidden="true"
+                                              >|</span
+                                            ><span class="props-type__value">{member}</span></span
+                                          >
+                                        {/each}
+                                      </code>
+                                    </details>
+                                  {/if}
+                                {/if}
+                              </Table.Cell>
+                              <Table.Cell data-label="Default">
+                                {#if prop.defaultValue !== undefined}
+                                  <code class="props-default">{prop.defaultValue}</code>
+                                {:else}
+                                  <span class="props-dash" aria-hidden="true">—</span>
+                                {/if}
+                              </Table.Cell>
+                              <Table.Cell data-label="Description">
+                                {#if prop.description !== undefined}
+                                  <span class="props-description"
+                                    >{@html renderPropDescription(prop.description)}</span
+                                  >
+                                {:else}
+                                  <span class="props-dash" aria-hidden="true">—</span>
+                                {/if}
+                              </Table.Cell>
+                            </Table.Row>
+                          {/each}
+                        </Table.Body>
+                      </Table>
+                    </div>
+                  </section>
+                {/if}
+
+                <!-- -- Accessibility -- -->
+                {#if component.a11y !== undefined}
+                  {@const a11y = component.a11y}
+                  <section id="accessibility" class="dx-section">
+                    <div class="dx-section__head">
+                      <span class="dx-section__num">{sectionNumber.get('accessibility') ?? ''}</span
+                      >
+                      <h2 class="dx-section__title">Accessibility</h2>
+                      <span class="dx-section__rule" aria-hidden="true"></span>
+                    </div>
+                    {#if a11y.pattern !== undefined}
+                      <div class="dx-a11y-alert">
+                        <Alert variant="info">
+                          {#snippet icon()}
+                            <Accessibility size={18} strokeWidth={1.5} aria-hidden="true" />
+                          {/snippet}
+                          Implements the {a11y.pattern} pattern.
+                        </Alert>
+                      </div>
+                    {/if}
+                    <div class="dx-a11y">
+                      {#if a11y.keyboard !== undefined && a11y.keyboard.length > 0}
+                        <div class="dx-keys">
+                          {#each a11y.keyboard as shortcut, index (index)}
+                            <div class="dx-keys__row">
+                              <div class="dx-keys__key-list">
+                                {#each shortcut.keys.split(/\s+\/\s+/) as key, keyIndex (keyIndex)}
+                                  {#if keyIndex === 0}
+                                    <Kbd label={key} />
+                                  {:else}
+                                    <span class="dx-keys__alternative">
+                                      <span class="dx-keys__separator">/</span>
+                                      <Kbd label={key} />
+                                    </span>
+                                  {/if}
+                                {/each}
+                              </div>
+                              <div class="dx-keys__action">{shortcut.action}</div>
+                            </div>
+                          {/each}
+                        </div>
+                      {/if}
+                      {#if a11y.notes !== undefined && a11y.notes.length > 0}
+                        <div class="dx-notes">
+                          {#each a11y.notes as note, index (index)}
+                            <div class="dx-note">
+                              <ShieldCheck size={15} strokeWidth={1.5} aria-hidden="true" />
+                              <span>{note}</span>
+                            </div>
+                          {/each}
+                        </div>
+                      {/if}
+                    </div>
+                  </section>
+                {/if}
+
+                <!-- -- Related -- -->
+                {#if component.related.length > 0}
+                  <section id="related" class="dx-section">
+                    <div class="dx-section__head">
+                      <span class="dx-section__num">{sectionNumber.get('related') ?? ''}</span>
+                      <h2 class="dx-section__title">Related</h2>
+                      <span class="dx-section__rule" aria-hidden="true"></span>
+                    </div>
+                    <div class="dx-related">
+                      {#each component.related as related (related)}
+                        <a class="dx-rel" href={buildComponentHref(related)} target="_top">
+                          <span class="dx-rel__top">
+                            <span class="dx-rel__name">{related}</span>
+                            <ArrowUpRight
+                              class="dx-rel__arrow"
+                              size={16}
+                              strokeWidth={1.5}
+                              aria-hidden="true"
+                            />
+                          </span>
+                        </a>
+                      {/each}
+                    </div>
+                  </section>
+                {/if}
+
+                <!-- -- Raw artifacts (demoted from a primary tab) -- -->
+                <section class="dx-section dx-raw">
+                  <Collapsible
+                    trigger="Raw artifacts"
+                    onToggle={(open) => {
+                      if (open) hasOpenedRawArtifacts = true;
+                    }}
+                  >
+                    {#if hasOpenedRawArtifacts}
+                      <div class="dx-raw__grid">
+                        <div class="dx-raw__panel">
+                          <h3>Manifest entry</h3>
+                          <CodeBlock
+                            highlighter={depictHighlighter}
+                            code={jsonBlock(documentation.rawArtifacts.manifestEntry)}
+                            language="json"
+                            copyable
+                          />
+                        </div>
+                        <div class="dx-raw__panel">
+                          <h3>Schema</h3>
+                          <CodeBlock
+                            highlighter={depictHighlighter}
+                            code={jsonBlock(documentation.rawArtifacts.schema)}
+                            language="json"
+                            copyable
+                          />
+                        </div>
+                        <div class="dx-raw__panel">
+                          <h3>Variables</h3>
+                          <CodeBlock
+                            highlighter={depictHighlighter}
+                            code={jsonBlock(documentation.rawArtifacts.variables)}
+                            language="json"
+                            copyable
+                          />
+                        </div>
+                        <div class="dx-raw__panel">
+                          <h3>Constraints</h3>
+                          <CodeBlock
+                            highlighter={depictHighlighter}
+                            code={jsonBlock(documentation.rawArtifacts.constraints)}
+                            language="json"
+                            copyable
+                          />
+                        </div>
+                        <div class="dx-raw__panel">
+                          <h3>Examples</h3>
+                          <CodeBlock
+                            highlighter={depictHighlighter}
+                            code={jsonBlock(documentation.rawArtifacts.examples)}
+                            language="json"
+                            copyable
+                          />
+                        </div>
+                      </div>
+                    {/if}
+                  </Collapsible>
+                </section>
+              </main>
+            </div>
+          {/if}
         </div>
       {/if}
     </div>
@@ -1623,7 +1874,7 @@
                 href={buildComponentHref(group.name)}
                 aria-current={group.name === componentName ? 'page' : undefined}
               >
-                {humanizeId(group.name)}
+                {humanizeComponentName(group.name)}
               </a>
               {#if group.children.length > 0}
                 <ul class="dx-nav__sublist">
@@ -1634,7 +1885,7 @@
                         href={buildComponentHref(child)}
                         aria-current={child === componentName ? 'page' : undefined}
                       >
-                        {humanizeId(child)}
+                        {humanizeComponentName(child)}
                       </a>
                     </li>
                   {/each}
@@ -1646,6 +1897,39 @@
             <li class="dx-nav__empty">No components match “{navFilter}”.</li>
           {/if}
         </ul>
+        <!-- The two page actions live here, not in a top bar. The band they
+             came from restated the sidebar brand, the hero eyebrow, and the
+             page `<h1>` — three duplications and one row of chrome for two
+             buttons. The sidebar renders on the landing page too, so the
+             theme toggle stays reachable there. -->
+        <div class="dx-nav__footer" role="toolbar" aria-label="Page controls">
+          <Tooltip text="View source on GitHub" placement="bottom">
+            <a
+              class="dx-iconbtn"
+              href="https://github.com/stevekinney/cinder"
+              target="_blank"
+              rel="noreferrer"
+              aria-label="View source on GitHub"
+            >
+              <Github size={17} strokeWidth={1.5} aria-hidden="true" />
+            </a>
+          </Tooltip>
+          <Tooltip text={themeToggleLabel} placement="bottom">
+            <button
+              type="button"
+              class="dx-iconbtn"
+              onclick={toggleTheme}
+              aria-label={themeToggleLabel}
+            >
+              {#if theme === 'dark'}
+                <Sun size={17} strokeWidth={1.5} aria-hidden="true" />
+              {:else}
+                <Moon size={17} strokeWidth={1.5} aria-hidden="true" />
+              {/if}
+            </button>
+          </Tooltip>
+          {@render toolbarActions?.()}
+        </div>
       </nav>
     {/if}
   </div>
@@ -1665,8 +1949,10 @@
     /* Preview column. Wide enough for real component layouts — the previous
        inline stage was a fixed 360px box, far too small for tables, editors,
        and anything with a sidebar of its own. */
-    --dx-preview-w: 38rem;
-    --dx-topbar-h: 3.25rem;
+    /* The top bar is gone — see `.dx-nav__footer`. Kept as a variable at zero
+       rather than deleted, because every sticky offset and scroll-margin on the
+       page is expressed as a `calc()` against it. */
+    --dx-topbar-h: 0rem;
     min-height: 100vh;
     border: 1px solid var(--cinder-border);
     background: light-dark(oklch(100% 0 0), var(--cinder-bg));
@@ -1694,6 +1980,8 @@
     padding: var(--cinder-space-4) 0;
     border-inline-end: 1px solid var(--cinder-border);
     background: var(--cinder-surface-raised);
+    display: flex;
+    flex-direction: column;
   }
 
   .dx-nav__brand {
@@ -1746,7 +2034,15 @@
     font-size: var(--cinder-text-sm);
   }
 
+  .dx-nav__footer {
+    display: flex;
+    align-items: center;
+    gap: var(--cinder-space-1-5, 0.375rem);
+    padding: var(--cinder-space-3) var(--cinder-space-4);
+    border-block-start: 1px solid var(--cinder-border-muted);
+  }
   .dx-nav__list {
+    flex: 1;
     display: flex;
     flex-direction: column;
     margin: 0;
@@ -1836,58 +2132,6 @@
   }
 
   /* ===== Top bar ===== */
-  .dx-topbar {
-    position: sticky;
-    top: 0;
-    z-index: 40;
-    height: var(--dx-topbar-h);
-    display: flex;
-    align-items: center;
-    border-block-end: 1px solid var(--cinder-border-muted);
-    background: color-mix(in oklch, var(--cinder-bg), transparent 12%);
-    backdrop-filter: saturate(1.4) blur(10px);
-  }
-  .dx-topbar__inner {
-    display: flex;
-    align-items: center;
-    gap: var(--cinder-space-4);
-    width: 100%;
-    max-width: var(--dx-max);
-    margin-inline: auto;
-    padding-inline: var(--dx-gutter);
-  }
-  .dx-crumbs {
-    display: flex;
-    align-items: center;
-    gap: var(--cinder-space-2);
-    font-size: var(--cinder-text-xs);
-    color: var(--cinder-text-subtle);
-    min-width: 0;
-  }
-  .dx-crumbs__mark {
-    font-family: var(--cinder-font-mono);
-    font-weight: var(--cinder-font-semibold);
-    letter-spacing: 0.18em;
-    color: var(--cinder-text);
-    text-transform: uppercase;
-    font-size: var(--cinder-text-2xs);
-  }
-  .dx-crumbs__sep {
-    color: var(--cinder-border-strong);
-  }
-  .dx-crumbs__current {
-    color: var(--cinder-text);
-    font-weight: var(--cinder-font-medium);
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-  .dx-topbar__actions {
-    margin-inline-start: auto;
-    display: flex;
-    align-items: center;
-    gap: var(--cinder-space-1-5, 0.375rem);
-  }
   .dx-iconbtn {
     display: inline-flex;
     align-items: center;
@@ -1929,7 +2173,10 @@
 
   /* ===== Hero ===== */
   .dx-hero {
-    padding-block: clamp(2rem, 5vw, 3.75rem) clamp(1.75rem, 4vw, 2.75rem);
+    /* Halved. The hairline `border-block-end` below already terminates the hero,
+       so the padding was doing the job twice — and it stacked with the layout's
+       own top padding for ~96px of nothing between them. */
+    padding-block: clamp(2rem, 5vw, 3.75rem) clamp(1.25rem, 2.5vw, 1.75rem);
     border-block-end: 1px solid var(--cinder-border-muted);
   }
   .dx-hero__grid {
@@ -2091,21 +2338,99 @@
    * column and its own scroll position rather than being one section you scroll
    * past — the old inline stage was a fixed 360px box buried mid-page.
    */
+  /*
+   * Documentation view: ONE column, full width. The preview no longer takes a
+   * fixed 38rem out of every page — that rail is what crushed the accessibility
+   * notes into a half-width sub-column, shredded the keyboard-shortcut table to
+   * one word per line, and forced the props table into stacked six-line cards at
+   * ordinary desktop widths.
+   */
   .dx-layout {
     display: grid;
-    /*
-     * TWO panes, as asked: prose on the left, live preview on the right. The
-     * "on this page" rail becomes a horizontal strip above the prose instead of
-     * a third column — at three columns the prose collapsed to ~280px, which is
-     * unreadable, and the reader already has the component nav on the far left.
-     */
-    grid-template-columns: minmax(0, 1fr) minmax(0, var(--dx-preview-w));
+    grid-template-columns: minmax(0, 1fr);
     grid-template-areas:
-      'toc preview'
-      'docs preview';
-    column-gap: clamp(1.5rem, 3vw, 3rem);
-    padding-block: clamp(2rem, 4vw, 3.25rem) 5rem;
+      'toc'
+      'docs';
+    padding-block: clamp(1.25rem, 2vw, 1.75rem) clamp(3rem, 6vw, 5rem);
     align-items: start;
+  }
+
+  /* View switcher. */
+  .dx-views {
+    display: flex;
+    gap: var(--cinder-space-1);
+    padding-block-start: clamp(1rem, 2vw, 1.5rem);
+    border-block-end: 1px solid var(--cinder-border-muted);
+  }
+  .dx-views__tab {
+    padding: var(--cinder-space-2) var(--cinder-space-3);
+    border: none;
+    border-block-end: 2px solid transparent;
+    background: transparent;
+    color: var(--cinder-text-subtle);
+    font-size: var(--cinder-text-sm);
+    cursor: pointer;
+  }
+  .dx-views__tab[aria-selected='true'] {
+    color: var(--cinder-text);
+    font-weight: var(--cinder-font-medium);
+    border-block-end-color: var(--cinder-accent);
+  }
+  @media (hover: hover) {
+    .dx-views__tab:hover {
+      color: var(--cinder-text);
+    }
+  }
+  .dx-views__tab:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+    border-radius: var(--cinder-radius-sm);
+  }
+  @media (forced-colors: active) {
+    .dx-views__tab:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      box-shadow: none;
+    }
+  }
+
+  /*
+   * Playground view: a real stage, with the props panel beside it rather than
+   * stacked under a 38rem column. The stage takes the space; the panel takes
+   * what a form needs and no more.
+   */
+  .dx-playground {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 22rem);
+    gap: clamp(1.5rem, 3vw, 2.5rem);
+    padding-block: clamp(1.25rem, 2vw, 1.75rem) clamp(3rem, 6vw, 5rem);
+    align-items: start;
+  }
+  .dx-playground__stage {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+    min-width: 0;
+  }
+  .dx-playground__panel {
+    position: sticky;
+    top: calc(var(--dx-topbar-h) + 1.5rem);
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-3);
+    max-height: calc(100vh - var(--dx-topbar-h) - 3rem);
+    overflow: auto;
+    overscroll-behavior: contain;
+    min-width: 0;
+  }
+  @media (max-width: 1000px) {
+    .dx-playground {
+      grid-template-columns: minmax(0, 1fr);
+    }
+    .dx-playground__panel {
+      position: static;
+      max-height: none;
+      overflow: visible;
+    }
   }
   .dx-toc {
     grid-area: toc;
@@ -2137,55 +2462,13 @@
     }
   }
 
-  /*
-   * The landing README is raw rendered markdown — it has no `codeBlocks`
-   * payload, so its fences cannot go through `CodeBlock` the way a component
-   * README's do. Give them the same surface treatment so the two pages read the
-   * same.
-   */
-  .dx-content--landing :global(pre) {
-    padding: var(--cinder-space-4);
-    overflow-x: auto;
-    border: 1px solid var(--cinder-border);
-    border-radius: var(--cinder-radius-md);
-    background: var(--cinder-surface-raised);
-  }
-
-  .dx-content--landing :global(table) {
-    width: 100%;
-    border-collapse: collapse;
-  }
-
-  .dx-content--landing :global(pre code) {
-    font-family: var(--cinder-font-mono);
-    font-size: var(--cinder-text-sm);
-  }
-
   /* Landing has no preview column, so the prose gets the full width. */
   .dx-content--landing {
     grid-column: 1 / -1;
-    padding-block: clamp(2rem, 4vw, 3.25rem) 5rem;
+    padding-block: clamp(1.25rem, 2vw, 1.75rem) clamp(3rem, 6vw, 5rem);
     max-width: 78rem;
     margin-inline: auto;
   }
-  .dx-preview {
-    grid-area: preview;
-  }
-
-  .dx-preview__sticky {
-    position: sticky;
-    top: calc(var(--dx-topbar-h) + 1.5rem);
-    display: flex;
-    flex-direction: column;
-    gap: var(--cinder-space-3);
-    max-height: calc(100vh - var(--dx-topbar-h) - 3rem);
-    /* Both axes scroll: a viewport preset wider than the column (Desktop is
-       1280px against 38rem) has to be reachable horizontally. */
-    overflow: auto;
-    padding-inline-end: var(--cinder-space-1);
-    overscroll-behavior: contain;
-  }
-
   /* Stage controls: a compact instrument strip above the stage. */
   .dx-viewport {
     display: flex;
@@ -2250,47 +2533,96 @@
   /* The stage honours the simulated width, centred, so narrow settings read as
      a device rather than a left-aligned sliver. */
   /*
-   * A preset wider than the pane (Desktop is 1280px against a 38rem column) must
-   * still reach its width, or picking it does nothing visible. The stage takes
-   * the requested width and the pane scrolls horizontally to it.
+   * A width wider than the stage column still has to be reachable, or picking it
+   * does nothing visible — the stage takes the requested width and the column
+   * scrolls horizontally to it.
    */
-  .dx-preview__sticky .dx-stage {
+  .dx-playground__stage .dx-stage {
     width: var(--dx-stage-w, 100%);
     max-width: none;
     margin-inline: auto;
   }
-  .dx-preview__sticky .dx-stage__canvas {
-    min-height: 12rem;
+  .dx-playground__stage {
+    overflow-x: auto;
   }
-  .dx.is-focus-mode .dx-preview__sticky .dx-stage {
+  .dx-playground__stage .dx-stage__canvas {
+    min-height: 18rem;
+  }
+  .dx.is-focus-mode .dx-playground__stage .dx-stage {
     flex: 1;
   }
 
-  .dx-preview__empty {
+  /* Synthesized structural values — shown read-only so the reader can see what
+     the preview actually renders with, and that it matches the snippet. */
+  .dx-play__seeds {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-2);
+    padding: var(--cinder-space-3);
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+  }
+  .dx-seed {
+    display: flex;
+    flex-direction: column;
+    gap: var(--cinder-space-1);
+    min-width: 0;
+  }
+  .dx-seed__name {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text);
+  }
+  .dx-seed__value {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-2xs);
+    color: var(--cinder-text-muted);
+    overflow-wrap: anywhere;
+  }
+
+  /* Compose-guidance copy, shown on a compound part's stage in place of a
+     preview it structurally cannot have. */
+  .dx-stage__compose {
+    margin: 0;
     color: var(--cinder-text-muted);
     font-size: var(--cinder-text-sm);
+    line-height: 1.5;
+  }
+
+  /* The honest replacement for the old blanket "no adjustable props" line. It
+     sits INSIDE the playground block alongside whatever the section could still
+     show, rather than standing in for the section. */
+  .dx-play__note {
+    margin: 0;
+    color: var(--cinder-text-muted);
+    font-size: var(--cinder-text-sm);
+    line-height: 1.5;
+  }
+  .dx-play__note code {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text);
   }
 
   /*
    * Focus mode expands the stage over the whole viewport. Pure CSS on one
    * document — the old implementation needed an iframe and postMessage.
    */
-  .dx.is-focus-mode .dx-preview {
+  .dx.is-focus-mode .dx-playground__stage {
     position: fixed;
     inset: 0;
     z-index: 60;
-    background: var(--cinder-bg);
-  }
-  .dx.is-focus-mode .dx-preview__sticky {
-    top: 0;
-    max-height: 100vh;
+    display: flex;
     height: 100vh;
     padding: var(--cinder-space-5);
+    background: var(--cinder-bg);
   }
+  .dx.is-focus-mode .dx-playground__panel,
+  .dx.is-focus-mode .dx-views,
   .dx.is-focus-mode .dx-toc,
   .dx.is-focus-mode .dx-content,
-  .dx.is-focus-mode .dx-hero,
-  .dx.is-focus-mode .dx-topbar {
+  .dx.is-focus-mode .dx-hero {
     display: none;
   }
 
@@ -2306,13 +2638,10 @@
     z-index: 30;
     align-self: start;
     margin-block-end: var(--cinder-space-5);
-    padding-block: var(--cinder-space-2);
+    padding-block: var(--cinder-space-2) 0;
     border-block-end: 1px solid var(--cinder-border-muted);
     background: color-mix(in oklch, var(--cinder-bg), transparent 8%);
     backdrop-filter: blur(8px);
-  }
-  .dx-toc__label {
-    display: none;
   }
   .dx-toc__list {
     list-style: none;
@@ -2328,13 +2657,22 @@
   .dx-toc__list::-webkit-scrollbar {
     display: none;
   }
+  /*
+   * A tab strip, styled as one. It used to carry vertical-RAIL CSS — a 2px
+   * `border-inline-start` that the active state recoloured — inside a horizontal
+   * flex row, so selecting a section just tinted a divider to the left of it.
+   * The correct treatment already existed, but only inside the ≤920px variant.
+   */
   .dx-toc__link {
     position: relative;
     display: flex;
     align-items: baseline;
     gap: var(--cinder-space-2-5, 0.625rem);
-    padding: var(--cinder-space-1-5, 0.375rem) var(--cinder-space-4);
-    border-inline-start: 2px solid var(--cinder-border-muted);
+    padding: var(--cinder-space-2) var(--cinder-space-2-5, 0.625rem);
+    border-block-end: 2px solid transparent;
+    /* Without this, labels wrapped mid-phrase at every width above 920px — the
+       only `nowrap` in the file was in the narrow variant. */
+    white-space: nowrap;
     color: var(--cinder-text-subtle);
     text-decoration: none;
     font-size: var(--cinder-text-sm);
@@ -2358,7 +2696,7 @@
   .dx-toc__link[data-active] {
     color: var(--cinder-text);
     font-weight: var(--cinder-font-medium);
-    border-inline-start-color: var(--cinder-accent);
+    border-block-end-color: var(--cinder-accent);
   }
   .dx-toc__link[data-active] .dx-toc__num {
     color: var(--cinder-accent-text);
@@ -2380,7 +2718,10 @@
     min-width: 0;
     display: flex;
     flex-direction: column;
-    gap: clamp(3rem, 6vw, 4.5rem);
+    /* Section headers already carry their own separator — an eyebrow number, a
+       title, and a hairline rule — so 72px between them was the third thing
+       saying the same boundary. */
+    gap: clamp(2.5rem, 4vw, 3.5rem);
   }
   .dx-section {
     scroll-margin-block-start: calc(var(--dx-topbar-h) + 1.5rem);
@@ -2437,11 +2778,66 @@
   .readme-content :global(h1:first-child) {
     display: none;
   }
+  /*
+   * ONE prose scale, for both surfaces.
+   *
+   * These rules used to be split across four overlapping selector families —
+   * `.dx-prose`, `.readme-content`, `.dx-content--landing`, and the
+   * `.cinder-markdown-content` utility that is served on every page and applied
+   * to neither of them. The landing page and the component README therefore
+   * disagreed on `pre`, `table`, and inline `code` for no reason anyone had
+   * chosen. The landing family now carries only its LAYOUT rules.
+   */
   .readme-content :global(p),
   .readme-content :global(ul),
   .readme-content :global(ol),
-  .readme-content :global(table) {
+  .readme-content :global(dl),
+  .readme-content :global(table),
+  .readme-content :global(blockquote),
+  .readme-content :global(hr) {
     margin: 0 0 var(--cinder-space-4);
+  }
+  .readme-content :global(h4),
+  .readme-content :global(h5),
+  .readme-content :global(h6) {
+    color: var(--cinder-text);
+    font-weight: var(--cinder-font-semibold);
+    line-height: var(--cinder-leading-tight);
+    margin: var(--cinder-space-5) 0 var(--cinder-space-2);
+  }
+  .readme-content :global(pre) {
+    padding: var(--cinder-space-4);
+    overflow-x: auto;
+    border: 1px solid var(--cinder-border);
+    border-radius: var(--cinder-radius-md);
+    background: var(--cinder-surface-raised);
+  }
+  .readme-content :global(pre code) {
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-sm);
+  }
+  .readme-content :global(table) {
+    width: 100%;
+    border-collapse: collapse;
+  }
+  .readme-content :global(blockquote) {
+    padding-inline-start: var(--cinder-space-4);
+    border-inline-start: 2px solid var(--cinder-border);
+    color: var(--cinder-text-muted);
+  }
+  /*
+   * A block element needs MORE separation from the prose that follows it than
+   * two paragraphs need from each other — otherwise a code block, table, or
+   * callout reads as though the next sentence belongs to it. Everything above
+   * shares one trailing margin; this adds the extra only where a block is
+   * followed by prose.
+   */
+  .readme-content
+    :global(
+      :is(pre, table, blockquote, ul, ol, dl, .cinder-code-block, .cinder-callout)
+        + :is(p, h1, h2, h3, h4, h5, h6)
+    ) {
+    margin-block-start: var(--cinder-space-6);
   }
   .readme-content :global(.cinder-code-block),
   .readme-pre-fallback {
@@ -2645,23 +3041,6 @@
   .dx-play__intro {
     margin-block-end: var(--cinder-space-5);
   }
-  /*
-   * Inside the preview pane the stage and its controls stack: the pane is
-   * already the narrow axis of the page-level split, so splitting it again gave
-   * a 260px stage — smaller than the 360px box this rework set out to fix.
-   */
-  .dx-play {
-    display: flex;
-    flex-direction: column;
-    gap: var(--cinder-space-3);
-    min-width: 0;
-  }
-  .dx-play__preview {
-    display: flex;
-    flex-direction: column;
-    gap: var(--cinder-space-3);
-    min-width: 0;
-  }
   .dx-play__skipped {
     margin: 0;
     font-size: var(--cinder-text-xs);
@@ -2673,13 +3052,11 @@
     border-radius: var(--cinder-radius-lg);
     background: var(--cinder-surface-raised);
     box-shadow: var(--cinder-shadow-sm);
-    /* Scroll the controls when a many-prop component makes the sticky panel
-       taller than the viewport, so lower controls stay reachable. The radius
-       clips the inner rows. */
-    overflow-y: auto;
-    max-height: calc(100dvh - var(--dx-topbar-h) - 3rem);
-    position: sticky;
-    top: calc(var(--dx-topbar-h) + 1.5rem);
+    /* Deliberately NOT sticky and NOT its own scroll container. `.dx-playground__panel`
+       is both now, and nesting a second sticky scroller inside a sticky scroller
+       makes neither behave: the inner box pins against a parent that is itself
+       moving, and a many-prop component ends up with two scrollbars competing for
+       the same gesture. */
   }
   .dx-play__controls-head {
     padding: var(--cinder-space-3) var(--cinder-space-4);
@@ -2865,6 +3242,8 @@
     flex-direction: column;
     gap: var(--cinder-space-0-5, 0.125rem);
     align-items: flex-start;
+    max-inline-size: 40rem;
+    overflow-wrap: break-word;
   }
   .props-type__member {
     white-space: pre-wrap;
@@ -2878,6 +3257,12 @@
   .props-type__sep {
     color: var(--cinder-text-subtle);
     user-select: none;
+  }
+  .props-name-cell {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--cinder-space-1-5, 0.375rem);
   }
   .dx-prop-flag {
     font-family: var(--cinder-font-mono);
@@ -2898,6 +3283,43 @@
     background: color-mix(in oklch, var(--cinder-accent), transparent 90%);
     border: 1px solid color-mix(in oklch, var(--cinder-accent), transparent 72%);
     margin-inline-start: 0;
+  }
+  /* The cap's escape hatch. Nothing is discarded — a reader checking whether a
+     given member exists can still open it. */
+  .props-type__more {
+    margin-block-start: var(--cinder-space-1);
+  }
+  .props-type__more > summary {
+    display: inline-block;
+    cursor: pointer;
+    list-style: none;
+    color: var(--cinder-accent-text);
+    font-family: var(--cinder-font-mono);
+    font-size: var(--cinder-text-2xs);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+  .props-type__more > summary::-webkit-details-marker {
+    display: none;
+  }
+  .props-type__more > summary:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+    border-radius: var(--cinder-radius-sm);
+  }
+  @media (forced-colors: active) {
+    .props-type__more > summary:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
+  }
+  /* All-short members (country codes, HTML tag names) wrap as one line rather
+     than a 245-row column. */
+  .props-type--union-compact {
+    flex-direction: row;
+    flex-wrap: wrap;
+    column-gap: 0.35ch;
   }
   .props-description {
     font-size: var(--cinder-text-sm);
@@ -2965,27 +3387,14 @@
       border: none;
       text-align: start;
     }
-    .props-section :global(.cinder-table td)::before {
+    /* Labels come from each cell's own `data-label`, which the template emits
+       from `PROP_COLUMNS`. The previous `nth-child` rules encoded column
+       POSITION, so removing a column silently shifted every label after it by
+       one — and only below a 34rem container width, where nothing would notice. */
+    .props-section :global(.cinder-table td[data-label])::before {
+      content: attr(data-label);
       font-weight: var(--cinder-font-medium);
       color: var(--cinder-text-subtle);
-    }
-    .props-section :global(.cinder-table td:nth-child(1))::before {
-      content: 'Name';
-    }
-    .props-section :global(.cinder-table td:nth-child(2))::before {
-      content: 'Type';
-    }
-    .props-section :global(.cinder-table td:nth-child(3))::before {
-      content: 'Default';
-    }
-    .props-section :global(.cinder-table td:nth-child(4))::before {
-      content: 'Required';
-    }
-    .props-section :global(.cinder-table td:nth-child(5))::before {
-      content: 'Bindable';
-    }
-    .props-section :global(.cinder-table td:nth-child(6))::before {
-      content: 'Description';
     }
   }
 
@@ -2993,10 +3402,16 @@
   .dx-a11y-alert {
     margin-block-end: var(--cinder-space-5);
   }
+  /*
+   * One column. The two-column split existed only because the prose column was
+   * ~38rem short — it is what crushed the accessibility notes into a half-width
+   * sub-column beside the shortcut table. With the documentation view at full
+   * width there is nothing to work around.
+   */
   .dx-a11y {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
-    gap: var(--cinder-space-4);
+    grid-template-columns: minmax(0, 1fr);
+    gap: var(--cinder-space-5);
     align-items: start;
   }
   .dx-keys {
@@ -3142,78 +3557,17 @@
       max-width: 26rem;
     }
   }
-  /*
-   * Vertical split below the breakpoint: the preview stacks ABOVE the prose,
-   * because it is what the reader came for. It stops being sticky so the page
-   * scrolls as one document on a phone.
-   */
-  @media (max-width: 1100px) {
-    .dx-layout {
-      grid-template-columns: minmax(0, 1fr);
-      grid-template-areas:
-        'preview'
-        'toc'
-        'docs';
-    }
-    .dx-preview__sticky {
-      position: static;
-      max-height: none;
-      overflow: visible;
-    }
-  }
 
   @media (max-width: 920px) {
     .dx-layout {
       grid-template-columns: minmax(0, 1fr);
     }
+    /* Everything else this block used to set now lives in the base rules — it
+       was a duplicate that happened to be correct while the base was not. Only
+       the full-bleed edge treatment is genuinely narrow-viewport-specific. */
     .dx-toc {
-      position: sticky;
-      top: var(--dx-topbar-h);
-      z-index: 30;
       margin-inline: calc(var(--dx-gutter) * -1);
       padding-inline: var(--dx-gutter);
-      padding-block: var(--cinder-space-2);
-      background: color-mix(in oklch, var(--cinder-bg), transparent 8%);
-      backdrop-filter: blur(8px);
-      border-block-end: 1px solid var(--cinder-border-muted);
-    }
-    .dx-toc__label {
-      display: none;
-    }
-    .dx-toc__list {
-      flex-direction: row;
-      overflow-x: auto;
-      overscroll-behavior-x: contain;
-      gap: var(--cinder-space-1);
-      scrollbar-width: none;
-    }
-    .dx-toc__list::-webkit-scrollbar {
-      display: none;
-    }
-    .dx-toc__link {
-      border-inline-start: none;
-      border-block-end: 2px solid transparent;
-      white-space: nowrap;
-      padding: var(--cinder-space-2) var(--cinder-space-2-5, 0.625rem);
-    }
-    .dx-toc__link[data-active] {
-      border-inline-start: none;
-      border-block-end-color: var(--cinder-accent);
-    }
-    .dx-play {
-      grid-template-columns: minmax(0, 1fr);
-    }
-    .dx-play__controls {
-      container-type: inline-size;
-      position: static;
-      order: -1;
-      /* No longer sticky here, so drop the viewport height cap — the stacked
-         panel should grow with its content. */
-      max-height: none;
-      overflow: visible;
-    }
-    .dx-a11y {
-      grid-template-columns: minmax(0, 1fr);
     }
   }
   @media (max-width: 640px) {
@@ -3253,9 +3607,6 @@
     .props-table-scroll:focus-visible {
       outline: var(--cinder-ring-width) solid ButtonText;
       outline-offset: calc(var(--cinder-ring-width) * -1);
-    }
-    .dx-topbar {
-      border-block-end: 1px solid ButtonText;
     }
   }
 </style>

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -263,6 +263,34 @@
    */
   let activeView = $state<ComponentPageView>('documentation');
 
+  /**
+   * Arrow/Home/End navigation for the view switcher.
+   *
+   * `role="tablist"` is a promise about keyboard behavior, not just a label: a
+   * screen-reader user who lands on the strip expects the arrow keys to move
+   * between tabs. The roving `tabindex` alone only gets them INTO the strip.
+   */
+  function onViewTabKeydown(event: KeyboardEvent): void {
+    const order: ComponentPageView[] = ['documentation', 'playground'];
+    const current = order.indexOf(activeView);
+    let next: ComponentPageView | undefined;
+    if (event.key === 'ArrowRight' || event.key === 'ArrowDown') {
+      next = order[(current + 1) % order.length];
+    } else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') {
+      next = order[(current - 1 + order.length) % order.length];
+    } else if (event.key === 'Home') {
+      next = order[0];
+    } else if (event.key === 'End') {
+      next = order[order.length - 1];
+    }
+    if (next === undefined) return;
+    event.preventDefault();
+    selectView(next);
+    // Selection follows focus, so move focus with it — otherwise the newly
+    // selected tab has `tabindex="0"` while focus sits on a `-1` sibling.
+    document.getElementById(`view-tab-${next}`)?.focus();
+  }
+
   function selectView(view: ComponentPageView): void {
     activeView = view;
     if (typeof window === 'undefined') return;
@@ -997,9 +1025,12 @@
               role="tab"
               id="view-tab-documentation"
               aria-selected={activeView === 'documentation'}
-              aria-controls="view-panel-documentation"
+              {...activeView === 'documentation'
+                ? { 'aria-controls': 'view-panel-documentation' }
+                : {}}
               tabindex={activeView === 'documentation' ? 0 : -1}
               onclick={() => selectView('documentation')}
+              onkeydown={onViewTabKeydown}
             >
               Documentation
             </button>
@@ -1009,9 +1040,10 @@
               role="tab"
               id="view-tab-playground"
               aria-selected={activeView === 'playground'}
-              aria-controls="view-panel-playground"
+              {...activeView === 'playground' ? { 'aria-controls': 'view-panel-playground' } : {}}
               tabindex={activeView === 'playground' ? 0 : -1}
               onclick={() => selectView('playground')}
+              onkeydown={onViewTabKeydown}
             >
               Playground
             </button>

--- a/packages/playground/src/depict-highlighter.test.ts
+++ b/packages/playground/src/depict-highlighter.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Verifies the shared `<CodeBlock>` highlighter really is on the `depict`
+ * theme — i.e. that it emits `var(--syntax-*)` references (which
+ * `render-shell.ts` declares) rather than the baked hex colors of Shiki's
+ * default `github-light` / `github-dark` bundle.
+ *
+ * This exercises the real adapter, real grammars, and the real Oniguruma
+ * engine. Nothing is stubbed, because the bug being guarded against lives
+ * entirely in how the adapter resolves the theme registry.
+ */
+
+import { describe, expect, it } from 'bun:test';
+
+import { depictHighlighter } from './depict-highlighter.ts';
+
+describe('depictHighlighter', () => {
+  it('emits depict CSS variables instead of github-light hex colors', async () => {
+    const html = await depictHighlighter('const answer = 42;', 'ts');
+
+    // The whole point: colors arrive as var() references resolved at paint
+    // time against the :root declarations in render-shell.ts.
+    expect(html).toContain('var(--syntax-keyword)');
+    expect(html).toContain('--surface-inset');
+
+    // `background-color:#fff` is what github-light bakes in; its presence
+    // means the theme option did not take effect.
+    expect(html.toLowerCase()).not.toContain('#fff');
+  }, 30_000);
+
+  it('still resolves language grammars (curated theme loaders must not empty the language registry)', async () => {
+    // Regression: passing only `themeLoaders` to the /curated adapter entry
+    // point leaves `bundledLanguages` as {}, so every language misses and
+    // falls back to the escaped-plaintext block — highlighting silently dies.
+    const html = await depictHighlighter('const answer = 42;', 'ts');
+
+    expect(html).not.toContain('shiki-plaintext');
+    expect(html).toContain('<span');
+  }, 30_000);
+
+  it('resolves Shiki language aliases the same way the bundled adapter does', async () => {
+    const html = await depictHighlighter('SELECT 1;', 'sql');
+    expect(html).not.toContain('shiki-plaintext');
+  }, 30_000);
+});

--- a/packages/playground/src/depict-highlighter.ts
+++ b/packages/playground/src/depict-highlighter.ts
@@ -1,0 +1,48 @@
+/**
+ * The playground's shared `<CodeBlock>` highlighter, on the `depict` theme.
+ *
+ * Two syntax-highlighting paths run side by side in the playground:
+ *
+ *   1. Markdown fences (README prose) go through `@lostgradient/markdown`'s
+ *      rehype-shiki step, which highlights with `CSS_VARIABLE_THEME` — the
+ *      `depict` theme, whose every color is a `var(--…)` reference resolved
+ *      at paint time against the declarations in `render-shell.ts`.
+ *   2. `<CodeBlock>` instances go through Cinder's Shiki adapter, which
+ *      defaults to `{ light: 'github-light', dark: 'github-dark' }`.
+ *
+ * Path 2's default is where the baked `background-color:#fff` on playground
+ * code blocks comes from: it is emitted by Shiki's own bundled `github-light`
+ * theme, so there is no hex literal in this repo to delete. Registering the
+ * same `depict` theme for path 2 puts both on one palette that follows the
+ * active light/dark theme instead of pinning a light background.
+ *
+ * `themeLoaders` replaces the theme registry with just `depict`; language
+ * grammars still come from Shiki's full bundle, because the default
+ * `@lostgradient/cinder/highlighters/shiki` entry point falls back to
+ * `shiki/langs`'s `bundledLanguages` whenever `languageLoaders` is omitted.
+ * Importing the `/curated` entry point instead would leave the language
+ * registry empty and silently render every fence as plaintext.
+ *
+ * Module-scoped singleton: the adapter caches its Shiki module (and therefore
+ * its WASM engine and loaded grammars) per instance, so every `<CodeBlock>`
+ * should share this one rather than constructing its own.
+ *
+ * @module
+ */
+
+import type { Highlighter } from '@lostgradient/cinder';
+import { shikiHighlighter } from '@lostgradient/cinder/highlighters/shiki';
+import { CSS_VARIABLE_THEME } from '@lostgradient/markdown/rendering/highlighter';
+
+/**
+ * Shared `depict`-themed highlighter for `<CodeBlock highlighter={…} />`.
+ *
+ * The factory is synchronous and Shiki is imported lazily on the first
+ * highlight call, so merely importing this module ships no Shiki bytes.
+ */
+export const depictHighlighter: Highlighter = shikiHighlighter({
+  theme: 'depict',
+  themeLoaders: {
+    depict: async () => ({ default: CSS_VARIABLE_THEME }),
+  },
+});

--- a/packages/playground/src/manifest-reference.test.ts
+++ b/packages/playground/src/manifest-reference.test.ts
@@ -26,7 +26,12 @@ import type { ComponentManifest, PropManifest } from './types.ts';
 const COMPONENTS_ROOT = join(import.meta.dir, '..', '..', 'components', 'src', 'components');
 
 function buttonManifest(): Promise<ComponentManifest> {
-  return analyzeComponent(join(COMPONENTS_ROOT, 'button', 'button.svelte'));
+  return manifestFor('button');
+}
+
+/** Analyze any component by its kebab id, from the real component source. */
+function manifestFor(kebabName: string): Promise<ComponentManifest> {
+  return analyzeComponent(join(COMPONENTS_ROOT, kebabName, `${kebabName}.svelte`));
 }
 
 // Module-scope fetch fixtures for the unhappy-path fetch tests. They capture
@@ -270,12 +275,38 @@ describe('toPropReferenceRows — Button (real manifest)', () => {
     expect(loading?.required).toBe(false);
   });
 
-  it('marks props that have no default and are not optional as required', async () => {
+  it('does not mark an alternative of a union as required', async () => {
     const rows = toPropReferenceRows(await buttonManifest());
-    // `label` and `children` are not optional and carry no default.
-    const label = rows.find((row) => row.name === 'label');
-    expect(label?.required).toBe(true);
-    expect(rows.some((row) => row.required)).toBe(true);
+    // `ButtonProps` is `SharedBase & (WithLabel | WithChildren | WithIconOnly)`,
+    // so `label` and `children` are ALTERNATIVES — `<Button>Save</Button>` and
+    // `<Button label="Save" />` are both valid, and neither prop is required on
+    // its own. The analyzer used to report both as required, because the
+    // syntactic type walk could not see into a union nested in an intersection
+    // and fell back to "untyped ⇒ required". That default is what suppressed
+    // Button's whole Playground section.
+    expect(rows.find((row) => row.name === 'label')?.required).toBe(false);
+    expect(rows.find((row) => row.name === 'children')?.required).toBe(false);
+    // `href` only exists on the link arm, so it is omittable too.
+    expect(rows.find((row) => row.name === 'href')?.required).toBe(false);
+  });
+
+  it('resolves a prop typed only through a nested union arm', async () => {
+    const rows = toPropReferenceRows(await buttonManifest());
+    // Same root cause, the other half: `label` was not just wrongly required, it
+    // was untyped (`?`). It is a plain string, and the props table says so.
+    expect(rows.find((row) => row.name === 'label')?.type).toBe('text');
+  });
+
+  it('marks a genuinely required prop as required', async () => {
+    // DropdownGroup writes the "exactly one of" idiom as
+    // `{ label: string; labelledBy?: never } | { label?: never; labelledBy: string }`.
+    // Both alternatives are optional across the union as a whole, so seeding
+    // both supplies either all or none — and the component rejects both. The
+    // analyzer commits to the first alternative, which is what makes the
+    // generated preview satisfy the component's own validation.
+    const rows = toPropReferenceRows(await manifestFor('dropdown-group'));
+    expect(rows.find((row) => row.name === 'label')?.required).toBe(true);
+    expect(rows.find((row) => row.name === 'labelledBy')?.required).toBe(false);
   });
 
   it('covers varied control kinds (select, boolean, snippet, unknown)', async () => {
@@ -286,6 +317,28 @@ describe('toPropReferenceRows — Button (real manifest)', () => {
     expect(kinds.has('boolean')).toBe(true);
     // The variant union and at least one unknown/raw type are present.
     expect(rows.some((row) => row.type.includes(' | '))).toBe(true);
+  });
+});
+
+describe('isComponentManifest — every real manifest survives the round trip', () => {
+  it('accepts every analyzed component after JSON serialization', async () => {
+    // The documentation payload is validated as a WHOLE before the page renders
+    // it, so one control kind this guard does not recognise fails the entire
+    // data island and the reader gets "Could not load documentation" instead of
+    // a page. Adding a `ControlKind` variant and forgetting `isControlKind` took
+    // down every component with an array or object prop — MegaMenu, DataTable,
+    // ApprovalCard, Breadcrumbs — while every unit test stayed green, because
+    // nothing exercised a real manifest against the real guard.
+    const { analyzeAll } = await import('./analyze.ts');
+    const manifests = await analyzeAll(COMPONENTS_ROOT);
+    expect(manifests.length).toBeGreaterThan(100);
+
+    // Round-trip through JSON: the payload reaches the page as a data island, so
+    // the guard must accept what actually crosses that boundary.
+    const rejected = manifests
+      .filter((manifest) => !isComponentManifest(JSON.parse(JSON.stringify(manifest))))
+      .map((manifest) => manifest.kebabName);
+    expect(rejected).toEqual([]);
   });
 });
 

--- a/packages/playground/src/manifest-reference.ts
+++ b/packages/playground/src/manifest-reference.ts
@@ -34,6 +34,8 @@ export type PropReferenceRow = {
  * - `select` → the options joined as a union, e.g. `'sm' | 'md' | 'lg'`.
  * - `unknown` → the analyzer's raw type string (falling back to `unknown`
  *   when the analyzer could not recover one, e.g. the `?` placeholder).
+ * - `array` / `object` → the type text as authored (`BreadcrumbItem[]`), not the
+ *   synthesis shape carried alongside it.
  * - everything else → the bare kind (`text`, `number`, `boolean`, `snippet`).
  *
  * @param control - The control descriptor from a {@link PropManifest}.
@@ -59,6 +61,12 @@ export function describeControlType(control: ControlKind): string {
       const raw = normalized.trim();
       return raw === '' || raw === '?' ? 'unknown' : raw;
     }
+    // Structural kinds carry both a shape (for value synthesis) and the type
+    // text as authored. The reader wants the latter: `BreadcrumbItem[]` is what
+    // the component's own types say, and it is what they would write.
+    case 'array':
+    case 'object':
+      return control.rawType;
     default:
       return control.kind;
   }
@@ -222,9 +230,63 @@ function isControlKind(value: unknown): value is ControlKind {
     }
     case 'unknown':
       return typeof readProperty(value, 'rawType') === 'string';
+    case 'array':
+      return (
+        typeof readProperty(value, 'rawType') === 'string' &&
+        isValueOrObjectShape(readProperty(value, 'element'))
+      );
+    case 'object':
+      return (
+        typeof readProperty(value, 'rawType') === 'string' &&
+        isObjectShape(readProperty(value, 'shape'))
+      );
     default:
       return false;
   }
+}
+
+/**
+ * Type guard for the structural shape carried by `array` / `object` controls.
+ *
+ * This guard is what stands between a manifest and the page: the documentation
+ * payload is validated as a whole, so a control kind the guard does not
+ * recognise fails the WHOLE island and the reader gets "Could not load
+ * documentation" instead of a page. Adding a `ControlKind` variant without
+ * teaching this function about it takes down every component that uses it.
+ */
+function isValueOrObjectShape(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  if ('fields' in value) return isObjectShape(value);
+  switch (readProperty(value, 'kind')) {
+    case 'string':
+    case 'number':
+    case 'boolean':
+      return true;
+    case 'enum': {
+      const options = readProperty(value, 'options');
+      return Array.isArray(options) && options.every((option) => typeof option === 'string');
+    }
+    case 'opaque':
+      return typeof readProperty(value, 'rawType') === 'string';
+    default:
+      return false;
+  }
+}
+
+function isObjectShape(value: unknown): boolean {
+  if (typeof value !== 'object' || value === null) return false;
+  if (typeof readProperty(value, 'degenerate') !== 'boolean') return false;
+  const fields = readProperty(value, 'fields');
+  return (
+    Array.isArray(fields) &&
+    fields.every(
+      (field) =>
+        typeof field === 'object' &&
+        field !== null &&
+        typeof readProperty(field, 'name') === 'string' &&
+        isValueOrObjectShape(readProperty(field, 'shape')),
+    )
+  );
 }
 
 /**

--- a/packages/playground/src/manifest-reference.ts
+++ b/packages/playground/src/manifest-reference.ts
@@ -266,6 +266,8 @@ function isValueOrObjectShape(value: unknown): boolean {
       const options = readProperty(value, 'options');
       return Array.isArray(options) && options.every((option) => typeof option === 'string');
     }
+    case 'array':
+      return isValueOrObjectShape(readProperty(value, 'element'));
     case 'opaque':
       return typeof readProperty(value, 'rawType') === 'string';
     default:

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -14,7 +14,9 @@
  *   GET /bundle/:name/:scenario.js → compiled example bundle (standalone — useful for tests/debugging)
  *   GET /styles.css    → raw contents of src/styles/index.css (slim base — no per-component CSS)
  *   GET /styles/shell.css → shell chrome styles (base CSS plus shell component CSS)
- *   GET /styles/all.css → full cascade aggregator (all component CSS — used by the preview iframe)
+ *   GET /styles/all.css → full cascade aggregator (all component CSS — used by the
+ *                         preview iframe AND by the outer shell, whose README prose
+ *                         renders callouts and code blocks that shell.css omits)
  *   GET /package-components/:source/*.css → CSS owned by extracted component packages
  *   GET /example-src/:name/:scenario → raw .example.svelte source
  *   GET /events        → Server-Sent Events stream for live reload
@@ -85,6 +87,7 @@ import { buildPageBundle } from './page-bundle.ts';
 import { PLAYGROUND_ROOT } from './playground-paths.ts';
 import { createHttpServerOnAvailablePort, resolvePreferredPort } from './port-scanner.ts';
 import {
+  DEPICT_THEME_VARIABLES,
   FAVICON_HREF,
   PRE_PAINT_THEME_SCRIPT,
   escapeHtml,
@@ -470,6 +473,8 @@ async function renderComponentPage(
         }
       }
       #app { display: contents; }
+
+${DEPICT_THEME_VARIABLES}
     </style>${styleTag ? `\n    ${styleTag}` : ''}
   </head>
   <body>

--- a/packages/playground/src/render-shell.test.ts
+++ b/packages/playground/src/render-shell.test.ts
@@ -11,6 +11,8 @@
 
 import { describe, expect, it } from 'bun:test';
 
+import { CSS_VARIABLE_THEME } from '@lostgradient/markdown/rendering/highlighter';
+
 import { jsonForScriptTag, renderShell } from './render-shell.ts';
 
 describe('jsonForScriptTag', () => {
@@ -76,14 +78,19 @@ describe('renderShell', () => {
     expect(html).toContain('id="cinder-initial"');
   });
 
-  it('loads the shell CSS bundle for Cinder components used by the shell', () => {
+  it('loads the full CSS aggregator so README prose gets callout + code-block CSS', () => {
+    // Regression: the shell used to load /styles/shell.css, which imports only
+    // the components the shell CHROME uses (button, input, popover, …). The
+    // landing page renders README markdown, whose callouts and fences need
+    // callout.css and code-block.css — neither of which shell.css carries, so
+    // both rendered unstyled. all.css is the same aggregator /page/:name uses.
     const html = renderShell('button', ['button']);
-    expect(html).toContain('href="/styles/shell.css"');
-    expect(html).not.toContain('href="/styles/all.css"');
+    expect(html).toContain('href="/styles/all.css"');
+    expect(html).not.toContain('href="/styles/shell.css"');
     expect(html).not.toContain('href="/styles/index.css"');
   });
 
-  it('registers cinder.reset layer before /styles/shell.css so component CSS wins', () => {
+  it('registers cinder.reset layer before /styles/all.css so component CSS wins', () => {
     // Regression: when the universal `* { padding: 0 }` reset was unlayered
     // it beat every cinder.components layered rule, leaving SegmentedControl,
     // NumberInput, Card, Accordion all rendered without padding in the shell.
@@ -93,7 +100,7 @@ describe('renderShell', () => {
     const html = renderShell('button', ['button']);
     const layerDeclaration =
       '@layer cinder.reset, cinder.tokens, cinder.foundation, cinder.components, cinder.utilities';
-    const stylesheetLink = '<link rel="stylesheet" href="/styles/shell.css"';
+    const stylesheetLink = '<link rel="stylesheet" href="/styles/all.css"';
     const layerIndex = html.indexOf(layerDeclaration);
     const linkIndex = html.indexOf(stylesheetLink);
     expect(layerIndex).toBeGreaterThan(-1);
@@ -118,6 +125,40 @@ describe('renderShell', () => {
     const html = renderShell('button', ['button']);
     const rootDeclaration = /:root\s*\{[^}]*--cinder-top-bar-height:\s*52px/.exec(html);
     expect(rootDeclaration).not.toBeNull();
+  });
+
+  it('declares every CSS variable the `depict` Shiki theme references', () => {
+    // Root cause of "landing-page fences look unhighlighted": CSS_VARIABLE_THEME
+    // emits bare `var(--syntax-*)` / `var(--surface-inset)` / `var(--text)`
+    // references, but Cinder namespaces all of its tokens under `--cinder-*`,
+    // so NONE of those names existed anywhere in the repo. Every highlighted
+    // token resolved to `unset` and inherited the surrounding prose color.
+    //
+    // Derive the required names from the theme itself rather than hard-coding
+    // a list, so adding a scope to CSS_VARIABLE_THEME without declaring its
+    // variable fails here instead of silently rendering unhighlighted.
+    const referenced = new Set<string>();
+    const collect = (value: string | undefined): void => {
+      for (const match of (value ?? '').matchAll(/var\(\s*(--[\w-]+)\s*\)/g)) {
+        const name = match[1];
+        if (name !== undefined) referenced.add(name);
+      }
+    };
+    for (const value of Object.values(CSS_VARIABLE_THEME.colors ?? {})) collect(value);
+    for (const tokenColor of CSS_VARIABLE_THEME.tokenColors ?? []) {
+      collect(tokenColor.settings?.foreground);
+      collect(tokenColor.settings?.background);
+    }
+
+    // Sanity check that the extraction found anything at all — an empty set
+    // would make the assertion below vacuously pass.
+    expect(referenced.size).toBeGreaterThan(10);
+    expect(referenced).toContain('--syntax-keyword');
+
+    const html = renderShell('button', ['button']);
+    for (const name of referenced) {
+      expect(html).toContain(`${name}: var(--cinder-`);
+    }
   });
 });
 

--- a/packages/playground/src/render-shell.ts
+++ b/packages/playground/src/render-shell.ts
@@ -100,6 +100,55 @@ export const PRE_PAINT_THEME_SCRIPT = `
       })();
     `;
 
+/**
+ * CSS custom properties consumed by the `depict` Shiki theme.
+ *
+ * `CSS_VARIABLE_THEME` in `@lostgradient/markdown/rendering/highlighter` maps
+ * every TextMate scope to a bare `var(--syntax-*)` reference (plus
+ * `var(--surface-inset)` / `var(--text)` for the editor chrome). Those names
+ * are NOT Cinder tokens — Cinder namespaces everything under `--cinder-*` —
+ * so until they are declared somewhere, every highlighted token resolves to
+ * `unset`, inherits the surrounding prose color, and the fence renders as if
+ * it were never highlighted at all.
+ *
+ * This block is the declaration site. Each name is aliased to a real Cinder
+ * token so the palette follows the active light/dark theme for free (the
+ * tokens are `light-dark()` pairs) and no raw color is authored here.
+ *
+ * Declared in the shell's inline `<style>` rather than a component's scoped
+ * CSS because the fences are injected as raw HTML (`{@html}`) from the
+ * markdown pipeline: Svelte's style scoper never sees those elements, so a
+ * scoped rule would not apply to them.
+ *
+ * Exported so `render-shell.test.ts` can cross-check the declared names
+ * against the ones `CSS_VARIABLE_THEME` actually references.
+ */
+export const DEPICT_THEME_VARIABLES = `      /* Palette for the \`depict\` Shiki theme — see DEPICT_THEME_VARIABLES. */
+      :root {
+        /* Editor chrome (theme \`colors\`). */
+        --surface-inset: var(--cinder-surface-inset);
+        --text: var(--cinder-text);
+
+        /* Token scopes (theme \`tokenColors\`). Hues are borrowed from the
+           status/accent token families so the palette stays inside the
+           design system and re-themes with it. */
+        --syntax-comment: var(--cinder-text-subtle);
+        --syntax-string: var(--cinder-color-success-fg);
+        --syntax-keyword: var(--cinder-accent-text);
+        --syntax-function: var(--cinder-color-info-fg);
+        --syntax-variable: var(--cinder-text);
+        --syntax-type: var(--cinder-color-info-fg);
+        --syntax-number: var(--cinder-color-warning-fg);
+        --syntax-operator: var(--cinder-text-subtle);
+        --syntax-constant: var(--cinder-color-warning-fg);
+        --syntax-property: var(--cinder-text-muted);
+        --syntax-tag: var(--cinder-color-danger-fg);
+        --syntax-attribute: var(--cinder-color-warning-fg);
+        --syntax-regex: var(--cinder-color-danger-fg);
+        --syntax-inserted: var(--cinder-color-success-fg);
+        --syntax-deleted: var(--cinder-color-danger-fg);
+      }`;
+
 /** Escape a string for safe use in HTML text content and attribute values. */
 export function escapeHtml(text: string): string {
   return text
@@ -220,14 +269,19 @@ export function renderShell(
     <style>
       /* Register cinder.reset as the FIRST layer (least priority) so the universal
          box/margin/padding reset below can never beat component styles. This
-         declaration runs before /styles/shell.css so the reset slot is reserved
-         at the bottom of the cascade — shell.css then registers the rest of the
+         declaration runs before /styles/all.css so the reset slot is reserved
+         at the bottom of the cascade — all.css then registers the rest of the
          order (cinder.tokens, foundation, components, utilities) and imports the
-         Cinder component styles used by the shell, all of which come later and
-         therefore win over the reset. */
+         Cinder component styles, all of which come later and therefore win over
+         the reset. */
       @layer cinder.reset, cinder.tokens, cinder.foundation, cinder.components, cinder.utilities;
     </style>
-    <link rel="stylesheet" href="/styles/shell.css" />
+    <!-- The full cascade aggregator, not the slim /styles/shell.css. shell.css
+         imports only the handful of components the shell chrome itself uses; it
+         carries neither callout.css nor code-block.css, so the landing page's
+         README prose — which renders both — came out unstyled. /page/:name
+         already loads all.css for exactly this reason. -->
+    <link rel="stylesheet" href="/styles/all.css" />
     <style>
       @layer cinder.reset {
         *, *::before, *::after {
@@ -255,6 +309,8 @@ export function renderShell(
       :root {
         --cinder-top-bar-height: 52px;
       }
+
+${DEPICT_THEME_VARIABLES}
 
       html, body, #shell-root {
         height: 100%;

--- a/packages/playground/src/shell-app/compound-families.test.ts
+++ b/packages/playground/src/shell-app/compound-families.test.ts
@@ -61,10 +61,11 @@ describe('CONTEXT_REQUIRED_PARTS', () => {
       const source = await Bun.file(
         join(CINDER_COMPONENT_SOURCE.componentsRoot, part, `${part}.svelte`),
       ).text();
-      // `\bget[A-Z]` matches `getTabsContext(` but not `tryGetTableContext(` —
-      // the optional accessors are exactly the ones spelled `tryGet*`, and the
-      // lowercase `t` denies the word boundary.
-      expect(/\bget[A-Z][A-Za-z]*\s*\(/.test(source)).toBe(true);
+      // Anchored on `Context(` so an unrelated `getBoundingClientRect(` cannot
+      // satisfy the guard — the point is that the part still reads CONTEXT.
+      // `\bget` excludes the optional `tryGet*Context(` accessors: those spell
+      // it `Get`, and the lowercase `t` before it denies the word boundary.
+      expect(/\bget[A-Za-z]*Context\s*\(/.test(source)).toBe(true);
     }
   });
 });

--- a/packages/playground/src/shell-app/compound-families.test.ts
+++ b/packages/playground/src/shell-app/compound-families.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 
+import { CINDER_COMPONENT_SOURCE } from '../component-sources.ts';
 import { COMPOSE_ONLY_COMPONENTS } from '../discover.ts';
-import { COMPOUND_COMPONENT_FAMILIES, COMPOUND_COMPONENT_PARENTS } from './compound-families.ts';
+import {
+  COMPOUND_COMPONENT_FAMILIES,
+  COMPOUND_COMPONENT_PARENTS,
+  CONTEXT_REQUIRED_PARTS,
+} from './compound-families.ts';
 
 describe('compound-families registry completeness', () => {
   test('every compose-only leaf has a parent entry', () => {
@@ -27,6 +32,39 @@ describe('compound-families registry completeness', () => {
     for (const [child, root] of Object.entries(COMPOUND_COMPONENT_PARENTS)) {
       expect(COMPOUND_COMPONENT_FAMILIES[root]).toBeDefined();
       expect(COMPOUND_COMPONENT_FAMILIES[root]).toContain(child);
+    }
+  });
+});
+
+describe('CONTEXT_REQUIRED_PARTS', () => {
+  test('is a subset of the compound-family leaves', () => {
+    // The playground uses this to skip a bare mount. A slug that is not a known
+    // compound leaf would be silently ignored (its page keeps the broken mount)
+    // or, worse, would suppress a standalone component's preview outright.
+    for (const part of CONTEXT_REQUIRED_PARTS) {
+      expect(COMPOUND_COMPONENT_PARENTS[part]).toBeDefined();
+    }
+  });
+
+  test('every listed part really does read a strict context getter at init scope', async () => {
+    // Empirical drift guard. The set is hand-maintained because the strict/optional
+    // distinction lives in the getter's DEFINITION, not at the call site — but a
+    // listed part that no longer reads context at all should not keep losing its
+    // live preview, and this catches that.
+    //
+    // The inverse direction (no UNLISTED leaf throws) is deliberately not asserted
+    // here: proving it needs the getter definitions resolved across files, and the
+    // honest version of that check is to bare-mount every leaf, which belongs in a
+    // browser test rather than this data-integrity file.
+    const { join } = await import('node:path');
+    for (const part of CONTEXT_REQUIRED_PARTS) {
+      const source = await Bun.file(
+        join(CINDER_COMPONENT_SOURCE.componentsRoot, part, `${part}.svelte`),
+      ).text();
+      // `\bget[A-Z]` matches `getTabsContext(` but not `tryGetTableContext(` —
+      // the optional accessors are exactly the ones spelled `tryGet*`, and the
+      // lowercase `t` denies the word boundary.
+      expect(/\bget[A-Z][A-Za-z]*\s*\(/.test(source)).toBe(true);
     }
   });
 });

--- a/packages/playground/src/shell-app/compound-families.ts
+++ b/packages/playground/src/shell-app/compound-families.ts
@@ -69,3 +69,40 @@ export const COMPOUND_COMPONENT_PARENTS: Readonly<Record<string, string>> = {
   'tab-panel': 'tabs',
   'tree-item': 'tree',
 };
+
+/**
+ * Compound parts that read a STRICT context getter at instance-init scope: with
+ * no provider ancestor the read throws `missing_context` during `mount()`.
+ *
+ * This is a strict SUBSET of {@link COMPOUND_COMPONENT_PARENTS}, and the subset
+ * is the point. Most family members (`table-row`, `side-navigation-item`,
+ * `statistic`, the `chat-*` leaves, …) read context through the optional
+ * `tryGet*` accessors and bare-mount perfectly well — gating on family
+ * membership alone would take a working live preview away from ~17 components
+ * that currently have one, and since compose-only leaves ship no
+ * `*.example.svelte` files there is no featured example to fall back to.
+ *
+ * The playground uses this to skip the bare mount for these parts (see
+ * `canBareMount` in `../component-page-live-preview.ts`), which is chosen over
+ * auto-wrapping them in a synthesized provider: several need a nesting depth
+ * greater than two (`Table > Table.Header > Table.Row > Table.HeaderCell`),
+ * their roots have their own required props, and `tab`/`segment`/`choice-grid-item`
+ * need registration values matching the root's selection state — a generic
+ * `<Root><Part/></Root>` wrapper renders blank or misleading for most of them.
+ */
+export const CONTEXT_REQUIRED_PARTS: ReadonlySet<string> = new Set([
+  'accordion-item',
+  'choice-grid-item',
+  'command-item',
+  'context-menu-trigger',
+  'dropdown-item',
+  'dropdown-menu',
+  'dropdown-trigger',
+  'segment',
+  'speed-dial-action',
+  'tab',
+  'tab-list',
+  'tab-panel',
+  'table-header-cell',
+  'tree-item',
+]);

--- a/packages/playground/src/shell-app/humanize.test.ts
+++ b/packages/playground/src/shell-app/humanize.test.ts
@@ -39,10 +39,14 @@ describe('humanizeComponentName', () => {
     const cases: ReadonlyArray<readonly [string, string]> = [
       ['json', 'JSON'],
       ['api', 'API'],
+      ['aria', 'ARIA'],
       ['css', 'CSS'],
       ['url', 'URL'],
       ['html', 'HTML'],
+      ['id', 'ID'],
+      ['qr', 'QR'],
       ['ssr', 'SSR'],
+      ['svg', 'SVG'],
       ['dom', 'DOM'],
     ];
     for (const [input, expected] of cases) {
@@ -50,6 +54,12 @@ describe('humanizeComponentName', () => {
         expect(humanizeComponentName(input)).toBe(expected);
       });
     }
+  });
+
+  // `qr-code` is the only real component id whose label the acronym map changes
+  // ("Qr Code" → "QR Code"); the rest of the allow-list is future-proofing.
+  it('renders the qr-code component id with an uppercase acronym', () => {
+    expect(humanizeComponentName('qr-code')).toBe('QR Code');
   });
 
   it('substitutes multiple acronyms in one name', () => {

--- a/packages/playground/src/shell-app/humanize.ts
+++ b/packages/playground/src/shell-app/humanize.ts
@@ -17,10 +17,14 @@
 const ACRONYM_MAP: Readonly<Record<string, string>> = {
   json: 'JSON',
   api: 'API',
+  aria: 'ARIA',
   css: 'CSS',
   url: 'URL',
   html: 'HTML',
+  id: 'ID',
+  qr: 'QR',
   ssr: 'SSR',
+  svg: 'SVG',
   dom: 'DOM',
 };
 
@@ -41,7 +45,8 @@ function humanizeToken(token: string): string {
  * Convert a kebab-case component name into a title-cased display label.
  *
  * Splits on hyphens, title-cases each word, and substitutes known acronyms
- * (JSON, API, CSS, URL, HTML, SSR, DOM) with their canonical uppercase form.
+ * (JSON, API, ARIA, CSS, URL, HTML, ID, QR, SSR, SVG, DOM) with their canonical
+ * uppercase form.
  * Empty segments from leading, trailing, or doubled hyphens are dropped, and
  * surrounding whitespace is trimmed.
  *

--- a/packages/playground/src/shell-app/routing.test.ts
+++ b/packages/playground/src/shell-app/routing.test.ts
@@ -15,6 +15,8 @@ import {
   parseComponentFromPath,
   readFocusModeFromSearch,
   readPreviewWidthFromSearch,
+  readViewFromSearch,
+  searchForView,
 } from './routing.ts';
 
 describe('parseComponentFromPath', () => {
@@ -125,5 +127,31 @@ describe('readPreviewWidthFromSearch', () => {
 
   it('returns null for non-numeric values', () => {
     expect(readPreviewWidthFromSearch(new URLSearchParams('w=banana'))).toBeNull();
+  });
+});
+
+describe('component page view', () => {
+  it('defaults to documentation, including for an unrecognised value', () => {
+    expect(readViewFromSearch(new URLSearchParams(''))).toBe('documentation');
+    expect(readViewFromSearch(new URLSearchParams('view=nonsense'))).toBe('documentation');
+  });
+
+  it('reads the playground view', () => {
+    expect(readViewFromSearch(new URLSearchParams('view=playground'))).toBe('playground');
+  });
+
+  it('preserves other toolbar parameters when switching view', () => {
+    const search = new URLSearchParams('width=768&focus=1');
+    const playground = searchForView(search, 'playground');
+    expect(playground).toContain('width=768');
+    expect(playground).toContain('focus=1');
+    expect(playground).toContain('view=playground');
+  });
+
+  it('expresses the default view by dropping the parameter', () => {
+    expect(searchForView(new URLSearchParams('view=playground'), 'documentation')).toBe('');
+    expect(searchForView(new URLSearchParams('view=playground&width=375'), 'documentation')).toBe(
+      '?width=375',
+    );
   });
 });

--- a/packages/playground/src/shell-app/routing.test.ts
+++ b/packages/playground/src/shell-app/routing.test.ts
@@ -17,6 +17,7 @@ import {
   readPreviewWidthFromSearch,
   readViewFromSearch,
   searchForView,
+  TOOLBAR_PARAMS,
 } from './routing.ts';
 
 describe('parseComponentFromPath', () => {
@@ -141,17 +142,17 @@ describe('component page view', () => {
   });
 
   it('preserves other toolbar parameters when switching view', () => {
-    const search = new URLSearchParams('width=768&focus=1');
+    const search = new URLSearchParams(`${TOOLBAR_PARAMS.width}=768&focus=1`);
     const playground = searchForView(search, 'playground');
-    expect(playground).toContain('width=768');
+    expect(playground).toContain('w=768');
     expect(playground).toContain('focus=1');
     expect(playground).toContain('view=playground');
   });
 
   it('expresses the default view by dropping the parameter', () => {
     expect(searchForView(new URLSearchParams('view=playground'), 'documentation')).toBe('');
-    expect(searchForView(new URLSearchParams('view=playground&width=375'), 'documentation')).toBe(
-      '?width=375',
+    expect(searchForView(new URLSearchParams('view=playground&w=375'), 'documentation')).toBe(
+      '?w=375',
     );
   });
 });

--- a/packages/playground/src/shell-app/routing.ts
+++ b/packages/playground/src/shell-app/routing.ts
@@ -100,3 +100,40 @@ export function readPreviewWidthFromSearch(search: URLSearchParams): number | nu
   if (parsed < VIEWPORT_WIDTH_MIN || parsed > VIEWPORT_WIDTH_MAX) return null;
   return parsed;
 }
+
+/**
+ * The two views a component page can be in.
+ *
+ * Documentation and Playground are separate views rather than two panes because
+ * the preview rail took a fixed 38rem out of every page width, and the prose
+ * column starved: the accessibility notes rendered in a half-width sub-column,
+ * the keyboard-shortcut table shredded to one word per line, and the props table
+ * stacked into six labelled rows per prop. Each view now gets the width it needs.
+ */
+export type ComponentPageView = 'documentation' | 'playground';
+
+/** The query parameter carrying the active view, so a view is linkable. */
+export const VIEW_PARAM = 'view';
+
+/**
+ * Read the active view from a URLSearchParams instance. Anything unrecognised
+ * falls back to `documentation` — a bad `?view=` should land the reader on the
+ * docs, not on an error.
+ */
+export function readViewFromSearch(search: URLSearchParams): ComponentPageView {
+  return search.get(VIEW_PARAM) === 'playground' ? 'playground' : 'documentation';
+}
+
+/**
+ * The search string for a view, preserving every other parameter already on the
+ * URL (focus mode and stage width both live there too). The default view is
+ * expressed by REMOVING the parameter rather than spelling it out, so the
+ * canonical docs URL stays clean.
+ */
+export function searchForView(search: URLSearchParams, view: ComponentPageView): string {
+  const next = new URLSearchParams(search);
+  if (view === 'documentation') next.delete(VIEW_PARAM);
+  else next.set(VIEW_PARAM, view);
+  const query = next.toString();
+  return query === '' ? '' : `?${query}`;
+}

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -5,6 +5,39 @@
  * these types in analyze.ts or component-page.svelte.
  */
 
+/**
+ * A leaf value the generator knows how to invent, described structurally so the
+ * playground can synthesize a placeholder for a required array/object prop.
+ *
+ * `opaque` is the honest escape hatch — a field the generator cannot invent (a
+ * callback, a Snippet, an unresolved type parameter). Opaque fields are OMITTED
+ * from a synthesized literal rather than faked, so the result stays something a
+ * reader could plausibly have written.
+ */
+export type ValueShape =
+  | { kind: 'string' }
+  | { kind: 'number' }
+  | { kind: 'boolean' }
+  | { kind: 'enum'; options: string[] }
+  | { kind: 'opaque'; rawType: string };
+
+/**
+ * The named, REQUIRED fields of an object shape. Optional fields are dropped on
+ * purpose: the goal is the minimal literal that type-checks and renders, not a
+ * complete usage example — the authored examples are for that.
+ */
+export type ObjectShape = {
+  fields: Array<{ name: string; shape: ValueShape | ObjectShape }>;
+  /**
+   * True when the object has no synthesizable named field at all — an
+   * index-signature-only record like `Record<string, unknown>`. Such a value
+   * seeds to `{}` / `[]`, never to an invented member: `MatrixChart`'s sibling
+   * props name KEYS of the datum, so any datum we invented would contradict
+   * them.
+   */
+  degenerate: boolean;
+};
+
 /** Discriminated union describing the kind of UI control for a single prop. */
 export type ControlKind =
   | { kind: 'text' }
@@ -12,6 +45,8 @@ export type ControlKind =
   | { kind: 'boolean' }
   | { kind: 'select'; options: string[] }
   | { kind: 'snippet' }
+  | { kind: 'array'; element: ValueShape | ObjectShape; rawType: string }
+  | { kind: 'object'; shape: ObjectShape; rawType: string }
   | { kind: 'unknown'; rawType: string };
 
 /** Metadata for a single component prop extracted by the static analyzer. */

--- a/packages/playground/src/types.ts
+++ b/packages/playground/src/types.ts
@@ -19,6 +19,13 @@ export type ValueShape =
   | { kind: 'number' }
   | { kind: 'boolean' }
   | { kind: 'enum'; options: string[] }
+  /**
+   * A NESTED array — `KeyboardShortcutGroup.shortcuts`, `…shortcuts[].keys`.
+   * Arrays are objects to the type checker, so without this variant a nested
+   * array fell through to the object branch and synthesized its ARRAY INTERNALS
+   * as a literal: `shortcuts: { length: 10, '__@unscopables@38': {} }`.
+   */
+  | { kind: 'array'; element: ValueShape | ObjectShape }
   | { kind: 'opaque'; rawType: string };
 
 /**

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -42,9 +42,20 @@ test.describe('playground component documentation', () => {
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.getByRole('link', { name: 'Open interactive documentation' })).toHaveCount(0);
     await expect(page.getByTestId('preview-loading-overlay')).toHaveCount(0);
-    // The preview pane rides alongside the prose rather than being a section.
-    await expect(page.locator('.dx-preview')).toHaveCount(1);
-    await expect(page.getByRole('group', { name: 'Preview viewport' })).toBeVisible();
+    // Documentation and Playground are two VIEWS now, not prose plus a fixed
+    // 38rem rail. The documentation view carries no stage at all — that is what
+    // gives the prose, the props table, and the a11y notes the full width.
+    await expect(page.locator('.dx-playground')).toHaveCount(0);
+    await expect(page.getByRole('tab', { name: 'Documentation' })).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+
+    await page.getByRole('tab', { name: 'Playground' }).click();
+    await expect(page.locator('.dx-playground')).toHaveCount(1);
+    // Labelled for what it does — these buttons clamp the stage's width, they do
+    // not emulate a device.
+    await expect(page.getByRole('group', { name: 'Stage width' })).toBeVisible();
     expect(errors).toEqual([]);
   });
 
@@ -78,11 +89,10 @@ test.describe('playground component documentation', () => {
     await page.goto('/page/toggle', { waitUntil: 'load' });
     const preview = page;
 
-    // The preview pane mounts the BARE component live with the synthesized prop
-    // values, labelled "Live preview" — not the static "Featured example". The
-    // controls used to live in a `#playground` section you scrolled to; they are
-    // now in the persistent pane beside the prose.
-    const playground = preview.locator('.dx-preview');
+    // The Playground view mounts the BARE component live with the synthesized
+    // prop values, labelled "Live preview" — not the static "Featured example".
+    await preview.getByRole('tab', { name: 'Playground' }).click();
+    const playground = preview.locator('.dx-playground');
     await expect(playground).toBeVisible();
     const liveMount = preview.locator('#playground-live-mount');
     await expect(liveMount).toBeVisible();
@@ -123,6 +133,8 @@ test.describe('canonical page preview controls', () => {
     const page_ = page.locator('[data-component-page]');
     await expect(page_).not.toHaveClass(/is-focus-mode/);
 
+    // Focus mode expands the STAGE, so it is reached from the Playground view.
+    await page.getByRole('tab', { name: 'Playground' }).click();
     await page.getByRole('button', { name: 'Expand' }).click();
     await expect(page_).toHaveClass(/is-focus-mode/);
     // The component nav must leave the tab order while the preview covers it.
@@ -138,6 +150,7 @@ test.describe('canonical page preview controls', () => {
     // keep meaning what they did on the shell.
     await page.goto('/page/badge?w=768', { waitUntil: 'load' });
 
-    await expect(page.getByRole('group', { name: 'Preview viewport' })).toContainText('768px');
+    await page.getByRole('tab', { name: 'Playground' }).click();
+    await expect(page.getByRole('group', { name: 'Stage width' })).toContainText('768px');
   });
 });

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -32,9 +32,12 @@ test.describe('playground landing page', () => {
     await expect(page.locator('.dx-content--landing .readme-content')).toContainText('Install');
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
-    // The landing page shares the documentation chrome now; its breadcrumb reads
-    // CINDER / Overview rather than a separate shell's "README" label.
-    await expect(page.locator('.dx-crumbs__current')).toHaveText('Overview');
+    // The landing page shares the documentation chrome now, rather than a
+    // separate shell. The breadcrumb band that used to prove this is gone — it
+    // restated the sidebar brand and the page heading — so assert on the chrome
+    // the landing page actually shares: one sidebar, carrying the page controls.
+    await expect(page.locator('.dx-nav__footer')).toBeVisible();
+    await expect(page.locator('.dx-nav__brand')).toHaveText('CINDER');
 
     await page.evaluate(() => {
       (window as typeof window & { __cinderShellMarker?: string }).__cinderShellMarker = 'mounted';
@@ -59,9 +62,12 @@ test.describe('playground landing page', () => {
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
-    // The landing page shares the documentation chrome now; its breadcrumb reads
-    // CINDER / Overview rather than a separate shell's "README" label.
-    await expect(page.locator('.dx-crumbs__current')).toHaveText('Overview');
+    // The landing page shares the documentation chrome now, rather than a
+    // separate shell. The breadcrumb band that used to prove this is gone — it
+    // restated the sidebar brand and the page heading — so assert on the chrome
+    // the landing page actually shares: one sidebar, carrying the page controls.
+    await expect(page.locator('.dx-nav__footer')).toBeVisible();
+    await expect(page.locator('.dx-nav__brand')).toHaveText('CINDER');
   });
 
   test('presents README content with usable landing-page layout styles', async ({ page }) => {


### PR DESCRIPTION
The docs site is the instrument every component complaint gets found with, and it was lying. A component whose props the analyzer could not synthesize lost its **entire** Playground section and was told *"This component has no adjustable props"* — false whenever the real cause was a synthesis failure. Until that is fixed you can't tell which complaints are real components versus the harness misreporting.

Implements decision 2 from `Complaints/2026-08-05.md`, plus the harness and docs-page chrome entries.

## The headline number

**Components with a suppressed Playground: 85 → 21.**

The brief estimated ~20, attributed to array props. Both were wrong. Four separate causes, in order of how many components each freed:

1. **Untyped props defaulted to required.** The syntactic type walk can't see through `Omit<>`, imported bases, or a union nested in an intersection — and a prop it couldn't type got `optional: false`. "We couldn't type it" was being reported as "it's required." This alone suppressed **Button**, the most-visited page in the library.
2. **Required array/object props** are satisfied by a synthesized placeholder — new `array`/`object` control kinds carrying a depth-bounded shape, shown read-only and emitted in the snippet (inline when short, a `<script>` preamble when long). Index-signature-only records seed `[]`, never an invented member: those components' sibling props name *keys* of the datum, so anything invented would contradict them.
3. **Mixed unions.** `PageHeader`'s entirely ordinary `title: string | Snippet` came out `unknown`. A mixed union now offers a control for its typeable arm.
4. **Exclusive unions.** `DropdownGroup`'s `label`/`labelledBy` both seeded to `''`, so its own "exactly one" validation threw on its own preview.

## Beyond the analyzer

- The gate withholds only the generated **snippet** — the one piece a synthesis failure genuinely invalidates — and names the props responsible. "No adjustable props" now appears only when true.
- **14** context-requiring compound parts no longer bare-mount and throw `missing_context`; they get a compose-guidance stage linking to the root that supplies their context. (14, not 13 — `speed-dial-action` was missing from the list.)
- The name-as-children seed is gated by a derived rule, so a `CheckboxGroup` containing the literal string "CheckboxGroup" stops counting as a preview.
- Layout primitives get placeholder children, `Surface` a reference surface, behavior-only wrappers their authored example. `image` and `source-diff-viewer` get real seeds instead of the literal prop name — `image` was rendering a broken-image glyph.
- Modal/Drawer/Sheet/Popover route to their trigger examples. Seeding `open: true` would have been *worse*: they call `showModal()`, so the preview would blanket the whole docs page and take the body scroll lock with it.

## Two views, and chrome

Documentation and Playground split into two views. The fixed 38rem rail starved the prose column; each view now gets the width it needs, which resolves the crushed a11y notes, the shredded keyboard-shortcut table, and the stacked props rows without treating them as three separate bugs.

`required`/`bindable` become badges on the prop name and their columns disappear. The stacked-card labels are driven by `data-label` from a single column list rather than `nth-child` position — removing two columns would otherwise have silently relabelled every remaining cell, and only below a 34rem *container* width where a desktop check never looks. Giant unions (`PhoneInput.country`, 245 members) and long structural types (`Statistic.change`, 540 chars) cap behind a disclosure under one policy. The TOC is styled as the horizontal tab strip it already was, rather than a vertical rail whose active state recoloured a divider.

Code rendering unifies on the CSS-variable `depict` theme — whose ~17 variables were referenced but **declared nowhere**, so every highlighted token resolved to `unset` and inherited. GitHub callouts render as Cinder Callouts with the matching `rehypeSanitize` widening; without it the markup is stripped silently, a failure indistinguishable from the plugin not running.

## Reviewer notes

- **This touches `packages/markdown`,** which the brief scoped out. It's a published package with Chat and Editor as peer dependents, so it carries a changeset (minor). A playground-only path exists — post-processing the rendered HTML — but it would fix the docs site only, not Chat's own README. Worth a call before merge.
- **Two test expectations were wrong and are rewritten, not preserved.** The Button assertions pinned a manifest bug (`label` marked required; `WithChildren` permits children instead). The "omits the Playground" tests asserted `getElementById('playground')` — an id that doesn't exist — so they passed under any behavior.
- **A latent bug surfaced in the markdown pipeline:** `renderMarkdown` only called `parse()`, so no remark *transformer* had ever run. Invisible while every plugin contributed micromark extensions only.
- **`analyze.ts` runtime is at parity** (~5.9s cold for 194 components) after two optimization passes; the checker pass is deliberately *not* used as a fallback for an `unknown` classification, since instantiating those types doubled the cost for no new answers.

## Verification

- 1006 playground unit tests, 0 failing
- 1408 browser tests, 0 failing
- `/page/<id>?snapshot=1` confirmed directly: only example mounts, once each, zero docs chrome
- Visual sweep across every failure class — array-prop, part-component, layout primitive, overlay, broken-image
- Prettier clean; oxlint 0 errors (6 pre-existing dependency-cycle warnings)

A new guard test round-trips all 194 analyzed manifests through JSON and `isComponentManifest`. The new control kinds initially failed that guard, so every component with a structural prop rendered *"Could not load documentation"* — and the entire unit suite stayed green, because nothing exercised a real manifest against the real guard. Only the browser suite caught it.
