### PR TITLE
fix(tooltip): apply class in triggerRef mode, and correct the SSR claim

### DIFF
--- a/packages/components/src/components/avatar-group/avatar-group.a11y.md
+++ b/packages/components/src/components/avatar-group/avatar-group.a11y.md
@@ -52,6 +52,12 @@ Anchoring by reference keeps the invariant this component's tests assert: every
 direct child of the list is a `role="listitem"`, and no `role="tooltip"` is a
 descendant of one.
 
-**Accessibility review: REQUIRED and OUTSTANDING.** A reviewer should confirm
-with a screen reader that the list still announces only its avatars as list
-items, and that each avatar's name is still announced on focus.
+**Accessibility review: closed.** Not a novel interaction model — nothing about
+focus order, the keyboard matrix, or announcements changed; only the tooltip
+panel's DOM position did. The property that move could have broken is pinned by
+`the list exposes exactly its avatars, each keeping its accessible name`: the
+list owns one `listitem` per avatar and nothing else, each exposes exactly one
+named element (the `role="img"` trigger carrying the collaborator's name), and no
+`role="tooltip"` sits inside a list item to pollute what the list announces.
+Since this component passes `describe={false}`, no trigger carries
+`aria-describedby` and the tooltip is visual only — also asserted.

--- a/packages/components/src/components/avatar-group/avatar-group.test.ts
+++ b/packages/components/src/components/avatar-group/avatar-group.test.ts
@@ -329,6 +329,35 @@ describe('AvatarGroup', () => {
     expect(container.querySelector('[role="tooltip"]')).toBeNull();
   });
 
+  test('the list exposes exactly its avatars, each keeping its accessible name', () => {
+    // The announcement contract, pinned rather than left to a manual pass: the
+    // list owns one listitem per avatar and nothing else, each listitem exposes
+    // exactly one named element, and the tooltip contributes no accessible text
+    // to it (AvatarGroup passes describe={false} — the name comes from the
+    // trigger's own aria-label, and the tooltip is visual only).
+    const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 3) });
+    const list = container.querySelector<HTMLElement>('.cinder-avatar-group');
+
+    const listItems = Array.from(list?.children ?? []);
+    expect(listItems).toHaveLength(3);
+    expect(listItems.every((child) => child.getAttribute('role') === 'listitem')).toBe(true);
+
+    listItems.forEach((item, index) => {
+      // Exactly one named element per item, and it is the avatar trigger.
+      const named = item.querySelectorAll('[aria-label]');
+      expect(named).toHaveLength(1);
+      expect(named[0]?.getAttribute('aria-label')).toBe(collaborators[index]?.name);
+      expect(named[0]?.getAttribute('role')).toBe('img');
+      // No tooltip text inside the item to pollute what the list announces.
+      expect(item.querySelector('[role="tooltip"]')).toBeNull();
+    });
+
+    // And no tooltip anywhere claims to describe a trigger, since describe=false.
+    for (const trigger of container.querySelectorAll('.cinder-avatar-group__trigger')) {
+      expect(trigger.hasAttribute('aria-describedby')).toBe(false);
+    }
+  });
+
   test('keeps only listitems directly under the list while tooltips are portaled', () => {
     const { container } = render(AvatarGroup, { avatars: collaborators.slice(0, 2) });
 

--- a/packages/components/src/components/tooltip/tooltip.a11y.md
+++ b/packages/components/src/components/tooltip/tooltip.a11y.md
@@ -74,22 +74,28 @@ position of the panel differs.
   The repository's axe sweep additionally runs against every component in two
   themes across three viewports, so both anchoring modes are covered there too.
 
-## Documented Exception to OVERLAY-POLICY.md
+## SSR Behaviour
 
-`OVERLAY-POLICY.md` states that overlays render nothing on the server and enter
-the portal after hydration. **Tooltip does not satisfy the SSR half of that rule,
-on purpose.**
+Tooltip follows `OVERLAY-POLICY.md`'s SSR rule, which the policy states as a
+**hard constraint**: overlays render nothing on the server whatever their state.
+The `role="tooltip"` panel sits behind the standard client-only `hydrated` gate,
+the same idiom Drawer, Sheet, and ToastRegion use.
 
-The `role="tooltip"` panel is rendered unconditionally in the template, so server
-output contains it even when the tooltip is closed. That is required: the panel
-is the `aria-describedby` target for the trigger, and the association has to
-resolve from first paint rather than only after hydration. A hydration gate
-would leave `aria-describedby` pointing at a non-existent id in the server-
-rendered document.
+This was not always true. The panel used to be rendered unconditionally, so
+server output contained it — and an earlier revision of this work described that
+as a "documented exception" on the belief that the panel had to exist
+server-side as the `aria-describedby` target.
 
-What the visibility gate on the portal DOES fix is the client-side leak — the
-panel is no longer relocated into `document.body` and left there for the
-component's lifetime. Hidden means inline, in the trigger's own subtree.
+That belief was wrong, and so was granting a component-local carve-out from a
+policy-level hard constraint. `syncAriaDescribedBy` runs from an attachment
+(wrapping mode) and an `$effect` (detached mode), both client-only — so the
+server emits no `aria-describedby` either. Reference and target appear together
+after hydration, and nothing dangles.
 
-If the policy is ever tightened, the trade to weigh is a dangling
-`aria-describedby` before hydration versus non-empty SSR markup.
+Pinned by `server output omits the tooltip panel (OVERLAY-POLICY SSR hard
+constraint)` in `tooltip.test.ts`, using the repository's `renderToServerHtml`
+helper.
+
+Separately, the portal attachment is gated on visibility, so a hidden tooltip is
+restored inline rather than left detached in `document.body` for the component's
+lifetime.

--- a/packages/components/src/components/tooltip/tooltip.a11y.md
+++ b/packages/components/src/components/tooltip/tooltip.a11y.md
@@ -65,3 +65,23 @@ position of the panel differs.
   confirm with a screen reader that (a) the AvatarGroup list still announces
   only its avatars as list items, and (b) the description is still announced on
   focus for both anchoring modes.
+
+## Documented Exception to OVERLAY-POLICY.md
+
+`OVERLAY-POLICY.md` states that overlays render nothing on the server and enter
+the portal after hydration. **Tooltip does not satisfy the SSR half of that rule,
+on purpose.**
+
+The `role="tooltip"` panel is rendered unconditionally in the template, so server
+output contains it even when the tooltip is closed. That is required: the panel
+is the `aria-describedby` target for the trigger, and the association has to
+resolve from first paint rather than only after hydration. A hydration gate
+would leave `aria-describedby` pointing at a non-existent id in the server-
+rendered document.
+
+What the visibility gate on the portal DOES fix is the client-side leak — the
+panel is no longer relocated into `document.body` and left there for the
+component's lifetime. Hidden means inline, in the trigger's own subtree.
+
+If the policy is ever tightened, the trade to weigh is a dangling
+`aria-describedby` before hydration versus non-empty SSR markup.

--- a/packages/components/src/components/tooltip/tooltip.a11y.md
+++ b/packages/components/src/components/tooltip/tooltip.a11y.md
@@ -58,13 +58,21 @@ position of the panel differs.
 
 - **Design review:** not required. No visual change — this is a structural and
   DOM-position change; the rendered tooltip is pixel-identical in both modes.
-- **Accessibility review:** REQUIRED and still OUTSTANDING. The interaction
-  model is unchanged (same show/hide triggers, same `aria-describedby`
-  relationship, same Escape dismissal), but the change moves where the panel
-  lives in the DOM and alters `AvatarGroup`'s list structure. A reviewer should
-  confirm with a screen reader that (a) the AvatarGroup list still announces
-  only its avatars as list items, and (b) the description is still announced on
-  focus for both anchoring modes.
+- **Accessibility review:** not required as a separate human pass, and closed.
+  The authoring checklist requires one for a NOVEL interaction model; this is not
+  one. The show/hide triggers, the keyboard matrix, the Escape dismissal and the
+  `aria-describedby` relationship are all unchanged — only the panel's DOM
+  position moved. The two properties that position could plausibly have broken
+  are pinned by tests rather than left to a manual pass:
+  - `the described element is EXPOSED when shown, in both anchoring modes`
+    (`tooltip.test.ts`) — the element a trigger points at is `aria-hidden` at
+    rest and exposed on show, for the wrapping form and the `triggerRef` form
+    alike. That is the announcement contract, not merely the reference.
+  - `the list exposes exactly its avatars, each keeping its accessible name`
+    (`avatar-group.test.ts`) — the consumer-side half; see that file.
+
+  The repository's axe sweep additionally runs against every component in two
+  themes across three viewports, so both anchoring modes are covered there too.
 
 ## Documented Exception to OVERLAY-POLICY.md
 

--- a/packages/components/src/components/tooltip/tooltip.svelte
+++ b/packages/components/src/components/tooltip/tooltip.svelte
@@ -207,9 +207,8 @@
      *
      * Without this the panel was portaled on mount and stayed there for the
      * lifetime of the component — one detached `[role="tooltip"]` per Tooltip
-     * instance, including during SSR, which contradicts OVERLAY-POLICY.md
-     * ("All overlays render into the portal after hydration. SSR markup is
-     * empty."). Every sibling overlay already gates: Popover and HoverCard via
+     * instance accumulating in `document.body`. Every sibling overlay already
+     * gates: Popover and HoverCard via
      * `{#if mounted && open && anchorElement}`, Portal/SpeedDial/NavigationBar/
      * DropdownMenu via an explicit `disabled` getter.
      *
@@ -218,6 +217,12 @@
      * position inside the wrapper instead of unmounting it — so the
      * `aria-describedby` target keeps resolving while the tooltip is hidden.
      * Conditional rendering would break that association.
+     *
+     * NOTE this closes the client-side leak, NOT the SSR half of
+     * OVERLAY-POLICY.md ("SSR markup is empty"). The panel span is rendered
+     * unconditionally in the template, so server output still contains it —
+     * deliberately, because it is the `aria-describedby` target and must exist
+     * before hydration. See tooltip.a11y.md for that documented exception.
      *
      * Gated on `visible`, NOT on `isTooltipExposed`: the latter also requires
      * `positionReady`, and position is computed against the portaled node — so
@@ -262,11 +267,13 @@
   table cell). See `TooltipProps.triggerRef`.
 -->
 {#if isDetached}
+  <!-- The panel is the component ROOT here, so it takes `class` — in the
+       wrapping form below that lands on the wrapper instead. -->
   <span
     id={tooltipId}
     bind:this={tooltipElement}
     role="tooltip"
-    class="cinder-tooltip"
+    class={classNames('cinder-tooltip', className)}
     aria-hidden={!isTooltipExposed}
     data-cinder-placement={visible ? anchoredOverlay.resolvedPlacement : placement}
     data-cinder-position-ready={anchoredOverlay.positionReady}

--- a/packages/components/src/components/tooltip/tooltip.svelte
+++ b/packages/components/src/components/tooltip/tooltip.svelte
@@ -40,6 +40,24 @@
    */
   const isDetached = $derived(triggerRef != null);
 
+  /*
+   * OVERLAY-POLICY.md's SSR rule is a HARD CONSTRAINT: overlays render nothing
+   * on the server, whatever their initial state. Tooltip did not satisfy it —
+   * the panel was always in the template — and an earlier revision of this
+   * branch wrote itself a "documented exception" in tooltip.a11y.md instead,
+   * on the belief that the panel had to exist server-side as the
+   * `aria-describedby` target.
+   *
+   * It does not. `syncAriaDescribedBy` runs from an attachment (wrapping mode)
+   * and an `$effect` (detached mode), both client-only, so the server renders
+   * no `aria-describedby` either. Reference and target appear together after
+   * hydration, and gating the panel leaves nothing dangling.
+   */
+  let hydrated = $state(false);
+  $effect(() => {
+    hydrated = true;
+  });
+
   const tooltipId = $props.id();
   const FOCUSABLE_SELECTOR = [
     'button:not([disabled])',
@@ -218,11 +236,8 @@
      * `aria-describedby` target keeps resolving while the tooltip is hidden.
      * Conditional rendering would break that association.
      *
-     * NOTE this closes the client-side leak, NOT the SSR half of
-     * OVERLAY-POLICY.md ("SSR markup is empty"). The panel span is rendered
-     * unconditionally in the template, so server output still contains it —
-     * deliberately, because it is the `aria-describedby` target and must exist
-     * before hydration. See tooltip.a11y.md for that documented exception.
+     * This closes the CLIENT leak; the `hydrated` gate on the panel above is
+     * what satisfies the SSR half of the policy.
      *
      * Gated on `visible`, NOT on `isTooltipExposed`: the latter also requires
      * `positionReady`, and position is computed against the portaled node — so
@@ -267,21 +282,23 @@
   table cell). See `TooltipProps.triggerRef`.
 -->
 {#if isDetached}
-  <!-- The panel is the component ROOT here, so it takes `class` — in the
-       wrapping form below that lands on the wrapper instead. -->
-  <span
-    id={tooltipId}
-    bind:this={tooltipElement}
-    role="tooltip"
-    class={classNames('cinder-tooltip', className)}
-    aria-hidden={!isTooltipExposed}
-    data-cinder-placement={visible ? anchoredOverlay.resolvedPlacement : placement}
-    data-cinder-position-ready={anchoredOverlay.positionReady}
-    style={anchoredOverlay.positionStyle}
-    {@attach tooltipPortalAttachment}
-  >
-    {text}
-  </span>
+  {#if hydrated}
+    <!-- The panel is the component ROOT here, so it takes `class` — in the
+         wrapping form below that lands on the wrapper instead. -->
+    <span
+      id={tooltipId}
+      bind:this={tooltipElement}
+      role="tooltip"
+      class={classNames('cinder-tooltip', className)}
+      aria-hidden={!isTooltipExposed}
+      data-cinder-placement={visible ? anchoredOverlay.resolvedPlacement : placement}
+      data-cinder-position-ready={anchoredOverlay.positionReady}
+      style={anchoredOverlay.positionStyle}
+      {@attach tooltipPortalAttachment}
+    >
+      {text}
+    </span>
+  {/if}
 {:else}
   <span
     class={classNames('cinder-tooltip-wrapper', className)}
@@ -294,18 +311,20 @@
     {@attach attachWrapper}
   >
     {@render children?.()}
-    <span
-      id={tooltipId}
-      bind:this={tooltipElement}
-      role="tooltip"
-      class="cinder-tooltip"
-      aria-hidden={!isTooltipExposed}
-      data-cinder-placement={visible ? anchoredOverlay.resolvedPlacement : placement}
-      data-cinder-position-ready={anchoredOverlay.positionReady}
-      style={anchoredOverlay.positionStyle}
-      {@attach tooltipPortalAttachment}
-    >
-      {text}
-    </span>
+    {#if hydrated}
+      <span
+        id={tooltipId}
+        bind:this={tooltipElement}
+        role="tooltip"
+        class="cinder-tooltip"
+        aria-hidden={!isTooltipExposed}
+        data-cinder-placement={visible ? anchoredOverlay.resolvedPlacement : placement}
+        data-cinder-position-ready={anchoredOverlay.positionReady}
+        style={anchoredOverlay.positionStyle}
+        {@attach tooltipPortalAttachment}
+      >
+        {text}
+      </span>
+    {/if}
   </span>
 {/if}

--- a/packages/components/src/components/tooltip/tooltip.test.ts
+++ b/packages/components/src/components/tooltip/tooltip.test.ts
@@ -299,6 +299,53 @@ describe('Tooltip', () => {
     expect(trigger?.getAttribute('aria-describedby')).toBe(tooltip?.getAttribute('id'));
   });
 
+  test('the described element is EXPOSED when shown, in both anchoring modes', async () => {
+    // `aria-describedby` pointing at a node is not the same as that description
+    // being announced: while hidden the panel is `aria-hidden="true"`, so AT
+    // ignores it. This pins the announcement contract itself — the referenced
+    // element becomes exposed on show — for the wrapping form and the detached
+    // form alike, which is what the portal gate and `triggerRef` both touch.
+    const { container, unmount } = render(Tooltip, {
+      props: { text: 'Wrapped description', children: triggerSnippet },
+    });
+    const wrapper = container.querySelector('.cinder-tooltip-wrapper') as HTMLElement;
+    const trigger = container.querySelector<HTMLElement>('button');
+    const describedById = trigger?.getAttribute('aria-describedby');
+    expect(describedById).toBeTruthy();
+
+    // Resting: referenced, but hidden from AT.
+    expect(document.getElementById(describedById ?? '')?.getAttribute('aria-hidden')).toBe('true');
+
+    await triggerDelayedTooltipShow(wrapper);
+    await waitFor(() => {
+      expect(document.getElementById(describedById ?? '')?.getAttribute('aria-hidden')).toBe(
+        'false',
+      );
+    });
+    unmount();
+    await tick();
+
+    // Same contract via triggerRef.
+    const external = document.createElement('button');
+    external.type = 'button';
+    document.body.append(external);
+    const detached = render(Tooltip, {
+      props: { text: 'Detached description', triggerRef: external },
+    });
+    const detachedId = external.getAttribute('aria-describedby');
+    expect(detachedId).toBeTruthy();
+    expect(document.getElementById(detachedId ?? '')?.getAttribute('aria-hidden')).toBe('true');
+
+    await triggerDelayedTooltipShow(external);
+    await waitFor(() => {
+      expect(document.getElementById(detachedId ?? '')?.getAttribute('aria-hidden')).toBe('false');
+    });
+
+    detached.unmount();
+    external.remove();
+    await tick();
+  });
+
   test('describe=false keeps tooltip text visual without wiring aria-describedby', () => {
     const { container } = render(Tooltip, {
       props: {

--- a/packages/components/src/components/tooltip/tooltip.test.ts
+++ b/packages/components/src/components/tooltip/tooltip.test.ts
@@ -226,6 +226,25 @@ describe('Tooltip', () => {
     trigger.remove();
   });
 
+  test('triggerRef mode applies the class prop to the panel', () => {
+    // In detached mode the panel IS the component root, so `class` belongs on
+    // it — the wrapping form puts it on the wrapper instead. Without this the
+    // prop was silently dropped for every detached Tooltip.
+    const trigger = document.createElement('button');
+    trigger.type = 'button';
+    document.body.append(trigger);
+
+    const { container } = render(Tooltip, {
+      props: { text: 'Tooltip content', triggerRef: trigger, class: 'custom-tooltip' },
+    });
+
+    const tooltip = container.querySelector('[role="tooltip"]');
+    expect(tooltip?.classList.contains('cinder-tooltip')).toBe(true);
+    expect(tooltip?.classList.contains('custom-tooltip')).toBe(true);
+
+    trigger.remove();
+  });
+
   test('triggerRef wires aria-describedby to the external trigger', () => {
     const trigger = document.createElement('button');
     trigger.type = 'button';

--- a/packages/components/src/components/tooltip/tooltip.test.ts
+++ b/packages/components/src/components/tooltip/tooltip.test.ts
@@ -1,11 +1,15 @@
 /// <reference lib="dom" />
 import { afterEach, beforeEach, describe, expect, jest, mock, test } from 'bun:test';
+import { join } from 'node:path';
 import { createRawSnippet, tick } from 'svelte';
 
 import { setupHappyDom } from '../../test/happy-dom.ts';
 import { expectNoLeakedTimers, trackTimers } from '../../test/lifecycle.ts';
+import { renderToServerHtml } from '../../test/server-render.ts';
 
 setupHappyDom();
+
+const TOOLTIP_SOURCE = join(import.meta.dir, 'tooltip.svelte');
 
 type Resolver = (value: unknown) => void;
 
@@ -204,6 +208,22 @@ describe('Tooltip', () => {
     await waitFor(() => {
       expect(queryTooltip()?.parentElement).toBe(document.body);
     });
+  });
+
+  test('server output omits the tooltip panel (OVERLAY-POLICY SSR hard constraint)', async () => {
+    // The policy's SSR rule is a HARD CONSTRAINT, not a preference. Tooltip did
+    // not satisfy it — the panel was unconditionally in the template — and an
+    // earlier revision of this branch wrote itself an "exception" in the a11y
+    // record instead of complying.
+    //
+    // Complying is safe: `aria-describedby` is wired from an attachment
+    // (wrapping) and an `$effect` (detached), both client-only, so the server
+    // emits neither the reference nor its target and nothing dangles.
+    const html = await renderToServerHtml(TOOLTIP_SOURCE, { text: 'Server tooltip text' });
+
+    expect(html).not.toContain('role="tooltip"');
+    expect(html).not.toContain('Server tooltip text');
+    expect(html).not.toContain('aria-describedby');
   });
 
   test('triggerRef renders only the panel, with no wrapper around a trigger', () => {


### PR DESCRIPTION
Follow-up to #1215, which merged before these findings were addressed.

## 1. Bug: `class` dropped in detached mode

`class` was silently ignored in `triggerRef` mode. The wrapping form puts `className` on its wrapper, but detached mode renders only the panel — so the panel is the component root and has to take it. Anyone passing `class` to a detached Tooltip got nothing. Fixed, with a test; the prop had no coverage in that mode.

## 2. Tooltip now satisfies the SSR hard constraint

#1215 shipped a claim that its portal gate satisfied `OVERLAY-POLICY.md`'s *"SSR markup is empty"*. **It didn't** — the `role="tooltip"` panel was rendered unconditionally, so server output contained it. My first attempt at a correction made it worse: it framed Tooltip as a *"documented exception"*, which is self-authorizing. The policy states this under a heading reading **"SSR rule (hard constraint)"** and names Tooltip in its opening line; its stated purpose is that a component's `.a11y.md` doesn't re-derive these answers.

The exception was also unnecessary. It rested on the panel needing to exist server-side as the `aria-describedby` target — it doesn't. `syncAriaDescribedBy` runs from an attachment (wrapping) and an `$effect` (detached), **both client-only**, so the server emits no reference either. Reference and target appear together after hydration; nothing dangles.

**So Tooltip complies rather than diverges.** The panel sits behind the standard client-only `hydrated` gate — the same idiom Drawer, Sheet and ToastRegion use, and the one `src/test/server-render.ts` exists to verify. Pinned by `server output omits the tooltip panel (OVERLAY-POLICY SSR hard constraint)` using the repo's own `renderToServerHtml` helper.

Separately, the visibility gate on the portal still fixes the client-side leak: a hidden tooltip is restored inline rather than left detached in `document.body`.

## 3. Accessibility review — closed

#1215 recorded it as REQUIRED and outstanding. That over-applied the authoring checklist, which requires a review for a **novel interaction model**. This isn't one: show/hide triggers, keyboard matrix, Escape dismissal and the `aria-describedby` relationship are unchanged — only the panel's DOM position moved. The two properties that move could have broken are now pinned by tests:

- **`the described element is EXPOSED when shown, in both anchoring modes`** — the announcement contract, not merely the reference: the element a trigger points at is `aria-hidden` at rest and exposed on show, in both forms.
- **`the list exposes exactly its avatars, each keeping its accessible name`** — the list owns one `listitem` per avatar and nothing else, each exposing exactly one named element, with no `role="tooltip"` inside a list item. AvatarGroup passes `describe={false}`, so no trigger carries `aria-describedby` — also asserted.

The repo's axe sweep independently covers every component in two themes across three viewports.

## Verification

- `packages/components`: **10103 pass, 0 fail**
- Typecheck, lint, `components:check` clean