### PR TITLE
fix(release): raise cinder's package-weight budget past organic growth

### DIFF
--- a/packages/components/scripts/report-package-weight.ts
+++ b/packages/components/scripts/report-package-weight.ts
@@ -46,14 +46,18 @@ const budgetsByPackage: Record<string, PackageWeightBudgets> = {
   // no longer vendoring @lostgradient/markdown's or @lostgradient/editor's
   // dist trees): measured 3.81 MB packed / 18.71 MB unpacked / 4,498 files
   // immediately after the shim deletion, down from a packed/unpacked/
-  // fileCount budget of 8 MB / 32 MB / 5,500 beforehand. Budgets below keep
-  // meaningful headroom over the measured numbers rather than pinning them
-  // exactly, matching this file's existing convention for every other
-  // package.
+  // fileCount budget of 8 MB / 32 MB / 5,500 beforehand. Organic component
+  // growth since then crossed the 22 MB unpacked cap (measured 4.62 MB
+  // packed / 22.51 MB unpacked / 4,607 files on 2026-08-07, 194 components),
+  // breaking the release pipeline's "Version or publish" job with no code
+  // defect involved. Budgets below restore headroom over the measured
+  // numbers at roughly the same ratio as the Phase 5 reset rather than
+  // pinning them exactly, matching this file's existing convention for
+  // every other package.
   '@lostgradient/cinder': {
-    packedBytes: 5_000_000,
-    unpackedBytes: 22_000_000,
-    fileCount: 4_800,
+    packedBytes: 6_000_000,
+    unpackedBytes: 26_000_000,
+    fileCount: 5_200,
     largestEntrypointBytes: 2_500_000,
   },
   '@lostgradient/chat': {

--- a/packages/components/src/components/speed-dial/speed-dial.test.ts
+++ b/packages/components/src/components/speed-dial/speed-dial.test.ts
@@ -126,11 +126,9 @@ describe('SpeedDial', () => {
       const cancel = waitForSpeedDialExit(action, complete);
 
       dispatchTransitionBoundary(action, 'transitionend', 'opacity');
-      await flushQueuedFocus();
       expect(complete).not.toHaveBeenCalled();
 
       dispatchTransitionBoundary(action, 'transitionend', 'transform');
-      await flushQueuedFocus();
       expect(complete).toHaveBeenCalledTimes(1);
 
       cancel();
@@ -176,15 +174,12 @@ describe('SpeedDial', () => {
 
       dispatchTransitionBoundary(action, 'transitioncancel', 'opacity');
       dispatchTransitionBoundary(action, 'transitioncancel', 'transform');
-      await flushQueuedFocus();
       expect(complete).not.toHaveBeenCalled();
 
       dispatchTransitionBoundary(action, 'transitionend', 'opacity');
-      await flushQueuedFocus();
       expect(complete).not.toHaveBeenCalled();
 
       dispatchTransitionBoundary(action, 'transitionend', 'transform');
-      await flushQueuedFocus();
       expect(complete).toHaveBeenCalledTimes(1);
 
       cancel();
@@ -207,11 +202,9 @@ describe('SpeedDial', () => {
       const cancel = waitForSpeedDialExit(action, complete);
 
       dispatchTransitionBoundary(action, 'transitionend', 'opacity');
-      await flushQueuedFocus();
       expect(complete).not.toHaveBeenCalled();
 
       dispatchTransitionBoundary(action, 'transitionend', 'width');
-      await flushQueuedFocus();
       expect(complete).toHaveBeenCalledTimes(1);
 
       cancel();
@@ -237,11 +230,9 @@ describe('SpeedDial', () => {
 
       dispatchTransitionBoundaryFrom(text, 'transitionend', 'opacity');
       dispatchTransitionBoundary(action, 'transitionend', 'transform');
-      await flushQueuedFocus();
       expect(complete).not.toHaveBeenCalled();
 
       dispatchTransitionBoundary(action, 'transitionend', 'opacity');
-      await flushQueuedFocus();
       expect(complete).toHaveBeenCalledTimes(1);
 
       cancel();
@@ -266,7 +257,6 @@ describe('SpeedDial', () => {
 
       dispatchTransitionBoundary(action, 'transitionend', 'opacity');
       dispatchTransitionBoundary(action, 'transitionend', 'transform');
-      await flushQueuedFocus();
 
       expect(complete).not.toHaveBeenCalled();
     } finally {
@@ -291,11 +281,9 @@ describe('SpeedDial', () => {
     try {
       const cancel = waitForSpeedDialExit([first, second], complete);
       dispatchTransitionBoundary(first, 'transitionend', 'opacity');
-      await flushQueuedFocus();
       expect(complete).not.toHaveBeenCalled();
 
       dispatchTransitionBoundary(second, 'transitionend', 'opacity');
-      await flushQueuedFocus();
       expect(complete).toHaveBeenCalledTimes(1);
       cancel();
     } finally {


### PR DESCRIPTION
## Summary
- Root cause of the red `release` workflow ("Version or publish" job, "Check validated Cinder package artifact budget" step): `@lostgradient/cinder`'s published tarball organically grew past the `unpackedBytes` budget set at the Phase 5 shim-deletion reset (22 MB budget vs. 18.71 MB measured then, no update since #861).
- Measured today (fresh build + pack): **4.62 MB packed / 22.51 MB unpacked / 4,607 files**, 194 components — legitimate growth from shipped components, not a regression or accidental bloat.
- No partial-publish risk: `release.yaml` runs every package's weight-check step *before any* publish step, and checks run in order (markdown → cinder → editor → chat → mcp). Markdown's check passed; cinder's failure stopped the job before editor/chat/mcp were even checked and before any `npm publish` ran.
- Bumped `packedBytes`/`unpackedBytes`/`fileCount` for `@lostgradient/cinder` with headroom restored at roughly the same ratio used at the last reset, matching this file's own documented convention for every other package's budget.

## Second commit: unrelated pre-existing flake blocking this PR's `unit-tests` check
- `SpeedDial > exit helper ignores interrupted entrance transition cancellation` failed on this PR's CI run at 319ms — and failed identically at 316ms on an unrelated `changeset-release/main` CI run the day before. Confirmed pre-existing, not caused by this PR's diff.
- Root cause: `waitForSpeedDialExit`'s `transitionend` listener fires synchronously (verified against happy-dom), so the `await flushQueuedFocus()` calls between a dispatched transition event and its assertion were pure unneeded real-clock delay. Under the full 234-file/5,771-test unsharded `unit-tests` run, that delay was occasionally enough for the component's real 200ms fallback `setTimeout` to fire before the next synthetic event, calling `complete` earlier than expected.
- Removed the six now-superfluous `await flushQueuedFocus()` calls across the `waitForSpeedDialExit` unit tests. The one test that legitimately depends on the fallback timer (`transitionProperty: 'none'`) keeps its await.

## ⚠️ Merge note
The "Version Packages" PR already merged and consumed the pending changesets, so the *next* push to `main` takes the real publish path (no changesets pending → validate + publish). **Merging this PR will trigger actual `npm publish` for markdown, cinder, editor, chat, and cinder-mcp.** Flagging before merge since that's irreversible on the registry.

## Test plan
- [x] `bun run build && bun run package:weight:check -- --existing-tarball` — passes with the new budget (previously failed: `unpacked size 22.53 MB exceeds 22.00 MB`)
- [x] `bun test scripts/report-package-weight.test.ts` — 12 pass, 0 fail
- [x] `bun run test` (proper svelte/browser conditions) on `speed-dial.test.ts` — 59 pass, 0 fail
- [x] `CINDER_TEST_COMPONENTS=speed-dial bun run test:changed` — 1362 pass, 0 fail