### PR TITLE
fix(scripts): gate prop-convention polarity prefixes on boolean types

### DIFF
--- a/packages/components/scripts/check-prop-conventions.test.ts
+++ b/packages/components/scripts/check-prop-conventions.test.ts
@@ -135,6 +135,11 @@ describe('check-prop-conventions type-aware surface pass', () => {
       'export type BooleanPrefixProps = { showSearch?: boolean; useNativeShare?: boolean | undefined };',
     'non-boolean-prefix':
       'export type NonBooleanPrefixProps = { hideDelay?: number; showCount?: number; disableReason?: string };',
+    'boolean-fence-arm': 'export type BooleanFenceArmProps = { showSearch?: undefined };',
+    'opaque-prefix':
+      'export type OpaquePrefixProps = { showSearch?: unknown; useNativeShare?: any };',
+    'generic-prefix':
+      'export type GenericPrefixProps<Item extends { id: string }, Flag extends boolean, Loose> = { showItem?: Item; showFlag?: Flag; showLoose?: Loose };',
   };
 
   function buildViolationsByFixture(): Map<
@@ -201,6 +206,31 @@ describe('check-prop-conventions type-aware surface pass', () => {
 
   test('passes a polarity-prefixed name whose resolved type is not boolean', () => {
     expect(violationsByFixture.get('non-boolean-prefix')).toEqual([]);
+  });
+
+  test('passes an undefined-only fence arm on a polarity-prefixed name', () => {
+    expect(violationsByFixture.get('boolean-fence-arm')).toEqual([]);
+  });
+
+  // Fails closed: `any`/`unknown` tell the checker nothing, so dropping
+  // OPAQUE_TYPE_FLAGS from the probe must not let the ban lapse silently.
+  test('keeps the polarity ban when the resolved type is opaque', () => {
+    expect(
+      (violationsByFixture.get('opaque-prefix') ?? [])
+        .map((violation) => violation.propName)
+        .toSorted(),
+    ).toEqual(['showSearch', 'useNativeShare']);
+  });
+
+  // A type parameter is judged by its constraint, so a provably non-boolean
+  // generic is the same false positive as `hideDelay?: number`; an
+  // unconstrained one keeps the ban.
+  test('resolves type parameters through their constraint', () => {
+    expect(
+      (violationsByFixture.get('generic-prefix') ?? [])
+        .map((violation) => violation.propName)
+        .toSorted(),
+    ).toEqual(['showFlag', 'showLoose']);
   });
 
   test('passes an undefined-only discriminated-union fence arm', () => {

--- a/packages/components/scripts/check-prop-conventions.test.ts
+++ b/packages/components/scripts/check-prop-conventions.test.ts
@@ -17,20 +17,20 @@ describe('check-prop-conventions', () => {
     expect(violations.map((violation) => violation.propName)).toEqual(['defaultValue']);
   });
 
-  test('flags show, allow, and use boolean prefixes', () => {
+  test('defers show/allow/use prefixes to the type-aware pass', () => {
     const source = `
       export type Props = {
         showSearch?: boolean;
         allowCustomValue?: boolean;
         useNativeShare?: boolean;
+        hideDelay?: number;
       };
     `;
 
-    expect(collectPropConventionViolations(source).map((violation) => violation.propName)).toEqual([
-      'showSearch',
-      'allowCustomValue',
-      'useNativeShare',
-    ]);
+    // Whether a polarity prefix is a violation depends on the prop's resolved
+    // type, so the syntactic pass leaves every prefixed name to the type-aware
+    // surface scan.
+    expect(collectPropConventionViolations(source)).toEqual([]);
   });
 
   test('flags React-style onClick; lowercase handlers are deferred to the type-aware pass', () => {
@@ -131,6 +131,10 @@ describe('check-prop-conventions type-aware surface pass', () => {
       'export type PointerForwardProps = { onpointerdown?: (event: PointerEvent) => void; onwheel?: (event: WheelEvent) => void };',
     'non-callable':
       'export type NonCallableProps = { onchange?: string; onmark?: ((event: Event) => void) | string };',
+    'boolean-prefix':
+      'export type BooleanPrefixProps = { showSearch?: boolean; useNativeShare?: boolean | undefined };',
+    'non-boolean-prefix':
+      'export type NonBooleanPrefixProps = { hideDelay?: number; showCount?: number; disableReason?: string };',
   };
 
   function buildViolationsByFixture(): Map<
@@ -182,6 +186,21 @@ describe('check-prop-conventions type-aware surface pass', () => {
       'onchange',
       'onmark',
     ]);
+  });
+
+  test('flags a polarity prefix on a boolean-valued prop', () => {
+    const violations = violationsByFixture.get('boolean-prefix') ?? [];
+    expect(violations.map((violation) => violation.propName).toSorted()).toEqual([
+      'showSearch',
+      'useNativeShare',
+    ]);
+    expect(
+      violations.every((violation) => violation.message.includes('adjective/state names')),
+    ).toBe(true);
+  });
+
+  test('passes a polarity-prefixed name whose resolved type is not boolean', () => {
+    expect(violationsByFixture.get('non-boolean-prefix')).toEqual([]);
   });
 
   test('passes an undefined-only discriminated-union fence arm', () => {

--- a/packages/components/scripts/check-prop-conventions.test.ts
+++ b/packages/components/scripts/check-prop-conventions.test.ts
@@ -148,6 +148,11 @@ describe('check-prop-conventions type-aware surface pass', () => {
     // interface, and a structural constraint satisfied by Boolean.prototype.
     'boolean-wrapper':
       'export type BooleanWrapperProps<Valued extends { valueOf(): boolean }> = { showWrapped?: Boolean; showValued?: Valued };',
+    // Deferred types: nothing is assignable to either while the type argument
+    // is unresolved, but `Deferred<true>` / `Indexed<{ flag: boolean }>` both
+    // expose a boolean.
+    'deferred-type':
+      'export type DeferredTypeProps<Flag extends boolean, Bag extends { flag: boolean }> = { showState?: Flag extends true ? boolean : number; showIndexed?: Bag["flag"] };',
   };
 
   function buildViolationsByFixture(): Map<
@@ -264,6 +269,16 @@ describe('check-prop-conventions type-aware surface pass', () => {
         .map((violation) => violation.propName)
         .toSorted(),
     ).toEqual(['showValued', 'showWrapped']);
+  });
+
+  // Nothing is assignable to an unresolved conditional or indexed access, so
+  // the assignability probe alone would clear both.
+  test('keeps the ban on deferred types that some instantiation makes boolean', () => {
+    expect(
+      (violationsByFixture.get('deferred-type') ?? [])
+        .map((violation) => violation.propName)
+        .toSorted(),
+    ).toEqual(['showIndexed', 'showState']);
   });
 
   test('passes an undefined-only discriminated-union fence arm', () => {

--- a/packages/components/scripts/check-prop-conventions.test.ts
+++ b/packages/components/scripts/check-prop-conventions.test.ts
@@ -140,6 +140,10 @@ describe('check-prop-conventions type-aware surface pass', () => {
       'export type OpaquePrefixProps = { showSearch?: unknown; useNativeShare?: any };',
     'generic-prefix':
       'export type GenericPrefixProps<Item extends { id: string }, Flag extends boolean, Loose> = { showItem?: Item; showFlag?: Flag; showLoose?: Loose };',
+    'wide-constraint':
+      'export type WideConstraintProps<Empty extends {}, Any extends unknown, Union extends string | boolean> = { showEmpty?: Empty; showAny?: Any; showUnion?: Union };',
+    'narrow-constraint':
+      'export type NarrowConstraintProps<Countable extends number, Named extends { id: string }, Callable extends () => void> = { showCountable?: Countable; showNamed?: Named; showCallable?: Callable };',
   };
 
   function buildViolationsByFixture(): Map<
@@ -231,6 +235,21 @@ describe('check-prop-conventions type-aware surface pass', () => {
         .map((violation) => violation.propName)
         .toSorted(),
     ).toEqual(['showFlag', 'showLoose']);
+  });
+
+  // A constraint that demands nothing (`{}`, `unknown`) still admits `true`,
+  // so the ban must stand — resolving the constraint must not become a way to
+  // launder a prefixed boolean past the gate.
+  test('keeps the ban when a constraint is wide enough to admit a boolean', () => {
+    expect(
+      (violationsByFixture.get('wide-constraint') ?? [])
+        .map((violation) => violation.propName)
+        .toSorted(),
+    ).toEqual(['showAny', 'showEmpty', 'showUnion']);
+  });
+
+  test('passes constraints that rule a boolean out', () => {
+    expect(violationsByFixture.get('narrow-constraint')).toEqual([]);
   });
 
   test('passes an undefined-only discriminated-union fence arm', () => {

--- a/packages/components/scripts/check-prop-conventions.test.ts
+++ b/packages/components/scripts/check-prop-conventions.test.ts
@@ -153,6 +153,10 @@ describe('check-prop-conventions type-aware surface pass', () => {
     // expose a boolean.
     'deferred-type':
       'export type DeferredTypeProps<Flag extends boolean, Bag extends { flag: boolean }> = { showState?: Flag extends true ? boolean : number; showIndexed?: Bag["flag"] };',
+    // Wrappers a boolean survives but plain assignability does not see:
+    // NoInfer's substitution, and a branded intersection.
+    'wrapped-boolean':
+      'declare const brand: unique symbol;\nexport type WrappedBooleanProps<Flag extends boolean> = { showDeferredFlag?: NoInfer<Flag>; showBranded?: boolean & { readonly [brand]: true } };',
   };
 
   function buildViolationsByFixture(): Map<
@@ -269,6 +273,16 @@ describe('check-prop-conventions type-aware surface pass', () => {
         .map((violation) => violation.propName)
         .toSorted(),
     ).toEqual(['showValued', 'showWrapped']);
+  });
+
+  // `boolean` is not assignable to `NoInfer<Flag>` or to a branded
+  // intersection, so the probe alone would clear both.
+  test('keeps the ban through NoInfer and branded-intersection wrappers', () => {
+    expect(
+      (violationsByFixture.get('wrapped-boolean') ?? [])
+        .map((violation) => violation.propName)
+        .toSorted(),
+    ).toEqual(['showBranded', 'showDeferredFlag']);
   });
 
   // Nothing is assignable to an unresolved conditional or indexed access, so

--- a/packages/components/scripts/check-prop-conventions.test.ts
+++ b/packages/components/scripts/check-prop-conventions.test.ts
@@ -144,6 +144,10 @@ describe('check-prop-conventions type-aware surface pass', () => {
       'export type WideConstraintProps<Empty extends {}, Any extends unknown, Union extends string | boolean> = { showEmpty?: Empty; showAny?: Any; showUnion?: Union };',
     'narrow-constraint':
       'export type NarrowConstraintProps<Countable extends number, Named extends { id: string }, Callable extends () => void> = { showCountable?: Countable; showNamed?: Named; showCallable?: Callable };',
+    // Object shapes a primitive boolean is still assignable to: the wrapper
+    // interface, and a structural constraint satisfied by Boolean.prototype.
+    'boolean-wrapper':
+      'export type BooleanWrapperProps<Valued extends { valueOf(): boolean }> = { showWrapped?: Boolean; showValued?: Valued };',
   };
 
   function buildViolationsByFixture(): Map<
@@ -250,6 +254,16 @@ describe('check-prop-conventions type-aware surface pass', () => {
 
   test('passes constraints that rule a boolean out', () => {
     expect(violationsByFixture.get('narrow-constraint')).toEqual([]);
+  });
+
+  // These expose members, so a member-count heuristic would clear them even
+  // though `true` is assignable to both.
+  test('keeps the ban on object shapes a primitive boolean satisfies', () => {
+    expect(
+      (violationsByFixture.get('boolean-wrapper') ?? [])
+        .map((violation) => violation.propName)
+        .toSorted(),
+    ).toEqual(['showValued', 'showWrapped']);
   });
 
   test('passes an undefined-only discriminated-union fence arm', () => {

--- a/packages/components/scripts/check-prop-conventions.test.ts
+++ b/packages/components/scripts/check-prop-conventions.test.ts
@@ -157,6 +157,10 @@ describe('check-prop-conventions type-aware surface pass', () => {
     // NoInfer's substitution, and a branded intersection.
     'wrapped-boolean':
       'declare const brand: unique symbol;\nexport type WrappedBooleanProps<Flag extends boolean> = { showDeferredFlag?: NoInfer<Flag>; showBranded?: boolean & { readonly [brand]: true } };',
+    // `{}` admits a boolean on its own, but it constrains nothing — the
+    // intersection is still a number.
+    'branded-non-boolean':
+      'export type BrandedNonBooleanProps = { showCount?: number & {}; showTag?: string & { readonly __tag: "id" } };',
   };
 
   function buildViolationsByFixture(): Map<
@@ -283,6 +287,10 @@ describe('check-prop-conventions type-aware surface pass', () => {
         .map((violation) => violation.propName)
         .toSorted(),
     ).toEqual(['showBranded', 'showDeferredFlag']);
+  });
+
+  test('passes intersections whose boolean-admitting arm constrains nothing', () => {
+    expect(violationsByFixture.get('branded-non-boolean')).toEqual([]);
   });
 
   // Nothing is assignable to an unresolved conditional or indexed access, so

--- a/packages/components/scripts/check-prop-conventions.ts
+++ b/packages/components/scripts/check-prop-conventions.ts
@@ -245,16 +245,16 @@ function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
   // `NoInfer<T>` and friends wrap the real type in a substitution — three
   // Props surfaces here already use it — so unwrap to what the consumer
   // actually sets.
-  if ((type.flags & ts.TypeFlags.Substitution) !== 0) {
-    return canHoldBoolean((type as ts.SubstitutionType).baseType, checker);
-  }
+  const substituted = substitutionBaseType(type);
+  if (substituted) return canHoldBoolean(substituted, checker);
 
   // A branded boolean (`boolean & { readonly __brand: unique symbol }`) is set
   // with a boolean, but the whole `boolean` type is not assignable to the
-  // intersection, so the probe below would clear it. Any boolean-capable
-  // constituent keeps the ban.
+  // intersection, so the probe below would clear it. Only a constituent that
+  // is ITSELF boolean counts: probing `canHoldBoolean` per constituent would
+  // ban `number & {}`, since `{}` admits a boolean on its own.
   if (type.isIntersection()) {
-    return type.types.some((constituent) => canHoldBoolean(constituent, checker));
+    return type.types.some((constituent) => contributesBoolean(constituent, checker));
   }
 
   // A bare type parameter says nothing on its own, but its constraint does:
@@ -297,6 +297,40 @@ function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
     return !demandsMembers;
   }
   return (type.flags & OPAQUE_TYPE_FLAGS) !== 0;
+}
+
+/**
+ * `NoInfer<T>` and other substitutions carry the real type in `baseType`,
+ * which is not on the public `Type` surface — widen with an optional member
+ * rather than narrowing to `ts.SubstitutionType`, which the type-aware lint
+ * rejects as an unsafe assertion.
+ */
+type SubstitutionLike = { baseType?: ts.Type };
+
+function substitutionBaseType(type: ts.Type): ts.Type | undefined {
+  if ((type.flags & ts.TypeFlags.Substitution) === 0) return undefined;
+  return (type as ts.Type & SubstitutionLike).baseType;
+}
+
+/**
+ * Whether a single intersection constituent is itself boolean, after
+ * unwrapping the indirections that hide one. Deliberately narrower than
+ * `canHoldBoolean`: a constituent that merely ADMITS a boolean (`{}`,
+ * `unknown`) constrains nothing, so it must not make `number & {}` read as a
+ * boolean prop.
+ */
+function contributesBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
+  if ((type.flags & ts.TypeFlags.BooleanLike) !== 0) return true;
+  const substituted = substitutionBaseType(type);
+  if (substituted) return contributesBoolean(substituted, checker);
+  if ((type.flags & ts.TypeFlags.TypeParameter) !== 0) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    return constraint ? contributesBoolean(constraint, checker) : false;
+  }
+  if (type.isUnion()) {
+    return type.types.some((constituent) => contributesBoolean(constituent, checker));
+  }
+  return false;
 }
 
 /**

--- a/packages/components/scripts/check-prop-conventions.ts
+++ b/packages/components/scripts/check-prop-conventions.ts
@@ -224,8 +224,9 @@ const OPAQUE_TYPE_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown;
  * Whether a polarity-prefixed prop can actually hold a boolean, which is the
  * only case the show/hide/disable prefix ban is about. `boolean` resolves to a
  * `true | false` union, so the probe runs per constituent after dropping the
- * nullish arms; a nullish-only arm is a discriminated-union fence with
- * nothing to set, and an opaque type keeps the ban.
+ * nullish and `never` arms; an arm left with nothing substantive is a
+ * discriminated-union fence with no value to set, and an opaque type keeps
+ * the ban.
  */
 function isBooleanLikePropType(type: ts.Type, checker: ts.TypeChecker): boolean {
   const constituents = type.isUnion() ? type.types : [type];
@@ -243,6 +244,19 @@ function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
   if ((type.flags & ts.TypeFlags.TypeParameter) !== 0) {
     const constraint = checker.getBaseConstraintOfType(type);
     return constraint ? isBooleanLikePropType(constraint, checker) : true;
+  }
+  // A structural constraint only excludes booleans when it actually demands
+  // something a boolean lacks. `T extends {}` demands nothing, so `true` is a
+  // legal instantiation and the ban must stand; `T extends { id: string }`
+  // rules booleans out. Members are the public-API stand-in for an
+  // assignability probe, which lives on the checker's internal surface.
+  if ((type.flags & ts.TypeFlags.Object) !== 0) {
+    const demandsMembers =
+      checker.getPropertiesOfType(type).length > 0 ||
+      checker.getIndexInfosOfType(type).length > 0 ||
+      checker.getSignaturesOfType(type, ts.SignatureKind.Call).length > 0 ||
+      checker.getSignaturesOfType(type, ts.SignatureKind.Construct).length > 0;
+    return !demandsMembers;
   }
   return (type.flags & OPAQUE_TYPE_FLAGS) !== 0;
 }

--- a/packages/components/scripts/check-prop-conventions.ts
+++ b/packages/components/scripts/check-prop-conventions.ts
@@ -8,8 +8,6 @@ const packageRoot = resolve(scriptDirectory, '..');
 const repositoryRoot = resolve(packageRoot, '..', '..');
 const documentationPath = 'docs/component-api-conventions.md';
 
-const booleanPrefixPattern = /^(show|allow|use|hide|disable|disallow)[A-Z]/;
-
 export const bannedNames = new Map<string, string>([
   ['defaultValue', 'Use bindable `value` plus a private reset target.'],
   ['filterItem', 'Use `filter`.'],
@@ -69,14 +67,9 @@ function checkPropName(
     violations.push({ filePath, line, propName, message: bannedMessage });
   }
 
-  if (booleanPrefixPattern.test(propName)) {
-    violations.push({
-      filePath,
-      line,
-      propName,
-      message: 'Boolean props must use adjective/state names, not show*/allow*/use* prefixes.',
-    });
-  }
+  // Polarity prefixes (show*/hide*/disable*, …) are NOT judged here either:
+  // the ban is about boolean polarity, and `hideDelay?: number` is a duration,
+  // not a flag — so it is a type question the type-aware pass answers.
 
   // Lowercase on* names are NOT judged here: any name can be a legitimate
   // native passthrough (onpointerdown, onwheel, …), so the distinction is a
@@ -161,7 +154,9 @@ export function collectPropConventionViolations(
 // One ts.Program over every *.types.ts resolves each exported Props surface's
 // properties through aliases, intersections, unions, and indexed accesses,
 // then gates every lowercase on* handler on its first parameter structurally
-// extending Event. Resolving the SURFACE (not the syntax tree) also closes
+// extending Event. The same resolution gates the show*/hide*/disable*
+// polarity ban on the property's type actually being boolean-like.
+// Resolving the SURFACE (not the syntax tree) also closes
 // the non-exported-helper blind spot: a violation is attributed to its true
 // declaration site even when that declaration lives in an unexported type
 // referenced by the exported Props.
@@ -216,6 +211,28 @@ function isNativePassthroughHandlerType(propType: ts.Type, checker: ts.TypeCheck
     const parameterType = checker.getTypeOfSymbolAtLocation(firstParameter, declaration);
     return isEventLikeParameterType(parameterType);
   });
+}
+
+const booleanPrefixPattern = /^(show|allow|use|hide|disable|disallow)[A-Z]/;
+
+// `any`/`unknown`/an unresolved type parameter tell the checker nothing, so
+// the name-based ban stands rather than silently lapsing.
+const OPAQUE_TYPE_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.TypeParameter;
+
+/**
+ * Whether a polarity-prefixed prop can actually hold a boolean, which is the
+ * only case the show/hide/disable prefix ban is about. `boolean` resolves to a
+ * `true | false` union, so the probe runs per constituent after dropping the
+ * nullish arms; a nullish-only arm is a discriminated-union fence with
+ * nothing to set, and an opaque type keeps the ban.
+ */
+function isBooleanLikePropType(type: ts.Type): boolean {
+  const constituents = type.isUnion() ? type.types : [type];
+  const substantive = constituents.filter((constituent) => !isNullishType(constituent));
+  if (substantive.length === 0) return false;
+  return substantive.some(
+    (constituent) => (constituent.flags & (ts.TypeFlags.BooleanLike | OPAQUE_TYPE_FLAGS)) !== 0,
+  );
 }
 
 function propsSurfaceNamesIn(sourceFile: ts.SourceFile): ts.Identifier[] {
@@ -284,13 +301,16 @@ export function collectResolvedSurfaceViolations(
           }
 
           if (booleanPrefixPattern.test(propName)) {
-            record({
-              filePath,
-              line,
-              propName,
-              message:
-                'Boolean props must use adjective/state names, not show*/allow*/use* prefixes.',
-            });
+            const propertyType = checker.getTypeOfSymbolAtLocation(property, site.declaration);
+            if (isBooleanLikePropType(propertyType)) {
+              record({
+                filePath,
+                line,
+                propName,
+                message:
+                  'Boolean props must use adjective/state names, not show*/allow*/use* prefixes.',
+              });
+            }
           }
 
           if (/^on[a-z]/.test(propName)) {

--- a/packages/components/scripts/check-prop-conventions.ts
+++ b/packages/components/scripts/check-prop-conventions.ts
@@ -220,6 +220,10 @@ const booleanPrefixPattern = /^(show|allow|use|hide|disable|disallow)[A-Z]/;
 // able to vouch for.
 const OPAQUE_TYPE_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown;
 
+// Types whose resolution waits on a type argument, so no instantiation-time
+// answer exists during the surface scan.
+const DEFERRED_TYPE_FLAGS = ts.TypeFlags.Conditional | ts.TypeFlags.IndexedAccess;
+
 /**
  * Whether a polarity-prefixed prop can actually hold a boolean, which is the
  * only case the show/hide/disable prefix ban is about. `boolean` resolves to a
@@ -245,6 +249,13 @@ function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
     const constraint = checker.getBaseConstraintOfType(type);
     return constraint ? isBooleanLikePropType(constraint, checker) : true;
   }
+  // A deferred type — an unresolved conditional or indexed access — has no
+  // single answer while the generic surface is being scanned. Nothing is
+  // assignable to `T extends true ? boolean : number` yet, so the probe below
+  // would clear it even though `Props<true>` exposes a boolean. Keep the ban,
+  // as with any other type the checker cannot vouch for.
+  if ((type.flags & DEFERRED_TYPE_FLAGS) !== 0) return true;
+
   // The real question for everything else is assignability: can this type
   // hold `true`? Flags cannot answer it — `{}`, `unknown`, `Boolean` and
   // `{ valueOf(): boolean }` all accept a boolean while carrying no

--- a/packages/components/scripts/check-prop-conventions.ts
+++ b/packages/components/scripts/check-prop-conventions.ts
@@ -245,11 +245,17 @@ function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
     const constraint = checker.getBaseConstraintOfType(type);
     return constraint ? isBooleanLikePropType(constraint, checker) : true;
   }
-  // A structural constraint only excludes booleans when it actually demands
-  // something a boolean lacks. `T extends {}` demands nothing, so `true` is a
-  // legal instantiation and the ban must stand; `T extends { id: string }`
-  // rules booleans out. Members are the public-API stand-in for an
-  // assignability probe, which lives on the checker's internal surface.
+  // The real question for everything else is assignability: can this type
+  // hold `true`? Flags cannot answer it — `{}`, `unknown`, `Boolean` and
+  // `{ valueOf(): boolean }` all accept a boolean while carrying no
+  // BooleanLike flag, and `{ id: string }` rejects one.
+  const assignable = booleanAssignableTo(type, checker);
+  if (assignable !== undefined) return assignable;
+
+  // Fallback when the checker's assignability surface is gone. A structural
+  // type only excludes booleans when it demands something a boolean lacks,
+  // which is right for `{}` versus `{ id: string }` but misses the wrapper
+  // shapes above — hence the probe first.
   if ((type.flags & ts.TypeFlags.Object) !== 0) {
     const demandsMembers =
       checker.getPropertiesOfType(type).length > 0 ||
@@ -259,6 +265,28 @@ function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
     return !demandsMembers;
   }
   return (type.flags & OPAQUE_TYPE_FLAGS) !== 0;
+}
+
+/**
+ * `getBooleanType`/`isTypeAssignableTo` answer the polarity question exactly,
+ * but neither is on the public TypeChecker surface. Both are feature-detected
+ * so a TypeScript upgrade that drops them degrades to the structural fallback
+ * in `canHoldBoolean` instead of crashing the gate.
+ */
+type AssignabilityProbe = {
+  getBooleanType?: () => ts.Type;
+  isTypeAssignableTo?: (source: ts.Type, target: ts.Type) => boolean;
+};
+
+function booleanAssignableTo(target: ts.Type, checker: ts.TypeChecker): boolean | undefined {
+  const probe = checker as ts.TypeChecker & AssignabilityProbe;
+  if (
+    typeof probe.getBooleanType !== 'function' ||
+    typeof probe.isTypeAssignableTo !== 'function'
+  ) {
+    return undefined;
+  }
+  return probe.isTypeAssignableTo(probe.getBooleanType(), target);
 }
 
 function propsSurfaceNamesIn(sourceFile: ts.SourceFile): ts.Identifier[] {

--- a/packages/components/scripts/check-prop-conventions.ts
+++ b/packages/components/scripts/check-prop-conventions.ts
@@ -241,6 +241,22 @@ function isBooleanLikePropType(type: ts.Type, checker: ts.TypeChecker): boolean 
 
 function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
   if ((type.flags & ts.TypeFlags.BooleanLike) !== 0) return true;
+
+  // `NoInfer<T>` and friends wrap the real type in a substitution — three
+  // Props surfaces here already use it — so unwrap to what the consumer
+  // actually sets.
+  if ((type.flags & ts.TypeFlags.Substitution) !== 0) {
+    return canHoldBoolean((type as ts.SubstitutionType).baseType, checker);
+  }
+
+  // A branded boolean (`boolean & { readonly __brand: unique symbol }`) is set
+  // with a boolean, but the whole `boolean` type is not assignable to the
+  // intersection, so the probe below would clear it. Any boolean-capable
+  // constituent keeps the ban.
+  if (type.isIntersection()) {
+    return type.types.some((constituent) => canHoldBoolean(constituent, checker));
+  }
+
   // A bare type parameter says nothing on its own, but its constraint does:
   // `Item extends { id: string }` can never be a boolean, so a generic
   // `showItem?: Item` is the same false positive as `hideDelay?: number`.
@@ -254,6 +270,11 @@ function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
   // assignable to `T extends true ? boolean : number` yet, so the probe below
   // would clear it even though `Props<true>` exposes a boolean. Keep the ban,
   // as with any other type the checker cannot vouch for.
+  //
+  // This is deliberately fail-closed rather than branch-inspecting: a
+  // deferred type whose every branch is non-boolean gets a false positive,
+  // which an author escapes by renaming one prop, whereas the opposite bias
+  // reopens the silent hole this pass exists to close.
   if ((type.flags & DEFERRED_TYPE_FLAGS) !== 0) return true;
 
   // The real question for everything else is assignability: can this type

--- a/packages/components/scripts/check-prop-conventions.ts
+++ b/packages/components/scripts/check-prop-conventions.ts
@@ -215,9 +215,10 @@ function isNativePassthroughHandlerType(propType: ts.Type, checker: ts.TypeCheck
 
 const booleanPrefixPattern = /^(show|allow|use|hide|disable|disallow)[A-Z]/;
 
-// `any`/`unknown`/an unresolved type parameter tell the checker nothing, so
-// the name-based ban stands rather than silently lapsing.
-const OPAQUE_TYPE_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags.TypeParameter;
+// `any`/`unknown` tell the checker nothing, so the name-based ban stands
+// rather than silently lapsing on exactly the surfaces the checker is least
+// able to vouch for.
+const OPAQUE_TYPE_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown;
 
 /**
  * Whether a polarity-prefixed prop can actually hold a boolean, which is the
@@ -226,13 +227,24 @@ const OPAQUE_TYPE_FLAGS = ts.TypeFlags.Any | ts.TypeFlags.Unknown | ts.TypeFlags
  * nullish arms; a nullish-only arm is a discriminated-union fence with
  * nothing to set, and an opaque type keeps the ban.
  */
-function isBooleanLikePropType(type: ts.Type): boolean {
+function isBooleanLikePropType(type: ts.Type, checker: ts.TypeChecker): boolean {
   const constituents = type.isUnion() ? type.types : [type];
   const substantive = constituents.filter((constituent) => !isNullishType(constituent));
   if (substantive.length === 0) return false;
-  return substantive.some(
-    (constituent) => (constituent.flags & (ts.TypeFlags.BooleanLike | OPAQUE_TYPE_FLAGS)) !== 0,
-  );
+  return substantive.some((constituent) => canHoldBoolean(constituent, checker));
+}
+
+function canHoldBoolean(type: ts.Type, checker: ts.TypeChecker): boolean {
+  if ((type.flags & ts.TypeFlags.BooleanLike) !== 0) return true;
+  // A bare type parameter says nothing on its own, but its constraint does:
+  // `Item extends { id: string }` can never be a boolean, so a generic
+  // `showItem?: Item` is the same false positive as `hideDelay?: number`.
+  // An unconstrained parameter still keeps the ban.
+  if ((type.flags & ts.TypeFlags.TypeParameter) !== 0) {
+    const constraint = checker.getBaseConstraintOfType(type);
+    return constraint ? isBooleanLikePropType(constraint, checker) : true;
+  }
+  return (type.flags & OPAQUE_TYPE_FLAGS) !== 0;
 }
 
 function propsSurfaceNamesIn(sourceFile: ts.SourceFile): ts.Identifier[] {
@@ -302,7 +314,7 @@ export function collectResolvedSurfaceViolations(
 
           if (booleanPrefixPattern.test(propName)) {
             const propertyType = checker.getTypeOfSymbolAtLocation(property, site.declaration);
-            if (isBooleanLikePropType(propertyType)) {
+            if (isBooleanLikePropType(propertyType, checker)) {
               record({
                 filePath,
                 line,


### PR DESCRIPTION
## What

The `show*`/`hide*`/`disable*` prefix ban was a name-only regex applied by **both** the syntactic and the resolved pass, so a legitimate non-boolean prop such as `hideDelay?: number` was reported as a boolean-polarity violation purely from its spelling. No current surface hits it, so this was a latent false-positive trap rather than a live break.

## How

The syntactic pass now defers prefix judgment to the type-aware pass, the same way lowercase `on*` names already do. The resolved pass consults the property's resolved type before recording:

- `boolean` resolves to a `true | false` union, so the probe runs per constituent after dropping the nullish arms.
- A nullish-only arm is a discriminated-union fence with nothing to set, so it passes.
- **Fails closed:** `any` and `unknown` keep the ban, so a broken-types file cannot smuggle a prefixed boolean through.
- `some` rather than `every` keeps a tri-state such as `boolean | 'auto'` flagged.
- A bare type parameter is judged by its **base constraint**, so a generic `showItem?: Item` where `Item extends { id: string }` stops reading as a boolean — the same false positive the issue reports, just on the type-parameter arm. An unconstrained parameter still keeps the ban.

## Verification

- `check:prop-conventions` gate green against the real component surface
- `packages/components`: typecheck clean, full suite 0 fail

New fixtures cover the three arms that previously had none: the `any`/`unknown` fail-closed path (so deleting `OPAQUE_TYPE_FLAGS` from the mask can no longer pass silently), the undefined-only fence arm, and constraint resolution.

No changeset: `scripts/` is not in the package's published `files`, so no runtime, type, or CSS surface moves.

Closes #1228