### PR TITLE
fix(chat): guard programmatic retryMessage against in-flight retries

### DIFF
--- a/.changeset/programmatic-retry-single-flight.md
+++ b/.changeset/programmatic-retry-single-flight.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Single-flight message retries at the dispatch layer and expose a guarded programmatic `retryMessage(messageId)` on the Chat instance, so a second retry for an id whose retry is still in flight is ignored regardless of entry point (UI Retry button or direct call).

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -65,6 +65,9 @@ type ChatImperative = {
   scrollToBottom: () => void;
   scrollToTop: () => void;
 };
+type ChatRetryImperative = {
+  retryMessage: (messageId: string) => void;
+};
 
 afterEach(() => {
   document.body.replaceChildren();
@@ -290,6 +293,159 @@ describe('ChatAdapter — command equivalence', () => {
 
     release();
     await retryFinished;
+
+    unmount(instance);
+  });
+
+  test('programmatic retryMessage for an in-flight id dispatches the adapter once', async () => {
+    // #1235 — the re-entrancy guard must live at the dispatch layer, not the
+    // UI click handler: a direct `chat.retryMessage(id)` call while a retry
+    // for that same id is still in flight must NOT dispatch the adapter again.
+    let calls = 0;
+    let release!: () => void;
+    const retryFinished = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const adapter: ChatAdapter = {
+      sendMessage: async () => {},
+      retryMessage: async () => {
+        calls += 1;
+        await retryFinished;
+      },
+    };
+    const { instance } = mountChat({
+      id: 'chat-programmatic-retry-single-flight',
+      conversation: failedConversation(),
+      adapter,
+    });
+    const chat = instance as unknown as ChatRetryImperative;
+
+    chat.retryMessage('failed-1');
+    chat.retryMessage('failed-1');
+    await Promise.resolve();
+    expect(calls).toBe(1);
+
+    release();
+    await retryFinished;
+
+    unmount(instance);
+  });
+
+  test('a programmatic retryMessage while a UI-initiated retry for the same id is in flight is ignored', async () => {
+    // #1235 — mixed entry points share ONE guard: Retry button first, then a
+    // programmatic call for the same id mid-flight → still a single dispatch.
+    let calls = 0;
+    let release!: () => void;
+    const retryFinished = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const adapter: ChatAdapter = {
+      sendMessage: async () => {},
+      retryMessage: async () => {
+        calls += 1;
+        await retryFinished;
+      },
+    };
+    const { container, instance } = mountChat({
+      id: 'chat-mixed-retry-single-flight',
+      conversation: failedConversation(),
+      adapter,
+    });
+    const chat = instance as unknown as ChatRetryImperative;
+
+    clickRetry(container);
+    chat.retryMessage('failed-1');
+    await Promise.resolve();
+    expect(calls).toBe(1);
+
+    release();
+    await retryFinished;
+
+    unmount(instance);
+  });
+
+  test('programmatic retryMessage for a DIFFERENT id dispatches while another retry is in flight', async () => {
+    // #1235 regression guard — the single-flight is PER MESSAGE ID: a retry
+    // for another failed message must not be blocked by an unrelated flight.
+    const retried: string[] = [];
+    const releases: Array<() => void> = [];
+    const adapter: ChatAdapter = {
+      sendMessage: async () => {},
+      retryMessage: async (id) => {
+        retried.push(id);
+        await new Promise<void>((resolve) => releases.push(resolve));
+      },
+    };
+    const now = '2026-06-02T00:00:00.000Z';
+    const failed = (id: string, position: number): Message => ({
+      id,
+      role: 'assistant',
+      content: `failed message ${position}`,
+      position,
+      createdAt: now,
+      metadata: { _deliveryStatus: 'failed' },
+      hidden: false,
+    });
+    const conversation: ConversationHistory = {
+      schemaVersion: 4,
+      id: 'adapter-two-failures',
+      status: 'active',
+      metadata: {},
+      ids: ['failed-1', 'failed-2'],
+      messages: { 'failed-1': failed('failed-1', 0), 'failed-2': failed('failed-2', 1) },
+      createdAt: now,
+      updatedAt: now,
+    };
+    const { instance } = mountChat({
+      id: 'chat-retry-different-id',
+      conversation,
+      adapter,
+    });
+    const chat = instance as unknown as ChatRetryImperative;
+
+    chat.retryMessage('failed-1');
+    chat.retryMessage('failed-2');
+    await Promise.resolve();
+    expect(retried).toEqual(['failed-1', 'failed-2']);
+
+    releases.forEach((releaseFlight) => releaseFlight());
+    unmount(instance);
+  });
+
+  test('programmatic retryMessage dispatches again after the first flight settles', async () => {
+    // #1235 regression guard — the guard clears when the flight ends, whether
+    // it resolved or rejected, so a LATER retry for the same id still works.
+    let calls = 0;
+    let release!: () => void;
+    let firstFlight = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const adapter: ChatAdapter = {
+      sendMessage: async () => {},
+      retryMessage: async () => {
+        calls += 1;
+        await firstFlight;
+      },
+    };
+    const { instance } = mountChat({
+      id: 'chat-retry-after-settle',
+      conversation: failedConversation(),
+      adapter,
+      onadaptererror: () => {},
+    });
+    const chat = instance as unknown as ChatRetryImperative;
+
+    chat.retryMessage('failed-1');
+    release();
+    await firstFlight;
+    // Let the dispatcher's finally-clear run before re-dispatching.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    firstFlight = Promise.resolve();
+    chat.retryMessage('failed-1');
+    await Promise.resolve();
+    expect(calls).toBe(2);
 
     unmount(instance);
   });

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -450,6 +450,43 @@ describe('ChatAdapter — command equivalence', () => {
     unmount(instance);
   });
 
+  test('an ASYNC onretry callback (no adapter) is single-flighted for the same in-flight id', async () => {
+    // #1235 review follow-up — an async function is assignable to the
+    // void-returning `onretry` type, and dispatchCommand discards the
+    // callback's return value. The dispatch layer must still hold the
+    // in-flight token until the async handler SETTLES (not just until it is
+    // invoked), so two rapid retries for the same id run the handler once.
+    let calls = 0;
+    let release!: () => void;
+    const retryFinished = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const { instance } = mountChat({
+      id: 'chat-async-callback-retry-single-flight',
+      conversation: failedConversation(),
+      onretry: async () => {
+        calls += 1;
+        await retryFinished;
+      },
+    });
+    const chat = instance as unknown as ChatRetryImperative;
+
+    chat.retryMessage('failed-1');
+    chat.retryMessage('failed-1');
+    await Promise.resolve();
+    expect(calls).toBe(1);
+
+    release();
+    await retryFinished;
+    // Let the finally-clear settle, then a LATER retry for the same id works.
+    await Promise.resolve();
+    await Promise.resolve();
+    chat.retryMessage('failed-1');
+    expect(calls).toBe(2);
+
+    unmount(instance);
+  });
+
   test('does not let an old conversation clear a newer retry flight', async () => {
     let calls = 0;
     const releases: Array<() => void> = [];

--- a/packages/chat/src/lib/components/chat/chat.svelte
+++ b/packages/chat/src/lib/components/chat/chat.svelte
@@ -105,6 +105,17 @@
     impl?.announce(message, level);
   }
 
+  /**
+   * Programmatically retry a failed message — the same guarded dispatch as the
+   * UI Retry button (#1235). A call for a message id whose retry is still in
+   * flight is ignored, so the adapter's `retryMessage` command (or the
+   * `onretry` callback) never double-fires for the same id regardless of entry
+   * point. No-op until mounted.
+   */
+  export function retryMessage(messageId: string): void {
+    impl?.retryMessage(messageId);
+  }
+
   /** Scroll the message viewport to the bottom. No-op until mounted. */
   export function scrollToBottom(): void {
     impl?.scrollToBottom();

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -1429,7 +1429,14 @@
     }
   }
 
-  function handleRetry(messageId: string): void {
+  // #897/#1235 — retries are single-flighted PER MESSAGE ID at the dispatch
+  // layer (mirroring how every command funnels through dispatchCommand), so the
+  // guard covers EVERY entry point — the UI Retry button and the exported
+  // programmatic `retryMessage()` — not just the click handler. A second retry
+  // for an id whose retry is still in flight is ignored; the flight token
+  // clears when the dispatch settles (resolve, reject, or sync throw), so a
+  // later retry for the same id dispatches again.
+  function dispatchRetryMessage(messageId: string): void {
     if (pendingRetryMessageTokens.has(messageId)) return;
     const flightToken = Symbol(messageId);
     pendingRetryMessageTokens = new Map(pendingRetryMessageTokens).set(messageId, flightToken);
@@ -1456,6 +1463,10 @@
       clearPending();
       throw error;
     }
+  }
+
+  function handleRetry(messageId: string): void {
+    dispatchRetryMessage(messageId);
   }
 
   function handleEdit(event: { messageId: string; content: string }): void {
@@ -1849,6 +1860,16 @@
       }
       scrollState.scrollToTop(viewport);
     }
+  }
+
+  /**
+   * Programmatically retry a failed message — the same guarded dispatch as the
+   * UI Retry button. A call for a message id whose retry is still in flight is
+   * ignored, so the adapter's `retryMessage` command (or the `onretry`
+   * callback) never double-fires for the same id regardless of entry point.
+   */
+  export function retryMessage(messageId: string): void {
+    dispatchRetryMessage(messageId);
   }
 
   export function focusInput(): void {

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -1447,6 +1447,13 @@
       pendingRetryMessageTokens = next;
     };
     try {
+      // `onretry` is typed as void-returning, but an async handler is
+      // assignable to that type and returns a promise at runtime.
+      // dispatchCommand deliberately discards the callback's return value, so
+      // capture it here — the in-flight token must hold until an async
+      // handler settles, not just until it is invoked, or two rapid retries
+      // for the same id would run the handler twice.
+      let callbackRun: Promise<void> | undefined;
       const run = dispatchCommand(
         'retryMessage',
         // Return `undefined` ONLY when the optional method is absent; otherwise
@@ -1455,9 +1462,13 @@
           resolvedAdapter.retryMessage
             ? Promise.resolve(resolvedAdapter.retryMessage(messageId))
             : undefined,
-        () => onretry?.(messageId),
+        () => {
+          const result = onretry?.(messageId) as void | Promise<void>;
+          if (result !== undefined) callbackRun = Promise.resolve(result);
+        },
       );
-      if (run !== undefined) void run.finally(clearPending);
+      const flight = run ?? callbackRun;
+      if (flight !== undefined) void flight.finally(clearPending);
       else clearPending();
     } catch (error) {
       clearPending();


### PR DESCRIPTION
Fixes #1235

## Problem

PR #904 single-flighted the UI retry path: a rapid double-click on a failed message's Retry button dispatches the adapter's `retryMessage` once. But the guard lived only on the UI click handler — there was no guarded programmatic entry point, and a direct retry dispatch for an id whose retry was still in flight fired the adapter command a second time (double-firing billed or otherwise non-idempotent APIs, per #897's original argument).

## Fix

- Moved the per-id in-flight guard to the retry dispatch layer itself (`dispatchRetryMessage` in `packages/chat/src/lib/components/chat/container/chat.svelte`), which every entry point now shares — mirroring how all commands funnel through `dispatchCommand`.
- Exported a guarded `retryMessage(messageId)` on the Chat instance (forwarded through the public wrapper like the other imperative methods), so consumers can retry programmatically and a second retry for an in-flight id is ignored regardless of entry point.
- The flight token still clears when the dispatch settles (resolve, reject, or sync throw), so a later retry for the same id dispatches again.

## Tests

New tests beside the #904 single-flight test in `packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts` (all fail before the fix, pass after):

- programmatic `retryMessage` for an in-flight id dispatches the adapter once
- a programmatic `retryMessage` while a UI-initiated retry for the same id is in flight is ignored (mixed entry points share one guard)
- a retry for a DIFFERENT id still dispatches while another retry is in flight
- a retry for the same id dispatches again after the first flight settles

Ran in `packages/chat`: `bun run test` (735 pass, 0 fail), `bun run lint` (clean), `bun run typecheck` (0 errors), `bun run components:check` (OK).

Changeset: patch bump for `@lostgradient/chat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhsXZt1sQAX5bNu3Pv4DuN