### PR TITLE
fix(chat): finish in-flight guarded scrolls before history-prepend capture

### DIFF
--- a/.changeset/prepend-anchor-at-top.md
+++ b/.changeset/prepend-anchor-at-top.md
@@ -1,0 +1,9 @@
+---
+'@lostgradient/chat': patch
+---
+
+Fix the history-prepend anchoring race when older messages are requested while a guarded programmatic scroll (most commonly a smooth scroll-to-top glide — the top is where the load-earlier trigger lives) is still animating (#1237).
+
+The capture used to snapshot a still-moving viewport, and the glide's smooth-scroll animation — with its absolute target of `scrollTop: 0`, where browsers also suppress native scroll anchoring — then raced Chat's instant restore corrections. Whichever landed last won: the restore could strand the viewport mid-transcript, or the glide could finish at 0 so the visible transcript shifted down by exactly the prepended block's height (with a #911-style overshoot as the third possible interleaving).
+
+`useChatScrollState` guarded scrolls now record their destination, and a new `finishUserScrollGuard()` completes an in-flight guarded scroll instantly at that destination (aborting the browser's animation) — `handleLoadHistory` calls it before capturing, so the capture always snapshots a parked viewport and the restore has nothing left to race. Loading earlier history mid-glide now deterministically parks the viewport at the old top with the previously visible content exactly where it was, the prepended block above it.

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -322,9 +322,14 @@
           scrollState.setAtBottom(false);
           updateAtBottomBinding(false);
         }
-        scrollState.withUserScrollGuard(viewport, () => {
-          chatVirtualizer.scrollToOffset(0, { behavior: scrollState.getScrollBehavior() });
-        });
+        scrollState.withUserScrollGuard(
+          viewport,
+          () => {
+            chatVirtualizer.scrollToOffset(0, { behavior: scrollState.getScrollBehavior() });
+          },
+          undefined,
+          () => 0,
+        );
       }
     },
     getScrollBehavior: scrollState.getScrollBehavior,
@@ -1368,6 +1373,17 @@
 
     isLoadingHistory = true;
     resetHistoryRestorationUserScrolling();
+    // #1237: a guarded programmatic scroll (scrollToTop / jump-to-latest) may
+    // still be animating when the user asks for older history — most commonly
+    // a scroll-to-top glide, since the top is where the load-earlier trigger
+    // lives. Capturing mid-animation would snapshot a moving viewport, and
+    // the still-running smooth-scroll animation (absolute target, e.g. 0)
+    // would then race the instant restore corrections — whichever landed last
+    // won, shifting the visible transcript by the prepended height or
+    // overshooting #911-style. Finish the guarded scroll instantly at its
+    // destination first, so the capture below snapshots a parked viewport and
+    // the restore has nothing left to race.
+    scrollState.finishUserScrollGuard();
     const requestId = ++historyLoadRequestId;
     captureHistoryScroll(requestId);
     if (pendingHistoryScroll === null) {
@@ -1837,9 +1853,14 @@
       // virtualizer remeasurement, and without this guard it would keep
       // snapping the viewport back toward the bottom mid-scroll since
       // `isUserScrolling` was never set for this branch.
-      scrollState.withUserScrollGuard(viewport, () => {
-        chatVirtualizer.scrollToOffset(0, { behavior: scrollState.getScrollBehavior() });
-      });
+      scrollState.withUserScrollGuard(
+        viewport,
+        () => {
+          chatVirtualizer.scrollToOffset(0, { behavior: scrollState.getScrollBehavior() });
+        },
+        undefined,
+        () => 0,
+      );
     } else {
       // Same canLeaveBottom reasoning as the virtualized branch above.
       const canLeaveBottom = !!viewport && viewport.scrollHeight > viewport.clientHeight;

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -97,7 +97,24 @@ export interface UseChatScrollStateReturn {
     viewport: HTMLElement | null,
     action: () => void,
     onSettled?: () => void,
+    destination?: () => number,
   ): void;
+  /**
+   * Instantly complete any in-flight `withUserScrollGuard`/`jumpToLatest`
+   * session: clear the guard, then issue an instant scroll to the session's
+   * declared `destination` (or pin the current position when the session
+   * declared none). The instant scroll aborts the browser's smooth-scroll
+   * animation, so nothing keeps animating toward a stale target afterwards.
+   *
+   * Call this before taking a scroll snapshot that must not race a
+   * still-animating programmatic scroll — e.g. the history-prepend capture
+   * (#1237): a load-earlier click mid scroll-to-top glide used to leave the
+   * glide's compositor animation (absolute target 0) racing the instant
+   * restore corrections, and whichever landed last won.
+   *
+   * Returns true when an active guarded session was finished.
+   */
+  finishUserScrollGuard(): boolean;
   /**
    * Immediately cancel any in-flight `withUserScrollGuard`/`jumpToLatest`
    * session and clear `isUserScrolling`, without arming a replacement timer.
@@ -214,6 +231,12 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
   // false while a later guarded scroll's animation is still in progress.
   let activeUserScrollGuardCancel: (() => void) | null = null;
   let activeUserScrollViewport: HTMLElement | null = null;
+  // Where the in-flight guarded scroll is headed, when its initiator declared
+  // one (scrollToTop → 0, jumpToLatest → the bottom). Read lazily so
+  // "the bottom" is computed against the scroll extent at finish time, not at
+  // guard start. Used by finishUserScrollGuard to complete the scroll
+  // instantly instead of leaving its animation racing a later instant scroll.
+  let activeUserScrollGuardDestination: (() => number) | null = null;
 
   /**
    * Set atBottom state directly.
@@ -450,6 +473,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     viewport: HTMLElement | null,
     action: () => void,
     onSettled?: () => void,
+    destination?: () => number,
   ): void {
     // Cancel any previous in-flight guard first: without this, an earlier
     // overlapping guarded scroll (e.g. jumpToLatest() immediately followed by
@@ -476,6 +500,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
       cancel();
       activeUserScrollGuardCancel = null;
       activeUserScrollViewport = null;
+      activeUserScrollGuardDestination = null;
       isUserScrolling = false;
       applyPendingSentinelEntry(viewport);
       onSettled?.();
@@ -488,6 +513,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
 
     activeUserScrollGuardCancel = cancel;
     activeUserScrollViewport = viewport;
+    activeUserScrollGuardDestination = destination ?? null;
     viewport?.addEventListener('scrollend', settle, { once: true });
     viewport?.addEventListener('scroll', armBackstop, { passive: true });
 
@@ -511,8 +537,31 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     activeUserScrollGuardCancel?.();
     activeUserScrollGuardCancel = null;
     activeUserScrollViewport = null;
+    activeUserScrollGuardDestination = null;
     isUserScrolling = false;
     applyPendingSentinelEntry(viewport);
+  }
+
+  /**
+   * Instantly complete any in-flight guarded scroll at its declared
+   * destination (or pin the current position when none was declared). See
+   * `UseChatScrollStateReturn.finishUserScrollGuard` for details.
+   */
+  function finishUserScrollGuard(): boolean {
+    if (activeUserScrollGuardCancel === null) return false;
+    const viewport = activeUserScrollViewport;
+    const destination = activeUserScrollGuardDestination;
+    clearUserScrollGuard();
+    if (viewport) {
+      // Either way this instant scroll aborts the browser's in-flight
+      // smooth-scroll animation; with a declared destination it also lands
+      // the scroll where the guarded session was already headed.
+      viewport.scrollTo({
+        top: destination ? destination() : viewport.scrollTop,
+        behavior: 'instant',
+      });
+    }
+    return true;
   }
 
   /**
@@ -534,9 +583,14 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     if (viewport.scrollHeight > viewport.clientHeight) {
       atBottom = false;
     }
-    withUserScrollGuard(viewport, () => {
-      viewport.scrollTo({ top: 0, behavior: getScrollBehavior() });
-    });
+    withUserScrollGuard(
+      viewport,
+      () => {
+        viewport.scrollTo({ top: 0, behavior: getScrollBehavior() });
+      },
+      undefined,
+      () => 0,
+    );
   }
 
   /**
@@ -563,6 +617,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
         const lastMessage = lastWrapper?.querySelector<HTMLElement>('.chat-message') ?? null;
         lastMessage?.focus();
       },
+      () => viewport.scrollHeight,
     );
   }
 
@@ -577,6 +632,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     activeUserScrollGuardCancel?.();
     activeUserScrollGuardCancel = null;
     activeUserScrollViewport = null;
+    activeUserScrollGuardDestination = null;
     isUserScrolling = false;
     pendingSentinelEntry = null;
   }
@@ -596,6 +652,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     scrollToTop,
     jumpToLatest,
     withUserScrollGuard,
+    finishUserScrollGuard,
     clearUserScrollGuard,
     getScrollBehavior,
     destroy,

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -581,3 +581,106 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(() => jest.advanceTimersByTime(600)).not.toThrow();
   });
 });
+
+describe('useChatScrollState — finishUserScrollGuard (regression for #1237)', () => {
+  // #1237: a load-earlier click while a smooth scroll-to-top glide was still
+  // animating used to capture a mid-flight scroll snapshot, and the glide's
+  // animation (absolute target 0) then raced the instant history-restore
+  // corrections — whichever landed last won. finishUserScrollGuard lets the
+  // capture path complete the guarded scroll instantly at its declared
+  // destination first, so there is nothing left to race.
+
+  function createTrackingViewport(): {
+    viewport: HTMLElement;
+    scrollCalls: { top: number; behavior: ScrollBehavior | undefined }[];
+  } {
+    const viewport = document.createElement('div');
+    Object.defineProperty(viewport, 'scrollHeight', { value: 2000, configurable: true });
+    Object.defineProperty(viewport, 'scrollTop', { value: 0, writable: true, configurable: true });
+    Object.defineProperty(viewport, 'clientHeight', { value: 400, configurable: true });
+    const scrollCalls: { top: number; behavior: ScrollBehavior | undefined }[] = [];
+    viewport.scrollTo = ((options?: ScrollToOptions | number, y?: number) => {
+      const top =
+        typeof options === 'number' ? (typeof y === 'number' ? y : options) : (options?.top ?? 0);
+      scrollCalls.push({
+        top,
+        behavior: typeof options === 'object' ? options?.behavior : undefined,
+      });
+      (viewport as { scrollTop: number }).scrollTop = top;
+    }) as typeof viewport.scrollTo;
+    document.body.appendChild(viewport);
+    return { viewport, scrollCalls };
+  }
+
+  test('finishing a scrollToTop guard lands the viewport at the top instantly and clears the guard', () => {
+    jest.useFakeTimers();
+    const state = useChatScrollState();
+    const { viewport, scrollCalls } = createTrackingViewport();
+    (viewport as unknown as { scrollTop: number }).scrollTop = 1200;
+
+    state.scrollToTop(viewport);
+    expect(state.isUserScrolling).toBe(true);
+    // Mimic the glide being partway to the top when history is requested.
+    (viewport as unknown as { scrollTop: number }).scrollTop = 700;
+
+    expect(state.finishUserScrollGuard()).toBe(true);
+    expect(state.isUserScrolling).toBe(false);
+    const finishingCall = scrollCalls.at(-1);
+    expect(finishingCall?.top).toBe(0);
+    expect(finishingCall?.behavior).toBe('instant');
+    expect(viewport.scrollTop).toBe(0);
+  });
+
+  test('finishing a jumpToLatest guard lands the viewport at the bottom', () => {
+    jest.useFakeTimers();
+    const state = useChatScrollState();
+    const { viewport, scrollCalls } = createTrackingViewport();
+
+    state.jumpToLatest(viewport);
+    expect(state.isUserScrolling).toBe(true);
+
+    expect(state.finishUserScrollGuard()).toBe(true);
+    expect(state.isUserScrolling).toBe(false);
+    const finishingCall = scrollCalls.at(-1);
+    expect(finishingCall?.top).toBe(2000);
+    expect(finishingCall?.behavior).toBe('instant');
+  });
+
+  test('finishing a guard with no declared destination pins the current position (still aborting the animation)', () => {
+    jest.useFakeTimers();
+    const state = useChatScrollState();
+    const { viewport, scrollCalls } = createTrackingViewport();
+    (viewport as unknown as { scrollTop: number }).scrollTop = 640;
+
+    state.withUserScrollGuard(viewport, () => {});
+    expect(state.isUserScrolling).toBe(true);
+
+    expect(state.finishUserScrollGuard()).toBe(true);
+    expect(state.isUserScrolling).toBe(false);
+    const finishingCall = scrollCalls.at(-1);
+    expect(finishingCall?.top).toBe(640);
+    expect(finishingCall?.behavior).toBe('instant');
+  });
+
+  test('finishing with no active guard is a no-op that reports false', () => {
+    jest.useFakeTimers();
+    const state = useChatScrollState();
+    const { scrollCalls } = createTrackingViewport();
+
+    expect(state.finishUserScrollGuard()).toBe(false);
+    expect(scrollCalls).toHaveLength(0);
+  });
+
+  test('a finished guard leaves no timer behind that could resurrect isUserScrolling', () => {
+    jest.useFakeTimers();
+    const state = useChatScrollState();
+    const { viewport } = createTrackingViewport();
+
+    state.scrollToTop(viewport);
+    state.finishUserScrollGuard();
+    expect(state.isUserScrolling).toBe(false);
+
+    expect(() => jest.advanceTimersByTime(600)).not.toThrow();
+    expect(state.isUserScrolling).toBe(false);
+  });
+});

--- a/packages/testing/tests/chat-harness.playwright.ts
+++ b/packages/testing/tests/chat-harness.playwright.ts
@@ -24,11 +24,12 @@ const HARNESS = '#example-mount-interactive-harness';
 /** Opens /page/chat and returns a Locator scoped to the harness mount. */
 async function openHarness(
   browser: Browser,
+  options?: { reducedMotion?: 'reduce' | 'no-preference' },
 ): Promise<{ page: Page; harness: Locator; dispose: () => Promise<void> }> {
   const context = await browser.newContext({
     baseURL: PLAYGROUND_URL,
     colorScheme: 'dark',
-    reducedMotion: 'reduce',
+    reducedMotion: options?.reducedMotion ?? 'reduce',
     viewport: { width: 1280, height: 900 },
   });
   await context.addInitScript(
@@ -440,6 +441,109 @@ test.describe('chat harness — scroll, unread, jump', () => {
           return Math.abs((after?.y ?? 0) - (afterTimeline?.y ?? 0) - beforeOffset);
         })
         .toBeLessThan(48);
+      await expect
+        .poll(async () => timeline.evaluate((element) => element.scrollTop))
+        .toBeGreaterThan(0);
+    } finally {
+      await dispose();
+    }
+  });
+
+  // Regression test for #1237: ask for older history while a smooth
+  // scroll-to-top glide is still in flight — the natural flow, since the top
+  // of the transcript is where the load-earlier trigger lives. The capture
+  // used to snapshot the still-moving viewport, and the glide's smooth-scroll
+  // animation (absolute target 0, where browsers also suppress native scroll
+  // anchoring) then raced Chat's instant restore corrections: whichever
+  // landed last won, either stranding the viewport mid-transcript or letting
+  // the glide finish at 0 so the transcript shifted by exactly the prepended
+  // height. Fixed by finishing the guarded scroll instantly at its
+  // destination before capturing, which makes the outcome deterministic: the
+  // viewport parks at the old top and the prepend leaves that content
+  // exactly where it was.
+  test('history prepend keeps the anchored message stable when parked at the top', async ({
+    browser,
+  }) => {
+    const { page, harness, dispose } = await openHarness(browser, {
+      reducedMotion: 'no-preference',
+    });
+    try {
+      await harness.locator('#t-history').click();
+      await harness.locator('[data-testid="seed-thread"]').click();
+
+      const timeline = harness.locator('.chat-timeline');
+      const anchor = timeline
+        .locator('.chat-message')
+        .filter({ hasText: 'Tell me about alpha.' })
+        .first();
+
+      // Pre-pass: measure the anchor's viewport-relative offset with the
+      // viewport genuinely parked at the top. This is the deterministic
+      // oracle the racy pass below must land on.
+      await harness.locator('[data-testid="scroll-top"]').click();
+      await expect.poll(async () => timeline.evaluate((element) => element.scrollTop)).toBe(0);
+      await page.waitForTimeout(150);
+      const parked = await anchor.boundingBox();
+      const parkedTimeline = await timeline.boundingBox();
+      expect(parked).not.toBeNull();
+      expect(parkedTimeline).not.toBeNull();
+      const parkedOffset = (parked?.y ?? 0) - (parkedTimeline?.y ?? 0);
+
+      // Back to the bottom, fully settled, so the next scroll-to-top is a
+      // real multi-hundred-millisecond glide.
+      await harness.locator('[data-testid="scroll-bottom"]').click();
+      await expect
+        .poll(async () =>
+          timeline.evaluate((element) =>
+            Math.abs(element.scrollHeight - element.clientHeight - element.scrollTop),
+          ),
+        )
+        .toBeLessThan(2);
+      await page.waitForTimeout(150);
+
+      // Racy pass: start the glide and ask for older history mid-flight.
+      // dispatchEvent rather than .click(): the trigger sits at the top of
+      // the transcript and Playwright's click would wait for stability and
+      // scroll on its own, destroying the mid-glide timing this regression
+      // depends on.
+      await harness.locator('[data-testid="scroll-top"]').click();
+      await timeline.getByRole('button', { name: /load earlier messages/i }).dispatchEvent('click');
+      await expectLoggedEvent(harness, 'onloadhistory');
+      await expect(timeline.getByText('Earlier context 1.1')).toBeAttached();
+
+      // Wait for restoration (and any leftover animation) to fully settle
+      // before measuring. Settling first — rather than polling for a
+      // momentarily-close position — matters because the failure mode is a
+      // race: a transiently correct position could still be shifted by
+      // whichever correction lands last.
+      await expect(timeline).not.toHaveAttribute('data-cinder-history-restoring');
+      await expect
+        .poll(async () =>
+          timeline.evaluate(
+            (element) =>
+              new Promise<boolean>((resolve) => {
+                const startTop = element.scrollTop;
+                let frames = 0;
+                const wait = () => {
+                  frames += 1;
+                  if (element.scrollTop !== startTop) resolve(false);
+                  else if (frames >= 8) resolve(true);
+                  else requestAnimationFrame(wait);
+                };
+                requestAnimationFrame(wait);
+              }),
+          ),
+        )
+        .toBe(true);
+
+      // The transcript parked at the old top: the content that was visible
+      // there is exactly where it was, with the prepended block above it.
+      const after = await anchor.boundingBox();
+      const afterTimeline = await timeline.boundingBox();
+      expect(after).not.toBeNull();
+      expect(afterTimeline).not.toBeNull();
+      expect(Math.abs((after?.y ?? 0) - (afterTimeline?.y ?? 0) - parkedOffset)).toBeLessThan(3);
+      // Position is held by scroll compensation, not by the prepend failing.
       await expect
         .poll(async () => timeline.evaluate((element) => element.scrollTop))
         .toBeGreaterThan(0);


### PR DESCRIPTION
Fixes #1237

## What was actually going wrong

The at-top prepend shift is a race between **an in-flight guarded programmatic scroll** and the history-restore corrections — not a missing at-top offset. The natural flow (`scrollToTop()` glide, then click the load-earlier trigger as soon as the top comes into view) meant `handleLoadHistory` captured its scroll snapshot while the smooth-scroll animation was still running toward its absolute target of `scrollTop: 0` — exactly where browsers also suppress native scroll anchoring, so nothing native could paper over the loser of the race:

- **Restore lands last** → it cancels the glide and pins the viewport to the mid-flight capture position, stranding the transcript mid-scroll (measured: anchor parked ~1400px from where the user was headed).
- **Glide lands last** → the animation finishes at 0 uncompensated, and the visible transcript shifts down by exactly the prepended block's height (the "~247px for 4 rows" in the issue).
- Stabilization corrections re-applied against the still-moving viewport account for the occasional #911-style overshoot.

A genuinely parked viewport (settled at `scrollTop: 0`, no animation) restores correctly before and after this change — instrumented browser runs confirmed the failing runs always had the glide still alive.

## The fix

- `useChatScrollState`'s guarded scrolls (`scrollToTop`, `jumpToLatest`, the virtualized jump-to-start/scroll-to-top guards) now record their **destination**.
- New `finishUserScrollGuard()`: instantly completes an in-flight guarded scroll at that destination (the instant `scrollTo` aborts the browser's smooth-scroll animation), clears the guard, and reports whether anything was finished.
- `handleLoadHistory` calls it before `captureHistoryScroll`, so the capture always snapshots a parked viewport and the restore has nothing left to race. Loading earlier history mid-glide now deterministically parks the viewport at the old top, with the previously visible content exactly where it was and the prepended block above it.

The #911/#917 restore + stabilization path, #997 deferred-history anchor preservation, and mid-scroll anchoring are untouched — user-initiated (wheel/pointer/keyboard) scrolling still wins over stabilization as before.

## Tests

- **New browser regression test** (`packages/testing/tests/chat-harness.playwright.ts`, "history prepend keeps the anchored message stable when parked at the top"): measures the anchor's parked-at-top offset, glides back down, then requests history mid-glide and asserts the settled outcome matches the parked offset within 3px (plus `scrollTop > 0`, i.e. real compensation). Fails 3/3 without the fix (1400.5px drift), passes 5/5 with it.
- **New unit tests** for `finishUserScrollGuard` (destination completion for top/bottom, pin-in-place for undeclared destinations, no-op reporting, no timer resurrection).

## Verification

- `bun run --filter=@lostgradient/chat test` — 736 pass
- `bun run --filter=@lostgradient/chat lint` — clean
- `bun run --filter=@lostgradient/chat typecheck` — clean
- `bun run --filter=@lostgradient/chat components:check` — OK
- `packages/testing` chat-harness Playwright suite — 35/35 pass (incl. all existing history/anchoring regressions), axe clean
- Changeset: patch bump for `@lostgradient/chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhsXZt1sQAX5bNu3Pv4DuN