### PR TITLE
fix(chat): settle virtualized bottom pin after measurement

### DIFF
--- a/.changeset/quiet-bottom-pin.md
+++ b/.changeset/quiet-bottom-pin.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Avoid repeated virtualized bottom corrections when the transcript is already settled at the bottom after row measurement.

--- a/packages/chat/src/lib/components/chat/chat-virtualization.test.ts
+++ b/packages/chat/src/lib/components/chat/chat-virtualization.test.ts
@@ -295,6 +295,36 @@ describe('Chat virtualization', () => {
     }
   });
 
+  test('settled virtualized bottom does not issue repeated corrections after measurement', async () => {
+    let conversation = longConversation(20);
+    const { container, rerender } = render(Chat, {
+      props: virtualizedProps(conversation),
+    });
+    const timeline = await waitForVirtualizedTimeline(container);
+    Object.defineProperty(timeline, 'clientHeight', { configurable: true, value: 100 });
+
+    await waitFor(() => expect(container.textContent).toContain('Message 19'));
+    await waitFor(() => expect(timeline.scrollTop).toBeGreaterThan(0));
+
+    let writes = 0;
+    let scrollTop = timeline.scrollTop;
+    Object.defineProperty(timeline, 'scrollTop', {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        writes += 1;
+        scrollTop = value;
+      },
+    });
+
+    // Rerendering the same pinned transcript re-runs the measurement-driven
+    // auto-stick dependency, but the viewport is already at its maximum.
+    await rerender(virtualizedProps(conversation));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(writes).toBe(0);
+  });
+
   // Regression test for #774: scrollToTop() fights the auto-stick-to-bottom
   // effect in virtualized mode and never reaches the top.
   //

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -683,8 +683,6 @@
           if (Math.abs((viewport.scrollTop || 0) - maximumOffset) <= 1) return;
           chatVirtualizer.scrollToOffset(chatVirtualizer.scrollSize, { behavior: 'instant' });
         } else {
-          const maximumOffset = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
-          if (Math.abs((viewport.scrollTop || 0) - maximumOffset) <= 1) return;
           viewport?.scrollTo({ top: viewport.scrollHeight, behavior: 'instant' });
         }
       });

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -673,8 +673,18 @@
         // would cancel that scroll's animation mid-flight (#1236).
         if (scrollState.isUserScrolling) return;
         if (isVirtualized) {
+          // A remeasurement can invalidate this effect without changing the
+          // viewport's actual position. Avoid another instant correction when
+          // the browser has already settled at the current bottom (#1243).
+          const maximumOffset = Math.max(
+            0,
+            chatVirtualizer.scrollSize - (viewport.clientHeight || virtualizationInitialHeight),
+          );
+          if (Math.abs((viewport.scrollTop || 0) - maximumOffset) <= 1) return;
           chatVirtualizer.scrollToOffset(chatVirtualizer.scrollSize, { behavior: 'instant' });
         } else {
+          const maximumOffset = Math.max(0, viewport.scrollHeight - viewport.clientHeight);
+          if (Math.abs((viewport.scrollTop || 0) - maximumOffset) <= 1) return;
           viewport?.scrollTo({ top: viewport.scrollHeight, behavior: 'instant' });
         }
       });


### PR DESCRIPTION
Fixes #1243

The auto-stick effect now checks the live viewport distance from the maximum offset before issuing an instant correction. This prevents repeated corrections when virtual row measurement re-runs after the viewport has already settled at the bottom.

Tests: focused Chat virtualization suite (20 pass).

@copilot please review
@codex please review