### PR TITLE
chat: bump conversationalist to ^0.6.0 and re-export the rewind helpers

### DIFF
--- a/.changeset/chat-conversationalist-0-6.md
+++ b/.changeset/chat-conversationalist-0-6.md
@@ -1,0 +1,7 @@
+---
+'@lostgradient/chat': minor
+---
+
+Bump Chat's `conversationalist` dependency to `^0.6.0` and re-export the new branch-rewind builders — `rewindBeforeMessage`, `rewindBeforePosition`, and the `RewindOptions` type — from the package root alongside the existing builder family.
+
+The dependency bump is consumer-visible in two ways. `updateStreamingMessage` (re-exported via `@lostgradient/chat`) now guards against writing to a message that is no longer streaming, so the late-token-after-stop race no-ops at the library boundary instead of every consumer hand-rolling a `shouldStop()` guard. And the rewind helpers are the operation Chat's own `editMessage` adapter command asks consumers to perform — rewind to just before the edited message, discard the superseded branch, re-send — which previously required assembling `ids`/`messages`/`updatedAt` by hand.

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
       "name": "@lostgradient/chat",
       "version": "0.7.1",
       "dependencies": {
-        "conversationalist": "^0.5.0",
+        "conversationalist": "^0.6.0",
         "zod": "4.4.1",
       },
       "devDependencies": {
@@ -759,7 +759,7 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "conversationalist": ["conversationalist@0.5.0", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.71.2", "zod": "^4.4.1" } }, "sha512-VfITXaRZaNF/P1rMFQdSj/31otp2UmEz5V6MCH231sJm47OIDDTAu9bFGcTkohAdrCxasI31zTgB9299j4aR6g=="],
+    "conversationalist": ["conversationalist@0.6.0", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.116.0", "zod": "^4.4.3" } }, "sha512-GOIyX4TTDWfA0k5ngnjNsKBPNMGPlzjFx7OI9zf1unRfs7SSYhCP5pNHLMCw8w6Vswt299YaHbdKH/ZSFLQODQ=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
       "name": "@lostgradient/chat",
       "version": "0.7.1",
       "dependencies": {
-        "conversationalist": "^0.6.0",
+        "conversationalist": "^0.6.1",
         "zod": "4.4.3",
       },
       "devDependencies": {
@@ -232,8 +232,6 @@
   },
   "packages": {
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
-
-    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.71.2", "", { "dependencies": { "json-schema-to-ts": "^3.1.1" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-TGNDEUuEstk/DKu0/TflXAEt+p+p/WhTlFzEnoosvbaDU2LTjm42igSdlL0VijrKpWejtOKxX0b8A7uc+XiSAQ=="],
 
     "@axe-core/playwright": ["@axe-core/playwright@4.11.3", "", { "dependencies": { "axe-core": "~4.11.4" }, "peerDependencies": { "playwright-core": ">= 1.0.0" } }, "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w=="],
 
@@ -759,7 +757,7 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "conversationalist": ["conversationalist@0.6.0", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.116.0", "zod": "^4.4.3" } }, "sha512-GOIyX4TTDWfA0k5ngnjNsKBPNMGPlzjFx7OI9zf1unRfs7SSYhCP5pNHLMCw8w6Vswt299YaHbdKH/ZSFLQODQ=="],
+    "conversationalist": ["conversationalist@0.6.1", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.116.0", "zod": "^4.4.3" }, "optionalPeers": ["@anthropic-ai/sdk"] }, "sha512-S+QhPrVO7YCFndUEt/oYYJXUdLzbNM93w0+AlxyDwGZ42lG2CCblOI987xyCZtf1MMOsz4pdOrCY3VKS8LA7hw=="],
 
     "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -1042,8 +1040,6 @@
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
-
-    "json-schema-to-ts": ["json-schema-to-ts@3.1.1", "", { "dependencies": { "@babel/runtime": "^7.18.3", "ts-algebra": "^2.0.0" } }, "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -1529,8 +1525,6 @@
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
 
-    "ts-algebra": ["ts-algebra@2.0.0", "", {}, "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="],
-
     "ts-morph": ["ts-morph@28.0.0", "", { "dependencies": { "@ts-morph/common": "~0.29.0", "code-block-writer": "^13.0.3" } }, "sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
@@ -1660,6 +1654,8 @@
     "cliui/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "conversationalist/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "global-prefix/which": ["which@1.3.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "which": "./bin/which" } }, "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -25,7 +25,7 @@
       "version": "0.7.1",
       "dependencies": {
         "conversationalist": "^0.6.0",
-        "zod": "4.4.1",
+        "zod": "4.4.3",
       },
       "devDependencies": {
         "@lostgradient/cinder": "workspace:*",
@@ -1622,6 +1622,10 @@
     "@changesets/apply-release-plan/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "@changesets/write/prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "@lostgradient/chat/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "@lostgradient/cinder/zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -168,7 +168,7 @@
     "validate:consumer": "bun run scripts/validate-consumer.ts"
   },
   "dependencies": {
-    "conversationalist": "^0.6.0",
+    "conversationalist": "^0.6.1",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -169,7 +169,7 @@
   },
   "dependencies": {
     "conversationalist": "^0.6.0",
-    "zod": "4.4.1"
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@lostgradient/cinder": "workspace:*",

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -168,7 +168,7 @@
     "validate:consumer": "bun run scripts/validate-consumer.ts"
   },
   "dependencies": {
-    "conversationalist": "^0.5.0",
+    "conversationalist": "^0.6.0",
     "zod": "4.4.1"
   },
   "devDependencies": {

--- a/packages/chat/scripts/pack-for-publish.ts
+++ b/packages/chat/scripts/pack-for-publish.ts
@@ -38,7 +38,7 @@ const STAGING_ROOT = join(PACKAGE_ROOT, 'node_modules', '.cache', 'publish-stagi
 const REQUIRED_PEERS = new Set(['@lostgradient/cinder', '@lostgradient/markdown', 'svelte']);
 const REQUIRED_DEPENDENCIES: Record<string, string> = {
   conversationalist: '^0.6.0',
-  zod: '4.4.1',
+  zod: '4.4.3',
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/chat/scripts/pack-for-publish.ts
+++ b/packages/chat/scripts/pack-for-publish.ts
@@ -37,7 +37,7 @@ const STAGING_ROOT = join(PACKAGE_ROOT, 'node_modules', '.cache', 'publish-stagi
 // never install or version-pick them directly.
 const REQUIRED_PEERS = new Set(['@lostgradient/cinder', '@lostgradient/markdown', 'svelte']);
 const REQUIRED_DEPENDENCIES: Record<string, string> = {
-  conversationalist: '^0.5.0',
+  conversationalist: '^0.6.0',
   zod: '4.4.1',
 };
 

--- a/packages/chat/scripts/pack-for-publish.ts
+++ b/packages/chat/scripts/pack-for-publish.ts
@@ -37,7 +37,7 @@ const STAGING_ROOT = join(PACKAGE_ROOT, 'node_modules', '.cache', 'publish-stagi
 // never install or version-pick them directly.
 const REQUIRED_PEERS = new Set(['@lostgradient/cinder', '@lostgradient/markdown', 'svelte']);
 const REQUIRED_DEPENDENCIES: Record<string, string> = {
-  conversationalist: '^0.6.0',
+  conversationalist: '^0.6.1',
   zod: '4.4.3',
 };
 

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -41,7 +41,7 @@ describe('Chat package ownership boundary', () => {
     expect(() => assertSourceManifest(chatManifest)).not.toThrow();
     expect(chatManifest.dependencies).toEqual({
       conversationalist: '^0.6.0',
-      zod: '4.4.1',
+      zod: '4.4.3',
     });
     // The Cinder floor tracks the Cinder minor released alongside Chat —
     // caret on 0.x pins the minor, so each Cinder minor bump MUST widen this

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -40,7 +40,7 @@ describe('Chat package ownership boundary', () => {
   test('keeps host-supplied runtime singletons peer-only and owns its conversation-model dependencies', () => {
     expect(() => assertSourceManifest(chatManifest)).not.toThrow();
     expect(chatManifest.dependencies).toEqual({
-      conversationalist: '^0.6.0',
+      conversationalist: '^0.6.1',
       zod: '4.4.3',
     });
     // The Cinder floor tracks the Cinder minor released alongside Chat —

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -40,7 +40,7 @@ describe('Chat package ownership boundary', () => {
   test('keeps host-supplied runtime singletons peer-only and owns its conversation-model dependencies', () => {
     expect(() => assertSourceManifest(chatManifest)).not.toThrow();
     expect(chatManifest.dependencies).toEqual({
-      conversationalist: '^0.5.0',
+      conversationalist: '^0.6.0',
       zod: '4.4.1',
     });
     // The Cinder floor tracks the Cinder minor released alongside Chat —

--- a/packages/chat/src/lib/components/chat/README.md
+++ b/packages/chat/src/lib/components/chat/README.md
@@ -136,6 +136,29 @@ used by Chat's failed-message label and Retry button. Apply the same pair around
 `retryMessage` and `editMessage` resends; the successful attempt clears the
 marker.
 
+### Edit and resend
+
+`ChatAdapter.editMessage` hands you the edited message's ID and new content;
+the superseded branch (the old reply, any tool calls after it) should be
+discarded before the edited content is re-sent. `rewindBeforeMessage` performs
+exactly that cut — it drops the named message and everything after it in the
+transcript, keeps tool-call/tool-result pairs atomic, and renumbers positions —
+so an edit flow never assembles `ids`/`messages`/`updatedAt` by hand:
+
+```ts
+import { appendUserMessage, rewindBeforeMessage } from '@lostgradient/chat';
+
+// Inside your ChatAdapter implementation:
+async editMessage({ messageId, content }) {
+  conversation = appendUserMessage(rewindBeforeMessage(conversation, messageId), content);
+  await yourBackend.send({ role: 'user', content });
+}
+```
+
+`rewindBeforePosition` is the position-keyed form, and both accept a
+`RewindOptions` bag (`preserveToolPairs: false` cuts strictly at the boundary,
+leaving a straddled tool call pending).
+
 > [!WARNING] `ChatAdapter.subscribe` runs inside Chat's own effect
 > Chat opens `subscribe` from inside its internal mount `$effect`, so a
 > synchronous `$state` write inside `subscribe` can throw

--- a/packages/chat/src/lib/components/chat/builders.test.ts
+++ b/packages/chat/src/lib/components/chat/builders.test.ts
@@ -16,6 +16,8 @@ import {
   createConversationHistory,
   markMessageDeliveryFailed,
   prependMessages,
+  rewindBeforeMessage,
+  rewindBeforePosition,
 } from './builders.ts';
 
 describe('chat conversation builders', () => {
@@ -133,6 +135,25 @@ describe('chat conversation builders', () => {
     expect(final.ids).toHaveLength(2);
     expect(final.messages[final.ids[0]!]!.position).toBe(0);
     expect(final.messages[final.ids[1]!]!.position).toBe(1);
+  });
+
+  test('re-exports the rewind helpers for edit-and-resend flows', () => {
+    let conversation = createConversationHistory({ id: 'conversation-rewind' });
+    conversation = appendUserMessage(conversation, 'Original question');
+    conversation = appendAssistantMessage(conversation, 'Superseded answer');
+    conversation = appendUserMessage(conversation, 'Follow-up');
+    const editedId = conversation.ids[1]!;
+
+    const byMessage = rewindBeforeMessage(conversation, editedId);
+    expect(byMessage.ids).toHaveLength(1);
+    expect(byMessage.messages[byMessage.ids[0]!]!.content).toBe('Original question');
+
+    const byPosition = rewindBeforePosition(conversation, 1);
+    expect(byPosition.ids).toEqual(byMessage.ids);
+
+    // A rewind that drops nothing is a no-op returning the same reference.
+    expect(rewindBeforePosition(conversation, 99)).toBe(conversation);
+    expect(rewindBeforeMessage(conversation, 'unknown-id')).toBe(conversation);
   });
 
   test('re-exports all tool transcript builder variants', async () => {

--- a/packages/chat/src/lib/components/chat/builders.ts
+++ b/packages/chat/src/lib/components/chat/builders.ts
@@ -22,6 +22,13 @@ export {
   prependMessages,
 } from 'conversationalist';
 
+// Branch-rewind builders — the operation Chat's own `editMessage` adapter
+// command asks consumers to perform ("rewind to just before the edited
+// message, discard the superseded branch, re-send"). `rewindBeforeMessage` is
+// the form edit flows usually want, since the adapter hands them a message id.
+export { rewindBeforeMessage, rewindBeforePosition } from 'conversationalist/context';
+export type { RewindOptions } from 'conversationalist/context';
+
 const DELIVERY_STATUS_METADATA_KEY = '_deliveryStatus';
 
 /** Mark a message as failed so Chat renders its retry affordance. */

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -52,7 +52,10 @@ export {
   createConversationHistory,
   markMessageDeliveryFailed,
   prependMessages,
+  rewindBeforeMessage,
+  rewindBeforePosition,
 } from './builders.ts';
+export type { RewindOptions } from './builders.ts';
 
 // Streaming conversation builders — keep the immutable snapshot and Chat's
 // imperative streaming surface in sync through the package's own


### PR DESCRIPTION
Fixes #1249.

Bumps Chat's `conversationalist` dependency `^0.5.0` → `^0.6.0` and re-exports the new branch-rewind builders — `rewindBeforeMessage`, `rewindBeforePosition`, and the `RewindOptions` type — from the package root, importing from `conversationalist/context` through the existing `builders.ts` seam.

Why this matters to consumers:

- **`updateStreamingMessage` is now guarded** (agent-bureau#296): a token arriving after finalize — the classic stop-button race — no-ops at the library boundary instead of silently growing a finalized message. Chat re-exports this function from its own dependency, so consumers only get the guard once Chat bumps.
- **The rewind helpers are the `editMessage` counterpart**: Chat's adapter contract asks consumers to "rewind to just before the edited message, discard the superseded branch, re-send", and until now that meant hand-assembling `ids`/`messages`/`updatedAt`. `rewindBeforeMessage` is id-keyed — exactly what the adapter command hands you. (Shipped correct: the transcript-order defect agent-bureau#313 found in the initial implementation was fixed before 0.6.0 published.)

Also updates both dependency-contract pins (`package-boundary.test.ts`, `pack-for-publish.ts`'s `REQUIRED_DEPENDENCIES`) to `^0.6.0`, adds a builders test covering the rewind re-exports (including the same-reference no-op contract), and documents the edit-and-resend pattern in the chat README.

Verified: `turbo run test typecheck lint --filter=@lostgradient/chat` — 758 tests green.

Downstream: chatroom drops its hand-rolled `rewindBefore` (`upstream: stevekinney/agent-bureau#306`) and its hand-rolled stream guard (`upstream: stevekinney/agent-bureau#296`) once this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhsXZt1sQAX5bNu3Pv4DuN