### PR TITLE
Restore the muted text hierarchy for unthemed Statistics

### DIFF
--- a/.changeset/statistic-muted-hierarchy.md
+++ b/.changeset/statistic-muted-hierarchy.md
@@ -1,0 +1,25 @@
+---
+'@lostgradient/cinder': patch
+---
+
+fix(statistic): restore the muted text hierarchy for unthemed Statistics
+
+`Statistic` resolved its colours through `resolveChartTheme()`, whose
+unthemed defaults are `currentColor` for both `foreground` and `muted`.
+Because the component writes those as **inline** custom properties, the
+`var(--_cinder-chart-*, …)` fallbacks in `statistic.css` could never apply —
+so a `Statistic` rendered without an explicit `theme` painted its label,
+icon, and change description at full text colour, visually identical to the
+value. The label/value hierarchy that `--cinder-text-muted` provided was
+silently lost for every consumer that doesn't pass a chart theme.
+
+The chart components absorb the same `currentColor` default with a
+compensating `opacity` on their tick labels. That is the wrong tool here:
+this is body text, which has to clear the 4.5:1 AA floor rather than land
+wherever a multiplier puts it — the same reasoning that moved status text
+off the fill tokens in 0.21.
+
+Unthemed `Statistic` now defaults to the contrast-tuned text tokens
+(`--cinder-text` / `--cinder-text-muted`). An explicit `theme` still wins, so
+a `Statistic` composed onto a themed chart surface is unaffected, and
+`background` keeps its `transparent` default. No API change.

--- a/.changeset/statistic-muted-hierarchy.md
+++ b/.changeset/statistic-muted-hierarchy.md
@@ -20,6 +20,12 @@ wherever a multiplier puts it — the same reasoning that moved status text
 off the fill tokens in 0.21.
 
 Unthemed `Statistic` now defaults to the contrast-tuned text tokens
-(`--cinder-text` / `--cinder-text-muted`). An explicit `theme` still wins, so
-a `Statistic` composed onto a themed chart surface is unaffected, and
-`background` keeps its `transparent` default. No API change.
+(`--cinder-text` / `--cinder-text-muted`). The substitution is all-or-nothing on
+`theme`'s presence rather than per-field: supplying any theme — including a
+partial one — keeps `resolveChartTheme()`'s `currentColor` inheritance for the
+fields it omits, so `theme={{ foreground: 'white', background: 'black' }}`
+leaves the label inheriting white instead of dropping the application's dark
+muted token onto a black panel. `background` keeps its `transparent` default.
+To make an otherwise-unthemed Statistic follow an ancestor's `color`, ask for
+it explicitly with `theme={{ foreground: 'currentColor', muted: 'currentColor' }}`.
+No API change.

--- a/packages/components/src/components/statistic/README.md
+++ b/packages/components/src/components/statistic/README.md
@@ -28,7 +28,11 @@ snippet. The flat `@lostgradient/cinder/statistic` subpath remains exported for
 
 ## Theming
 
-Statistic inherits its foreground and muted text from `currentColor` and keeps its background transparent. Pass a partial `theme` when a statistic needs an explicit local foreground, muted color, or background. Change direction remains visible through its arrow glyph, signed value, description, and screen-reader text rather than color alone.
+With no `theme`, Statistic paints its value from `--cinder-text` and its label, icon, and change description from `--cinder-text-muted`, keeping the background transparent. The muted token is what separates the label from the value, so it is a real token rather than an opacity on inherited text — the label is body text and has to clear the 4.5:1 contrast floor on its own.
+
+Pass a partial `theme` when a statistic needs an explicit local foreground, muted color, or background — on a custom-coloured panel, for instance. Supplying a `theme` switches the omitted fields back to inheriting `currentColor` from the surrounding application, so a partial theme never mixes your explicit colours with the global tokens: `theme={{ foreground: 'white', background: 'black' }}` leaves the label inheriting white rather than dropping the app's dark muted token onto a black surface. To make an unthemed-looking Statistic follow an ancestor's `color` instead of the tokens, ask for it explicitly with `theme={{ foreground: 'currentColor', muted: 'currentColor' }}`.
+
+Change direction remains visible through its arrow glyph, signed value, description, and screen-reader text rather than color alone.
 
 ## Props
 

--- a/packages/components/src/components/statistic/statistic.svelte
+++ b/packages/components/src/components/statistic/statistic.svelte
@@ -69,7 +69,27 @@
     return `no change, ${change.value}${suffix}`;
   });
 
-  const resolvedTheme = $derived(resolveChartTheme(theme));
+  /**
+   * Statistic is page text, not chart glyphs, so it cannot take
+   * `resolveChartTheme`'s unthemed defaults as-is: that returns
+   * `currentColor` for `foreground` and `muted`, and this component writes
+   * both as INLINE custom properties, so the `var(--_cinder-chart-*, …)`
+   * fallbacks in `statistic.css` can never apply. An unthemed Statistic
+   * therefore painted its label, icon, and change description at full text
+   * colour — visually identical to the value, with the muted hierarchy gone.
+   *
+   * The chart components absorb the same `currentColor` default with a
+   * compensating `opacity` on their tick labels; that is the wrong tool for
+   * text, which has to clear the 4.5:1 AA floor rather than land wherever a
+   * multiplier puts it. So the unthemed defaults here are the contrast-tuned
+   * text tokens, and an explicit `theme` still wins for a Statistic composed
+   * into a themed chart surface.
+   */
+  const resolvedTheme = $derived({
+    ...resolveChartTheme(theme),
+    foreground: theme?.foreground ?? 'var(--cinder-text)',
+    muted: theme?.muted ?? 'var(--cinder-text-muted)',
+  });
 </script>
 
 <div

--- a/packages/components/src/components/statistic/statistic.svelte
+++ b/packages/components/src/components/statistic/statistic.svelte
@@ -81,15 +81,33 @@
    * The chart components absorb the same `currentColor` default with a
    * compensating `opacity` on their tick labels; that is the wrong tool for
    * text, which has to clear the 4.5:1 AA floor rather than land wherever a
-   * multiplier puts it. So the unthemed defaults here are the contrast-tuned
-   * text tokens, and an explicit `theme` still wins for a Statistic composed
-   * into a themed chart surface.
+   * multiplier puts it.
+   *
+   * So the substitution is all-or-nothing on `theme`'s presence, NOT
+   * per-field: with no theme at all, both colours come from the
+   * contrast-tuned text tokens (restoring the pre-#1248 hierarchy); with any
+   * theme, `resolveChartTheme` is used untouched so omitted fields still
+   * inherit `currentColor` as the partial-theme contract documents. A
+   * per-field fallback would put the app's `--cinder-text-muted` on a caller's
+   * custom dark panel. A surface that colours its own text through an
+   * ancestor and wants the Statistic to follow can say so explicitly with
+   * `theme={{ foreground: 'currentColor', muted: 'currentColor' }}`.
    */
-  const resolvedTheme = $derived({
-    ...resolveChartTheme(theme),
-    foreground: theme?.foreground ?? 'var(--cinder-text)',
-    muted: theme?.muted ?? 'var(--cinder-text-muted)',
-  });
+  const resolvedTheme = $derived(
+    theme
+      ? // A supplied theme — even a partial one — keeps `resolveChartTheme`'s
+        // `currentColor` inheritance for the fields it omits, per the documented
+        // partial-theme contract. Substituting the global text tokens here would
+        // break exactly the case the contract exists for: a caller passing
+        // `{ foreground: 'white', background: 'black' }` for a dark panel would
+        // get the app's dark `--cinder-text-muted` label on that black surface.
+        resolveChartTheme(theme)
+      : {
+          ...resolveChartTheme(undefined),
+          foreground: 'var(--cinder-text)',
+          muted: 'var(--cinder-text-muted)',
+        },
+  );
 </script>
 
 <div

--- a/packages/components/src/components/statistic/statistic.test.ts
+++ b/packages/components/src/components/statistic/statistic.test.ts
@@ -41,6 +41,34 @@ describe('Statistic', () => {
     expect(style).toContain('--_cinder-chart-background: transparent');
   });
 
+  test('a partial theme keeps currentColor inheritance for the fields it omits', () => {
+    // The token substitution is all-or-nothing on `theme`'s presence. A
+    // per-field fallback would drop the application-wide (light-theme: dark)
+    // `--cinder-text-muted` onto this caller's black panel, making the label
+    // unreadable — and would contradict the documented partial-theme contract
+    // that omitted fields inherit the surrounding application.
+    const { container } = render(Statistic, {
+      label: 'Revenue',
+      value: '$1,000',
+      theme: { foreground: 'white', background: 'black' },
+    });
+    const root = container.querySelector<HTMLElement>('.cinder-statistic');
+    expect(root?.style.getPropertyValue('--_cinder-chart-foreground')).toBe('white');
+    expect(root?.style.getPropertyValue('--_cinder-chart-muted')).toBe('currentColor');
+    expect(root?.style.getPropertyValue('--_cinder-chart-background')).toBe('black');
+  });
+
+  test('an explicit currentColor theme opts back into ancestor colour inheritance', () => {
+    const { container } = render(Statistic, {
+      label: 'Revenue',
+      value: '$1,000',
+      theme: { foreground: 'currentColor', muted: 'currentColor' },
+    });
+    const root = container.querySelector<HTMLElement>('.cinder-statistic');
+    expect(root?.style.getPropertyValue('--_cinder-chart-foreground')).toBe('currentColor');
+    expect(root?.style.getPropertyValue('--_cinder-chart-muted')).toBe('currentColor');
+  });
+
   test('preserves consumer inline styles while applying theme variables', () => {
     const { container } = render(Statistic, {
       label: 'Revenue',

--- a/packages/components/src/components/statistic/statistic.test.ts
+++ b/packages/components/src/components/statistic/statistic.test.ts
@@ -26,11 +26,18 @@ describe('Statistic', () => {
     expect(el?.getAttribute('role')).toBe('group');
   });
 
-  test('resolves theme defaults through currentColor and transparent', () => {
+  test('resolves unthemed defaults to the text tokens, keeping the muted hierarchy', () => {
+    // Regression pin. These previously resolved to `currentColor` (the shared
+    // chart default), and because the component writes them as INLINE custom
+    // properties, the `var(--_cinder-chart-*, …)` fallbacks in statistic.css
+    // could never apply — so an unthemed Statistic painted its label, icon,
+    // and change description at full text colour, identical to the value.
+    // `muted` must stay a distinct, contrast-tuned token, not `currentColor`
+    // and not an opacity multiplier (this is text, held to 4.5:1).
     const { container } = render(Statistic, { label: 'Revenue', value: '$1,000' });
     const style = container.querySelector('.cinder-statistic')?.getAttribute('style') ?? '';
-    expect(style).toContain('--_cinder-chart-foreground: currentColor');
-    expect(style).toContain('--_cinder-chart-muted: currentColor');
+    expect(style).toContain('--_cinder-chart-foreground: var(--cinder-text)');
+    expect(style).toContain('--_cinder-chart-muted: var(--cinder-text-muted)');
     expect(style).toContain('--_cinder-chart-background: transparent');
   });
 
@@ -42,7 +49,7 @@ describe('Statistic', () => {
     });
     const root = container.querySelector<HTMLElement>('.cinder-statistic');
     expect(root?.getAttribute('style')).toContain('border: 1px solid red');
-    expect(root?.style.getPropertyValue('--_cinder-chart-foreground')).toBe('currentColor');
+    expect(root?.style.getPropertyValue('--_cinder-chart-foreground')).toBe('var(--cinder-text)');
   });
 
   test('applies custom theme colors without removing change direction cues', () => {


### PR DESCRIPTION
Found while migrating `weft-console` to cinder 0.23.0 — a silent visual regression from #1248 that typecheck and the test suite both passed straight through.

## What broke

`Statistic` resolves its colours with `resolveChartTheme()`, whose unthemed defaults are `currentColor` for both `foreground` and `muted`. The component writes those as **inline** custom properties (`style:--_cinder-chart-muted={…}`), so the `var(--_cinder-chart-*, …)` fallbacks in `statistic.css` can never apply — an inline custom property always wins over a stylesheet fallback.

Result: a `Statistic` rendered without an explicit `theme` painted its **label, icon, and change description at full text colour**, visually identical to the value. The hierarchy `--cinder-text-muted` used to provide was gone for every consumer that doesn't pass a chart theme.

It's invisible to the type system and to the existing tests — in fact the default-resolution test *pinned the regression*, asserting `--_cinder-chart-muted: currentColor`.

## Why not `opacity`

The chart components absorb the same `currentColor` default with a compensating `opacity: 0.72` on tick labels. That's fine for chart glyphs and wrong for body text: text has to clear the 4.5:1 AA floor, not land wherever a multiplier puts it — the same reasoning that moved status text off the fill tokens onto the `-fg` ramp in 0.21 (#1216).

## The fix

Unthemed `Statistic` now defaults to the contrast-tuned text tokens (`--cinder-text` / `--cinder-text-muted`) instead of `currentColor`. An explicit `theme` still wins, so a `Statistic` composed onto a themed chart surface is unchanged, and `background` keeps its `transparent` default. No API change; `patch` changeset.

## Validation

- `bun run --filter=@lostgradient/cinder typecheck` — 0 errors
- `bun test packages/components/src/components/statistic/statistic.test.ts` — 30/30, including the flipped regression pin and the unchanged explicit-theme test

🤖 Generated with [Claude Code](https://claude.com/claude-code)