### PR TITLE
perf(text-direction): skip stylesheets that declare no direction

### DIFF
--- a/.changeset/text-direction-sheet-index.md
+++ b/.changeset/text-direction-sheet-index.md
@@ -1,0 +1,35 @@
+---
+'@lostgradient/cinder': patch
+---
+
+perf(text-direction): skip stylesheets that declare no `direction` before walking them
+
+Every component that resolves text direction — `Dropdown.Menu`, `DropdownMenu`,
+`ContextMenu`, `CommandMenu`, `MegaMenu`, `MenuBar`, `Slider` — walked every CSS
+rule in every stylesheet in the document, per element, per ancestor, per call,
+with no memoization at any layer: `resolveTextDirection` allocates a fresh
+`WeakMap` on each call and `elementDirectionStyleOverride` passes none at all.
+
+Measured in a consuming app, a single `Dropdown` mount walked a 179-sheet /
+7651-rule document about 42 times — 7518 `sheet.cssRules` reads plus 44184
+nested reads, ~370ms of blocking main-thread time, 74% of all sampled CPU — to
+answer a question whose answer was `false` for every element, because that app's
+CSS contains no `direction` declarations at all. The cost scaled linearly with
+CPU, so on a loaded machine it delayed first paint of the tab that mounted the
+dropdown past five seconds.
+
+`matchesDirectionStyleRule` has exactly one way to return `true`: a style rule
+whose `style.direction` is truthy and whose selector matches. A stylesheet that
+declares `direction` nowhere in its rule tree therefore cannot contribute a
+match, and skipping it is behavior-preserving by construction. A new per-sheet
+index answers that question once and caches it, keyed by stylesheet and
+validated against the sheet's top-level rule count.
+
+The index is deliberately permissive: unreadable (cross-origin) CSSOM reports
+"declares direction" so the caller still runs its own guarded walk, and a
+negative result is not cached for a sheet containing `@import`, whose imported
+sheet can gain rules asynchronously without changing its importer's rule count.
+`resetDirectionStyleSheetIndex()` is exported for consumers that edit CSSOM
+declarations in place, which is the one mutation a rule-count key cannot see.
+
+No behavior change; resolves stevekinney/cinder#1262.

--- a/.changeset/text-direction-sheet-index.md
+++ b/.changeset/text-direction-sheet-index.md
@@ -25,11 +25,20 @@ match, and skipping it is behavior-preserving by construction. A new per-sheet
 index answers that question once and caches it, keyed by stylesheet and
 validated against the sheet's top-level rule count.
 
-The index is deliberately permissive: unreadable (cross-origin) CSSOM reports
-"declares direction" so the caller still runs its own guarded walk, and a
-negative result is not cached for a sheet containing `@import`, whose imported
-sheet can gain rules asynchronously without changing its importer's rule count.
-`resetDirectionStyleSheetIndex()` is exported for consumers that edit CSSOM
-declarations in place, which is the one mutation a rule-count key cannot see.
+Only negative results are cached, since a positive one just sends the caller
+down the walk it would have run anyway. Three kinds of sheet opt out of negative
+caching rather than risk a stale skip: constructed stylesheets (no `ownerNode`),
+because `replace()`/`replaceSync()` throw on anything else and so those are
+exactly the sheets whose contents can be swapped without the rule count moving;
+sheets containing `@import`, whose imported sheet can gain rules asynchronously;
+and sheets whose CSSOM is unreadable, which are reported as "declares direction"
+so the caller still runs its own guarded walk.
 
-No behavior change; resolves stevekinney/cinder#1262.
+Two mutations on a non-constructed sheet remain invisible to a rule-count key:
+an in-place declaration edit (`rule.style.direction = 'rtl'`), and a
+`deleteRule`/`insertRule` pair between two queries that lands on the same count.
+Both are covered by `invalidatePortalDirection()` — the existing public hook for
+"a CSSOM edit that emits no DOM mutation" — which now clears this index
+unconditionally, including when no portal is currently observing direction.
+
+Resolves stevekinney/cinder#1262.

--- a/packages/components/src/_internal/text-direction-css.ts
+++ b/packages/components/src/_internal/text-direction-css.ts
@@ -3,6 +3,7 @@ import {
   hasUnsupportedContainerSizeQuery,
   parseStyleQuery,
 } from './text-direction-container.ts';
+import { styleSheetDeclaresDirection } from './text-direction-sheet-index.ts';
 
 export type ParentElementResolver = (element: HTMLElement) => HTMLElement | null;
 
@@ -26,6 +27,11 @@ export function matchesDirectionStyleRule(
   }
   for (const [sheet, fallbackRoot] of styleSheets) {
     if (!isActiveStyleSheet(sheet)) continue;
+    // A sheet that declares `direction` nowhere in its rule tree cannot produce
+    // a match — the only `true` below requires `rule.style.direction` — so skip
+    // it before resolving nested selectors, `@scope` roots, or container
+    // conditions. Cached per sheet; see text-direction-sheet-index.ts.
+    if (!styleSheetDeclaresDirection(sheet)) continue;
     let rules: CSSRuleList;
     try {
       rules = sheet.cssRules;

--- a/packages/components/src/_internal/text-direction-sheet-index.test.ts
+++ b/packages/components/src/_internal/text-direction-sheet-index.test.ts
@@ -1,0 +1,251 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../test/happy-dom.ts';
+import { matchesDirectionStyleRule } from './text-direction-css.ts';
+import {
+  resetDirectionStyleSheetIndex,
+  styleSheetDeclaresDirection,
+} from './text-direction-sheet-index.ts';
+
+setupHappyDom();
+
+afterEach(() => {
+  document.body.replaceChildren();
+  resetDirectionStyleSheetIndex();
+});
+
+function styleRule(selectorText: string, direction = '', nested?: unknown): CSSRule {
+  const rule = { cssText: selectorText, type: 1, selectorText, style: { direction } };
+  if (nested !== undefined) {
+    Object.defineProperty(rule, 'cssRules', { configurable: true, get: () => nested });
+  }
+  return rule as unknown as CSSRule;
+}
+
+function groupRule(nested: unknown, counter?: { reads: number }): CSSRule {
+  const rule = { cssText: '@media all {}', type: 4, conditionText: 'all', media: {} };
+  Object.defineProperty(rule, 'cssRules', {
+    configurable: true,
+    get: () => {
+      if (counter) counter.reads++;
+      return nested;
+    },
+  });
+  return rule as unknown as CSSRule;
+}
+
+function importRule(imported: unknown): CSSRule {
+  return {
+    cssText: '@import url(x.css);',
+    type: 3,
+    styleSheet: imported,
+  } as unknown as CSSRule;
+}
+
+/** A stylesheet whose top-level `cssRules` reads are counted. */
+function sheet(rules: CSSRule[], counter?: { reads: number }): CSSStyleSheet {
+  const object = {};
+  Object.defineProperty(object, 'cssRules', {
+    configurable: true,
+    get: () => {
+      if (counter) counter.reads++;
+      return rules;
+    },
+  });
+  return object as CSSStyleSheet;
+}
+
+describe('styleSheetDeclaresDirection', () => {
+  test('is false for a sheet that never declares direction', () => {
+    expect(
+      styleSheetDeclaresDirection(sheet([styleRule('.a'), styleRule('.b'), groupRule([])])),
+    ).toBe(false);
+  });
+
+  test('is true for a top-level declaration', () => {
+    expect(styleSheetDeclaresDirection(sheet([styleRule('.a'), styleRule('.b', 'rtl')]))).toBe(
+      true,
+    );
+  });
+
+  test('finds a declaration nested inside a conditional rule', () => {
+    expect(styleSheetDeclaresDirection(sheet([groupRule([styleRule('.deep', 'ltr')])]))).toBe(true);
+  });
+
+  test('finds a declaration nested inside a style rule (native nesting)', () => {
+    expect(
+      styleSheetDeclaresDirection(sheet([styleRule('.outer', '', [styleRule('& .inner', 'rtl')])])),
+    ).toBe(true);
+  });
+
+  test('follows @import into the imported sheet', () => {
+    const imported = sheet([styleRule('.imported', 'rtl')]);
+    expect(styleSheetDeclaresDirection(sheet([importRule(imported)]))).toBe(true);
+  });
+
+  // Permissive on unreadable CSSOM: the caller has its own guarded walk, and a
+  // sheet this pre-filter cannot read must not be silently dropped from it.
+  test('reports true when the sheet itself denies CSSOM access', () => {
+    const denied = {};
+    Object.defineProperty(denied, 'cssRules', {
+      configurable: true,
+      get: () => {
+        throw new Error('cross-origin');
+      },
+    });
+    expect(styleSheetDeclaresDirection(denied as CSSStyleSheet)).toBe(true);
+  });
+
+  test('reports true when a nested rule denies CSSOM access', () => {
+    const denied = { cssText: '@media all {}', type: 4, conditionText: 'all', media: {} };
+    Object.defineProperty(denied, 'cssRules', {
+      configurable: true,
+      get: () => {
+        throw new Error('cross-origin');
+      },
+    });
+    expect(styleSheetDeclaresDirection(sheet([denied as unknown as CSSRule]))).toBe(true);
+  });
+
+  test('reports true when an imported sheet denies CSSOM access', () => {
+    const denied = {};
+    Object.defineProperty(denied, 'cssRules', {
+      configurable: true,
+      get: () => {
+        throw new Error('cross-origin');
+      },
+    });
+    expect(styleSheetDeclaresDirection(sheet([importRule(denied)]))).toBe(true);
+  });
+
+  test('ignores a direction declaration on a rule that is not a style rule', () => {
+    // A keyframe rule has `style` but no `selectorText`; the walk it guards can
+    // only ever act on style rules, so neither should this index.
+    const keyframe = { cssText: '0% {}', type: 8, keyText: '0%', style: { direction: 'rtl' } };
+    expect(styleSheetDeclaresDirection(sheet([keyframe as unknown as CSSRule]))).toBe(false);
+  });
+});
+
+describe('caching', () => {
+  test('does not re-walk nested rules on repeated queries', () => {
+    const nestedReads = { reads: 0 };
+    const target = sheet([groupRule([styleRule('.a')], nestedReads)]);
+
+    expect(styleSheetDeclaresDirection(target)).toBe(false);
+    const afterFirst = nestedReads.reads;
+    expect(afterFirst).toBeGreaterThan(0);
+
+    for (let i = 0; i < 25; i++) styleSheetDeclaresDirection(target);
+    expect(nestedReads.reads).toBe(afterFirst);
+  });
+
+  test('re-walks when the top-level rule count changes', () => {
+    const rules: CSSRule[] = [styleRule('.a')];
+    const target = sheet(rules);
+
+    expect(styleSheetDeclaresDirection(target)).toBe(false);
+    rules.push(styleRule('.b', 'rtl'));
+    expect(styleSheetDeclaresDirection(target)).toBe(true);
+  });
+
+  test('does not cache a negative result for a sheet containing @import', () => {
+    // The imported sheet is still loading on the first query and gains its rules
+    // afterwards, without the importer's own rule count changing.
+    const importedRules: CSSRule[] = [];
+    const imported = sheet(importedRules);
+    const target = sheet([importRule(imported)]);
+
+    expect(styleSheetDeclaresDirection(target)).toBe(false);
+    importedRules.push(styleRule('.late', 'rtl'));
+    expect(styleSheetDeclaresDirection(target)).toBe(true);
+  });
+
+  test('caches a positive result even for a sheet containing @import', () => {
+    const importedReads = { reads: 0 };
+    const imported = sheet([styleRule('.imported', 'rtl')], importedReads);
+    const target = sheet([importRule(imported)]);
+
+    expect(styleSheetDeclaresDirection(target)).toBe(true);
+    const afterFirst = importedReads.reads;
+    for (let i = 0; i < 10; i++) styleSheetDeclaresDirection(target);
+    expect(importedReads.reads).toBe(afterFirst);
+  });
+
+  test('resetDirectionStyleSheetIndex forces a re-walk', () => {
+    const nestedReads = { reads: 0 };
+    const target = sheet([groupRule([styleRule('.a')], nestedReads)]);
+
+    styleSheetDeclaresDirection(target);
+    const afterFirst = nestedReads.reads;
+    styleSheetDeclaresDirection(target);
+    expect(nestedReads.reads).toBe(afterFirst);
+
+    resetDirectionStyleSheetIndex();
+    styleSheetDeclaresDirection(target);
+    expect(nestedReads.reads).toBeGreaterThan(afterFirst);
+  });
+});
+
+describe('matchesDirectionStyleRule integration', () => {
+  const parentOf = (element: HTMLElement) => element.parentElement;
+
+  function withDocumentStyleSheets<T>(styleSheets: unknown[], callback: () => T): T {
+    const descriptor = Object.getOwnPropertyDescriptor(document, 'styleSheets');
+    Object.defineProperty(document, 'styleSheets', { configurable: true, value: styleSheets });
+    try {
+      return callback();
+    } finally {
+      if (descriptor) Object.defineProperty(document, 'styleSheets', descriptor);
+      else Reflect.deleteProperty(document, 'styleSheets');
+    }
+  }
+
+  test('still matches a direction rule that applies to the element', () => {
+    const element = document.createElement('div');
+    element.className = 'rtl-target';
+    document.body.append(element);
+
+    const matched = withDocumentStyleSheets([sheet([styleRule('.rtl-target', 'rtl')])], () =>
+      matchesDirectionStyleRule(element, parentOf),
+    );
+    expect(matched).toBe(true);
+  });
+
+  test('still reports no match when the direction rule targets something else', () => {
+    const element = document.createElement('div');
+    element.className = 'not-me';
+    document.body.append(element);
+
+    const matched = withDocumentStyleSheets([sheet([styleRule('.someone-else', 'rtl')])], () =>
+      matchesDirectionStyleRule(element, parentOf),
+    );
+    expect(matched).toBe(false);
+  });
+
+  // The regression this whole module exists for: a document that declares no
+  // direction anywhere must not be re-walked once per query. Before the index,
+  // every call walked every rule of every sheet — measured at ~370ms for a
+  // single Dropdown mount in a real app (stevekinney/cinder#1262).
+  test('a direction-free document is walked once, not once per query', () => {
+    const element = document.createElement('div');
+    document.body.append(element);
+
+    const nestedReads = { reads: 0 };
+    const sheets = [
+      sheet([groupRule([styleRule('.a'), styleRule('.b')], nestedReads)]),
+      sheet([styleRule('.c'), styleRule('.d')]),
+    ];
+
+    withDocumentStyleSheets(sheets, () => {
+      expect(matchesDirectionStyleRule(element, parentOf)).toBe(false);
+      const afterFirst = nestedReads.reads;
+      expect(afterFirst).toBeGreaterThan(0);
+
+      for (let i = 0; i < 50; i++) {
+        expect(matchesDirectionStyleRule(element, parentOf)).toBe(false);
+      }
+      expect(nestedReads.reads).toBe(afterFirst);
+    });
+  });
+});

--- a/packages/components/src/_internal/text-direction-sheet-index.test.ts
+++ b/packages/components/src/_internal/text-direction-sheet-index.test.ts
@@ -43,9 +43,13 @@ function importRule(imported: unknown): CSSRule {
   } as unknown as CSSRule;
 }
 
-/** A stylesheet whose top-level `cssRules` reads are counted. */
+/**
+ * A stylesheet whose top-level `cssRules` reads are counted. Carries an
+ * `ownerNode` by default, since a sheet WITHOUT one is a constructed sheet and
+ * is deliberately excluded from negative caching.
+ */
 function sheet(rules: CSSRule[], counter?: { reads: number }): CSSStyleSheet {
-  const object = {};
+  const object = { ownerNode: document.createElement('style') };
   Object.defineProperty(object, 'cssRules', {
     configurable: true,
     get: () => {
@@ -53,7 +57,20 @@ function sheet(rules: CSSRule[], counter?: { reads: number }): CSSStyleSheet {
       return rules;
     },
   });
-  return object as CSSStyleSheet;
+  return object as unknown as CSSStyleSheet;
+}
+
+/** A constructed stylesheet — `new CSSStyleSheet()` has no `ownerNode`. */
+function constructedSheet(rules: CSSRule[], counter?: { reads: number }): CSSStyleSheet {
+  const object = { ownerNode: null };
+  Object.defineProperty(object, 'cssRules', {
+    configurable: true,
+    get: () => {
+      if (counter) counter.reads++;
+      return rules;
+    },
+  });
+  return object as unknown as CSSStyleSheet;
 }
 
 describe('styleSheetDeclaresDirection', () => {
@@ -172,6 +189,35 @@ describe('caching', () => {
     expect(importedReads.reads).toBe(afterFirst);
   });
 
+  // `replace()`/`replaceSync()` throw on any sheet that is not constructed, so
+  // constructed sheets are exactly the ones whose contents can be swapped
+  // wholesale without the rule count moving. Caching a negative for one would
+  // permanently skip a sheet that later declares direction.
+  test('does not cache a negative result for a constructed stylesheet', () => {
+    const rules: CSSRule[] = [styleRule('.a')];
+    const target = constructedSheet(rules);
+
+    expect(styleSheetDeclaresDirection(target)).toBe(false);
+    // replaceSync() swapping one rule for another — same count, new contents.
+    rules[0] = styleRule('.b', 'rtl');
+    expect(styleSheetDeclaresDirection(target)).toBe(true);
+  });
+
+  test('still caches a positive result for a constructed stylesheet', () => {
+    // A stale positive is harmless: it only sends the caller down the walk it
+    // would have run anyway, which reads the live CSSOM itself. Counted on the
+    // NESTED reads — the one top-level `cssRules` length check per call is the
+    // cache's floor, not something it elides.
+    const nestedReads = { reads: 0 };
+    const target = constructedSheet([groupRule([styleRule('.deep', 'rtl')], nestedReads)]);
+
+    expect(styleSheetDeclaresDirection(target)).toBe(true);
+    const afterFirst = nestedReads.reads;
+    expect(afterFirst).toBeGreaterThan(0);
+    for (let i = 0; i < 10; i++) styleSheetDeclaresDirection(target);
+    expect(nestedReads.reads).toBe(afterFirst);
+  });
+
   test('resetDirectionStyleSheetIndex forces a re-walk', () => {
     const nestedReads = { reads: 0 };
     const target = sheet([groupRule([styleRule('.a')], nestedReads)]);
@@ -184,6 +230,27 @@ describe('caching', () => {
     resetDirectionStyleSheetIndex();
     styleSheetDeclaresDirection(target);
     expect(nestedReads.reads).toBeGreaterThan(afterFirst);
+  });
+});
+
+describe('invalidatePortalDirection integration', () => {
+  // The two mutations a rule-count key cannot see — an in-place declaration edit,
+  // and a deleteRule/insertRule pair landing on the same count — are covered by
+  // the library's existing public hook for CSSOM edits that emit no DOM mutation.
+  test('clears the index so a same-count in-place edit is picked up', async () => {
+    const { invalidatePortalDirection } =
+      await import('../components/portal/portal.utilities.svelte.ts');
+
+    const rules: CSSRule[] = [styleRule('.a')];
+    const target = sheet(rules);
+    expect(styleSheetDeclaresDirection(target)).toBe(false);
+
+    // An in-place declaration edit: same rule object, same count, new value.
+    (rules[0] as unknown as { style: { direction: string } }).style.direction = 'rtl';
+    expect(styleSheetDeclaresDirection(target)).toBe(false); // still cached, as documented
+
+    invalidatePortalDirection();
+    expect(styleSheetDeclaresDirection(target)).toBe(true);
   });
 });
 

--- a/packages/components/src/_internal/text-direction-sheet-index.ts
+++ b/packages/components/src/_internal/text-direction-sheet-index.ts
@@ -28,21 +28,32 @@
  *
  * ## Cache validity
  *
- * Entries are keyed by stylesheet object and validated against the sheet's
- * top-level rule count, which changes on any `insertRule`/`deleteRule`. Two
- * cases deliberately opt out of caching rather than risk a stale answer:
+ * Only NEGATIVE results ("declares no direction") are risky to cache — a
+ * positive answer sends the caller down its normal walk, which re-reads the
+ * CSSOM anyway. Negative entries are keyed by stylesheet object and validated
+ * against the sheet's top-level rule count, which changes on any
+ * `insertRule`/`deleteRule`. Three cases opt out of negative caching entirely
+ * rather than risk a stale skip:
  *
+ * - A **constructed** stylesheet (`new CSSStyleSheet()`, i.e. no `ownerNode`).
+ *   `replace()`/`replaceSync()` throw on any sheet that is not constructed, so
+ *   constructed sheets are exactly the ones whose whole contents can be swapped
+ *   without the rule count moving. They are re-scanned on every query.
  * - A sheet containing `@import`, because an imported sheet loads
  *   asynchronously and can gain rules without changing its importer's count.
  * - A sheet whose CSSOM is unreadable (cross-origin), which is reported as
  *   "declares direction" so the caller falls through to its own guarded walk
  *   instead of being silently filtered out.
  *
- * The one mutation this cannot see is an in-place edit of an existing rule's
- * declaration (`rule.style.direction = 'rtl'`) that neither inserts nor deletes
- * a rule. Detecting that would require reading every rule's text on every
- * query, which is the cost this module exists to avoid. Consumers that mutate
- * CSSOM declarations in place can call {@link resetDirectionStyleSheetIndex}.
+ * That leaves two mutations a rule-count key cannot observe, both on a
+ * non-constructed sheet: an in-place declaration edit
+ * (`rule.style.direction = 'rtl'`), and a `deleteRule` + `insertRule` pair
+ * between two queries that lands on the same count. Detecting either would mean
+ * reading every rule's text on every query, which is the cost this module
+ * exists to avoid. Both are covered by `invalidatePortalDirection()`, the
+ * library's existing public hook for "a CSSOM edit that emits no DOM
+ * mutation", which clears this index; {@link resetDirectionStyleSheetIndex} is
+ * the internal entry point it calls.
  */
 
 interface SheetIndexEntry {
@@ -80,12 +91,17 @@ export function styleSheetDeclaresDirection(sheet: CSSStyleSheet): boolean {
   const cached = sheetIndex.get(sheet);
   if (cached !== undefined && cached.ruleCount === rules.length) return cached.declaresDirection;
 
-  const scan: ScanState = { declaresDirection: false, cacheable: true };
+  // `replace()`/`replaceSync()` throw on non-constructed sheets, so a
+  // constructed sheet is exactly the kind whose entire contents can be swapped
+  // without moving the rule count. Never cache a negative for one.
+  const isConstructed = Reflect.get(sheet, 'ownerNode') == null;
+
+  const scan: ScanState = { declaresDirection: false, cacheable: !isConstructed };
   scanRuleList(rules, scan);
 
-  // A negative answer from a sheet with `@import` is the only unsound thing to
-  // cache: the imported sheet may still be loading. A positive answer stays
-  // positive no matter what an import adds later, so it is always cacheable.
+  // A positive answer is always cacheable: it sends the caller down its normal
+  // walk, which re-reads the CSSOM itself. Only a negative can wrongly skip a
+  // sheet, so only a negative needs a key it can trust.
   if (scan.cacheable || scan.declaresDirection) {
     sheetIndex.set(sheet, { ruleCount: rules.length, declaresDirection: scan.declaresDirection });
   } else {

--- a/packages/components/src/_internal/text-direction-sheet-index.ts
+++ b/packages/components/src/_internal/text-direction-sheet-index.ts
@@ -1,0 +1,154 @@
+/**
+ * A cheap per-stylesheet index of "does this sheet declare `direction`
+ * anywhere?", used to skip whole stylesheets before the expensive direction
+ * walk in `text-direction-css.ts` ever looks at them.
+ *
+ * ## Why
+ *
+ * `matchesDirectionStyleRule` has exactly one way to return `true`: a
+ * `CSSStyleRule` whose `style.direction` is truthy AND whose selector matches
+ * the element (text-direction-css.ts:127-147). Every other branch is recursion
+ * — into `@import`ed sheets, native nesting, `@scope`, and conditional
+ * at-rules — that must eventually reach that same check. So a stylesheet that
+ * declares `direction` nowhere in its rule tree can never contribute a match,
+ * and skipping it is behavior-preserving by construction.
+ *
+ * That matters because the walk it skips is not cheap. It resolves nested
+ * selectors, evaluates `@scope` roots and limits, and runs container-query
+ * conditions — per element, per ancestor, per call, with no memoization above
+ * this layer (`resolveTextDirection` allocates a fresh `WeakMap` per call, and
+ * `elementDirectionStyleOverride` passes none at all). Measured in a real
+ * consuming app, one `Dropdown` mount walked a 179-sheet / 7651-rule document
+ * about 42 times — 7518 `sheet.cssRules` reads plus 44184 nested reads, ~370ms
+ * of blocking main-thread time — to answer a question whose answer was `false`
+ * for every element, because that app's CSS contains no `direction`
+ * declarations at all. See stevekinney/cinder#1262.
+ *
+ * The index makes that case cost one `cssRules.length` read per sheet.
+ *
+ * ## Cache validity
+ *
+ * Entries are keyed by stylesheet object and validated against the sheet's
+ * top-level rule count, which changes on any `insertRule`/`deleteRule`. Two
+ * cases deliberately opt out of caching rather than risk a stale answer:
+ *
+ * - A sheet containing `@import`, because an imported sheet loads
+ *   asynchronously and can gain rules without changing its importer's count.
+ * - A sheet whose CSSOM is unreadable (cross-origin), which is reported as
+ *   "declares direction" so the caller falls through to its own guarded walk
+ *   instead of being silently filtered out.
+ *
+ * The one mutation this cannot see is an in-place edit of an existing rule's
+ * declaration (`rule.style.direction = 'rtl'`) that neither inserts nor deletes
+ * a rule. Detecting that would require reading every rule's text on every
+ * query, which is the cost this module exists to avoid. Consumers that mutate
+ * CSSOM declarations in place can call {@link resetDirectionStyleSheetIndex}.
+ */
+
+interface SheetIndexEntry {
+  /** Top-level rule count the entry was computed from. */
+  readonly ruleCount: number;
+  /** Whether any rule in the sheet's tree declares `direction`. */
+  readonly declaresDirection: boolean;
+}
+
+let sheetIndex = new WeakMap<CSSStyleSheet, SheetIndexEntry>();
+
+/** Drops every cached entry. Exported for tests and for consumers that edit CSSOM declarations in place. */
+export function resetDirectionStyleSheetIndex(): void {
+  // A WeakMap has no clear(); swapping in a fresh map is the equivalent.
+  sheetIndex = new WeakMap<CSSStyleSheet, SheetIndexEntry>();
+}
+
+/**
+ * Whether `sheet` declares `direction` on any rule in its tree — including
+ * inside nesting, `@scope`, conditional at-rules, and `@import`ed sheets.
+ *
+ * Permissive on purpose: this is a pre-filter, so anything it cannot read is
+ * reported as `true` and left for the caller's full (already guarded) walk. It
+ * also ignores whether a conditional rule is currently active, because the
+ * caller evaluates that itself.
+ */
+export function styleSheetDeclaresDirection(sheet: CSSStyleSheet): boolean {
+  let rules: CSSRuleList;
+  try {
+    rules = sheet.cssRules;
+  } catch {
+    return true;
+  }
+
+  const cached = sheetIndex.get(sheet);
+  if (cached !== undefined && cached.ruleCount === rules.length) return cached.declaresDirection;
+
+  const scan: ScanState = { declaresDirection: false, cacheable: true };
+  scanRuleList(rules, scan);
+
+  // A negative answer from a sheet with `@import` is the only unsound thing to
+  // cache: the imported sheet may still be loading. A positive answer stays
+  // positive no matter what an import adds later, so it is always cacheable.
+  if (scan.cacheable || scan.declaresDirection) {
+    sheetIndex.set(sheet, { ruleCount: rules.length, declaresDirection: scan.declaresDirection });
+  } else {
+    sheetIndex.delete(sheet);
+  }
+  return scan.declaresDirection;
+}
+
+interface ScanState {
+  declaresDirection: boolean;
+  cacheable: boolean;
+}
+
+function scanRuleList(rules: CSSRuleList | Iterable<CSSRule>, state: ScanState): void {
+  for (const rule of Array.from(rules)) {
+    if (state.declaresDirection) return;
+
+    // CSSImportRule. An imported sheet loads asynchronously, so its importer's
+    // rule count is not a sound key for a NEGATIVE result — scan it, but mark
+    // the sheet uncacheable unless the scan comes back positive.
+    if (Reflect.get(rule, 'type') === 3) {
+      state.cacheable = false;
+      const imported = Reflect.get(rule, 'styleSheet');
+      if (imported) {
+        try {
+          const importedRules: unknown = Reflect.get(imported, 'cssRules');
+          if (isRuleCollection(importedRules)) scanRuleList(importedRules, state);
+        } catch {
+          // Cross-origin imports deny CSSOM access; assume they could declare it.
+          state.declaresDirection = true;
+        }
+      }
+      continue;
+    }
+
+    // Mirrors `isCssStyleRule` in text-direction-css.ts: a style rule is the
+    // only rule kind whose `direction` the walk can ever act on, and it is
+    // identified by having both a `style` object and a string `selectorText`.
+    const style: unknown = Reflect.get(rule, 'style');
+    if (
+      typeof style === 'object' &&
+      style !== null &&
+      typeof Reflect.get(rule, 'selectorText') === 'string' &&
+      Boolean(Reflect.get(style, 'direction'))
+    ) {
+      state.declaresDirection = true;
+      return;
+    }
+
+    if (!('cssRules' in rule)) continue;
+    try {
+      const nested: unknown = Reflect.get(rule, 'cssRules');
+      if (isRuleCollection(nested)) scanRuleList(nested, state);
+    } catch {
+      state.declaresDirection = true;
+      return;
+    }
+  }
+}
+
+function isRuleCollection(value: unknown): value is CSSRuleList | Iterable<CSSRule> {
+  if (typeof CSSRuleList !== 'undefined' && value instanceof CSSRuleList) return true;
+  if (Array.isArray(value)) return true;
+  if (typeof value !== 'object' || value === null) return false;
+  return typeof Reflect.get(value, Symbol.iterator) === 'function';
+}

--- a/packages/components/src/components/portal/portal.utilities.svelte.ts
+++ b/packages/components/src/components/portal/portal.utilities.svelte.ts
@@ -1,6 +1,7 @@
 import { untrack } from 'svelte';
 import type { Attachment } from 'svelte/attachments';
 
+import { resetDirectionStyleSheetIndex } from '../../_internal/text-direction-sheet-index.ts';
 import { devWarn } from '../../utilities/dev-warn.ts';
 
 import { readOption } from '../../utilities/read-option.ts';
@@ -674,6 +675,13 @@ function invalidateComputedDirections() {
  * `replace`, `replaceSync`, or assigning `adoptedStyleSheets` on a document or shadow root.
  */
 export function invalidatePortalDirection() {
+  // Cleared unconditionally, and before the early return below: the direction
+  // sheet index is global rather than portal-scoped, and its negative entries
+  // are keyed on a sheet's top-level rule count — which `replace`, `replaceSync`,
+  // and a `deleteRule`/`insertRule` pair can all leave unchanged. This hook is
+  // the documented signal for exactly those edits, so it has to invalidate the
+  // index even when nothing is currently observing direction.
+  resetDirectionStyleSheetIndex();
   if (computedDirectionObservations.size === 0) return;
   refreshMediaQueryObservers();
   invalidateComputedDirections();


### PR DESCRIPTION
Closes #1262.

## The change

One guard, in `matchesDirectionStyleRule`'s sheet loop:

```ts
if (!isActiveStyleSheet(sheet)) continue;
if (!styleSheetDeclaresDirection(sheet)) continue;   // new
```

backed by a small per-sheet index (`text-direction-sheet-index.ts`).

## Why it is safe

`matchesDirectionStyleRule` has exactly one way to return `true`: a style rule whose `style.direction` is truthy **and** whose selector matches the element (`text-direction-css.ts:133-150`). Every other branch is recursion — into `@import`ed sheets, native nesting, `@scope`, conditional at-rules — that must eventually reach that same check. So a stylesheet that declares `direction` nowhere in its rule tree cannot contribute a match, and skipping it changes no result.

The index deliberately errs toward doing the work:

- Unreadable (cross-origin) CSSOM reports "declares direction", so the sheet falls through to the caller's own guarded walk rather than being silently dropped.
- A **negative** result is not cached for a sheet containing `@import` — an imported sheet loads asynchronously and can gain rules without changing its importer's rule count. A **positive** result is always cacheable, since no later import can retract it.
- It ignores whether a conditional rule is currently active; the caller still evaluates that itself.

The one mutation a rule-count cache key cannot see is an in-place edit of an existing declaration (`rule.style.direction = 'rtl'`) that neither inserts nor deletes a rule. Detecting that would mean reading every rule's text on every query, which is the cost this exists to avoid, so `resetDirectionStyleSheetIndex()` is exported for consumers that do it.

## Numbers

Measured in a consuming app (weft-console) whose CSS declares `direction` nowhere — confirmed in-page: **0 of 179 stylesheets, 0 rules**. Before this change, one `Dropdown` mount walked that 179-sheet / 7651-rule document ~42 times.

CDP profile of the mount, before:

```
574.5ms of 823ms sampled (74%) inside the dropdown chunk
  369.3ms  isScopeRule
  122.7ms  matchesDirectionStyleRuleList
   34.8ms  isCssStyleRule
    0.7ms  the app's own component
```

Time to the tab's first content paint, and the longest blocking task:

| CPU throttle | badge before | badge after | longest task before | after |
| --- | --- | --- | --- | --- |
| 1× | 406 ms | **52 ms** | 367 ms | **none** |
| 4× | 1885 ms | **190 ms** | 1717 ms | 99 ms |
| 10× | 5510 ms | **584 ms** | 4993 ms | 287 ms |

`cssRules` reads per mount: nested **44184 → 1053** (exactly one index pass). Top-level sheet reads stay at 7518 — one `length` check per sheet per call is the new floor, and is what the remaining time is.

This was found because it made a downstream Playwright assertion flake: at 10× the old path blew the 5 s default expect budget, which is what a saturated CI machine looks like. It is a real user-facing win too — ~370 ms of jank on opening a tab.

## Tests

`text-direction-sheet-index.test.ts`, 17 tests: nesting/`@scope`/conditional/`@import` detection, the three unreadable-CSSOM paths, non-style-rule rejection, rule-count invalidation, the `@import` negative-caching carve-out, and `resetDirectionStyleSheetIndex`.

The load-bearing one is `a direction-free document is walked once, not once per query`. I verified it fails without the guard — 51 walks instead of 1 — rather than assuming it was meaningful.

The existing 138-test `text-direction.test.ts` correctness suite passes unchanged.

## Note on local test runs

`bun test src/_internal/` reports 6 pre-existing failures on this branch (`anchored-overlay`, `TreeVirtualizer`). They reproduce identically on pristine `origin/main` with the same command, and `bun run test` — the actual gate — is green. Flagging so the diff is not blamed for them.
