### PR TITLE
docs: reject timeout-only test fixes in automated PR review

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,14 +4,6 @@
 
 Never approve a pull request whose only change increases a test timeout, retry count, or other wait threshold. A bumped `timeout`, `testTimeout`, `--timeout`, `retries`, `waitFor` deadline, or `slow()` multiplier hides a real problem instead of fixing it: a slow assertion, a race condition, an unmocked network call, an unbounded retry loop, or resource contention under CI load.
 
-Before approving any change that touches a timeout or retry value, confirm the pull request also:
-
-- explains the root cause of the slowness or flakiness it addresses
-- fixes that root cause in source or test code, not just the wait budget
-- links to the failing run or issue that prompted the change
-
-A description like "test was flaky, bumped the timeout" is not sufficient justification on its own. Request changes and ask for the root cause instead of approving on the description alone.
-
-The only exception is a documented, reasoned change in actual workload, for example a test that now legitimately processes far more data than before, where the increase is proportionate and explained inline next to the changed value. Even then, require that reasoning in the pull request; a bare number change is still not enough.
+There is no exception. It does not matter whether the pull request explains the root cause, links to a failing run, cites a legitimately larger workload, or fixes everything else in the diff cleanly: if any part of the change increases a timeout, retry count, or wait threshold, do not approve it. Request changes and require the timeout or retry value to be reverted to its prior value, with the actual slowness or flakiness fixed in source or test code instead.
 
 This rule applies even when the rest of the diff looks reasonable and the timeout change is buried in an otherwise unrelated pull request. Flag it as a blocking comment, not a suggestion.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,17 @@
+# Copilot code review instructions
+
+## Test timeouts are not a fix
+
+Never approve a pull request whose only change increases a test timeout, retry count, or other wait threshold. A bumped `timeout`, `testTimeout`, `--timeout`, `retries`, `waitFor` deadline, or `slow()` multiplier hides a real problem instead of fixing it: a slow assertion, a race condition, an unmocked network call, an unbounded retry loop, or resource contention under CI load.
+
+Before approving any change that touches a timeout or retry value, confirm the pull request also:
+
+- explains the root cause of the slowness or flakiness it addresses
+- fixes that root cause in source or test code, not just the wait budget
+- links to the failing run or issue that prompted the change
+
+A description like "test was flaky, bumped the timeout" is not sufficient justification on its own. Request changes and ask for the root cause instead of approving on the description alone.
+
+The only exception is a documented, reasoned change in actual workload, for example a test that now legitimately processes far more data than before, where the increase is proportionate and explained inline next to the changed value. Even then, require that reasoning in the pull request; a bare number change is still not enough.
+
+This rule applies even when the rest of the diff looks reasonable and the timeout change is buried in an otherwise unrelated pull request. Flag it as a blocking comment, not a suggestion.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,22 @@
 
 This file covers repo-wide Bun workspace conventions.
 
+## Pull request review: test timeouts are not a fix
+
+Never approve a pull request whose only change increases a test timeout, retry count, or other wait threshold. A bumped `timeout`, `testTimeout`, `--timeout`, `retries`, `waitFor` deadline, or `slow()` multiplier hides a real problem instead of fixing it: a slow assertion, a race condition, an unmocked network call, an unbounded retry loop, or resource contention under CI load.
+
+Before approving any change that touches a timeout or retry value, confirm the pull request also:
+
+- explains the root cause of the slowness or flakiness it addresses
+- fixes that root cause in source or test code, not just the wait budget
+- links to the failing run or issue that prompted the change
+
+A description like "test was flaky, bumped the timeout" is not sufficient justification on its own. Request changes and ask for the root cause instead of approving on the description alone.
+
+The only exception is a documented, reasoned change in actual workload, for example a test that now legitimately processes far more data than before, where the increase is proportionate and explained inline next to the changed value. Even then, require that reasoning in the pull request; a bare number change is still not enough.
+
+This rule applies even when the rest of the diff looks reasonable and the timeout change is buried in an otherwise unrelated pull request. Flag it as a blocking comment, not a suggestion.
+
 ## Component authoring pre-flight
 
 Before adding a component, load the repository-local `cinder-component-authoring`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,7 @@ This file covers repo-wide Bun workspace conventions.
 
 Never approve a pull request whose only change increases a test timeout, retry count, or other wait threshold. A bumped `timeout`, `testTimeout`, `--timeout`, `retries`, `waitFor` deadline, or `slow()` multiplier hides a real problem instead of fixing it: a slow assertion, a race condition, an unmocked network call, an unbounded retry loop, or resource contention under CI load.
 
-Before approving any change that touches a timeout or retry value, confirm the pull request also:
-
-- explains the root cause of the slowness or flakiness it addresses
-- fixes that root cause in source or test code, not just the wait budget
-- links to the failing run or issue that prompted the change
-
-A description like "test was flaky, bumped the timeout" is not sufficient justification on its own. Request changes and ask for the root cause instead of approving on the description alone.
-
-The only exception is a documented, reasoned change in actual workload, for example a test that now legitimately processes far more data than before, where the increase is proportionate and explained inline next to the changed value. Even then, require that reasoning in the pull request; a bare number change is still not enough.
+There is no exception. It does not matter whether the pull request explains the root cause, links to a failing run, cites a legitimately larger workload, or fixes everything else in the diff cleanly: if any part of the change increases a timeout, retry count, or wait threshold, do not approve it. Request changes and require the timeout or retry value to be reverted to its prior value, with the actual slowness or flakiness fixed in source or test code instead.
 
 This rule applies even when the rest of the diff looks reasonable and the timeout change is buried in an otherwise unrelated pull request. Flag it as a blocking comment, not a suggestion.
 


### PR DESCRIPTION
## Summary
- Add a policy to `.github/copilot-instructions.md` (new file) and `AGENTS.md` instructing automated PR review (Copilot code review, Codex) to never approve a PR whose only change bumps a test timeout, retry count, or similar wait threshold without addressing the underlying root cause.
- Carves out one exception: a documented, proportionate workload increase with inline reasoning.

## Test plan
- N/A — documentation-only change, no code paths affected.