### PR TITLE
ci: attach dev-server output to readiness failures, and record what #1270 was not

### DIFF
--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1219,34 +1219,47 @@ const SERVER_OUTPUT_TAIL_LINES = 60;
 const SERVER_OUTPUT_TAIL_CHARS = 8_000;
 
 /**
- * Format a dev server's captured output for a failure message, keeping the END.
+ * Bound ONE stream's captured output, keeping the end and announcing any cut.
  *
- * A wedged or erroring Vite server can emit a lot, and dumping all of it bloats
- * CI logs and buries the useful part — which is almost always the last thing it
- * said before it stopped answering. Truncation is announced rather than silent,
- * so a reader knows there was more and can pull the full log from the run.
+ * The tail is what matters — the last thing the server said before it stopped
+ * answering — but the announcement matters just as much: a diagnostic that
+ * silently drops data is worse than no diagnostic, because it reads as complete.
  */
-function formatServerOutputTail(output: string): string {
-  if (output.length === 0) return ': (no output)';
+function formatStreamTail(name: string, raw: string): string {
+  const stream = raw.trim();
+  if (stream.length === 0) return `  ${name}: (empty)`;
 
-  const lines = output.split('\n');
-  let kept = lines.slice(-SERVER_OUTPUT_TAIL_LINES);
-  let droppedLines = lines.length - kept.length;
-  let text = kept.join('\n');
+  const lines = stream.split('\n');
+  const keptLines = lines.slice(-SERVER_OUTPUT_TAIL_LINES);
+  const droppedLines = lines.length - keptLines.length;
 
+  let text = keptLines.join('\n');
+  let charsDropped = 0;
   if (text.length > SERVER_OUTPUT_TAIL_CHARS) {
+    charsDropped = text.length - SERVER_OUTPUT_TAIL_CHARS;
     text = text.slice(-SERVER_OUTPUT_TAIL_CHARS);
-    const firstNewline = text.indexOf('\n');
-    if (firstNewline !== -1) text = text.slice(firstNewline + 1);
-    kept = text.split('\n');
-    droppedLines = lines.length - kept.length;
   }
 
-  const header =
-    droppedLines > 0
-      ? ` (last ${kept.length} of ${lines.length} lines; ${droppedLines} earlier line(s) omitted)`
-      : ` (${lines.length} line(s))`;
-  return `${header}:\n${text}`;
+  // Report both kinds of truncation independently. Deriving one from the other
+  // hides the single-very-long-line case, where no lines are dropped but a lot
+  // of characters are.
+  const notes: string[] = [`${lines.length} line(s)`];
+  if (droppedLines > 0) notes.push(`${droppedLines} earlier line(s) omitted`);
+  if (charsDropped > 0) notes.push(`${charsDropped} leading char(s) omitted mid-line`);
+
+  return `  ${name} (${notes.join('; ')}):\n${text}`;
+}
+
+/**
+ * Format a dev server's captured streams for a failure message.
+ *
+ * stdout and stderr are bounded SEPARATELY and both are always shown. Joining
+ * them and taking one tail would let a noisy stderr evict stdout completely,
+ * which is exactly the case where knowing what the server was serving matters.
+ */
+function formatServerOutput(stdout: string, stderr: string): string {
+  if (stdout.trim().length === 0 && stderr.trim().length === 0) return ': (no output)';
+  return `:\n${formatStreamTail('stdout', stdout)}\n${formatStreamTail('stderr', stderr)}`;
 }
 
 async function assertSvelteKitDevChatHydrationRoute(
@@ -1288,6 +1301,8 @@ async function assertSvelteKitDevChatHydrationRoute(
 
   try {
     const routeUrl = `http://127.0.0.1:${httpPort}/chat-layout`;
+    // Elapsed, not allocated — see the dev-SSR readiness failure below.
+    const chatLayoutStartedAt = Date.now();
     await waitForReadyHtml({
       url: routeUrl,
       timeoutMs: SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS,
@@ -1298,13 +1313,13 @@ async function assertSvelteKitDevChatHydrationRoute(
       const message = error instanceof Error ? error.message : String(error);
       // Same reasoning as the dev-SSR readiness failure below: surface the
       // server's own output, since "we stopped waiting" says nothing about why.
+      const waitedMs = Date.now() - chatLayoutStartedAt;
       devServer.kill();
       await devServer.exited;
-      const output = `${await devServerStdout}\n${await devServerStderr}`.trim();
       fail(
         `sveltekit-consumer ${label} /chat-layout dev readiness failed: ${message}\n` +
-          `(port ${httpPort})\n` +
-          `dev server output${formatServerOutputTail(output)}`,
+          `(waited ${waitedMs}ms; port ${httpPort})\n` +
+          `dev server output${formatServerOutput(await devServerStdout, await devServerStderr)}`,
       );
     });
 
@@ -1371,6 +1386,11 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
         );
       }
       const routeUrl = `http://127.0.0.1:${httpPort}${routePath}`;
+      // Elapsed, not allocated. `remainingReadinessBudget` is what this route
+      // was ALLOWED; if the server dies on startup the wait rejects almost
+      // immediately, and reporting the allocation would log a 25-second route
+      // wait after a single poll.
+      const routeStartedAt = Date.now();
       const body = await waitForReadyHtml({
         url: routeUrl,
         timeoutMs: remainingReadinessBudget,
@@ -1389,17 +1409,18 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
         // Measure at failure time. `remainingReadinessBudget` was computed
         // BEFORE the wait, so reporting it here would describe the budget this
         // attempt started with, not what was left when it gave up.
+        const waitedMs = Date.now() - routeStartedAt;
         const spentMs = Date.now() - (readinessDeadline - SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS);
         const leftMs = Math.max(0, readinessDeadline - Date.now());
         devServer.kill();
         await devServer.exited;
-        const output = `${await devServerStdout}\n${await devServerStderr}`.trim();
         fail(
           `sveltekit-consumer ${label} ${routePath} dev SSR readiness failed: ${message}\n` +
-            `(waited ${remainingReadinessBudget}ms on this route; ${spentMs}ms spent and ` +
-            `${leftMs}ms left of the shared ${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms budget; ` +
+            `(waited ${waitedMs}ms on this route of ${remainingReadinessBudget}ms allowed; ` +
+            `${spentMs}ms spent and ${leftMs}ms left of the shared ` +
+            `${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms budget; ` +
             `poll ${SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS}ms; port ${httpPort})\n` +
-            `dev server output${formatServerOutputTail(output)}`,
+            `dev server output${formatServerOutput(await devServerStdout, await devServerStderr)}`,
         );
       });
 

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1258,9 +1258,18 @@ async function assertSvelteKitDevChatHydrationRoute(
       pollIntervalMs: SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS,
       runningServer: devServer,
       isReady: (html) => html.includes('Empty Chat hydration') && html.includes('No messages yet'),
-    }).catch((error) => {
+    }).catch(async (error) => {
       const message = error instanceof Error ? error.message : String(error);
-      fail(`sveltekit-consumer ${label} /chat-layout dev readiness failed: ${message}`);
+      // Same reasoning as the dev-SSR readiness failure below: surface the
+      // server's own output, since "we stopped waiting" says nothing about why.
+      devServer.kill();
+      await devServer.exited;
+      const output = `${await devServerStdout}\n${await devServerStderr}`.trim();
+      fail(
+        `sveltekit-consumer ${label} /chat-layout dev readiness failed: ${message}\n` +
+          `dev server output (port ${httpPort}):\n` +
+          (output.length > 0 ? output : '(no output)'),
+      );
     });
 
     // This server deliberately uses Vite's default dependency optimizer. The
@@ -1332,9 +1341,25 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
         pollIntervalMs: SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS,
         runningServer: devServer,
         isReady: (html) => markers.every((marker) => html.includes(marker)),
-      }).catch((error) => {
+      }).catch(async (error) => {
         const message = error instanceof Error ? error.message : String(error);
-        fail(`sveltekit-consumer ${label} ${routePath} dev SSR readiness failed: ${message}`);
+        // Report what the server was DOING, not just that we gave up on it.
+        // `timeout waiting for ready HTML (last error: The operation timed
+        // out.)` on its own cannot distinguish a slow render from a wedged
+        // optimizer from something else answering on this port — which is
+        // exactly why the 2026-08-12 release failure (#1270) could not be
+        // diagnosed from its logs. The output promises only resolve once the
+        // streams close, so the server has to be killed before it can be read.
+        devServer.kill();
+        await devServer.exited;
+        const output = `${await devServerStdout}\n${await devServerStderr}`.trim();
+        fail(
+          `sveltekit-consumer ${label} ${routePath} dev SSR readiness failed: ${message}\n` +
+            `dev server output (${remainingReadinessBudget}ms remaining of a shared ` +
+            `${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms budget, poll ` +
+            `${SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS}ms, port ${httpPort}):\n` +
+            (output.length > 0 ? output : '(no output)'),
+        );
       });
 
       const missingMarkers = markers.filter((marker) => !body.includes(marker));
@@ -1345,6 +1370,38 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
       }
     }
 
+    // WHAT THE 2026-08-12 RELEASE FAILURE (#1270) WAS NOT.
+    //
+    // Splitting these routes attacks render cost, which is the right instinct.
+    // But the failure that motivated it was not render cost, and the following
+    // were each eliminated by measurement rather than argument, so nobody
+    // repeats the experiments:
+    //
+    //   - Transform waterfall / slow render. Cold `/dev-ssr` (pre-split, whole
+    //     graph, `.vite` and `.svelte-kit/output` deleted): 0.67s on macOS,
+    //     1.086s on Linux in Docker at `--cpus=2` installing the packed tarball
+    //     as CI does. Server ready in ~1.4s, warm render 11ms. Never near 5s.
+    //   - "Just slow" as a category. Aborting PARTIALLY RETAINS Vite's work: a
+    //     retry after a 300ms abort finished in 0.630s against 1.086s cold. So a
+    //     slow render RECOVERS — each attempt resumes warmer and one lands. The
+    //     failing run made no progress across five attempts in 25s.
+    //   - Pipe-buffer backpressure. The output promises below are created at
+    //     spawn and only awaited later, which would deadlock a chatty child once
+    //     the ~64KB pipe filled. Bun drains eagerly: a child writing 512KB with
+    //     the promise un-awaited for 4s ran to completion and exited 0.
+    //   - Server death. `waitForReadyHtml` checks `exitCode` every poll and
+    //     reports it distinctly; the failure reported timeouts instead.
+    //   - Retry pile-up. Six CONCURRENT requests to a cold fixture each returned
+    //     in 0.667s, identical to one — Vite dedupes the module-graph work, so
+    //     there is no contention to compound.
+    //   - Sibling-fixture contention. release.yaml runs each package's
+    //     `validate:consumer` as a separate sequential step in one job.
+    //
+    // What that leaves: a server accepting connections and never answering, and
+    // never recovering — wedged, not slow. Cause still unknown. Do not widen a
+    // timeout on recurrence (AGENTS.md forbids it, correctly); read the server
+    // output the failure handlers now attach.
+    //
     // Deliberately NO client-hydration assertion for these focused dev routes.
     // This phase owns only their transform-on-request SSR HTML; the focused
     // /chat-layout helper above owns dev-mode browser hydration against the

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1213,6 +1213,42 @@ function extractPublishedPackageSourceMapWarnings(logOutput: string): string[] {
   return [...new Set(warningLines)];
 }
 
+/** Lines of dev-server output to keep when a readiness wait fails. */
+const SERVER_OUTPUT_TAIL_LINES = 60;
+/** Hard character ceiling, in case the server emits very long single lines. */
+const SERVER_OUTPUT_TAIL_CHARS = 8_000;
+
+/**
+ * Format a dev server's captured output for a failure message, keeping the END.
+ *
+ * A wedged or erroring Vite server can emit a lot, and dumping all of it bloats
+ * CI logs and buries the useful part — which is almost always the last thing it
+ * said before it stopped answering. Truncation is announced rather than silent,
+ * so a reader knows there was more and can pull the full log from the run.
+ */
+function formatServerOutputTail(output: string): string {
+  if (output.length === 0) return ': (no output)';
+
+  const lines = output.split('\n');
+  let kept = lines.slice(-SERVER_OUTPUT_TAIL_LINES);
+  let droppedLines = lines.length - kept.length;
+  let text = kept.join('\n');
+
+  if (text.length > SERVER_OUTPUT_TAIL_CHARS) {
+    text = text.slice(-SERVER_OUTPUT_TAIL_CHARS);
+    const firstNewline = text.indexOf('\n');
+    if (firstNewline !== -1) text = text.slice(firstNewline + 1);
+    kept = text.split('\n');
+    droppedLines = lines.length - kept.length;
+  }
+
+  const header =
+    droppedLines > 0
+      ? ` (last ${kept.length} of ${lines.length} lines; ${droppedLines} earlier line(s) omitted)`
+      : ` (${lines.length} line(s))`;
+  return `${header}:\n${text}`;
+}
+
 async function assertSvelteKitDevChatHydrationRoute(
   fixtureDirectory: string,
   label: string,
@@ -1267,8 +1303,8 @@ async function assertSvelteKitDevChatHydrationRoute(
       const output = `${await devServerStdout}\n${await devServerStderr}`.trim();
       fail(
         `sveltekit-consumer ${label} /chat-layout dev readiness failed: ${message}\n` +
-          `dev server output (port ${httpPort}):\n` +
-          (output.length > 0 ? output : '(no output)'),
+          `(port ${httpPort})\n` +
+          `dev server output${formatServerOutputTail(output)}`,
       );
     });
 
@@ -1350,15 +1386,20 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
         // exactly why the 2026-08-12 release failure (#1270) could not be
         // diagnosed from its logs. The output promises only resolve once the
         // streams close, so the server has to be killed before it can be read.
+        // Measure at failure time. `remainingReadinessBudget` was computed
+        // BEFORE the wait, so reporting it here would describe the budget this
+        // attempt started with, not what was left when it gave up.
+        const spentMs = Date.now() - (readinessDeadline - SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS);
+        const leftMs = Math.max(0, readinessDeadline - Date.now());
         devServer.kill();
         await devServer.exited;
         const output = `${await devServerStdout}\n${await devServerStderr}`.trim();
         fail(
           `sveltekit-consumer ${label} ${routePath} dev SSR readiness failed: ${message}\n` +
-            `dev server output (${remainingReadinessBudget}ms remaining of a shared ` +
-            `${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms budget, poll ` +
-            `${SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS}ms, port ${httpPort}):\n` +
-            (output.length > 0 ? output : '(no output)'),
+            `(waited ${remainingReadinessBudget}ms on this route; ${spentMs}ms spent and ` +
+            `${leftMs}ms left of the shared ${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms budget; ` +
+            `poll ${SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS}ms; port ${httpPort})\n` +
+            `dev server output${formatServerOutputTail(output)}`,
         );
       });
 
@@ -1375,16 +1416,26 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
     // Splitting these routes attacks render cost, which is the right instinct.
     // But the failure that motivated it was not render cost, and the following
     // were each eliminated by measurement rather than argument, so nobody
-    // repeats the experiments:
+    // repeats the experiments.
     //
-    //   - Transform waterfall / slow render. Cold `/dev-ssr` (pre-split, whole
-    //     graph, `.vite` and `.svelte-kit/output` deleted): 0.67s on macOS,
-    //     1.086s on Linux in Docker at `--cpus=2` installing the packed tarball
-    //     as CI does. Server ready in ~1.4s, warm render 11ms. Never near 5s.
-    //   - "Just slow" as a category. Aborting PARTIALLY RETAINS Vite's work: a
-    //     retry after a 300ms abort finished in 0.630s against 1.086s cold. So a
-    //     slow render RECOVERS — each attempt resumes warmer and one lands. The
-    //     failing run made no progress across five attempts in 25s.
+    // PROVENANCE, because absolute numbers age: all timings below were taken on
+    // 2026-08-12 against the PRE-SPLIT single `/dev-ssr` route at commit
+    // ee74c4ced, on an Apple-silicon laptop and (where noted) Linux in Docker at
+    // `--cpus=2`, with `node_modules/.vite` and `.svelte-kit/output` deleted and
+    // the packed tarball installed as CI does. Treat them as one dated
+    // observation of the ORDER OF MAGNITUDE — roughly a second, not roughly ten
+    // — not as thresholds to assert against. #1271 has since reduced per-route
+    // cost further.
+    //
+    //   - Transform waterfall / slow render. Cold render 0.67s (macOS) and
+    //     1.086s (Linux, 2 vCPU); server ready ~1.4s; warm render 11ms. An
+    //     order of magnitude below the 5s per-attempt cap, not marginally under.
+    //   - "Just slow" as a category. This is the structural one, and it does not
+    //     depend on the absolute numbers: aborting PARTIALLY RETAINS Vite's
+    //     work. A retry after a 300ms abort finished in 0.630s against 1.086s
+    //     cold. So a slow render RECOVERS — each attempt resumes warmer than the
+    //     last and one lands. The failing run made no progress across five
+    //     attempts in 25s, which no amount of mere slowness produces.
     //   - Pipe-buffer backpressure. The output promises below are created at
     //     spawn and only awaited later, which would deadlock a chatty child once
     //     the ~64KB pipe filled. Bun drains eagerly: a child writing 512KB with


### PR DESCRIPTION
Replaces #1272, rebuilt on top of #1271 rather than replayed through conflicts.

#1271 split the cold dev SSR route into three, attacking render cost. That is the right instinct. This adds the diagnostics its failure path still lacks, plus the negative results from investigating #1270 so nobody re-derives them.

**No timeout, retry count, or wait threshold is touched.** Verified by grepping the diff, not from memory.

## The diagnostics

Both readiness failures now kill the server, drain its streams, and print stdout/stderr with the port and remaining budget.

`timeout waiting for ready HTML (last error: The operation timed out.)` cannot distinguish a slow render from a wedged optimizer from something else answering on that port. That is precisely why #1270 could not be diagnosed from its logs, and why I guessed wrong about it three times before measuring.

## What #1270 was NOT

Each eliminated by measurement rather than argument, and recorded in the source:

| Hypothesis | Measurement | Verdict |
|---|---|---|
| Transform waterfall / slow render | cold `/dev-ssr` 0.67s macOS; **1.086s Linux at `--cpus=2`** installing the packed tarball as CI does; warm 11ms | never near 5s |
| **Slowness as a category** | aborting **partially retains** work — a retry after a 300ms abort finished in **0.630s** vs 1.086s cold | slow renders *recover*; the failing run made **no progress across five attempts in 25s** |
| Pipe-buffer backpressure | child writing 512KB with the output promise un-awaited for 4s ran to completion, exit 0 | Bun drains eagerly |
| Server death | `waitForReadyHtml` checks `exitCode` each poll and reports it distinctly | failure reported timeouts |
| Retry pile-up | 6 **concurrent** cold requests: 0.667s each, identical to one | Vite dedupes; nothing to compound |
| Sibling-fixture contention | `release.yaml` runs each `validate:consumer` as a sequential step | no competing server |

The second row is the load-bearing one: it rules out the whole "slow" family, which is what the original comment assumed and what I assumed twice. A slow render resumes warmer on each attempt and lands. Making *no* progress for 25 seconds is a wedged server.

## Still unresolved

Why it wedged. I would rather ship an open question with instrumentation than a fourth tidy story — I have already had three disproven by my own measurements.

## Why #1272 is closed

It carried a per-attempt threshold change I later reverted after #1273 landed, then needed its comments corrected twice for describing behavior it no longer had. Rebuilding on current `main` was cleaner than dragging that history through a conflicted rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhsXZt1sQAX5bNu3Pv4DuN