### PR TITLE
fix(editor): keep the toRuntimeThreads example out of the packed import closure

### DIFF
--- a/packages/editor/src/lib/comments/types.ts
+++ b/packages/editor/src/lib/comments/types.ts
@@ -469,10 +469,10 @@ export function toPersistedThreads(threads: Thread[]): PersistedThread[] {
  * `ReviewEditor` and `toRuntimeThreads` are both exported from the
  * `review-editor` subpath. The import lines are left out of the example below
  * on purpose: validate-consumer greps the packed `dist/**` text for import
- * specifiers and cannot tell a documentation comment from real code, so naming
- * this package's own subpath in a doc block fails the packed-import closure
- * check at release time. The README carries the full copy-paste version with
- * its imports.
+ * specifiers and cannot tell a documentation comment from real code, so an
+ * import-shaped reference to this package's own subpath in a doc block fails
+ * the packed-import closure check at release time. The README carries the full
+ * copy-paste version with its imports.
  *
  * Reading storage inside `onMount` also matters — the component script runs on
  * the server under SSR, where `localStorage` does not exist.

--- a/packages/editor/src/lib/comments/types.ts
+++ b/packages/editor/src/lib/comments/types.ts
@@ -466,14 +466,30 @@ export function toPersistedThreads(threads: Thread[]): PersistedThread[] {
  * @param threads - Persisted threads, typically `ReviewState.threads`
  * @returns Runtime threads suitable for the `threads` prop
  *
+ * `ReviewEditor` and `toRuntimeThreads` are both exported from the
+ * `review-editor` subpath. The import lines are left out of the example below
+ * on purpose: validate-consumer greps the packed `dist/**` text for import
+ * specifiers and cannot tell a documentation comment from real code, so naming
+ * this package's own subpath in a doc block fails the packed-import closure
+ * check at release time. The README carries the full copy-paste version with
+ * its imports.
+ *
+ * Reading storage inside `onMount` also matters — the component script runs on
+ * the server under SSR, where `localStorage` does not exist.
+ *
  * @example
  * ```svelte
  * <script lang="ts">
- *   import { ReviewEditor, toRuntimeThreads } from '@lostgradient/editor/review-editor';
+ *   let value = $state('');
+ *   let threads = $state<Thread[]>([]);
  *
- *   const saved = JSON.parse(localStorage.getItem('review-state') ?? 'null');
- *   let value = $state(saved.content);
- *   let threads = $state(toRuntimeThreads(saved.threads));
+ *   onMount(() => {
+ *     const stored = localStorage.getItem('review-state');
+ *     if (stored === null) return;
+ *     const saved: ReviewState = JSON.parse(stored);
+ *     value = saved.content;
+ *     threads = toRuntimeThreads(saved.threads);
+ *   });
  * </script>
  *
  * <ReviewEditor id="review" bind:value bind:threads />

--- a/packages/editor/src/lib/comments/types.ts
+++ b/packages/editor/src/lib/comments/types.ts
@@ -480,6 +480,7 @@ export function toPersistedThreads(threads: Thread[]): PersistedThread[] {
  * @example
  * ```svelte
  * <script lang="ts">
+ *   // The README's complete example imports onMount from Svelte.
  *   let value = $state('');
  *   let threads = $state<Thread[]>([]);
  *


### PR DESCRIPTION
The `release` run on `5f1e9b573` failed on `Validate Editor package artifact`, so **cinder 0.24.2 and editor 0.8.0 were versioned but never published**. npm is still on 0.24.1 / 0.7.0.

```
packed production imports are not declared peers:
  dist/comments/types.js: @lostgradient/editor/review-editor
```

## Cause

`assertImportClosure` (`packages/editor/scripts/validate-consumer.ts:220`) greps every packed `dist/**/*.{js,svelte,css}` with

```ts
/(?:\bfrom\s*|\bimport\s*\()\s*['"]([^'"]+)['"]/gu
```

That reads file *text*, not syntax, so it cannot tell a documentation comment from real code. The `@example` block added to `toRuntimeThreads` in #1274 contained

```ts
import { ReviewEditor, toRuntimeThreads } from '@lostgradient/editor/review-editor';
```

and JSDoc survives into the emitted `dist/comments/types.js`. A package cannot declare itself as its own peer, so the check can never pass with that line present.

## Fix

The example omits its import lines and names the subpath in prose instead. It also reads storage inside `onMount`, matching the README — the component script runs on the server under SSR, where `localStorage` does not exist.

## Why nothing caught it earlier

`validate:consumer` for the editor package runs **only** on the release path. PR CI, `main-green`, both package test suites, typecheck, and lint all passed with the bad comment in place. The four required PR checks cannot see this class of failure.

Worth noting the trap for anyone editing that file: my first attempt at this fix explained the problem in a comment that itself contained the literal `from '<specifier>'` pattern, which the same regex matches — trading one violation for another. Any prose near this code has to avoid that shape.

## Verification

`bun run --filter='@lostgradient/editor' validate:consumer` — the exact script the release job runs:

```
[validate-consumer] OK — isolated artifact, import closure, client build, plugin SSR,
plain-Node SSR, and svelte-check bind: forwarding verified
```

Editor suite 603 pass / 0 fail, typecheck 0 errors.

No changeset: this changes a doc comment only, and the pending 0.24.2 / 0.8.0 versions are already committed to `main`. Merging this should let the publish path run to completion for those versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1279