### PR TITLE
fix(editor): use live Milkdown selection updates

### DIFF
--- a/.changeset/bright-selections-1288.md
+++ b/.changeset/bright-selections-1288.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/editor': patch
+---
+
+Use Milkdown's live selection payload for selection-change notifications so review anchors and toolbar state do not lag one transaction behind.

--- a/packages/editor/src/lib/editor/editor.selection.test.ts
+++ b/packages/editor/src/lib/editor/editor.selection.test.ts
@@ -1,0 +1,70 @@
+/// <reference lib="dom" />
+import { TextSelection } from '@milkdown/prose/state';
+import { afterEach, describe, expect, test } from 'bun:test';
+import { setupHappyDom } from '../test/happy-dom.ts';
+import { createEditor } from './editor.ts';
+import type { EditorState } from './types.ts';
+
+setupHappyDom();
+
+let editorState: EditorState | undefined;
+
+afterEach(async () => {
+  if (editorState) {
+    editorState.markDestroyed();
+    await editorState.editor.destroy();
+    editorState = undefined;
+  }
+});
+
+describe('createEditor selection notifications', () => {
+  test('emits Milkdown selection during a selection-only transaction', async () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const selections: Array<{ from: number; to: number; isCollapsed: boolean }> = [];
+
+    editorState = await createEditor(container, {
+      initialContent: 'selection regression',
+      onselectionchange: (selection) => {
+        if (selection) selections.push(selection);
+      },
+    });
+
+    const transaction = editorState.view.state.tr.setSelection(
+      TextSelection.create(editorState.view.state.doc, 1, 10),
+    );
+    editorState.view.dispatch(transaction);
+
+    expect(selections.at(-1)).toEqual({ from: 1, to: 10, isCollapsed: false });
+    container.remove();
+  });
+
+  test('document updates resynchronize selection after the listener debounce', async () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const selections: Array<{ from: number; to: number; isCollapsed: boolean }> = [];
+
+    editorState = await createEditor(container, {
+      initialContent: 'document regression',
+      onselectionchange: (selection) => {
+        if (selection) selections.push(selection);
+      },
+    });
+
+    editorState.view.dispatch(
+      editorState.view.state.tr.setSelection(
+        TextSelection.create(editorState.view.state.doc, 2, 8),
+      ),
+    );
+    const transaction = editorState.view.state.tr.insertText('x', 1);
+    editorState.view.dispatch(transaction);
+
+    // The selectionUpdated callback must report the mapped selection while
+    // the document-change listener is still inside its debounce window.
+    expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
+    container.remove();
+  });
+});

--- a/packages/editor/src/lib/editor/editor.selection.test.ts
+++ b/packages/editor/src/lib/editor/editor.selection.test.ts
@@ -39,7 +39,7 @@ describe('createEditor selection notifications', () => {
     container.remove();
   });
 
-  test('document updates resynchronize selection after the listener debounce', async () => {
+  test('emits the mapped selection during the document-update debounce window', async () => {
     const container = document.createElement('div');
     document.body.append(container);
     const selections: Array<{ from: number; to: number; isCollapsed: boolean }> = [];

--- a/packages/editor/src/lib/editor/editor.selection.test.ts
+++ b/packages/editor/src/lib/editor/editor.selection.test.ts
@@ -62,9 +62,6 @@ describe('createEditor selection notifications', () => {
     // The selectionUpdated callback must report the mapped selection while
     // the document-change listener is still inside its debounce window.
     expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
-    await new Promise((resolve) => setTimeout(resolve, 350));
-
-    expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
     container.remove();
   });
 });

--- a/packages/editor/src/lib/editor/editor.selection.test.ts
+++ b/packages/editor/src/lib/editor/editor.selection.test.ts
@@ -1,6 +1,8 @@
 /// <reference lib="dom" />
 import { TextSelection } from '@milkdown/prose/state';
 import { afterEach, describe, expect, test } from 'bun:test';
+import type { FakeClock } from '../test/fake-clock.js';
+import { installFakeClock } from '../test/fake-clock.js';
 import { setupHappyDom } from '../test/happy-dom.js';
 import { createEditor } from './editor.js';
 import type { EditorState } from './types.js';
@@ -8,8 +10,12 @@ import type { EditorState } from './types.js';
 setupHappyDom();
 
 let editorState: EditorState | undefined;
+let clock: FakeClock | undefined;
 
 afterEach(async () => {
+  clock?.advance(200);
+  clock?.restore();
+  clock = undefined;
   if (editorState) {
     editorState.markDestroyed();
     await editorState.editor.destroy();
@@ -29,7 +35,6 @@ describe('createEditor selection notifications', () => {
         if (selection) selections.push(selection);
       },
     });
-
     const transaction = editorState.view.state.tr.setSelection(
       TextSelection.create(editorState.view.state.doc, 1, 10),
     );
@@ -50,6 +55,7 @@ describe('createEditor selection notifications', () => {
         if (selection) selections.push(selection);
       },
     });
+    clock = installFakeClock();
 
     editorState.view.dispatch(
       editorState.view.state.tr.setSelection(
@@ -62,6 +68,7 @@ describe('createEditor selection notifications', () => {
     // The selectionUpdated callback must report the mapped selection while
     // the document-change listener is still inside its debounce window.
     expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
+    clock.advance(200);
     container.remove();
   });
 });

--- a/packages/editor/src/lib/editor/editor.selection.test.ts
+++ b/packages/editor/src/lib/editor/editor.selection.test.ts
@@ -1,9 +1,9 @@
 /// <reference lib="dom" />
 import { TextSelection } from '@milkdown/prose/state';
 import { afterEach, describe, expect, test } from 'bun:test';
-import { setupHappyDom } from '../test/happy-dom.ts';
-import { createEditor } from './editor.ts';
-import type { EditorState } from './types.ts';
+import { setupHappyDom } from '../test/happy-dom.js';
+import { createEditor } from './editor.js';
+import type { EditorState } from './types.js';
 
 setupHappyDom();
 
@@ -62,7 +62,7 @@ describe('createEditor selection notifications', () => {
     // The selectionUpdated callback must report the mapped selection while
     // the document-change listener is still inside its debounce window.
     expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
-    await new Promise((resolve) => setTimeout(resolve, 250));
+    await new Promise((resolve) => setTimeout(resolve, 350));
 
     expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
     container.remove();

--- a/packages/editor/src/lib/editor/editor.ts
+++ b/packages/editor/src/lib/editor/editor.ts
@@ -127,7 +127,10 @@ export async function createEditor(
       // 2. updated - fires on document changes (which also change the selection position)
       // Together, these ensure the toolbar always reflects the current cursor position.
       if (onselectionchange) {
-        const notifySelectionChange = (listenerContext: Ctx) => {
+        const notifySelectionChange = (
+          listenerContext: Ctx,
+          liveSelection?: { from: number; to: number },
+        ) => {
           // Skip if editor is destroyed
           if (isDestroyed) return;
 
@@ -143,7 +146,7 @@ export async function createEditor(
           // Guard against view not being ready or state not yet attached
           if (!view?.state) return;
 
-          const { from, to } = view.state.selection;
+          const { from, to } = liveSelection ?? view.state.selection;
           const selection: EditorSelection = {
             from,
             to,
@@ -154,10 +157,12 @@ export async function createEditor(
         };
 
         // Listen for selection-only changes (clicking without editing)
-        listenerManager.selectionUpdated(notifySelectionChange);
+        listenerManager.selectionUpdated((listenerContext, selection) =>
+          notifySelectionChange(listenerContext, selection),
+        );
 
         // Listen for document changes (which also affect selection position)
-        listenerManager.updated(notifySelectionChange);
+        listenerManager.updated((listenerContext) => notifySelectionChange(listenerContext));
       }
     })
     .use(commonmark)


### PR DESCRIPTION
## Summary
- use Milkdown's live selection in selectionUpdated callbacks
- preserve post-transaction document resync behavior
- add regressions for selection-only staleness and the document debounce window

Closes #1288