### PR TITLE
fix(editor,chat): three accessibility defects found by a three-engine matrix

### DIFF
--- a/.changeset/artifact-panel-returns-focus.md
+++ b/.changeset/artifact-panel-returns-focus.md
@@ -1,0 +1,11 @@
+---
+'@lostgradient/chat': patch
+---
+
+Return focus when the artifact panel closes, instead of dropping it on `<body>`.
+
+`ArtifactPanel` focuses its Close button on mount so a keyboard user lands inside the panel — deliberate and good — but nothing restored focus on unmount. Closing therefore left `document.activeElement` as `<body>`: the next Tab restarts at the top of the document, and a screen reader announces nothing. Reproduced identically in Chromium, Firefox, and WebKit, so this was never an engine quirk.
+
+The attachment now captures the previously focused element before taking focus and restores it on teardown, guarded on `isConnected` — restoring to a detached node is a silent no-op that would leave the bug in place with no signal. Stated plainly because it is a real limit: a consumer whose close also removes the control that opened the panel still has to manage focus itself, since by teardown the panel has no surviving element of its own to offer either.
+
+Fixes #1299.

--- a/.changeset/snapshot-mode-reaches-editor-content.md
+++ b/.changeset/snapshot-mode-reaches-editor-content.md
@@ -1,0 +1,11 @@
+---
+'@lostgradient/editor': patch
+---
+
+Make `snapshotMode` actually suppress the selection in the editor content, which it never did in any engine.
+
+The rule was authored as `[data-snapshot-mode] *`, and inside a Svelte `<style>` a bare `*` compiles to `:where(.svelte-…)` — so the descendant half could only match elements the component itself rendered. `.milkdown` and `.ProseMirror` are created at runtime by Milkdown with no scope class, so it never applied to them. Chromium looked correct only because Blink inherits `user-select`, which css-ui-4 defines as non-inherited and Gecko implements as such; Firefox reporting `auto` there is the spec-correct value, and is what surfaced this.
+
+`:global(*)` alone is not the whole fix. A real drag inside a snapshot-mode editor selected and repainted in **both** Chromium and Firefox even where `user-select` computed to `none`, because ProseMirror's contenteditable stays selectable regardless. A transparent `::selection` is what makes the surface pixel-stable, which is what the prop documents.
+
+Fixes #1298.

--- a/.changeset/webkit-composer-submit-is-clickable.md
+++ b/.changeset/webkit-composer-submit-is-clickable.md
@@ -1,0 +1,13 @@
+---
+'@lostgradient/editor': patch
+---
+
+Make the comment composer's inline submit button clickable in WebKit, where it did nothing at all.
+
+The button is revealed by `:focus-within` on its container, which also flips it from `pointer-events: none` to `auto`. WebKit does not focus a `<button>` on mousedown — so mid-gesture the textarea blurred, `:focus-within` dropped, `pointer-events` returned to `none` before mouseup, and the mouseup hit-tested to the textarea instead. Per spec the `click` then retargeted to the nearest common ancestor, the wrapper `<div>`, so the button never saw a click and the form never submitted. In Safari the composer's primary affordance was dead and the only working path was the undiscoverable Cmd+Enter.
+
+Worth stating because it decides where the fix belongs: the engine behavior is benign on its own. A minimal page with no component code submits an ungated textarea+button form identically in all three engines; only the `:focus-within` gate breaks it, and only in WebKit. The stylesheet is what turned a spec-legal engine behavior into a broken control.
+
+Fixed by suppressing mousedown's default focus change on the submit, so the textarea keeps focus for the whole gesture and `:focus-within` never drops. Not fixed by keeping `pointer-events: auto` while `opacity: 0`, which would leave an invisible click target over the textarea. `CommentComposer` is shared, so this covers the inline composer, the thread popover, and the selection popover.
+
+Fixes #1295.

--- a/packages/chat/src/lib/components/chat/artifact/artifact-panel.focus-restore.test.ts
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-panel.focus-restore.test.ts
@@ -1,0 +1,69 @@
+/// <reference lib="dom" />
+import { afterEach, describe, expect, test } from 'bun:test';
+import { createRawSnippet, tick } from 'svelte';
+
+import { setupHappyDom } from '../../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: ArtifactPanel } = await import('./artifact-panel.svelte');
+
+/**
+ * The panel focuses its Close button on mount so a keyboard user lands inside it.
+ * It gave nothing back on unmount, so closing dropped focus on `<body>` — next
+ * Tab restarts at the top of the document, and a screen reader is silent.
+ * Reproduced identically in Chromium, Firefox, and WebKit before the fix, so it
+ * was never an engine quirk.
+ */
+/** The panel requires a `children` snippet; its content is irrelevant here. */
+const body = createRawSnippet(() => ({ render: () => '<p>artifact body</p>' }));
+
+const appended: HTMLElement[] = [];
+
+afterEach(() => {
+  for (const element of appended.splice(0)) element.remove();
+});
+
+function mountOpener(): HTMLButtonElement {
+  const opener = document.createElement('button');
+  document.body.appendChild(opener);
+  appended.push(opener);
+  opener.focus();
+  return opener;
+}
+
+describe('ArtifactPanel focus', () => {
+  test('returns focus to whatever opened it', async () => {
+    const opener = mountOpener();
+
+    const { unmount } = render(ArtifactPanel, { props: { title: 'Hero', children: body } });
+    await tick();
+
+    // The taking half, restated because it is the reason the giving half is
+    // owed rather than merely nice: the panel deliberately moves focus.
+    expect(document.activeElement?.getAttribute('aria-label')).toBe('Close artifact panel');
+
+    unmount();
+    await tick();
+
+    expect(document.activeElement).toBe(opener);
+    expect(document.activeElement).not.toBe(document.body);
+  });
+
+  test('does not throw when the opener was removed while the panel was open', async () => {
+    // Restoring to a detached node is a silent no-op — `.focus()` succeeds and
+    // focus stays put — so the guard exists to keep that from being an error
+    // rather than to rescue focus. The panel has no surviving element of its
+    // own to offer by teardown; a consumer whose close also removes the opener
+    // has to manage focus itself, and this pins that the panel degrades quietly
+    // rather than throwing on the way out.
+    const opener = mountOpener();
+
+    const { unmount } = render(ArtifactPanel, { props: { title: 'Hero', children: body } });
+    await tick();
+
+    opener.remove();
+    expect(() => unmount()).not.toThrow();
+  });
+});

--- a/packages/chat/src/lib/components/chat/artifact/artifact-panel.svelte
+++ b/packages/chat/src/lib/components/chat/artifact/artifact-panel.svelte
@@ -21,8 +21,36 @@
 
   const titleId = $derived(`${instanceId}-panel-title`);
 
+  /**
+   * Take focus on open, and give it back on close.
+   *
+   * The taking half is deliberate: a keyboard user who opens the panel should
+   * land inside it rather than being left behind in the transcript. The giving
+   * half was missing, and the asymmetry is the whole bug — a component that
+   * moves focus owes a restore, or closing drops the user on `<body>`, where the
+   * next Tab restarts at the top of the document and a screen reader says
+   * nothing. Reproduced identically in Chromium, Firefox, and WebKit, so this
+   * was never an engine quirk.
+   *
+   * `isConnected` is checked because restoring to a detached node is a silent
+   * no-op: `.focus()` succeeds, focus stays on `<body>`, and the bug is back
+   * with no signal. Stated rather than papered over — if a consumer's close ALSO
+   * removes the control that opened the panel, this restores nothing, because by
+   * teardown the panel has no surviving element of its own to offer either. That
+   * consumer has to manage focus itself, the same way `createFocusTrap`'s
+   * `restoreFallback` exists for exactly that case. The common path, where the
+   * message row outlives the panel, is what this fixes.
+   *
+   * This is `role="complementary"`, not a dialog: nothing here traps focus, and
+   * nothing should. The contract is only "return it where you found it".
+   */
   function focusOnMount(element: HTMLButtonElement) {
+    const previous = document.activeElement;
     element.focus();
+
+    return () => {
+      if (previous instanceof HTMLElement && previous.isConnected) previous.focus();
+    };
   }
 </script>
 

--- a/packages/editor/src/lib/components/markdown-editor/markdown-editor.svelte
+++ b/packages/editor/src/lib/components/markdown-editor/markdown-editor.svelte
@@ -961,10 +961,32 @@
    * so visual regression screenshots are pixel-stable across runs.
    * Scoped to [data-snapshot-mode] so normal editing is completely unaffected.
    */
+  /*
+   * `:global(*)` and a transparent `::selection`, and both halves are load-bearing.
+   *
+   * Svelte scopes a bare `*` to `:where(.svelte-…)`, so the descendant half only
+   * ever reached elements this component rendered — never `.milkdown` /
+   * `.ProseMirror`, which Milkdown creates at runtime with no scope class. That
+   * was true in every engine; Chromium merely LOOKED correct because Blink
+   * inherits `user-select`, which css-ui-4 defines as non-inherited and Gecko
+   * implements as such. Firefox reporting `auto` there is the spec-correct value
+   * and is what surfaced this.
+   *
+   * `user-select` alone would still not deliver the promise: a real drag inside a
+   * snapshot-mode editor selected and repainted in BOTH Chromium and Firefox even
+   * where the property computed to `none`, because ProseMirror's contenteditable
+   * stays selectable regardless. Painting the selection transparent is what
+   * actually makes the surface pixel-stable, which is what the prop documents.
+   */
   .markdown-editor-wrapper[data-snapshot-mode],
-  .markdown-editor-wrapper[data-snapshot-mode] * {
+  .markdown-editor-wrapper[data-snapshot-mode] :global(*) {
     caret-color: transparent;
     user-select: none;
+  }
+
+  .markdown-editor-wrapper[data-snapshot-mode] :global(::selection) {
+    background: transparent;
+    color: inherit;
   }
 
   /* Template completion popup (DEP-583) */

--- a/packages/editor/src/lib/components/review-editor/comment-composer.svelte
+++ b/packages/editor/src/lib/components/review-editor/comment-composer.svelte
@@ -180,7 +180,35 @@
     ></textarea>
 
     <div class="comment-composer-inline-submit">
-      <Button type="submit" variant="primary" size="xs" disabled={!canSubmit} {loading}>
+      <!--
+        `onmousedown` preventDefault keeps this button clickable in WebKit, and
+        it is load-bearing rather than defensive.
+
+        The button is revealed by `:focus-within` on the container below, which
+        also flips it from `pointer-events: none` to `auto`. WebKit does not
+        focus a `<button>` on mousedown — so mid-gesture the textarea blurs,
+        `:focus-within` drops, `pointer-events` goes back to `none` BEFORE
+        mouseup, and the mouseup hit-tests to the textarea instead. Per spec the
+        `click` then retargets to the nearest common ancestor, the wrapper
+        `<div>`, so the button never sees a click and the form never submits.
+        The only working path left was the undiscoverable Cmd+Enter.
+
+        Suppressing mousedown's default focus change means the textarea keeps
+        focus through the whole gesture, so `:focus-within` never drops. Chromium
+        and Firefox were unaffected either way — they focus the button on
+        mousedown, which keeps `:focus-within` true via the container.
+
+        Not fixed by keeping `pointer-events: auto` while `opacity: 0`: that
+        leaves an invisible click target sitting over the textarea.
+      -->
+      <Button
+        type="submit"
+        variant="primary"
+        size="xs"
+        disabled={!canSubmit}
+        {loading}
+        onmousedown={(event: MouseEvent) => event.preventDefault()}
+      >
         {loading ? 'Sending...' : 'Comment'}
       </Button>
     </div>

--- a/packages/editor/src/lib/components/review-editor/comment-composer.webkit-submit.test.ts
+++ b/packages/editor/src/lib/components/review-editor/comment-composer.webkit-submit.test.ts
@@ -1,0 +1,59 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+import { setupHappyDom } from '../../test/happy-dom.ts';
+
+setupHappyDom();
+
+const { render } = await import('@testing-library/svelte');
+const { default: CommentComposer } = await import('./comment-composer.svelte');
+
+/**
+ * The inline submit is revealed by `:focus-within` on its container, which also
+ * flips it from `pointer-events: none` to `auto`. WebKit does not focus a
+ * `<button>` on mousedown, so mid-gesture the textarea blurred, `:focus-within`
+ * dropped, `pointer-events` went back to `none` before mouseup, and the mouseup
+ * hit-tested to the textarea — the `click` then retargeted to the wrapper `<div>`
+ * and the form never submitted. Clicking "Comment" did nothing in Safari; only
+ * the undiscoverable Cmd+Enter worked.
+ *
+ * WHAT THIS FILE CAN AND CANNOT PROVE. happy-dom does not model hit-testing,
+ * `:focus-within`, computed `pointer-events`, or WebKit's focus policy, so it
+ * cannot reproduce the failure and no test here should pretend to. What it CAN
+ * check is the mechanism the fix rests on: that mousedown's default action is
+ * suppressed, which is the single thing that keeps focus in the textarea for the
+ * duration of the gesture. Remove the handler and this goes red.
+ *
+ * The end-to-end behavior is pinned where it is observable — in a consumer's
+ * real-browser suite running WebKit.
+ */
+describe('CommentComposer inline submit', () => {
+  test('suppresses the default focus change on mousedown, so :focus-within survives the click', () => {
+    const { container } = render(CommentComposer, {
+      props: { value: 'A reply', onsubmit: () => {} },
+    });
+
+    const submit = container.querySelector<HTMLButtonElement>('button[type="submit"]');
+    expect(submit).not.toBeNull();
+
+    const event = new MouseEvent('mousedown', { bubbles: true, cancelable: true });
+    submit!.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  test('does not suppress the click itself, which is what actually submits', () => {
+    // Guards the direction of the fix: preventing mousedown must not turn into
+    // preventing the activation. If this ever went the other way the button
+    // would be inert in EVERY engine rather than just WebKit.
+    const { container } = render(CommentComposer, {
+      props: { value: 'A reply', onsubmit: () => {} },
+    });
+
+    const submit = container.querySelector<HTMLButtonElement>('button[type="submit"]');
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    submit!.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
+  });
+});

--- a/packages/editor/src/lib/components/review-editor/comment-composer.webkit-submit.test.ts
+++ b/packages/editor/src/lib/components/review-editor/comment-composer.webkit-submit.test.ts
@@ -30,7 +30,7 @@ const { default: CommentComposer } = await import('./comment-composer.svelte');
 describe('CommentComposer inline submit', () => {
   test('suppresses the default focus change on mousedown, so :focus-within survives the click', () => {
     const { container } = render(CommentComposer, {
-      props: { value: 'A reply', onsubmit: () => {} },
+      props: { id: 'test-composer', value: 'A reply', onsubmit: () => {} },
     });
 
     const submit = container.querySelector<HTMLButtonElement>('button[type="submit"]');
@@ -47,7 +47,7 @@ describe('CommentComposer inline submit', () => {
     // preventing the activation. If this ever went the other way the button
     // would be inert in EVERY engine rather than just WebKit.
     const { container } = render(CommentComposer, {
-      props: { value: 'A reply', onsubmit: () => {} },
+      props: { id: 'test-composer', value: 'A reply', onsubmit: () => {} },
     });
 
     const submit = container.querySelector<HTMLButtonElement>('button[type="submit"]');

--- a/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
+++ b/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
@@ -1911,9 +1911,31 @@
    * so visual regression screenshots are pixel-stable across runs.
    * Scoped to [data-snapshot-mode] so normal editing is completely unaffected.
    */
+  /*
+   * `:global(*)` and a transparent `::selection`, and both halves are load-bearing.
+   *
+   * Svelte scopes a bare `*` to `:where(.svelte-…)`, so the descendant half only
+   * ever reached elements this component rendered — never `.milkdown` /
+   * `.ProseMirror`, which Milkdown creates at runtime with no scope class. That
+   * was true in every engine; Chromium merely LOOKED correct because Blink
+   * inherits `user-select`, which css-ui-4 defines as non-inherited and Gecko
+   * implements as such. Firefox reporting `auto` there is the spec-correct value
+   * and is what surfaced this.
+   *
+   * `user-select` alone would still not deliver the promise: a real drag inside a
+   * snapshot-mode editor selected and repainted in BOTH Chromium and Firefox even
+   * where the property computed to `none`, because ProseMirror's contenteditable
+   * stays selectable regardless. Painting the selection transparent is what
+   * actually makes the surface pixel-stable, which is what the prop documents.
+   */
   .review-editor-container[data-snapshot-mode],
-  .review-editor-container[data-snapshot-mode] * {
+  .review-editor-container[data-snapshot-mode] :global(*) {
     caret-color: transparent;
     user-select: none;
+  }
+
+  .review-editor-container[data-snapshot-mode] :global(::selection) {
+    background: transparent;
+    color: inherit;
   }
 </style>

--- a/packages/editor/src/lib/components/snapshot-mode-scoping.test.ts
+++ b/packages/editor/src/lib/components/snapshot-mode-scoping.test.ts
@@ -1,0 +1,51 @@
+/// <reference lib="dom" />
+import { describe, expect, test } from 'bun:test';
+
+/**
+ * `snapshotMode` promises no selection highlights and a pixel-stable surface.
+ * Its rule was authored as `[data-snapshot-mode] *`, and inside a Svelte
+ * `<style>` a bare `*` compiles to `:where(.svelte-…)` — so the descendant half
+ * could only ever match elements the component itself rendered. `.milkdown` and
+ * `.ProseMirror` are created at runtime by Milkdown with no scope class, so the
+ * rule never reached the editor content in ANY engine.
+ *
+ * Chromium looked correct only because Blink inherits `user-select`, which
+ * css-ui-4 defines as non-inherited; Gecko implements it as such, which is why
+ * Firefox is the engine that surfaced this.
+ *
+ * WHY THIS IS A SOURCE ASSERTION. The defect is in how Svelte scopes the
+ * selector, so it lives in the authored CSS — by the time happy-dom is involved
+ * there is no cascade to observe, and it models neither `::selection` nor
+ * scoped-style compilation. Asserting the authored form pins the exact thing
+ * that was wrong. The behavioral half — that a drag no longer paints a
+ * selection — is pinned in a consumer's real-browser suite across three engines,
+ * which is where it is observable and where the bug was found.
+ */
+const FILES = [
+  ['markdown-editor', 'markdown-editor/markdown-editor.svelte', '.markdown-editor-wrapper'],
+  ['review-editor', 'review-editor/review-editor-impl.svelte', '.review-editor-container'],
+] as const;
+
+describe('snapshotMode CSS reaches the editor content', () => {
+  for (const [label, path, container] of FILES) {
+    test(`${label}: the descendant rule escapes Svelte's scoping`, async () => {
+      const source = await Bun.file(new URL(`./${path}`, import.meta.url)).text();
+
+      expect(source).toContain(`${container}[data-snapshot-mode] :global(*)`);
+      // The bare form is what Svelte scopes into uselessness. Asserting its
+      // absence is what makes a revert fail here rather than silently.
+      expect(source).not.toContain(`${container}[data-snapshot-mode] * {`);
+    });
+
+    test(`${label}: the selection itself is painted transparent`, async () => {
+      // `user-select: none` alone does not deliver the promise: a real drag
+      // selected and repainted in Chromium AND Firefox even where the property
+      // computed to `none`, because ProseMirror's contenteditable stays
+      // selectable regardless. Suppressing the paint is what makes it stable.
+      const source = await Bun.file(new URL(`./${path}`, import.meta.url)).text();
+
+      expect(source).toContain(`${container}[data-snapshot-mode] :global(::selection)`);
+      expect(source).toMatch(/::selection\)\s*\{\s*background:\s*transparent/);
+    });
+  }
+});

--- a/packages/editor/src/lib/test/happy-dom.ts
+++ b/packages/editor/src/lib/test/happy-dom.ts
@@ -4,10 +4,84 @@ type Global = typeof globalThis & Record<string, unknown>;
 
 let installed = false;
 
+/*
+ * Mirrors `packages/components/src/test/happy-dom.ts`. Duplicated rather than
+ * imported because a test helper reaching across package boundaries is exactly
+ * what `check:consumer-boundaries` exists to prevent; if a third package needs
+ * it, extract it to `@lostgradient/testing` rather than adding a second copy.
+ *
+ * Ported here because the editor package hit the same divergence the moment a
+ * test unmounted a rendered component: 0 tests failed and the run still failed,
+ * because the throw escapes as an "unhandled error between tests" that Bun
+ * counts separately from assertions. Easy to miss if you read only the
+ * pass/fail lines.
+ */
+/**
+ * Align happy-dom's `Element.prototype.remove()` with the DOM spec, which
+ * makes `ChildNode.remove()` a no-op when the node has already been removed
+ * from its parent. happy-dom currently routes the call through
+ * `parentNode.removeChild(this)` using a stale `parentNode` pointer, which
+ * throws when the parent's child-array no longer contains the node — Svelte
+ * 5's `flushSync` effect-teardown trips this during fixture unmount and the
+ * throw escapes through a Promise executor, surfacing as an "unhandled
+ * error between tests" in Bun. The patch ONLY narrows the spec divergence
+ * for `Element.prototype.remove`; it does NOT touch the explicit
+ * `Node.prototype.removeChild` API, so misuse of that API still throws.
+ *
+ * Reference: WHATWG DOM § ChildNode.remove() — "remove this from its parent
+ * (if any)".
+ */
+function alignElementRemoveWithChildNodeSpec(happyWindow: Window): void {
+  const elementCtor = Reflect.get(happyWindow, 'Element') as unknown;
+  if (typeof elementCtor !== 'function') return;
+  const proto = Reflect.get(elementCtor, 'prototype') as Record<string, unknown> | undefined;
+  if (!proto) return;
+  const original = proto['remove'];
+  if (typeof original !== 'function') return;
+  type ElementRemove = (this: Element) => void;
+  const originalFn = original as ElementRemove;
+  proto['remove'] = function patchedRemove(this: Element): void {
+    const parent = this.parentNode;
+    if (parent === null) return;
+    // Spec: "remove this from its parent (if any)". If the parent has
+    // already forgotten this node, treat the call as a no-op rather than
+    // throwing — that's the spec-aligned outcome for `ChildNode.remove()`.
+    if (typeof parent.contains === 'function' && !parent.contains(this)) {
+      return;
+    }
+    try {
+      originalFn.call(this);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not a child of this node')) {
+        // happy-dom bug: removeChild fails even when the element is in
+        // parent.childNodes and parent.contains(this) is true. This happens
+        // when a sibling insertion (e.g. anchor.before(newNode)) corrupts the
+        // internal parent-child tracking, causing removeChild to lose the
+        // reference even though childNodes still lists it.
+        //
+        // Workaround: move the element into a detached DocumentFragment, which
+        // goes through appendChild's code path rather than removeChild's broken
+        // one, effectively detaching it from the live DOM without needing
+        // removeChild to succeed.
+        try {
+          document.createDocumentFragment().appendChild(this);
+        } catch {
+          // If appendChild also fails (unlikely), there is nothing more to do.
+          // The element may remain in the DOM; this is a pre-existing happy-dom
+          // limitation.
+        }
+        return;
+      }
+      throw error;
+    }
+  };
+}
+
 export function setupHappyDom(): void {
   if (installed) return;
 
   const happyWindow = new Window();
+  alignElementRemoveWithChildNodeSpec(happyWindow);
   const target = globalThis as Global;
 
   for (const key of Object.getOwnPropertyNames(happyWindow)) {


### PR DESCRIPTION
Closes #1295.

In WebKit, clicking the comment composer's **Comment** button did nothing. No `submit`, no `commentcreate`/`threadcreate`, no announcement, composer still populated. Only the undiscoverable Cmd+Enter worked. Chromium and Firefox were unaffected.

Found from the consumer side in `stevekinney/chatroom`, by adding WebKit and Firefox to its Playwright matrix.

## Mechanism

The inline submit is revealed by `:focus-within` on its container, which also flips it from `pointer-events: none` to `auto`. WebKit does not focus a `<button>` on mousedown, so mid-gesture the textarea blurs, `:focus-within` drops, and `pointer-events` returns to `none` **between mousedown and mouseup**. The mouseup then hit-tests to the textarea, and per spec `click` retargets to the nearest common inclusive ancestor — the wrapper `<div>`. The button never receives `click`; the form never submits.

Capture-phase trace of one click, WebKit vs the others:

```
webkit    mousedown BUTTON  -> focusout TEXTAREA (active=BODY, pe=none) -> mouseup TEXTAREA -> click DIV      (no submit)
chromium  mousedown BUTTON  -> focusin  BUTTON                          -> mouseup BUTTON   -> click BUTTON -> submit FORM
firefox   ditto
```

## Why this is ours and not "just Safari"

A minimal page with **no Svelte and no component code**, comparing a plain textarea+submit form against the same `:focus-within` gate:

```
[chromium] plain: click,submit    gated: click,submit
[firefox]  plain: click,submit    gated: click,submit
[webkit]   plain: click,submit    gated: mousedown only, then click retargets to DIV - no submit
```

WebKit submits the **ungated** form exactly like the other two. Click-doesn't-focus is benign on its own; our stylesheet is what converts it into a dead primary affordance.

Four more controls, all in WebKit, all pointing at the same line:

- "Delete thread" - a popover button *not* gated on `:focus-within` - clicks and fires normally.
- Injecting `pointer-events: auto !important` on the submit -> `commentcreate` fires.
- Adding `mousedown` preventDefault -> `commentcreate` fires.
- Cmd+Enter and programmatic `button.click()` both work, so the submit logic itself was never broken.

## The fix

`preventDefault()` on the submit's `mousedown`, so the textarea keeps focus through the gesture and `:focus-within` never drops.

Deliberately **not** "keep `pointer-events: auto` while `opacity: 0`" - that leaves an invisible click target sitting over the textarea.

`CommentComposer` is shared, so this covers the inline composer, the thread popover, and the selection popover.

## What the test does and does not claim

happy-dom models neither hit-testing, nor `:focus-within`, nor computed `pointer-events`, nor WebKit's focus policy - so it cannot reproduce this failure, and the new test says so in its own header rather than implying coverage it does not have. What it pins is the mechanism the fix rests on: mousedown's default is suppressed, and click's is not. Removing the handler turns the first red; the second is a direction guard, so a fix that overshot into cancelling activation (inert in *every* engine) would be caught.

The end-to-end half is pinned where it is observable - the consumer's WebKit suite, which is what found this.

## Verification

`editor` 681 pass / 0 fail, typecheck 0 errors, `components:check` clean. `lint` is clean once `@lostgradient/markdown` is built - the editor package's `lint` script, unlike the components package's, does not build it first, which is a pre-existing sharp edge unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)