### PR TITLE
fix(editor): namespace DiffToolbar ids and scope DiffViewer's keyboard shortcuts per instance

### DIFF
--- a/.changeset/diff-viewer-multi-instance-id-and-keyboard-scoping.md
+++ b/.changeset/diff-viewer-multi-instance-id-and-keyboard-scoping.md
@@ -1,0 +1,13 @@
+---
+'@lostgradient/editor': minor
+---
+
+Fix two multi-instance defects in `DiffViewer`, found building a standalone `/exercises/diff-viewer` route with more than one instance on a page.
+
+`DiffToolbar` hardcoded `id="diff-view-mode"` on every instance instead of deriving one per instance. `SegmentedControl` derives its label element's id as `${id}-label` from whatever id it's given, so with more than one `DiffViewer` rendering its default toolbar, every instance produced the identical `id="diff-view-mode"` / `id="diff-view-mode-label"` pair. `getElementById` resolves only the first match in the document, so `aria-labelledby` on every instance after the first pointed at the FIRST instance's label — a screen-reader user opening the second or third viewer's view-mode radiogroup was announced the first viewer's label, not its own. Fixed by deriving the id from `$props.id()` (with an optional `id` prop for a consumer to override), matching the rest of the package's id-generation convention — the same convention `diff-viewer.svelte` already used for its front-matter block, just never extended to the toolbar. Fixes #1309.
+
+`DiffViewer` also bound its `]` / `[` / `Ctrl+Shift+D` shortcuts with a bare `<svelte:window onkeydown>`, guarded only against typing into a form field. With more than one `DiffViewer` on a page, every instance's listener fired on the same keystroke regardless of which one — if any — had focus: pressing `]` with focus on the page body, or on a button inside one viewer's own toolbar, advanced every viewer on the page at once. Fixed by moving the listener onto the component's own root element instead of `window`: a `keydown` only reaches an element listener when the event's target is that element or one of its descendants, and DOM focus is exclusive to a single element in the whole document, so at most one `DiffViewer` instance can ever react to a given keystroke. This is a genuine behavior change, not just a bug fix — with a single `DiffViewer` on a page, the shortcuts previously worked with focus anywhere on the page, including the body; they now require focus somewhere inside that instance first (e.g. a toolbar button). Fixes #1310.
+
+Minor, not patch: the id `DiffToolbar` renders is no longer the literal `"diff-view-mode"` (a selector-contract change for any consumer querying it directly, as chatroom's own exercise suite did), and the keyboard-shortcut scoping change is consumer-visible behavior even on a page with a single `DiffViewer`.
+
+Also documents, in this package's README, that `DiffViewer`'s `toolbar` snippet prop is intentionally total replacement (unlike `@lostgradient/chat`'s `renderDefault`-based row/part overrides) — a judgement call recorded rather than a defect, with no code change attached.

--- a/packages/chat/README.md
+++ b/packages/chat/README.md
@@ -112,3 +112,17 @@ Pass a `mermaidRenderer` snippet to delegate only the Mermaid branch to an appli
 ```
 
 The Mermaid snippet has type `Snippet<[content: string, type: 'mermaid']>`. `ArtifactViewer` invokes it only when `type` is `mermaid`; HTML, SVG, and code continue through their built-in renderers unless a code snippet is supplied. The application-owned component is responsible for loading Mermaid, handling asynchronous rendering and errors, and applying its required content-safety policy.
+
+## Overriding built-in rendering
+
+`Chat`'s per-row and per-part overrides (`row`, `messagePart`) are inversion-of-control snippets: each receives the thing being rendered plus a `renderDefault` snippet that renders Chat's own built-in output for it. Supplying an override wraps the built-in rendering rather than replacing it outright — a consumer adds markup around `renderDefault()`'s output, or conditionally calls it, but the built-in behavior stays reachable:
+
+```svelte
+{#snippet messagePart(part, renderDefault)}
+  <div class="my-wrapper">
+    {@render renderDefault(part)}
+  </div>
+{/snippet}
+```
+
+This is a deliberate difference from `@lostgradient/editor`'s `DiffViewer`, whose `toolbar` override is total replacement with no `renderDefault` — see the "DiffViewer toolbar override" section of [`@lostgradient/editor`'s README](https://github.com/stevekinney/cinder/blob/main/packages/editor/README.md) for why. Message-part and row rendering carry built-in behavior (streaming state, tool-call presentation, artifact resolution) that most wrappers want to keep and only augment, which is what `renderDefault` is for.

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -49,6 +49,29 @@ by Svelte — there is no separate `/styles` subpath for those two.
 Each component subpath also exposes `/schema`, `/variables`, and `/examples`. Only
 `review-editor` additionally exposes `/styles` (see above).
 
+### DiffViewer toolbar override
+
+`DiffViewer`'s `toolbar` snippet prop is **total replacement**, not inversion of control: supplying
+it removes the entire built-in toolbar — the view-mode control, stat badges, copy and revert
+actions, and change navigation — with whatever the snippet renders instead. Unlike
+`@lostgradient/chat`'s `messagePart`/`row` overrides (see the "Overriding built-in rendering"
+section of [`@lostgradient/chat`'s README](https://github.com/stevekinney/cinder/blob/main/packages/chat/README.md)),
+`toolbar` receives a read-only `DiffToolbarContext` (`hasChanges`, `hunks`, `stats`, `viewMode`) and
+no `renderDefault` snippet — there is no way back to the built-in toolbar from inside an override.
+
+This is intentional, not an oversight: a caller embedding a standalone diff view outside a chat or
+review context may want a fully custom toolbar with no built-in chrome at all, which total
+replacement gives directly. Chat's built-in row and part rendering carries state (streaming,
+tool-call presentation, artifact resolution) that most overrides want to keep and only augment —
+`DiffViewer`'s toolbar does not carry equivalent state, so replacing it outright is a reasonable
+default rather than a gap.
+
+One sharp edge worth knowing: `toolbarActions` — documented as the way to add a button to the
+toolbar _without_ replacing it — is only rendered from inside the _built-in_ toolbar. Supplying
+both `toolbar` and `toolbarActions` silently drops `toolbarActions`, since the override branch
+never renders it. If you need both custom chrome and the extra action, put the action's markup
+directly inside your `toolbar` snippet instead of relying on `toolbarActions`.
+
 ## Why a separate package
 
 `@lostgradient/cinder` used to carry milkdown, prosemirror, and this package's headless runtime as

--- a/packages/editor/src/lib/components/diff-viewer/diff-toolbar.svelte
+++ b/packages/editor/src/lib/components/diff-viewer/diff-toolbar.svelte
@@ -7,6 +7,15 @@
   import type { DiffViewerMode } from './diff-viewer.types.ts';
 
   export type DiffToolbarProps = Omit<HTMLAttributes<HTMLDivElement>, 'class'> & {
+    /**
+     * Base id for this toolbar's internal ids (currently the view-mode
+     * segmented control and its label). Optional: when omitted, a stable id
+     * is generated via `$props.id()`, matching Checkbox/Input and the rest of
+     * the package's id-generation convention. Provide it when a consumer
+     * mounts more than one `DiffToolbar`-bearing `DiffViewer` on the same
+     * page and needs a known, stable id to reference — cinder#1309.
+     */
+    id?: string;
     /** Current view mode (bindable) */
     viewMode?: DiffViewerMode;
     /** Diff statistics */
@@ -55,6 +64,7 @@
   } from '@lostgradient/cinder/icons';
 
   let {
+    id,
     viewMode = $bindable<DiffViewerMode>('unified'),
     stats,
     changeCount,
@@ -76,12 +86,22 @@
   const tier = $derived<DiffTier>(diffState?.tier ?? 'realtime');
   const isStale = $derived(diffState?.isStale ?? false);
   const isComputing = $derived(diffState?.isComputing ?? false);
+
+  // Per-instance id for the view-mode control, matching the rest of the
+  // package's convention (Checkbox, Tabs, Dropdown, …): an explicit `id` prop
+  // wins, otherwise fall back to Svelte's SSR-stable `$props.id()`. Previously
+  // this was the literal "diff-view-mode" on every instance, which collided
+  // across multiple `DiffViewer`s on one page — `SegmentedControl` derives its
+  // label id as `${id}-label`, so every instance's `aria-labelledby` resolved
+  // to the FIRST instance's label via `getElementById` (cinder#1309).
+  const generatedId = $props.id();
+  const resolvedViewModeId = $derived(id ?? generatedId);
 </script>
 
 <div class={classNames('diff-toolbar', className)} {...rest}>
   <div class="toolbar-left">
     <SegmentedControl
-      id="diff-view-mode"
+      id={resolvedViewModeId}
       selectionMode="single"
       size="sm"
       label="View mode"

--- a/packages/editor/src/lib/components/diff-viewer/diff-viewer.svelte
+++ b/packages/editor/src/lib/components/diff-viewer/diff-viewer.svelte
@@ -376,6 +376,26 @@
 
   const VIEW_MODES: DiffViewerMode[] = ['unified', 'final', 'original'];
 
+  // Instance-owned, not window-owned (cinder#1310). This used to be a bare
+  // `<svelte:window onkeydown>` with only an input/textarea/contenteditable
+  // guard, so with more than one `DiffViewer` on a page every instance's
+  // listener fired on the same keystroke regardless of which one (if any)
+  // had focus. Binding the handler on this instance's own root element
+  // instead relies on ordinary DOM event bubbling: a `keydown` only reaches
+  // an element listener if the event's target — which for a global key
+  // shortcut is always the currently focused element, or `<body>` when
+  // nothing in particular is focused — is that element or one of its
+  // descendants. Because focus is exclusive to a single element in the
+  // whole document, at most one `DiffViewer` instance can ever have the
+  // focused element inside its own subtree at a time, so at most one
+  // instance's handler can ever fire for a given keystroke. This is a
+  // deliberate behavior change, not just a bug fix: a keystroke with focus
+  // on `<body>` (or anywhere outside this instance's own DOM) no longer
+  // triggers navigation, even with a single `DiffViewer` on the page —
+  // previously it did, because the listener was global. A user who wants
+  // to use `]` / `[` / `Ctrl+Shift+D` now needs focus somewhere inside the
+  // viewer first (e.g. a toolbar button), which is what makes the shortcuts
+  // belong to the instance that has them rather than to the page.
   function handleKeydown(event: KeyboardEvent) {
     const target = event.target as HTMLElement;
     if (target.matches('input, textarea, [contenteditable]')) return;
@@ -394,18 +414,18 @@
   }
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
 <!-- Expose data-ready for E2E test synchronization (DEP-138) -->
 <Surface
   class={classNames('diff-viewer', className)}
   data-ready={!diffState.isComputing && !diffState.isStale ? true : undefined}
+  onkeydown={handleKeydown}
 >
   <!-- Toolbar: Full override or default -->
   {#if toolbar}
     {@render toolbar(toolbarContext)}
   {:else}
     <DiffToolbar
+      id={`${instanceId}-view-mode`}
       bind:viewMode
       stats={diffStats}
       {changeCount}

--- a/packages/editor/src/lib/components/diff-viewer/diff-viewer.test.ts
+++ b/packages/editor/src/lib/components/diff-viewer/diff-viewer.test.ts
@@ -452,3 +452,123 @@ describe('DiffViewer: front-matter section', () => {
     expect(source).toMatch(/id=\{`\$\{instanceId\}-front-matter`\}/);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cinder#1309 — DiffToolbar's hardcoded view-mode id collided across instances
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Find a descendant element with the given id, without relying on `#id` CSS-selector escaping. */
+function findById(container: HTMLElement, id: string): Element | null {
+  return Array.from(container.querySelectorAll('[id]')).find((el) => el.id === id) ?? null;
+}
+
+describe('DiffViewer: toolbar id uniqueness (cinder#1309)', () => {
+  test('two DiffToolbar instances mounted without an explicit id get distinct view-mode ids', () => {
+    // Reverting the diff-toolbar.svelte fix (restoring the literal
+    // id="diff-view-mode") makes both instances produce the SAME id here,
+    // which fails the inequality assertions below.
+    const { container: containerA } = render(DiffToolbar, {
+      stats: { added: 1, removed: 0, modified: 0 },
+      changeCount: 1,
+      currentChangeIndex: 0,
+      hasChanges: true,
+    });
+    const { container: containerB } = render(DiffToolbar, {
+      stats: { added: 0, removed: 1, modified: 0 },
+      changeCount: 1,
+      currentChangeIndex: 0,
+      hasChanges: true,
+    });
+
+    const radiogroupA = containerA.querySelector('[role="radiogroup"]');
+    const radiogroupB = containerB.querySelector('[role="radiogroup"]');
+    expect(radiogroupA).not.toBeNull();
+    expect(radiogroupB).not.toBeNull();
+    expect(radiogroupA?.id).toBeTruthy();
+    expect(radiogroupB?.id).toBeTruthy();
+
+    // The actual bug: both were the literal "diff-view-mode" regardless of
+    // how many instances were on the page.
+    expect(radiogroupA?.id).not.toBe(radiogroupB?.id);
+
+    const labelledByA = radiogroupA?.getAttribute('aria-labelledby');
+    const labelledByB = radiogroupB?.getAttribute('aria-labelledby');
+    expect(labelledByA).toBeTruthy();
+    expect(labelledByB).toBeTruthy();
+    expect(labelledByA).not.toBe(labelledByB);
+
+    // Each aria-labelledby resolves to a label INSIDE THAT INSTANCE's own
+    // container...
+    expect(findById(containerA, labelledByA as string)).not.toBeNull();
+    expect(findById(containerB, labelledByB as string)).not.toBeNull();
+
+    // ...and, the actual consequence of the collision: A's label id must not
+    // resolve inside B's container (a real getElementById lookup from B's
+    // radiogroup would otherwise silently find A's label, which is exactly
+    // what happened before the fix).
+    expect(findById(containerB, labelledByA as string)).toBeNull();
+    expect(findById(containerA, labelledByB as string)).toBeNull();
+  });
+
+  test('an explicit id prop is honoured and its paired label id follows it', () => {
+    const { container } = render(DiffToolbar, {
+      id: 'my-toolbar-view-mode',
+      stats: { added: 0, removed: 0, modified: 0 },
+      changeCount: 0,
+      currentChangeIndex: -1,
+      hasChanges: false,
+    });
+
+    const radiogroup = container.querySelector('[role="radiogroup"]');
+    expect(radiogroup?.id).toBe('my-toolbar-view-mode');
+    expect(radiogroup?.getAttribute('aria-labelledby')).toBe('my-toolbar-view-mode-label');
+    expect(findById(container, 'my-toolbar-view-mode-label')).not.toBeNull();
+  });
+
+  test('diff-viewer.svelte passes a $props.id()-derived id to DiffToolbar, not the colliding literal', async () => {
+    // The behavioural tests above prove DiffToolbar namespaces its view-mode
+    // id from whatever `id` it receives — but the actual bug lived in
+    // diff-viewer.svelte, which never passed an id at all (so DiffToolbar's
+    // own internal `$props.id()` fallback was never reached from a stable,
+    // predictable per-instance value at the call site — instead the literal
+    // default markup hardcoded "diff-view-mode" directly). The composed shell
+    // cannot be mounted under happy-dom (see the file header), so the
+    // shell-level wiring is guarded at the source level. Reverting the
+    // diff-viewer.svelte change (removing the `id={...}` prop passed to
+    // <DiffToolbar>) fails this test.
+    const source = await Bun.file(new URL('./diff-viewer.svelte', import.meta.url)).text();
+
+    expect(source).not.toMatch(/id=["']diff-view-mode["']/);
+    expect(source).toMatch(/<DiffToolbar[\s\S]*?id=\{`\$\{instanceId\}-view-mode`\}/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cinder#1310 — DiffViewer's window-level key bindings fired on every instance
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DiffViewer: keyboard shortcut ownership (cinder#1310)', () => {
+  test("handleKeydown is bound on the component's own root, not on <svelte:window>", async () => {
+    // The composed shell cannot be mounted under happy-dom (see the file
+    // header), so — like the two shell-wiring tests above — this guards the
+    // fix at the source level. Before the fix, `<svelte:window
+    // onkeydown={handleKeydown} />` meant every DiffViewer instance on a page
+    // reacted to every keystroke, regardless of focus. The fix removes the
+    // window-level listener and instead binds `onkeydown` on this instance's
+    // own <Surface> root: because keydown only reaches an element listener
+    // when the event's target is that element or one of its descendants, and
+    // focus is exclusive to a single element in the whole document, at most
+    // one DiffViewer instance can ever have the focused element inside its
+    // own subtree — so at most one instance's handler can ever fire for a
+    // given keystroke. Reverting the fix (restoring
+    // `<svelte:window onkeydown={handleKeydown} />` and removing `onkeydown`
+    // from the <Surface> tag) fails this test.
+    const source = await Bun.file(new URL('./diff-viewer.svelte', import.meta.url)).text();
+
+    // Tight enough to match only the actual markup (not this file's own
+    // prose, which mentions the old `<svelte:window onkeydown>` tag without
+    // the `={handleKeydown}` binding it had when it was live markup).
+    expect(source).not.toMatch(/<svelte:window\s+onkeydown=\{handleKeydown\}/);
+    expect(source).toMatch(/<Surface\b[\s\S]*?onkeydown=\{handleKeydown\}/);
+  });
+});


### PR DESCRIPTION
## Summary

Two multi-instance defects in `DiffViewer`, found and reproduced live (real Chromium, production preview build) while building chatroom's standalone `/exercises/diff-viewer` route with more than one instance on a page.

- `DiffToolbar` hardcoded `id="diff-view-mode"` on every instance. `SegmentedControl` derives its label id as `${id}-label` from whatever id it receives, so every `DiffViewer` instance after the first had its view-mode radiogroup's `aria-labelledby` resolve (via `getElementById`) to the FIRST instance's label. Fixed by deriving the id from `$props.id()`, with an optional `id` prop override, matching the package's existing id-generation convention — the same one `diff-viewer.svelte` already used for its front-matter block. Fixes #1309.
- `DiffViewer` bound `]` / `[` / `Ctrl+Shift+D` with a bare `<svelte:window onkeydown>`, guarded only against typing in a form field. With more than one instance on a page, every instance's listener fired on the same keystroke regardless of focus. Fixed by moving the listener onto the component's own root element instead of `window`: a `keydown` only reaches an element listener when its target is that element or a descendant, and DOM focus is exclusive to one element document-wide, so at most one instance can ever react to a given keystroke. **This is a deliberate behavior change**, called out in the changeset: with a single `DiffViewer` on a page, the shortcuts previously fired with focus anywhere on the page (including `<body>`); they now require focus somewhere inside that instance first. Fixes #1310.

Also rides in this PR (no separate issue — documentation only, per `chatroom`'s `CLAUDE.md` DV-2 judgement): both packages' READMEs now record that `DiffViewer`'s `toolbar` snippet is intentionally **total replacement**, unlike `@lostgradient/chat`'s `renderDefault`-based row/part overrides, plus the sharp edge that supplying both `toolbar` and `toolbarActions` silently drops the latter.

## Why minor, not patch

The id `DiffToolbar` renders is no longer the literal `"diff-view-mode"` — a selector-contract change for anyone querying it directly. The keyboard-scoping change is consumer-visible behavior even for a single-instance page. Both are called out in the changeset.

## Test plan

- [x] New tests in `packages/editor/src/lib/components/diff-viewer/diff-viewer.test.ts`: two behavioral `DiffToolbar` mounts proving per-instance id uniqueness + explicit-id override, plus source-level assertions for the `diff-viewer.svelte` shell wiring for both fixes (the composed shell can't mount under happy-dom — same documented limitation the existing front-matter-id test works around).
- [x] Reverted both component fixes via `git stash` (keeping the new tests), ran the suite, confirmed exactly the 4 new tests fail and no others regress, then restored and confirmed all 26 pass again.
- [x] Full `packages/editor` suite: 689 pass / 0 fail. Full `packages/chat` suite: 779 pass / 0 fail.
- [x] `packages/editor` and `packages/chat`: typecheck, lint, `components:check` all clean.
- [x] `npx changeset status`: only `@lostgradient/editor` bumps, at `minor`.

## Not included

`packages/chat/README.md`'s edit has no changeset — it's documentation-only and doesn't need `@lostgradient/chat` to republish immediately; it rides chat's next real release.

Fixes stevekinney/cinder#1309, Fixes stevekinney/cinder#1310