### PR TITLE
docs(chat): add missing changeset for the DV-2 README section

### DIFF
--- a/.changeset/chat-readme-diffviewer-toolbar-boundary.md
+++ b/.changeset/chat-readme-diffviewer-toolbar-boundary.md
@@ -1,0 +1,7 @@
+---
+'@lostgradient/chat': patch
+---
+
+Document, in this package's README, that `Chat`'s `row`/`messagePart` overrides are inversion-of-control (each receives a `renderDefault` snippet and wraps the built-in rendering) — the counterpart half of the judgement call recorded in [#1311](https://github.com/stevekinney/cinder/pull/1311), which added the matching note to `@lostgradient/editor`'s README about `DiffViewer`'s `toolbar` prop being total replacement with no `renderDefault`, deliberately unlike `Chat`'s.
+
+#1311 shipped the README section itself in this package but only added a changeset for `@lostgradient/editor`, so the "Overriding built-in rendering" section landed on `main` without ever going out in a `@lostgradient/chat` release. This changeset is the missing release trigger for content that's already merged — no code or README change here, patch because it's docs-only.


### PR DESCRIPTION
## Summary

PR #1311 added an "Overriding built-in rendering" section to `packages/chat/README.md` — the Chat-side half of the DV-2 duplication-boundary judgement (Chat's `row`/`messagePart` overrides wrap built-in rendering via `renderDefault`, unlike `DiffViewer`'s total-replacement `toolbar`). That PR's changeset targeted only `@lostgradient/editor`, so the chat README content merged to `main` without ever triggering a `@lostgradient/chat` release. `@lostgradient/chat@0.9.3` published *before* #1311 even merged, and its README on npm has no mention of this section.

This PR adds the missing changeset. No code or README change — the content is already on `main`.

## Test plan

- [x] `bunx changeset status` reports exactly one pending release: `@lostgradient/chat` patch (0.9.3 → 0.9.4)
- [x] `.changeset/config.json` has no `fixed`/`linked` arrays coupling chat to other packages, so this changeset won't bump anything else
- [x] `bunx prettier --check` passes on the new changeset file
- [x] Confirmed `packages/chat/README.md` on `origin/main` (commit `7dcc81cbc`+) contains the "Overriding built-in rendering" section
- [x] Confirmed via `npm view @lostgradient/chat readme` that the published 0.9.3 README does not contain it