### PR TITLE
fix(editor): normalize front matter in toolbar diffStats and generateMarkdownSummary

### DIFF
--- a/.changeset/markdown-summary-normalization.md
+++ b/.changeset/markdown-summary-normalization.md
@@ -20,7 +20,10 @@ edit had touched.
 `generateUnifiedDiff`'s own default, and normalizes through the same shared `normalizeDocument`
 (now factored out of `unified-diff.ts` into `export/normalize-document.ts` so `diffStats`, this
 function, and `generateUnifiedDiff` share one implementation — see the cinder#1307 changeset in
-this same batch). Pass `normalizeInputs: false` to restore the previous raw-string comparison.
+this same batch). Pass `normalizeInputs: false` for a byte-for-byte raw comparison, including
+CRLF line endings — stricter than `generateUnifiedDiff`'s own `normalizeInputs: false`, which
+still folds CRLF to LF even with normalization off (a pre-existing quirk of that function, not a
+contract this new option inherits).
 
 This changes `generateMarkdownSummary`'s default output for formatting-only and
 blank-line-only edits: they no longer appear in the "Changes Made" section or count toward

--- a/.changeset/markdown-summary-normalization.md
+++ b/.changeset/markdown-summary-normalization.md
@@ -1,0 +1,28 @@
+---
+'@lostgradient/editor': patch
+---
+
+Fix `generateMarkdownSummary` disagreeing with `generateUnifiedDiff` about whether an edit
+happened (cinder#1318).
+
+`generateMarkdownSummary` ran `computeLineDiff` directly on the raw `original`/`current`
+strings, with no normalization at all — no CRLF handling, no front-matter awareness, no
+blank-line collapsing. `generateUnifiedDiff` normalizes both inputs by default
+(`normalizeInputs: true`) through `normalizeDocument`, which strips leading blank lines from the
+body before re-serializing and reattaches front matter through a single canonical separator. So
+two documents whose front matter and body were byte-identical, differing only in how many blank
+lines separated the closing `---` from the body (or only in line-ending style), made
+`generateUnifiedDiff` report zero hunks ("nothing changed") while `generateMarkdownSummary`
+reported a two-line edit — genuinely disagreeing outputs for a `ReviewState` no consumer-visible
+edit had touched.
+
+`generateMarkdownSummary` now takes a `normalizeInputs` option, defaulting to `true` to match
+`generateUnifiedDiff`'s own default, and normalizes through the same shared `normalizeDocument`
+(now factored out of `unified-diff.ts` into `export/normalize-document.ts` so `diffStats`, this
+function, and `generateUnifiedDiff` share one implementation — see the cinder#1307 changeset in
+this same batch). Pass `normalizeInputs: false` to restore the previous raw-string comparison.
+
+This changes `generateMarkdownSummary`'s default output for formatting-only and
+blank-line-only edits: they no longer appear in the "Changes Made" section or count toward
+`changeCount`, matching what `generateUnifiedDiff` and the diff panel already reported for the
+same input. CRLF line endings no longer leak a literal `\r` into the ` ```diff ` code fence.

--- a/.changeset/review-editor-toolbar-diff-stats-front-matter.md
+++ b/.changeset/review-editor-toolbar-diff-stats-front-matter.md
@@ -1,0 +1,21 @@
+---
+'@lostgradient/editor': patch
+---
+
+Fix ReviewEditor's toolbar change counter over-counting front-matter edits (cinder#1307).
+
+The toolbar's `diffStats` normalized the whole document — front matter and body together —
+with `normalize()`, a Markdown pipeline with no front-matter step. Handed `---\ntitle: …\n---`
+it read the fences as a thematic break plus a setext heading and re-emitted the closing
+underline at the new content's width, so shortening `owner: jane` to `owner: bob` changed the
+value line AND (because it no longer recognized the fence) the underline beneath it — one real
+edit counted as two modified lines, while the diff panel and `exportUnifiedDiff()` (already
+fixed for this in cinder#1285) correctly reported one.
+
+`diffStats` is now computed by `computeReviewEditorDiffStats`, a small function pulled out of
+`review-editor-impl.svelte` into its own module so it is testable without mounting the
+component (which needs a real browser DOM for Milkdown). It calls the same front-matter-aware
+`normalizeDocument` `generateUnifiedDiff` already used, split out of `unified-diff.ts` into
+`export/normalize-document.ts` so it has exactly one implementation instead of one per
+consumer — see the cinder#1318 changeset in this same batch for the second consumer that fix
+reaches.

--- a/.changeset/review-editor-toolbar-diff-stats-front-matter.md
+++ b/.changeset/review-editor-toolbar-diff-stats-front-matter.md
@@ -19,3 +19,8 @@ component (which needs a real browser DOM for Milkdown). It calls the same front
 `export/normalize-document.ts` so it has exactly one implementation instead of one per
 consumer — see the cinder#1318 changeset in this same batch for the second consumer that fix
 reaches.
+
+The same fix also reaches `createReviewEditorState` (`@lostgradient/editor/review-editor`'s
+exported state-manager factory): it had its own copy of the same bare-`normalize()` `diffStats`
+computation, a second public API path that disagreed with the fixed toolbar about the same
+content until it was routed through `computeReviewEditorDiffStats` too.

--- a/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.test.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the ReviewEditor toolbar's diff-stats computation (cinder#1307).
+ *
+ * `computeReviewEditorDiffStats` is exercised directly here rather than through
+ * a mounted `ReviewEditor`: the component is too heavy to mount in happy-dom
+ * (Milkdown + ProseMirror internals fail in non-browser DOMs — see
+ * `review-editor.snapshot-mode.test.ts`), but this computation only touches
+ * its two string arguments and needs no DOM at all.
+ *
+ * A source pin below covers the half this file's behavioral test cannot: that
+ * `review-editor-impl.svelte` actually calls this function for `diffStats`
+ * rather than reintroducing a direct `normalize()` call that would make the
+ * bug come back invisibly to this test file.
+ */
+import { describe, expect, test } from 'bun:test';
+import { computeReviewEditorDiffStats } from './review-editor-diff-stats.ts';
+
+describe('computeReviewEditorDiffStats', () => {
+  test('counts a one-line front-matter value edit as one modified line, not two', () => {
+    // cinder#1307's exact repro: normalize() has no front-matter step, so handed
+    // the whole document it re-reads the `---` fences as a thematic break plus a
+    // setext heading and re-emits the closing underline at the new content
+    // width. Shortening `owner: jane` to `owner: bob` changes nothing about the
+    // dash count, but normalize() shortens BOTH the value line and (because it
+    // no longer thinks it is a fence) the underline it invents beneath it — one
+    // real edit surfacing as two modified lines.
+    const original = '---\ntitle: Release Plan\nowner: jane\n---\n\n# Release Plan\n\nShip it.\n';
+    const current = '---\ntitle: Release Plan\nowner: bob\n---\n\n# Release Plan\n\nShip it.\n';
+
+    expect(computeReviewEditorDiffStats(original, current)).toEqual({
+      added: 0,
+      removed: 0,
+      modified: 1,
+    });
+  });
+
+  test('agrees with generateUnifiedDiff on the same front-matter edit', () => {
+    // generateUnifiedDiff already got the cinder#1285 fix. Both counts should
+    // describe the same edit the same way: one line changed (getDiffStats
+    // counts a paired -/+ as one "modified" line; generateUnifiedDiff reports
+    // it as one addition and one deletion).
+    const original = '---\ntitle: Release Plan\nowner: jane\n---\n\nShip it.\n';
+    const current = '---\ntitle: Release Plan\nowner: bob\n---\n\nShip it.\n';
+
+    expect(computeReviewEditorDiffStats(original, current)).toEqual({
+      added: 0,
+      removed: 0,
+      modified: 1,
+    });
+  });
+
+  test('still normalizes the body underneath front matter', () => {
+    // A list-marker-only change is exactly what normalization exists to
+    // swallow; front-matter handling must not cost us that.
+    const original = '---\ntitle: Plan\n---\n\n- one\n- two\n';
+    const starred = '---\ntitle: Plan\n---\n\n* one\n* two\n';
+
+    expect(computeReviewEditorDiffStats(original, starred)).toEqual({
+      added: 0,
+      removed: 0,
+      modified: 0,
+    });
+  });
+
+  test('reports no changes for identical documents with front matter', () => {
+    const document = '---\ntitle: Plan\nowner: jane\n---\n\nBody text.\n';
+
+    expect(computeReviewEditorDiffStats(document, document)).toEqual({
+      added: 0,
+      removed: 0,
+      modified: 0,
+    });
+  });
+
+  test('returns zeroed stats when there is no original (new document)', () => {
+    expect(computeReviewEditorDiffStats('', 'New content')).toEqual({
+      added: 0,
+      removed: 0,
+      modified: 0,
+    });
+  });
+});
+
+describe('review-editor-impl.svelte wiring (cinder#1307)', () => {
+  const implementationSource = Bun.file(
+    new URL('./review-editor-impl.svelte', import.meta.url).pathname,
+  ).text();
+
+  test('diffStats is computed through computeReviewEditorDiffStats, not a direct normalize() call', async () => {
+    const source = await implementationSource;
+
+    // The component cannot be mounted in this package's test harness (Milkdown
+    // needs a real browser DOM), so the behavioral test above cannot see
+    // review-editor-impl.svelte at all. This pin closes that gap: if the
+    // component reverted to computing diffStats with its own `normalize()`
+    // call, the front-matter bug would come back with every test in this file
+    // still green.
+    expect(source).toMatch(
+      /const diffStats = \$derived\.by\(\s*\(\)\s*=>\s*computeReviewEditorDiffStats\(/,
+    );
+    expect(source).toContain(
+      "import { computeReviewEditorDiffStats } from './review-editor-diff-stats.ts';",
+    );
+
+    // Guard against a regression that keeps the import but adds back an
+    // inline normalize()-based computation elsewhere in the diffStats block.
+    const diffStatsBlock = source.slice(
+      source.indexOf('const diffStats = $derived.by'),
+      source.indexOf('const diffStats = $derived.by') + 200,
+    );
+    expect(diffStatsBlock).not.toMatch(/normalize\(/);
+  });
+});

--- a/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.ts
@@ -1,0 +1,43 @@
+/**
+ * Toolbar change-count computation for ReviewEditor.
+ *
+ * Pulled out of `review-editor-impl.svelte` so it is testable directly: the
+ * component itself is too heavy to mount in happy-dom (Milkdown + ProseMirror
+ * internals fail in non-browser DOMs — see
+ * `review-editor.snapshot-mode.test.ts`), but this computation only ever
+ * touches its two string arguments, so it does not need the component at all.
+ */
+import { computeLineDiff, getDiffStats } from '@lostgradient/markdown/diff/line-diff';
+import { normalizeDocument } from '../../export/normalize-document.js';
+
+export interface ReviewEditorDiffStats {
+  added: number;
+  removed: number;
+  modified: number;
+}
+
+/**
+ * Compute the toolbar's added/removed/modified counts for a document pair.
+ *
+ * Must use the same front-matter-aware {@link normalizeDocument} the diff
+ * panel and `generateUnifiedDiff` use, not the bare `normalize()` pipeline —
+ * handed a whole document with front matter, `normalize()` misreads the `---`
+ * fences as a thematic break plus a setext heading and rewrites the closing
+ * fence's underline to match the content's width, so an edit that only
+ * changes a front-matter value's length is counted as two modified lines
+ * (the value AND the now-different-length underline) instead of one
+ * (cinder#1307).
+ */
+export function computeReviewEditorDiffStats(
+  original: string,
+  current: string,
+): ReviewEditorDiffStats {
+  if (!original) {
+    return { added: 0, removed: 0, modified: 0 };
+  }
+
+  const normalizedOriginal = normalizeDocument(original);
+  const normalizedCurrent = normalizeDocument(current);
+  const lineDiffs = computeLineDiff(normalizedOriginal, normalizedCurrent);
+  return getDiffStats(lineDiffs);
+}

--- a/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
+++ b/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
@@ -23,7 +23,8 @@
   import { createChangeTracker } from '../../utilities/change-tracker.svelte.ts';
   import { stringifyOrNull } from '../../utilities/stringify.ts';
   import MarkdownEditor from '../markdown-editor/markdown-editor.svelte';
-  import { contentEquals, normalize } from '@lostgradient/markdown/pipeline';
+  import { contentEquals } from '@lostgradient/markdown/pipeline';
+  import { computeReviewEditorDiffStats } from './review-editor-diff-stats.ts';
   import { textOffsetToProseMirrorPosition } from '../../editor/index.ts';
   import { createAnchorPlugin, anchorPluginKey } from '../../anchor-decorations.ts';
   import {
@@ -66,7 +67,6 @@
   } from './review-editor-selection-geometry.ts';
   import DiffViewer from '../diff-viewer/diff-viewer.svelte';
   import SelectionPopover from '@lostgradient/cinder/selection-popover';
-  import { computeLineDiff, getDiffStats } from '@lostgradient/markdown/diff/line-diff';
   import {
     generateMarkdownSummary,
     generateUnifiedDiff,
@@ -185,18 +185,10 @@
 
   /**
    * Compute diff statistics from original vs current content.
-   * Uses the same line-diff algorithm as DiffViewer for consistency.
+   * Uses the same front-matter-aware normalization as generateUnifiedDiff and
+   * the diff panel (cinder#1307) — see computeReviewEditorDiffStats.
    */
-  const diffStats = $derived.by(() => {
-    if (!original) {
-      return { added: 0, removed: 0, modified: 0 };
-    }
-    // Normalize both inputs to avoid false positives from formatting differences
-    const normalizedOriginal = normalize(original);
-    const normalizedCurrent = normalize(value);
-    const lineDiffs = computeLineDiff(normalizedOriginal, normalizedCurrent);
-    return getDiffStats(lineDiffs);
-  });
+  const diffStats = $derived.by(() => computeReviewEditorDiffStats(original, value));
 
   /** Whether there are any content changes */
   const hasContentChanges = $derived(

--- a/packages/editor/src/lib/components/review-editor/review-editor-state.svelte.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-state.svelte.ts
@@ -13,10 +13,9 @@
  * @module
  */
 
-import { computeLineDiff, getDiffStats } from '@lostgradient/markdown/diff/line-diff';
-import { normalize } from '@lostgradient/markdown/pipeline';
 import type { Thread } from '../../comments/index.ts';
 import { generateMarkdownSummary } from '../../export/index.ts';
+import { computeReviewEditorDiffStats } from './review-editor-diff-stats.ts';
 import type {
   ReviewEditorDiffViewMode as DiffViewMode,
   ReviewEditorViewType as ViewType,
@@ -94,18 +93,13 @@ export function createReviewEditorState(options: ReviewEditorStateOptions): Revi
   let activeView = $state<ViewType>('editor');
   let diffViewMode = $state<DiffViewMode>('unified');
 
-  // Computed diff statistics
-  const diffStats = $derived.by((): DiffStats => {
-    const original = getOriginal();
-    if (!original) {
-      return { added: 0, removed: 0, modified: 0 };
-    }
-    // Normalize both inputs to avoid false positives from formatting differences
-    const normalizedOriginal = normalize(original);
-    const normalizedCurrent = normalize(getValue());
-    const lineDiffs = computeLineDiff(normalizedOriginal, normalizedCurrent);
-    return getDiffStats(lineDiffs);
-  });
+  // Computed diff statistics. Front-matter-aware (cinder#1307): must use the
+  // same computeReviewEditorDiffStats the ReviewEditor toolbar uses, not a
+  // bare normalize() call, or this exported state manager silently disagrees
+  // with the component's own diffStats about the same content.
+  const diffStats = $derived.by(
+    (): DiffStats => computeReviewEditorDiffStats(getOriginal(), getValue()),
+  );
 
   // Whether there are any content changes
   const hasContentChanges = $derived(

--- a/packages/editor/src/lib/components/review-editor/review-editor-state.test.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-state.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Tests for `createReviewEditorState`'s diffStats (cinder#1307).
+ *
+ * `createReviewEditorState` (exported publicly from `@lostgradient/editor/review-editor`)
+ * is a second, independent public API path to the same "how many lines
+ * changed" question the ReviewEditor toolbar answers. It had its own copy of
+ * the same bare-`normalize()` bug #1307 fixed in the toolbar's `diffStats`:
+ * a consumer building their own review UI on top of this state manager saw
+ * the front-matter-edit-counted-as-two-lines bug even after the toolbar was
+ * fixed, because this file never called the fix.
+ *
+ * `$derived.by` runs fine outside a component or `$effect.root` for a single
+ * synchronous read (no reactive tracking is needed here, just evaluation),
+ * matching how `review-editor-anchors-orphan.test.ts` exercises
+ * `createAnchorManager` the same way.
+ */
+import { describe, expect, test } from 'bun:test';
+import { createReviewEditorState } from './review-editor-state.svelte.ts';
+
+describe('createReviewEditorState diffStats', () => {
+  test('counts a one-line front-matter value edit as one modified line, not two', () => {
+    const original = '---\ntitle: Release Plan\nowner: jane\n---\n\nShip it.\n';
+    const current = '---\ntitle: Release Plan\nowner: bob\n---\n\nShip it.\n';
+
+    const state = createReviewEditorState({
+      getOriginal: () => original,
+      getValue: () => current,
+      getThreads: () => [],
+    });
+
+    expect(state.diffStats).toEqual({ added: 0, removed: 0, modified: 1 });
+  });
+
+  test('agrees with the ReviewEditor toolbar for the same content', () => {
+    // Both public paths must describe the same edit the same way. Regressing
+    // either one back to a bare normalize() call would make them disagree
+    // again, silently, for any consumer using both.
+    const original = '---\ntitle: Plan\nowner: jane\n---\n\n# Plan\n\nBody.\n';
+    const current = '---\ntitle: Plan\nowner: bob\n---\n\n# Plan\n\nBody.\n';
+
+    const state = createReviewEditorState({
+      getOriginal: () => original,
+      getValue: () => current,
+      getThreads: () => [],
+    });
+
+    expect(state.diffStats).toEqual({ added: 0, removed: 0, modified: 1 });
+  });
+
+  test('still normalizes the body underneath front matter', () => {
+    const original = '---\ntitle: Plan\n---\n\n- one\n- two\n';
+    const starred = '---\ntitle: Plan\n---\n\n* one\n* two\n';
+
+    const state = createReviewEditorState({
+      getOriginal: () => original,
+      getValue: () => starred,
+      getThreads: () => [],
+    });
+
+    expect(state.diffStats).toEqual({ added: 0, removed: 0, modified: 0 });
+    expect(state.hasContentChanges).toBe(false);
+  });
+
+  test('returns zeroed stats when there is no original', () => {
+    const state = createReviewEditorState({
+      getOriginal: () => '',
+      getValue: () => 'New content',
+      getThreads: () => [],
+    });
+
+    expect(state.diffStats).toEqual({ added: 0, removed: 0, modified: 0 });
+  });
+});

--- a/packages/editor/src/lib/export/index.ts
+++ b/packages/editor/src/lib/export/index.ts
@@ -12,7 +12,19 @@ export { generateCommentsExport, generateCommentsJSON } from './comments-export.
 export { generateMarkdownSummary } from './markdown-summary.js';
 export { generateUnifiedDiff } from './unified-diff.js';
 
+/**
+ * Front-matter-aware document normalization shared by every export that diffs
+ * or counts changes across a whole `ReviewState` document
+ * (`generateUnifiedDiff`, `generateMarkdownSummary`, and the ReviewEditor
+ * toolbar's `diffStats`). Exported so a future consumer computing its own
+ * change count reuses this instead of re-deriving front-matter handling — see
+ * the module doc in `normalize-document.ts` for why that has already gone
+ * wrong twice (cinder#1307, cinder#1318).
+ */
+export { normalizeDocument, splitDocument } from './normalize-document.js';
+
 // Types
+export type { DocumentParts } from './normalize-document.js';
 export type {
   CommentsExportOptions,
   CommentsExportResult,

--- a/packages/editor/src/lib/export/markdown-summary.test.ts
+++ b/packages/editor/src/lib/export/markdown-summary.test.ts
@@ -362,4 +362,92 @@ describe('generateMarkdownSummary', () => {
       expect(result.stats.threadCount).toBe(2);
     });
   });
+
+  describe('normalization (cinder#1318)', () => {
+    // generateMarkdownSummary used to run computeLineDiff directly on the raw
+    // original/current strings, with no CRLF handling and no front-matter
+    // awareness — unlike generateUnifiedDiff, whose normalizeInputs default
+    // runs both through normalizeDocument first. That gap let the two exports
+    // disagree about whether the exact same ReviewState contained a real edit.
+
+    test('front matter, repro 1: blank-line padding after the closing fence is not a change', () => {
+      // Exact repro from cinder#1318. Same front matter, same body text; the
+      // only difference is how many blank lines separate the closing `---`
+      // from the body (one vs. three). generateUnifiedDiff already reports
+      // zero hunks for this pair — generateMarkdownSummary must agree.
+      const frontMatter = ['---', 'title: Release Plan', 'draft: true', '---'].join('\n');
+      const state = createState({
+        original: `${frontMatter}\n\nAlpha line.`,
+        current: `${frontMatter}\n\n\n\nAlpha line.`,
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toBe('No changes or feedback to report.');
+      expect(result.stats.changeCount).toBe(0);
+    });
+
+    test('front matter, repro 1 with feedback: the changes section is omitted, the feedback section is not', () => {
+      const frontMatter = ['---', 'title: Release Plan', 'draft: true', '---'].join('\n');
+      const state = createState({
+        original: `${frontMatter}\n\nAlpha line.`,
+        current: `${frontMatter}\n\n\n\nAlpha line.`,
+        threads: [createThread()],
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).not.toContain('## Changes Made');
+      expect(result.markdown).toContain('## Feedback');
+      expect(result.stats.changeCount).toBe(0);
+    });
+
+    test('repro 2: blank-line padding with no front matter at all is not a change', () => {
+      // Proves the root cause is missing normalization in general, not a gap
+      // specific to front-matter parsing.
+      const state = createState({
+        original: 'Alpha.\n\nBeta.',
+        current: 'Alpha.\n\n\n\nBeta.',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toBe('No changes or feedback to report.');
+      expect(result.stats.changeCount).toBe(0);
+    });
+
+    test('CRLF-only differences are not a change, and no literal \\r reaches the diff fence', () => {
+      const state = createState({
+        original: 'Line 1\r\nLine 2\r\nLine 3',
+        current: 'Line 1\nLine 2\nLine 3',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toBe('No changes or feedback to report.');
+      expect(result.stats.changeCount).toBe(0);
+    });
+
+    test('a genuine edit alongside CRLF differences is still reported, without a stray \\r', () => {
+      const state = createState({
+        original: 'Line 1\r\nLine 2\r\nLine 3',
+        current: 'Line 1\nLine 2 modified\nLine 3',
+      });
+      const result = generateMarkdownSummary(state);
+
+      expect(result.markdown).toContain('## Changes Made');
+      expect(result.markdown).toContain('+Line 2 modified');
+      expect(result.markdown).not.toContain('\r');
+    });
+
+    test('normalizeInputs: false restores the raw, unnormalized comparison', () => {
+      // The same opt-out generateUnifiedDiff offers, for callers that want
+      // formatting-only differences to count as edits.
+      const frontMatter = ['---', 'title: Release Plan', 'draft: true', '---'].join('\n');
+      const state = createState({
+        original: `${frontMatter}\n\nAlpha line.`,
+        current: `${frontMatter}\n\n\n\nAlpha line.`,
+      });
+      const result = generateMarkdownSummary(state, { normalizeInputs: false });
+
+      expect(result.markdown).toContain('## Changes Made');
+      expect(result.stats.changeCount).toBeGreaterThan(0);
+    });
+  });
 });

--- a/packages/editor/src/lib/export/markdown-summary.test.ts
+++ b/packages/editor/src/lib/export/markdown-summary.test.ts
@@ -437,12 +437,28 @@ describe('generateMarkdownSummary', () => {
     });
 
     test('normalizeInputs: false restores the raw, unnormalized comparison', () => {
-      // The same opt-out generateUnifiedDiff offers, for callers that want
-      // formatting-only differences to count as edits.
+      // For callers that want formatting-only differences (blank-line
+      // padding, Markdown canonicalization) to count as edits.
       const frontMatter = ['---', 'title: Release Plan', 'draft: true', '---'].join('\n');
       const state = createState({
         original: `${frontMatter}\n\nAlpha line.`,
         current: `${frontMatter}\n\n\n\nAlpha line.`,
+      });
+      const result = generateMarkdownSummary(state, { normalizeInputs: false });
+
+      expect(result.markdown).toContain('## Changes Made');
+      expect(result.stats.changeCount).toBeGreaterThan(0);
+    });
+
+    test('normalizeInputs: false preserves CRLF differences too — a genuinely raw comparison', () => {
+      // Deliberately does NOT mirror generateUnifiedDiff's own normalizeInputs:
+      // false branch, which still folds CRLF to LF even with normalization
+      // "off". This option's doc comment promises a raw, verbatim comparison;
+      // a CRLF-only difference must count as an edit for that promise to be
+      // true rather than true only for some kinds of formatting difference.
+      const state = createState({
+        original: 'Line 1\r\nLine 2\r\nLine 3',
+        current: 'Line 1\nLine 2\nLine 3',
       });
       const result = generateMarkdownSummary(state, { normalizeInputs: false });
 

--- a/packages/editor/src/lib/export/markdown-summary.ts
+++ b/packages/editor/src/lib/export/markdown-summary.ts
@@ -12,6 +12,7 @@
 
 import { computeLineDiff } from '@lostgradient/markdown/diff/line-diff';
 import type { PersistedThread, ReviewState } from '../comments/types.js';
+import { normalizeDocument } from './normalize-document.js';
 import type { MarkdownSummaryOptions, MarkdownSummaryResult } from './types.js';
 
 /**
@@ -40,6 +41,12 @@ export function generateMarkdownSummary(
     includeTimestamps = false,
     includeAuthorIds = false,
     contextLines = 2,
+    // Mirrors generateUnifiedDiff's own default: without this, a document
+    // whose front matter and body are byte-identical to another can still be
+    // reported as a real edit purely from CRLF or blank-line formatting
+    // differences that normalizeDocument treats as equivalent everywhere else
+    // in this package (cinder#1318).
+    normalizeInputs = true,
   } = options;
 
   const sections: string[] = [];
@@ -47,8 +54,20 @@ export function generateMarkdownSummary(
   let threadCount = 0;
 
   // Document Changes Section
-  const original = state.original ?? '';
-  const current = state.content;
+  const originalContent = state.original ?? '';
+  const currentContent = state.content;
+
+  // Normalize both inputs the same way generateUnifiedDiff does, so the two
+  // exports agree about whether an edit happened. Without this,
+  // computeLineDiff runs on raw strings with no CRLF handling and no
+  // front-matter awareness, and can disagree with generateUnifiedDiff about
+  // documents that are semantically identical.
+  const original = normalizeInputs
+    ? normalizeDocument(originalContent)
+    : originalContent.replace(/\r\n?/g, '\n');
+  const current = normalizeInputs
+    ? normalizeDocument(currentContent)
+    : currentContent.replace(/\r\n?/g, '\n');
 
   if (original !== current) {
     const changesSection = generateChangesSection(original, current, contextLines);

--- a/packages/editor/src/lib/export/markdown-summary.ts
+++ b/packages/editor/src/lib/export/markdown-summary.ts
@@ -62,12 +62,17 @@ export function generateMarkdownSummary(
   // computeLineDiff runs on raw strings with no CRLF handling and no
   // front-matter awareness, and can disagree with generateUnifiedDiff about
   // documents that are semantically identical.
-  const original = normalizeInputs
-    ? normalizeDocument(originalContent)
-    : originalContent.replace(/\r\n?/g, '\n');
-  const current = normalizeInputs
-    ? normalizeDocument(currentContent)
-    : currentContent.replace(/\r\n?/g, '\n');
+  //
+  // Deliberately NOT mirroring generateUnifiedDiff's own normalizeInputs:
+  // false branch here, which still folds CRLF to LF even with normalization
+  // "off" — a pre-existing wrinkle in that function, not a contract this new
+  // option needs to inherit. `normalizeInputs: false` promises a raw,
+  // verbatim comparison (see MarkdownSummaryOptions' doc comment); honoring
+  // that for CRLF as well as Markdown canonicalization is what makes the
+  // option's own contract true rather than only true for some formatting
+  // differences and not others.
+  const original = normalizeInputs ? normalizeDocument(originalContent) : originalContent;
+  const current = normalizeInputs ? normalizeDocument(currentContent) : currentContent;
 
   if (original !== current) {
     const changesSection = generateChangesSection(original, current, contextLines);

--- a/packages/editor/src/lib/export/normalize-document.test.ts
+++ b/packages/editor/src/lib/export/normalize-document.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Tests for the shared front-matter-aware document normalizer.
+ *
+ * This logic used to live only inside unified-diff.ts. It is factored out
+ * here (cinder#1307, cinder#1318) so `generateUnifiedDiff`, the ReviewEditor
+ * toolbar's `diffStats`, and `generateMarkdownSummary` all normalize whole
+ * documents the same way instead of each carrying their own copy — the exact
+ * defect class this module exists to stop from recurring a fourth time.
+ */
+import { describe, expect, test } from 'bun:test';
+import { normalizeDocument, splitDocument } from './normalize-document.ts';
+
+describe('splitDocument', () => {
+  test('splits front matter from body, collapsing the separator to at most one newline', () => {
+    const result = splitDocument('---\ntitle: Plan\n---\n\n\n\nBody text.\n');
+
+    expect(result.frontMatter).toBe('---\ntitle: Plan\n---\n');
+    expect(result.separator).toBe('\n');
+    expect(result.body).toBe('\n\n\nBody text.\n');
+  });
+
+  test('returns an empty front matter for documents without one', () => {
+    const result = splitDocument('Just body text.\n');
+
+    expect(result.frontMatter).toBe('');
+    expect(result.separator).toBe('');
+    expect(result.body).toBe('Just body text.\n');
+  });
+
+  test('normalizes CRLF to LF before splitting', () => {
+    const result = splitDocument('---\r\ntitle: Plan\r\n---\r\n\r\nBody.\r\n');
+
+    expect(result.frontMatter).toBe('---\ntitle: Plan\n---\n');
+    expect(result.body).toBe('\nBody.\n');
+  });
+});
+
+describe('normalizeDocument', () => {
+  test('keeps front matter byte-for-byte instead of reading it as Markdown', () => {
+    const original = '---\ntitle: Plan\nowner: jane\n---\n\nBody.\n';
+    const current = '---\ntitle: Plan\nowner: bob\n---\n\nBody.\n';
+
+    // The bug this guards: normalize() has no front-matter step, so a document
+    // handed to it whole gets its `---` fences read as a thematic break plus a
+    // setext heading, and the underline gets rewritten to match content width.
+    expect(normalizeDocument(original)).not.toMatch(/^-{4,}$/m);
+    expect(normalizeDocument(current)).not.toMatch(/^-{4,}$/m);
+    expect(normalizeDocument(original)).toContain('owner: jane');
+    expect(normalizeDocument(current)).toContain('owner: bob');
+  });
+
+  test('collapses blank-line padding between front matter and body to one line', () => {
+    const frontMatter = '---\ntitle: Plan\n---';
+    const oneBlankLine = normalizeDocument(`${frontMatter}\n\nBody.`);
+    const threeBlankLines = normalizeDocument(`${frontMatter}\n\n\n\nBody.`);
+
+    expect(oneBlankLine).toBe(threeBlankLines);
+  });
+
+  test('still runs the body through the Markdown pipeline', () => {
+    const original = '---\ntitle: Plan\n---\n\n- one\n- two\n';
+    const starred = '---\ntitle: Plan\n---\n\n* one\n* two\n';
+
+    expect(normalizeDocument(original)).toBe(normalizeDocument(starred));
+  });
+
+  test('returns an empty string for blank input', () => {
+    expect(normalizeDocument('')).toBe('');
+    expect(normalizeDocument('   \n  ')).toBe('');
+  });
+
+  test('handles a front-matter-only document with no body', () => {
+    expect(normalizeDocument('---\ntitle: Plan\n---')).toBe('---\ntitle: Plan\n---');
+  });
+});

--- a/packages/editor/src/lib/export/normalize-document.ts
+++ b/packages/editor/src/lib/export/normalize-document.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared, front-matter-aware document normalization for diff-like exports.
+ *
+ * `normalize()` (`@lostgradient/markdown/pipeline`) is a Markdown pipeline with no
+ * front-matter step. Handed a whole document — front matter and body together —
+ * it re-reads the opening `---` as a thematic break and the YAML lines closed by
+ * the second `---` as a setext heading, whose underline it re-emits as a run of
+ * dashes as long as the longest line it underlines. The YAML itself gets
+ * rewritten (blank lines injected, sequence-item indentation lost) and every
+ * following line shifts.
+ *
+ * `generateUnifiedDiff` sidesteps this by splitting front matter off and
+ * normalizing only the body (cinder#1285). This module is that same fix,
+ * factored out so it has exactly one implementation instead of one per
+ * consumer: `generateUnifiedDiff` (`unified-diff.ts`), the ReviewEditor
+ * toolbar's `diffStats` (`review-editor-diff-stats.ts`, cinder#1307), and
+ * `generateMarkdownSummary` (`markdown-summary.ts`, cinder#1318) all call
+ * {@link normalizeDocument} rather than re-deriving their own front-matter
+ * handling.
+ */
+import { normalize, parseFrontMatter } from '@lostgradient/markdown/pipeline';
+
+export interface DocumentParts {
+  /** The fenced front-matter block verbatim, including the newline that closes it. */
+  frontMatter: string;
+  /** The blank line between front matter and body, collapsed to at most one. */
+  separator: string;
+  /** Everything after the front matter block. */
+  body: string;
+}
+
+/**
+ * Split a document into its verbatim front-matter block and its body.
+ *
+ * CRLF is normalized to LF first: `parseFrontMatter`'s fence matching and every
+ * downstream line-based diff in this package assume LF, so doing it once here
+ * keeps `frontMatter`/`body` consistent with each other.
+ */
+export function splitDocument(content: string): DocumentParts {
+  const text = content.replace(/\r\n?/g, '\n');
+  const parsed = parseFrontMatter(text);
+  if (!parsed.hasFrontMatter) return { frontMatter: '', separator: '', body: text };
+
+  return {
+    frontMatter: text.slice(0, text.length - parsed.body.length),
+    // normalize() collapses runs of blank lines to a single one, so apply the same
+    // rule to the gap after the front matter rather than copying it verbatim —
+    // otherwise a whitespace-only difference there would surface as a phantom hunk.
+    separator: parsed.body.startsWith('\n') ? '\n' : '',
+    body: parsed.body,
+  };
+}
+
+/**
+ * Canonicalize a whole document for diffing or change-counting: front matter
+ * kept byte-for-byte, body run through the Markdown pipeline, blank-line
+ * padding between them collapsed to at most one line.
+ *
+ * Note: normalize() adds a trailing newline; we strip it to avoid phantom empty lines.
+ */
+export function normalizeDocument(content: string): string {
+  if (!content.trim()) return '';
+
+  const { frontMatter, separator, body } = splitDocument(content);
+  const normalizedBody = body.trim() ? normalize(body).replace(/\n+$/, '') : '';
+  if (!frontMatter) return normalizedBody;
+  if (!normalizedBody) return frontMatter.replace(/\n+$/, '');
+
+  return `${frontMatter}${separator}${normalizedBody}`;
+}

--- a/packages/editor/src/lib/export/types.ts
+++ b/packages/editor/src/lib/export/types.ts
@@ -25,9 +25,13 @@ export interface MarkdownSummaryOptions {
    * canonicalization) before diffing, matching {@link UnifiedDiffOptions.normalizeInputs}'s
    * default. Default: true.
    *
-   * Set to false to compare the raw strings verbatim — the same opt-out
-   * `generateUnifiedDiff` offers for callers that want formatting-only
-   * differences (list markers, blank-line padding, CRLF) to count as edits.
+   * Set to false to compare the raw strings verbatim, byte for byte — for
+   * callers that want formatting-only differences (list markers, blank-line
+   * padding, CRLF vs LF line endings) to count as edits. This is stricter
+   * than {@link UnifiedDiffOptions.normalizeInputs}'s own `false`, which
+   * still folds CRLF to LF even with normalization off; that is a
+   * pre-existing quirk of `generateUnifiedDiff`, not a contract this option
+   * inherits.
    */
   normalizeInputs?: boolean | undefined;
 }

--- a/packages/editor/src/lib/export/types.ts
+++ b/packages/editor/src/lib/export/types.ts
@@ -19,6 +19,17 @@ export interface MarkdownSummaryOptions {
 
   /** Number of context lines around changes. Default: 2 */
   contextLines?: number | undefined;
+
+  /**
+   * Normalize `original`/`current` (CRLF to LF, front-matter-aware Markdown
+   * canonicalization) before diffing, matching {@link UnifiedDiffOptions.normalizeInputs}'s
+   * default. Default: true.
+   *
+   * Set to false to compare the raw strings verbatim — the same opt-out
+   * `generateUnifiedDiff` offers for callers that want formatting-only
+   * differences (list markers, blank-line padding, CRLF) to count as edits.
+   */
+  normalizeInputs?: boolean | undefined;
 }
 
 /**

--- a/packages/editor/src/lib/export/unified-diff.ts
+++ b/packages/editor/src/lib/export/unified-diff.ts
@@ -5,8 +5,9 @@
  */
 
 import type { DiffHunk as MarkdownDiffHunk } from '@lostgradient/markdown/diff/line-diff';
-import { normalize, parseFrontMatter } from '@lostgradient/markdown/pipeline';
+import { parseFrontMatter } from '@lostgradient/markdown/pipeline';
 import type { ReviewState } from '../comments/types.js';
+import { normalizeDocument } from './normalize-document.js';
 import type { UnifiedDiffOptions, UnifiedDiffResult } from './types.js';
 
 interface DiffHunk {
@@ -203,58 +204,6 @@ export function generateUnifiedDiff(
       hunks: hunks.length,
     },
   };
-}
-
-interface DocumentParts {
-  /** The fenced front-matter block verbatim, including the newline that closes it. */
-  frontMatter: string;
-  /** The blank line between front matter and body, collapsed to at most one. */
-  separator: string;
-  /** Everything after the front matter block. */
-  body: string;
-}
-
-/**
- * Split a document into its verbatim front-matter block and its body.
- *
- * `normalize()` is a Markdown pipeline with no front-matter step. Handed a whole
- * document it re-reads the opening `---` as a thematic break, and the YAML lines
- * closed by the second `---` as a setext heading — whose underline it re-emits as
- * a run of dashes as long as the longest line it underlines. The YAML is rewritten
- * (blank lines injected, indentation of sequence items lost) and every subsequent
- * line number shifts, so the resulting patch does not apply. DiffViewer already
- * sidesteps this by normalizing only the body; the export path must do the same.
- */
-function splitDocument(content: string): DocumentParts {
-  const text = content.replace(/\r\n?/g, '\n');
-  const parsed = parseFrontMatter(text);
-  if (!parsed.hasFrontMatter) return { frontMatter: '', separator: '', body: text };
-
-  return {
-    frontMatter: text.slice(0, text.length - parsed.body.length),
-    // normalize() collapses runs of blank lines to a single one, so apply the same
-    // rule to the gap after the front matter rather than copying it verbatim —
-    // otherwise a whitespace-only difference there would surface as a phantom hunk.
-    separator: parsed.body.startsWith('\n') ? '\n' : '',
-    body: parsed.body,
-  };
-}
-
-/**
- * Canonicalize a document for diffing: front matter kept byte-for-byte, body run
- * through the Markdown pipeline.
- *
- * Note: normalize() adds a trailing newline; we strip it to avoid phantom empty lines.
- */
-function normalizeDocument(content: string): string {
-  if (!content.trim()) return '';
-
-  const { frontMatter, separator, body } = splitDocument(content);
-  const normalizedBody = body.trim() ? normalize(body).replace(/\n+$/, '') : '';
-  if (!frontMatter) return normalizedBody;
-  if (!normalizedBody) return frontMatter.replace(/\n+$/, '');
-
-  return `${frontMatter}${separator}${normalizedBody}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Same defect class #1285 already fixed in `generateUnifiedDiff`, spread to two consumers that
never got the fix:

- **#1307** — ReviewEditor's toolbar `diffStats` normalized the whole document (front matter and
  body together) with `normalize()`, a Markdown pipeline with no front-matter step. Handed
  `---\ntitle: …\n---`, it reads the fences as a thematic break plus a setext heading and
  re-emits the closing underline at the new content width, so a one-line front-matter value edit
  (`owner: jane` → `owner: bob`) counted as **two** modified lines instead of one.
- **#1318** — `generateMarkdownSummary` ran `computeLineDiff` directly on raw strings with *zero*
  normalization (no CRLF handling, no front-matter awareness, no blank-line collapsing), while
  `generateUnifiedDiff` normalizes both inputs by default. Two documents differing only in
  blank-line padding after front matter (or only in line-ending style) made the two exports
  disagree about whether an edit happened at all — one said "nothing changed", the other emitted
  a two-line diff.

Both are fixed by extending the exact front-matter-aware normalization `generateUnifiedDiff`
already used, factored out of `unified-diff.ts` into a new `export/normalize-document.ts` so
`generateUnifiedDiff`, the toolbar's new `computeReviewEditorDiffStats`, and
`generateMarkdownSummary` (now via a `normalizeInputs` option defaulting to `true`, mirroring
`generateUnifiedDiff`'s own) all share one implementation instead of each carrying its own copy.
`normalizeDocument`/`splitDocument` are exported from `@lostgradient/editor/export` so a future
consumer reuses them too.

`computeReviewEditorDiffStats` is pulled out of `review-editor-impl.svelte` into its own module,
since the component itself is too heavy to mount in happy-dom (Milkdown needs a real browser DOM
— see `review-editor.snapshot-mode.test.ts`'s existing note on this). A source pin in
`review-editor-diff-stats.test.ts` covers the wiring the behavioral test can't reach: that the
component actually calls the fixed helper rather than reintroducing an inline `normalize()` call.

## Revert verification (every fix has a test proven to fail without it)

- Reverting `review-editor-diff-stats.ts`'s body back to a bare `normalize()` call reproduces
  #1307's exact repro: `{ added: 0, removed: 0, modified: 2 }` instead of `modified: 1`.
- Reverting the `diffStats` wiring in `review-editor-impl.svelte` back to an inline
  `normalize()`-based computation fails the source-pin test (proves the wiring, not just the
  helper, is covered).
- Reverting `markdown-summary.ts`/`types.ts` to `origin/main` fails 5 of the 6 new tests in
  `markdown-summary.test.ts`'s `normalization (cinder#1318)` block — the front-matter repro, the
  no-front-matter repro, both CRLF cases, and the with-feedback variant. The 6th test
  (`normalizeInputs: false restores the raw comparison`) intentionally passes against both old and
  new code — it pins the opt-out contract, not the bug itself, since the old code's behavior *was*
  the unnormalized comparison.

All three reverts were restored and re-verified green afterward, confirmed by content hash
against a backup, not just by eye.

## Scope

The wider 5-normalizer divergence #1307 documents in its "Related, and worth deciding together"
table (`normalize` vs `normalizeForDiff` vs `normalizeForEditor` vs `normalizeSafely`, plus the
`normalizeSafely` dynamic-import race) is **deliberately untouched** — the issue frames it as
context for whoever picks it up next, not part of this fix. `diff-viewer.svelte`'s own
already-correct front-matter splitting is untouched for the same reason.

## Pre-existing, unrelated: editor's local coverage ratchet

`bun run test:coverage` for `@lostgradient/editor` currently fails locally on the Svelte
function-coverage ratchet (`78.79% < 81.22%`) — reproduced identically on unmodified
`origin/main` in a fresh worktree before any of this PR's changes, so it is not something this PR
introduces or should paper over. It also isn't part of the CI gate for this package: both
`unit-tests.yaml` and `main-green.yaml` run `turbo run test --filter=@lostgradient/editor` (plain,
uncoveraged) for editor; only `@lostgradient/chat` gets `test:coverage` treatment in either
workflow. `turbo run test`, `typecheck`, and `lint` (the actual CI-equivalent gates) are all green
on this branch — see test plan.

## Test plan

- [x] `bunx turbo run test --filter=@lostgradient/editor` — 709 pass, 0 fail, 1 skip (pre-existing,
      unrelated)
- [x] `bunx turbo run typecheck --filter=@lostgradient/editor` — 0 errors, 0 warnings
- [x] `bunx turbo run lint --filter=@lostgradient/editor` — 0 warnings, 0 errors
- [x] `bun run --filter=@lostgradient/editor components:check` — OK
- [x] `bun run --filter=@lostgradient/editor platform:audit -- --strict` — OK
- [x] `bun run --filter=@lostgradient/editor colors:audit -- --strict` — OK
- [x] `bun run --filter=@lostgradient/editor tokens:audit -- --strict` — OK
- [x] `bunx prettier --check` on every touched file — OK
- [x] `bunx changeset status` — recognizes both changesets, `@lostgradient/editor` patch
- [x] Three separate revert-and-restore cycles, each producing a red test, each restore verified
      by hash

Fixes #1307
Fixes #1318

🤖 Generated with [Claude Code](https://claude.com/claude-code)