### PR TITLE
editor: fix ReviewEditor data-ready liveness, tab aria-controls, and popover modality

### DIFF
--- a/.changeset/review-editor-readiness-and-tab-and-modal-aria.md
+++ b/.changeset/review-editor-readiness-and-tab-and-modal-aria.md
@@ -52,6 +52,16 @@ keep escapable. Fixed by closing the thread popover in the same
 "left the editor view" branch that already clears the (separate) selection
 popover for the same reason.
 
+That popover-close, in turn, unmounts `ThreadPopover`, and its own focus trap
+unconditionally restores focus on deactivate — even when the SAME
+interaction that triggered the close (arrow-key roving-tabindex on the view
+switcher) had already moved focus to the newly active tab a moment earlier
+in the same call stack, stealing it back to the trap's `restoreFallback`
+(the sidebar toggle). Corrected by re-asserting focus on the active tab
+after `tick()`, once the trap's own restore has had its say — there is no
+reactive hook into the trap's restore decision from the outside, so this
+corrects the result rather than preventing the race.
+
 Verified against the real Chromium accessibility tree (via the CDP
 `Accessibility` domain), not just DOM attribute presence, for all three:
 `role="textbox"` appearing/disappearing on the ProseMirror node in step with

--- a/.changeset/review-editor-readiness-and-tab-and-modal-aria.md
+++ b/.changeset/review-editor-readiness-and-tab-and-modal-aria.md
@@ -1,0 +1,52 @@
+---
+'@lostgradient/editor': patch
+---
+
+Fix three `ReviewEditor` a11y/state-liveness defects, all found by
+`stevekinney/chatroom`'s `/exercises/review-*` suite carrying them as pinned
+known-bug regression tests.
+
+`data-ready` was a latch (`editorViewReady`) set true on the inner editor's
+first `onready`/selection-change and never cleared. Switching to the Diff or
+Summary tab destroys the `MarkdownEditor` instance behind the `{#if
+activeView === 'editor'}` branch, but `data-ready` kept reporting `"true"`
+with no editor mounted — a consumer that waits on `data-ready` after a view
+switch was acting on an editor that no longer existed. Fixed by deriving the
+reset from `editorRef` itself (which Svelte's own `bind:this` unbinds to
+`undefined` on unmount) rather than from a one-way latch, so `data-ready`
+means "an editor is available right now" and comes back once the editor view
+remounts and finishes initializing. Fixes #1301.
+
+Two of the three view tabs (`Diff`, `Summary`) always pointed `aria-controls`
+at a panel id that was not in the document, because the view area renders
+exactly one panel via an `{#if}`/`{:else if}`/`{:else}` chain — the inactive
+views' panels are removed entirely, not hidden. A screen reader following the
+tab-to-panel relationship on an inactive tab found nothing. Fixed by only
+passing `controls` to the ACTIVE segment; the inactive tabs now claim no
+panel at all instead of a dangling one, which axe's `aria-valid-attr-value`
+rule (every IDREF-valued ARIA attribute must resolve) confirms is clean.
+Fixes #1303.
+
+The thread popover declared `role="dialog" aria-modal="true"` while nothing
+outside it — `.review-editor-main`, the comment sidebar — was made `inert` or
+`aria-hidden`, and the component's own F6 landmark navigation deliberately
+moves focus OUT of the popover into `.review-editor-main` while it stays
+open. `aria-modal="true"` is a promise that everything outside the dialog is
+unavailable; this popover never kept that promise, and F6 proves it was never
+meant to. Chose to drop `aria-modal="true"` (rather than making the popover
+genuinely modal by adding `inert` to the surrounding regions and removing
+F6) because F6-out-without-closing is the popover's actual, intended
+behavior — an anchored, non-modal comment popover, the same pattern as
+Google Docs or a GitHub PR review thread, not a page-blocking dialog. The
+existing Tab-trap-within-the-popover and Escape-to-restore behavior needed no
+change either way and are unaffected. Fixes #1305.
+
+Verified against the real Chromium accessibility tree (via the CDP
+`Accessibility` domain), not just DOM attribute presence, for all three:
+`role="textbox"` appearing/disappearing on the ProseMirror node in step with
+`data-ready` (#1301, an implicit ARIA role from `contenteditable` with no DOM
+attribute to assert on directly), an `aria-valid-attr-value` axe pass on the
+tablist (#1303), and the computed `modal` AX property on the popover node
+(#1305) — the same category of gap that made cinder#1292's first fix attempt
+wrong until it was checked against the computed tree instead of attribute
+presence alone.

--- a/.changeset/review-editor-readiness-and-tab-and-modal-aria.md
+++ b/.changeset/review-editor-readiness-and-tab-and-modal-aria.md
@@ -41,6 +41,17 @@ Google Docs or a GitHub PR review thread, not a page-blocking dialog. The
 existing Tab-trap-within-the-popover and Escape-to-restore behavior needed no
 change either way and are unaffected. Fixes #1305.
 
+Review follow-up on #1305: the thread popover's anchor only exists in the
+editor view, so leaving it (Diff/Summary) unmounts `editorRef` — the same
+unbind #1301's fix relies on. That turned F6's `customFocusHandler` for the
+`'editor'` region into a no-op (`editorRef?.getView()?.focus()` on a null
+ref) that still returned `true`, suppressing the region navigator's fallback
+and stranding focus inside a popover pointing at content that was no longer
+rendered — precisely the failure mode dropping `aria-modal` was supposed to
+keep escapable. Fixed by closing the thread popover in the same
+"left the editor view" branch that already clears the (separate) selection
+popover for the same reason.
+
 Verified against the real Chromium accessibility tree (via the CDP
 `Accessibility` domain), not just DOM attribute presence, for all three:
 `role="textbox"` appearing/disappearing on the ProseMirror node in step with

--- a/packages/editor/src/lib/components/review-editor/review-editor-controls.svelte
+++ b/packages/editor/src/lib/components/review-editor/review-editor-controls.svelte
@@ -150,16 +150,30 @@
       value={activeView}
       onValueChange={handleViewChange}
     >
-      <Segment value="editor" controls={viewPanelIds?.editor}>
+      <!--
+        `controls` is only passed for the ACTIVE segment (cinder#1303). The view
+        area below renders exactly one panel at a time via an `{#if}` chain — the
+        other two views' panels are not in the document at all, not merely
+        hidden — so an inactive tab's `aria-controls` would point at an id that
+        does not exist. A dangling id reference is worse than an absent one: it
+        fails "every IDREF resolves" (axe's aria-valid-attr-value, and any
+        screen reader that follows the tab-to-panel relationship), where
+        omitting `controls` on the inactive tabs is simply a tab that doesn't
+        (yet) claim to control anything.
+      -->
+      <Segment value="editor" controls={activeView === 'editor' ? viewPanelIds?.editor : undefined}>
         {#snippet leading()}<Pencil class="cinder-icon-xs" />{/snippet}
         Editor
       </Segment>
       {#if showDiffTabs}
-        <Segment value="diff" controls={viewPanelIds?.diff}>
+        <Segment value="diff" controls={activeView === 'diff' ? viewPanelIds?.diff : undefined}>
           {#snippet leading()}<GitBranch class="cinder-icon-xs" />{/snippet}
           Diff
         </Segment>
-        <Segment value="summary" controls={viewPanelIds?.summary}>
+        <Segment
+          value="summary"
+          controls={activeView === 'summary' ? viewPanelIds?.summary : undefined}
+        >
           {#snippet leading()}<FileText class="cinder-icon-xs" />{/snippet}
           Summary
         </Segment>

--- a/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
+++ b/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
@@ -129,6 +129,23 @@
   // Track when editor view is ready (for effects that need to wait for async editor creation)
   let editorViewReady = $state(false);
 
+  // `editorViewReady` is a latch set true by `handleSelectionChange`/the
+  // `MarkdownEditor` `onready` callback below, but nothing symmetrically
+  // cleared it when the editor view unmounted (cinder#1301): switching to the
+  // Diff or Summary tab destroys the `MarkdownEditor` instance behind the
+  // `{#if activeView === 'editor'}` branch, `editorRef` unbinds back to
+  // `undefined` (Svelte's own `bind:this` contract on block teardown), but the
+  // latch stayed `true` — so `data-ready` kept reporting an editor that no
+  // longer existed. Deriving the reset from `editorRef` itself, rather than
+  // from `activeView`, covers every teardown path (view switch, and any other
+  // reason the inner editor unmounts) without duplicating that branching logic
+  // here.
+  $effect(() => {
+    if (!editorRef) {
+      editorViewReady = false;
+    }
+  });
+
   // Track current selection for thread creation
   let currentSelection = $state<EditorSelection | null>(null);
 

--- a/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
+++ b/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
@@ -16,6 +16,7 @@
 </script>
 
 <script lang="ts">
+  import { tick } from 'svelte';
   import { classNames } from '../../utilities/class-names.ts';
   import { devWarn } from '../../utilities/dev-warn.ts';
   import { useReducedMotion } from '../../utilities/use-reduced-motion.svelte.ts';
@@ -1761,7 +1762,34 @@
         // clears for the same "left the editor view" reason, means F6 never
         // gets the chance to strand: there is nothing left to navigate away
         // from.
-        handlePopoverClose();
+        if (popoverThreadId !== null) {
+          handlePopoverClose();
+
+          // Second review-round finding: closing the popover here unmounts
+          // it, and its OWN focus trap unconditionally restores focus on
+          // deactivate — to whatever had focus when the popover opened, or
+          // its restoreFallback (the sidebar toggle) — even when THIS SAME
+          // interaction already moved focus to the newly active tab a
+          // moment earlier in the same call stack. Concretely, for the
+          // arrow-key roving-tabindex path: `SegmentedControlController`
+          // calls `toggle()` (reaching this callback, synchronously) and
+          // THEN focuses the destination tab — so the trap's restore, which
+          // runs when this state change flushes, lands AFTER that focus
+          // move and steals it. There is no reactive hook into the trap's
+          // own restore decision from here (it is not exposed as
+          // reactive), so this corrects it afterward instead: `tick()`
+          // resolves once the pending state changes above — including the
+          // trap's synchronous `deactivate()` — have been applied, and only
+          // then is it safe to re-assert focus on the tab that is actually
+          // selected now.
+          tick().then(() => {
+            if (activeView !== view || !containerElement) return;
+            const activeTab = containerElement.querySelector<HTMLElement>(
+              '.review-editor-controls [role="tab"][aria-selected="true"]',
+            );
+            activeTab?.focus();
+          });
+        }
       }
       activeView = view;
       announce(`Switched to ${view} view`);

--- a/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
+++ b/packages/editor/src/lib/components/review-editor/review-editor-impl.svelte
@@ -1749,6 +1749,19 @@
         selectionPopoverPosition = null;
         capturedSelectionForPopover = null;
         selectionPopoverExpanded = false;
+
+        // Close the thread popover too (cinder#1305 review follow-up): its
+        // anchor only exists in the editor view, and leaving it destroys
+        // editorRef (the same unbind #1301 relies on), which turns F6's
+        // `customFocusHandler` for the 'editor' region into a no-op
+        // (`editorRef?.getView()?.focus()` on a null ref) that still returns
+        // `true` — suppressing the navigator's fallback and stranding focus
+        // inside a popover pointing at content that is no longer rendered.
+        // Closing here, alongside the selection popover this branch already
+        // clears for the same "left the editor view" reason, means F6 never
+        // gets the chance to strand: there is nothing left to navigate away
+        // from.
+        handlePopoverClose();
       }
       activeView = view;
       announce(`Switched to ${view} view`);

--- a/packages/editor/src/lib/components/review-editor/thread-popover.svelte
+++ b/packages/editor/src/lib/components/review-editor/thread-popover.svelte
@@ -152,11 +152,31 @@
   });
 </script>
 
+<!--
+  Deliberately `role="dialog"` WITHOUT `aria-modal="true"` (cinder#1305). This
+  is an anchored, non-modal dialog — the same pattern as a comment popover in
+  Google Docs or a GitHub PR review thread — not a blocking modal, and the
+  component's own keyboard design says so: F6 landmark navigation
+  (`handleContainerKeyDown` in `review-editor-impl.svelte`) deliberately moves
+  focus from this popover to `.review-editor-main` while the popover stays
+  open, so a reviewer can jump back to the document without closing the
+  thread. `aria-modal="true"` is a promise that everything outside the dialog
+  is unavailable; nothing here makes `.review-editor-main` or the comment
+  sidebar `inert` while this is open, and F6 proves they are still reachable
+  on purpose. Making the markup honest about that (rather than adding
+  `inert`/`aria-hidden` to the rest of the editor and removing F6) is the
+  smaller change AND the one that keeps this popover's actual, intended
+  workflow — F6 out, `Escape` or click-outside to close, `Tab` cycling the
+  popover's own controls while it has focus. Tab-trapping while non-modal is
+  intentional here too: this is a transient, anchored control surface (much
+  like a menu or combobox listbox), not a page-blocking dialog, so trapping
+  Tab within it while open — while still leaving F6/Escape/click-outside as
+  explicit ways out — is consistent, not contradictory.
+-->
 <div
   bind:this={popoverElement}
   {id}
   role="dialog"
-  aria-modal="true"
   aria-labelledby="{id}-title"
   tabindex="-1"
   class={classNames('thread-popover', className)}

--- a/packages/testing/tests/review-editor-readiness-and-modality.playwright.ts
+++ b/packages/testing/tests/review-editor-readiness-and-modality.playwright.ts
@@ -361,9 +361,14 @@ test.describe('ReviewEditor thread popover modality (cinder#1305)', () => {
     await expect(diffTab).toHaveAttribute('aria-selected', 'true');
     await expect(popover).toHaveCount(0);
 
-    // Focus must land somewhere real, not get stranded and not drop to
-    // <body>.
-    const strandedOnBody = await page.evaluate(() => document.activeElement === document.body);
-    expect(strandedOnBody).toBe(false);
+    // Third-round review finding: closing the popover here unmounts it, and
+    // its OWN focus trap unconditionally restores focus on deactivate —
+    // stealing focus BACK from the tab that ArrowRight just moved it to,
+    // landing it on the trap's restoreFallback (the sidebar toggle) instead.
+    // A weaker "just not <body>" assertion would not have caught this: the
+    // sidebar toggle is a real, valid element, just the WRONG one — the
+    // roving-tabindex/ARIA-tabs contract requires focus to stay on the tab
+    // that was just activated.
+    await expect(diffTab).toBeFocused();
   });
 });

--- a/packages/testing/tests/review-editor-readiness-and-modality.playwright.ts
+++ b/packages/testing/tests/review-editor-readiness-and-modality.playwright.ts
@@ -1,0 +1,292 @@
+/**
+ * Browser coverage for three `ReviewEditor` a11y/state-liveness bugs, all
+ * filed against the same route (`/page/review-editor?snapshot=1`):
+ *
+ *   - cinder#1301: `data-ready` is a latch that is set once and never
+ *     cleared, so it keeps reporting "ready" after the editor view unmounts.
+ *   - cinder#1303: two of the three view tabs always point `aria-controls`
+ *     at an element id that is not in the document, because the inactive
+ *     views are removed via `{#if}` rather than hidden.
+ *   - cinder#1305: the thread popover declares `aria-modal="true"` while
+ *     nothing outside it is made inert, and F6 deliberately navigates focus
+ *     out of it.
+ *
+ * Every scenario below pairs a plain DOM assertion with a check against the
+ * REAL Chromium accessibility tree (via the CDP Accessibility domain, since
+ * Playwright's own `page.accessibility` API was removed in this Playwright
+ * version and `locator.ariaSnapshot()` only reports role/name, not computed
+ * properties like `modal`). A DOM attribute can say one thing while the
+ * browser's actual accessibility computation says another — that gap is
+ * exactly what made cinder#1292's first fix attempt wrong until it was
+ * checked against the computed tree instead of just attribute presence.
+ */
+import { expect, test, type Page } from '@playwright/test';
+
+import { runAxe } from '../src/helpers/axe.ts';
+
+const ROUTE = '/page/review-editor?snapshot=1';
+const BASIC = '#example-mount-basic';
+const WITH_COMMENTS = '#example-mount-with-comments';
+
+/**
+ * Resolve the REAL Chromium-computed accessible role for `selector` (scoped
+ * under `containerSelector`), via the CDP Accessibility domain rather than a
+ * DOM attribute read. Returns `null` when the element does not exist, is
+ * accessibility-ignored, or the browser reports no role.
+ */
+async function computedAxRole(
+  page: Page,
+  containerSelector: string,
+  selector: string,
+): Promise<string | null> {
+  const client = await page.context().newCDPSession(page);
+  try {
+    await client.send('DOM.enable');
+    await client.send('Accessibility.enable');
+    const { root } = await client.send('DOM.getDocument', { depth: -1, pierce: true });
+    const container = await client.send('DOM.querySelector', {
+      nodeId: root.nodeId,
+      selector: containerSelector,
+    });
+    if (!container.nodeId) return null;
+    const target = await client.send('DOM.querySelector', {
+      nodeId: container.nodeId,
+      selector,
+    });
+    if (!target.nodeId) return null;
+    const { nodes } = await client.send('Accessibility.getPartialAXTree', {
+      nodeId: target.nodeId,
+      fetchRelatives: false,
+    });
+    const node = nodes[0];
+    if (!node || node.ignored) return null;
+    const role = node.role?.value;
+    return typeof role === 'string' ? role : null;
+  } finally {
+    await client.detach();
+  }
+}
+
+/**
+ * Read a single computed AX property (e.g. `'modal'`) off the REAL Chromium
+ * accessibility tree for `selector`. Returns `undefined` when the element
+ * does not exist or the browser reports no such property.
+ */
+async function computedAxProperty(
+  page: Page,
+  selector: string,
+  propertyName: string,
+): Promise<unknown> {
+  const client = await page.context().newCDPSession(page);
+  try {
+    await client.send('DOM.enable');
+    await client.send('Accessibility.enable');
+    const { root } = await client.send('DOM.getDocument', { depth: -1, pierce: true });
+    const target = await client.send('DOM.querySelector', { nodeId: root.nodeId, selector });
+    if (!target.nodeId) return undefined;
+    const { nodes } = await client.send('Accessibility.getPartialAXTree', {
+      nodeId: target.nodeId,
+      fetchRelatives: false,
+    });
+    const node = nodes[0];
+    const property = node?.properties?.find((candidate) => candidate.name === propertyName);
+    return property?.value.value;
+  } finally {
+    await client.detach();
+  }
+}
+
+async function openBasicReviewEditor(page: Page) {
+  await page.goto(ROUTE, { waitUntil: 'load' });
+  const container = page.locator(`${BASIC} [data-testid="review-editor"]`);
+  await expect(container).toHaveAttribute('data-ready', 'true');
+  return container;
+}
+
+test.describe('ReviewEditor data-ready liveness (cinder#1301)', () => {
+  test('data-ready clears when the editor view unmounts and returns when it remounts', async ({
+    page,
+  }) => {
+    const container = await openBasicReviewEditor(page);
+
+    // Sanity: while mounted, the REAL accessibility tree (not just a DOM
+    // attribute) exposes the editor's contenteditable surface as a textbox.
+    // ProseMirror's contenteditable div gets this role IMPLICITLY from
+    // `contenteditable` per the HTML-AAM — there is no `role="textbox"`
+    // attribute in the DOM to assert on directly, which is exactly why this
+    // needs the computed tree rather than a `toHaveAttribute` check.
+    await expect.poll(() => computedAxRole(page, BASIC, '.ProseMirror')).toBe('textbox');
+
+    const diffTab = page.locator(BASIC).getByRole('tab', { name: 'Diff', exact: true });
+    await diffTab.click();
+
+    // Plain DOM assertion: the editor panel and its ProseMirror content are
+    // gone from the document entirely (removed by the `{#if}` chain), not
+    // merely hidden.
+    await expect(page.locator(`${BASIC} [id$="-editor-panel"]`)).toHaveCount(0);
+    await expect(page.locator(`${BASIC} .ProseMirror`)).toHaveCount(0);
+
+    // The bug: `data-ready` used to stay "true" here because the latch that
+    // sets it was never cleared on unmount.
+    await expect(container).not.toHaveAttribute('data-ready');
+
+    // Accessibility-tree assertion: no textbox role survives the unmount —
+    // there is nothing left for the browser to expose.
+    expect(await computedAxRole(page, BASIC, '.ProseMirror')).toBeNull();
+
+    // Switch back: the readiness signal must also come BACK when the editor
+    // view remounts and finishes initializing, not just clear once and stay
+    // cleared. This is the half of the contract an "always false" over-fix
+    // would still fail.
+    const editorTab = page.locator(BASIC).getByRole('tab', { name: 'Editor', exact: true });
+    await editorTab.click();
+    await expect(container).toHaveAttribute('data-ready', 'true');
+    await expect.poll(() => computedAxRole(page, BASIC, '.ProseMirror')).toBe('textbox');
+  });
+});
+
+test.describe('ReviewEditor view-tab aria-controls (cinder#1303)', () => {
+  test('every tab aria-controls resolves to a real panel, and follows the active view', async ({
+    page,
+  }) => {
+    await openBasicReviewEditor(page);
+
+    const tabs = page.locator(`${BASIC} [role="tab"]`);
+    await expect(tabs).toHaveCount(3);
+
+    async function readTabState() {
+      return page.locator(`${BASIC} [role="tab"]`).evaluateAll((elements) =>
+        elements.map((element) => ({
+          name: element.textContent?.trim() ?? '',
+          selected: element.getAttribute('aria-selected'),
+          controls: element.getAttribute('aria-controls'),
+          resolves: element.getAttribute('aria-controls')
+            ? document.getElementById(element.getAttribute('aria-controls')!) !== null
+            : null,
+        })),
+      );
+    }
+
+    const initial = await readTabState();
+    for (const tab of initial) {
+      if (tab.controls !== null) {
+        expect(tab.resolves, `${tab.name} tab's aria-controls should resolve`).toBe(true);
+      }
+    }
+    // Exactly the active (Editor) tab claims a panel; the inactive two make
+    // no claim at all rather than a dangling one.
+    const editorTab = initial.find((tab) => tab.name === 'Editor');
+    const diffTab = initial.find((tab) => tab.name === 'Diff');
+    const summaryTab = initial.find((tab) => tab.name === 'Summary');
+    expect(editorTab?.selected).toBe('true');
+    expect(editorTab?.controls).not.toBeNull();
+    expect(diffTab?.controls).toBeNull();
+    expect(summaryTab?.controls).toBeNull();
+
+    await page.locator(BASIC).getByRole('tab', { name: 'Diff', exact: true }).click();
+
+    const afterDiff = await readTabState();
+    for (const tab of afterDiff) {
+      if (tab.controls !== null) {
+        expect(tab.resolves, `${tab.name} tab's aria-controls should resolve`).toBe(true);
+      }
+    }
+    const diffTabAfter = afterDiff.find((tab) => tab.name === 'Diff');
+    const editorTabAfter = afterDiff.find((tab) => tab.name === 'Editor');
+    expect(diffTabAfter?.selected).toBe('true');
+    expect(diffTabAfter?.controls).not.toBeNull();
+    expect(editorTabAfter?.controls).toBeNull();
+
+    // Accessibility-engine assertion: axe's aria-valid-attr-value rule checks
+    // that every IDREF-valued ARIA attribute (aria-controls included)
+    // resolves to a real element. A dangling id is exactly what this rule
+    // exists to catch.
+    const buckets = await runAxe(
+      page,
+      { slug: 'review-editor', theme: 'light', viewport: 'desktop', fixture: 'basic-tabs' },
+      { include: `${BASIC} .review-editor-controls` },
+    );
+    const idrefViolations = [
+      ...buckets.critical,
+      ...buckets.serious,
+      ...buckets.moderate,
+      ...buckets.minor,
+    ].filter((violation) => violation.id === 'aria-valid-attr-value');
+    expect(idrefViolations, JSON.stringify(idrefViolations, null, 2)).toHaveLength(0);
+  });
+});
+
+test.describe('ReviewEditor thread popover modality (cinder#1305)', () => {
+  async function openThreadPopover(page: Page) {
+    await page.goto(ROUTE, { waitUntil: 'load' });
+    const container = page.locator(`${WITH_COMMENTS} [data-testid="review-editor"]`);
+    await expect(container).toHaveAttribute('data-ready', 'true');
+
+    const anchor = page.locator(`${WITH_COMMENTS} [data-thread-id="thread-architecture-title"]`);
+    await anchor.first().click();
+
+    const popover = page.locator(`${WITH_COMMENTS} .thread-popover`);
+    await expect(popover).toBeVisible();
+    return popover;
+  }
+
+  test('the popover does not claim aria-modal, and the browser agrees', async ({ page }) => {
+    const popover = await openThreadPopover(page);
+
+    await expect(popover).toHaveAttribute('role', 'dialog');
+    await expect(popover).not.toHaveAttribute('aria-modal');
+
+    // The DOM attribute is gone; confirm the browser's own computed
+    // accessibility property agrees rather than assuming attribute absence
+    // is sufficient. `modal` is a real CDP AXPropertyName Chromium computes
+    // for the node, independent of what the DOM markup says.
+    const modalProperty = await computedAxProperty(
+      page,
+      `${WITH_COMMENTS} .thread-popover`,
+      'modal',
+    );
+    expect(modalProperty).not.toBe(true);
+  });
+
+  test('F6 still reaches the editor without closing the popover, and the popover is still closable', async ({
+    page,
+  }) => {
+    const popover = await openThreadPopover(page);
+
+    await popover.locator('.thread-popover-close').focus();
+    await expect(popover.locator('.thread-popover-close')).toBeFocused();
+
+    // F6 is the component's OWN documented escape hatch from this popover —
+    // preserving it (rather than trapping focus entirely, which a
+    // "make it actually modal" fix would have required) is part of why
+    // removing `aria-modal` rather than adding `inert` was the chosen fix.
+    await page.keyboard.press('F6');
+    const focusInMain = await page.evaluate((mainSelector) => {
+      const main = document.querySelector(mainSelector);
+      return !!(main && document.activeElement && main.contains(document.activeElement));
+    }, `${WITH_COMMENTS} .review-editor-main`);
+    expect(focusInMain).toBe(true);
+
+    // Non-modal means the popover survives focus leaving it — a real modal
+    // dialog's focus trap would never have let focus leave in the first
+    // place.
+    await expect(popover).toBeVisible();
+
+    // Cycle back with Shift+F6 and confirm Escape still closes it — the
+    // existing Tab-trap / Escape-restore behavior the issue explicitly says
+    // is fine and should not regress.
+    await page.keyboard.press('Shift+F6');
+    const focusInPopover = await page.evaluate(() => {
+      const popoverElement = document.querySelector('.thread-popover');
+      return !!(
+        popoverElement &&
+        document.activeElement &&
+        popoverElement.contains(document.activeElement)
+      );
+    });
+    expect(focusInPopover).toBe(true);
+
+    await page.keyboard.press('Escape');
+    await expect(popover).toHaveCount(0);
+  });
+});

--- a/packages/testing/tests/review-editor-readiness-and-modality.playwright.ts
+++ b/packages/testing/tests/review-editor-readiness-and-modality.playwright.ts
@@ -90,7 +90,7 @@ async function computedAxProperty(
     });
     const node = nodes[0];
     const property = node?.properties?.find((candidate) => candidate.name === propertyName);
-    return property?.value.value;
+    return property?.value?.value;
   } finally {
     await client.detach();
   }
@@ -214,6 +214,40 @@ test.describe('ReviewEditor view-tab aria-controls (cinder#1303)', () => {
     ].filter((violation) => violation.id === 'aria-valid-attr-value');
     expect(idrefViolations, JSON.stringify(idrefViolations, null, 2)).toHaveLength(0);
   });
+
+  test('keyboard roving-tabindex navigation settles on a resolving aria-controls, not a stale one', async ({
+    page,
+  }) => {
+    // Review round finding: SegmentedControlController.handleKeydown calls
+    // toggle() (updates `activeView`) and then focuses the destination tab
+    // SYNCHRONOUSLY, before Svelte's own reactive DOM patch for that state
+    // change has necessarily been applied. This drives that exact path (a
+    // real ArrowRight keypress, not a click) and asserts the SETTLED state
+    // once Playwright reads it back — which is also the earliest point a
+    // real screen reader could ever observe it, since AT reads the
+    // accessibility tree only after the current script task yields back to
+    // the browser's render/AX pipeline, by which point Svelte's synchronous
+    // post-handler flush has already run.
+    await openBasicReviewEditor(page);
+
+    const editorTab = page.locator(BASIC).getByRole('tab', { name: 'Editor', exact: true });
+    await editorTab.focus();
+    await expect(editorTab).toBeFocused();
+
+    await page.keyboard.press('ArrowRight');
+
+    const diffTab = page.locator(BASIC).getByRole('tab', { name: 'Diff', exact: true });
+    await expect(diffTab).toBeFocused();
+    await expect(diffTab).toHaveAttribute('aria-selected', 'true');
+
+    const controlsId = await diffTab.getAttribute('aria-controls');
+    expect(controlsId).not.toBeNull();
+    const resolves = await page.evaluate((id) => document.getElementById(id) !== null, controlsId!);
+    expect(resolves).toBe(true);
+
+    // The tab that lost selection makes no aria-controls claim at all.
+    await expect(editorTab).not.toHaveAttribute('aria-controls');
+  });
 });
 
 test.describe('ReviewEditor thread popover modality (cinder#1305)', () => {
@@ -288,5 +322,48 @@ test.describe('ReviewEditor thread popover modality (cinder#1305)', () => {
 
     await page.keyboard.press('Escape');
     await expect(popover).toHaveCount(0);
+  });
+
+  test('switching away from the editor view closes the popover instead of stranding focus in it', async ({
+    page,
+  }) => {
+    // Review round finding: the popover's anchor only exists in the editor
+    // view. Leaving it unmounts editorRef (the same unbind #1301's fix
+    // relies on), which turns F6's `customFocusHandler` for the 'editor'
+    // region into a no-op (`editorRef?.getView()?.focus()` on a null ref)
+    // that still returns `true` — suppressing the navigator's fallback and
+    // stranding focus inside a popover pointing at content no longer
+    // rendered. `onViewChange` already clears the (unrelated) selection
+    // popover for the same "left the editor view" reason; the thread popover
+    // needed the same treatment.
+    //
+    // The view change here is driven via the tablist's ArrowRight
+    // roving-tabindex handler, not a click: `SegmentedControlController`'s
+    // keyboard path calls `toggle()` and `.focus()` directly with no
+    // synthetic `click` event, so it does NOT pass through
+    // `createClickOutside`'s click listener — which would otherwise close
+    // the popover on its own (any click landing outside it, including a
+    // real OR keyboard-synthesized one on the Diff tab, triggers that
+    // listener) and mask whether THIS fix is what actually closed it.
+    const popover = await openThreadPopover(page);
+
+    const editorTab = page.locator(WITH_COMMENTS).getByRole('tab', { name: 'Editor', exact: true });
+    await editorTab.focus();
+    await expect(editorTab).toBeFocused();
+    // Moving focus via .focus() (not a click) must not have already closed
+    // the popover — otherwise the assertions below would not be exercising
+    // the view-change path at all.
+    await expect(popover).toBeVisible();
+
+    await page.keyboard.press('ArrowRight');
+
+    const diffTab = page.locator(WITH_COMMENTS).getByRole('tab', { name: 'Diff', exact: true });
+    await expect(diffTab).toHaveAttribute('aria-selected', 'true');
+    await expect(popover).toHaveCount(0);
+
+    // Focus must land somewhere real, not get stranded and not drop to
+    // <body>.
+    const strandedOnBody = await page.evaluate(() => document.activeElement === document.body);
+    expect(strandedOnBody).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Fixes three `ReviewEditor` a11y/state-liveness defects, all filed against `stevekinney/chatroom`'s pinned `/exercises/review-*` regression tests (ROADMAP `A11Y-4`).

- Fixes #1301 — `data-ready` was a set-once latch (`editorViewReady`) that was never cleared when the editor view unmounted (e.g. switching to the Diff or Summary tab destroys the `MarkdownEditor` behind the `{#if activeView === 'editor'}` branch). It kept reporting `"true"` with no editor mounted. Fixed by resetting the latch from `editorRef` itself — which Svelte's own `bind:this` unbinds to `undefined` on unmount — rather than from a one-way flag, so `data-ready` means "an editor is available right now" and comes back once the view remounts and finishes initializing.
- Fixes #1303 — the `Diff` and `Summary` tabs always pointed `aria-controls` at a panel id that was never in the document, because the view area renders exactly one panel via an `{#if}`/`{:else if}`/`{:else}` chain. Fixed by only passing `controls` to the currently-active `Segment`; the inactive tabs now claim no panel at all instead of a dangling one — the smaller-scoped option the issue itself suggested.
- Fixes #1305 — the thread popover declared `role="dialog" aria-modal="true"` while nothing outside it (`.review-editor-main`, the comment sidebar) was made `inert`, and the component's own F6 landmark navigation deliberately moves focus OUT of the popover while it stays open.

### The #1305 semantic choice

This one has a real choice, not just a mechanical fix, and I went with **removing `aria-modal="true"`** rather than making the popover genuinely modal (adding `inert`/`aria-hidden` to the surrounding regions and removing the F6 escape hatch). Reasoning:

- F6-out-without-closing is the popover's own **documented, intentional** keyboard design (`focusRegions` in `review-editor-impl.svelte` explicitly includes `'popover'` as a peer of `'editor'`, cycled via F6) — not an accident that happened to contradict the attribute.
- This is an anchored, transient comment popover — the same interaction pattern as a Google Docs or GitHub PR review comment thread — not a page-blocking dialog. Making it genuinely modal would be a real behavior regression to fix an attribute mismatch.
- The existing Tab-trap-within-the-popover and Escape-to-restore-focus behavior needed no change either way (the issue confirms both already work correctly) and are unaffected by either choice.

Dropping the attribute is the smaller change AND the one that keeps the popover's actual, intended workflow intact.

## Verification

All three fixes are verified against the **real Chromium accessibility tree** (via the CDP `Accessibility` domain), not just DOM attribute presence — `packages/testing/tests/review-editor-readiness-and-modality.playwright.ts`:

- #1301: the ProseMirror node's *implicit* `textbox` role (from `contenteditable`, no DOM attribute exists to assert on directly) appears/disappears in step with `data-ready`.
- #1303: axe's `aria-valid-attr-value` rule (which checks every IDREF-valued ARIA attribute resolves) passes on the tablist; a plain DOM check also confirms every present `aria-controls` resolves.
- #1305: the computed `modal` AX property on the popover node is confirmed `!== true`, not just the DOM attribute's absence.

This mirrors the project's own documented caution (in chatroom's CLAUDE.md, re: cinder#1292) that a DOM-attribute-only check can pass while the actual computed accessibility semantics are still wrong.

Each fix was verified by reverting it (via `git stash` on just that file) and confirming the corresponding test goes red, then restoring it and confirming green again — done individually for all three, plus a final full run together.

## Test plan

- [x] `packages/testing/tests/review-editor-readiness-and-modality.playwright.ts` — new, all 4 tests pass with fixes, each relevant test fails when its fix is reverted
- [x] Existing `segmented-control-layout.playwright.ts`, `editors-complex-residual.playwright.ts`, `a11y-regressions.playwright.ts` still pass (no regressions from the tablist `controls` change)
- [x] `packages/editor` — `bun run lint`, `bun run typecheck`, `bun run test` (689 pass), `bun run components:check` all green
- [x] Workspace-wide `bun run typecheck` and `bun run lint` green (turbo, all packages)
- [x] `bunx prettier --check` and `bunx stylelint` on touched files clean
- [x] Changeset added (`@lostgradient/editor` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)