### PR TITLE
test: stop hardcoding the Markdown peer range literal in package-boundary tests

### DIFF
--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -52,15 +52,31 @@ describe('Chat package ownership boundary', () => {
     // consumer resolved its own Lucide against Cinder's prebuilt SSR bundle
     // and hit a hydration_mismatch, while Chat's README says Lucide is not
     // needed at all.
+    // `@lostgradient/cinder` and `@lostgradient/markdown` are both excluded
+    // from this literal comparison, not just Cinder: both ranges move
+    // across releases (Cinder moved on cinder#879's reconciliation, Markdown
+    // on this repo's own `reconcile-internal-peers.ts`, which post-#1330
+    // widened this range to `^0.3.0` on `changeset-release/main` the moment
+    // this test's PR merged) and each has its own dynamic guard below
+    // ("...covering the current ... version") that actually tracks the
+    // released version instead of hardcoding one. A previous version of
+    // this test hardcoded `@lostgradient/markdown: '^0.2.0'` here anyway,
+    // which is exactly the kind of drift the dynamic guards exist to
+    // prevent -- it went stale the first time this range moved, and failed
+    // CI on the version-packages PR that moved it for a reason unrelated to
+    // any actual regression.
     const remainingPeerDependencies = Object.fromEntries(
       Object.entries(chatManifest.peerDependencies ?? {}).filter(
-        ([peer]) => peer !== '@lostgradient/cinder',
+        ([peer]) => peer !== '@lostgradient/cinder' && peer !== '@lostgradient/markdown',
       ),
     );
     expect(remainingPeerDependencies).toEqual({
-      '@lostgradient/markdown': '^0.2.0',
       svelte: '>=5.56.0 <6',
     });
+    // Still pins the peer *set* (that Markdown must be declared at all),
+    // just not its exact range -- that's what the dynamic guard below
+    // checks.
+    expect(Object.keys(chatManifest.peerDependencies ?? {})).toContain('@lostgradient/markdown');
     expect(runtimeExternalSpecifiers(chatManifest)).toEqual([
       '@lostgradient/cinder',
       '@lostgradient/cinder/*',

--- a/packages/editor/scripts/package-boundary.test.ts
+++ b/packages/editor/scripts/package-boundary.test.ts
@@ -56,13 +56,25 @@ describe('Editor package ownership boundary', () => {
       '@floating-ui/dom': '1.7.6',
       'esm-env': '^1.2.0',
     });
+    // `@lostgradient/cinder` and `@lostgradient/markdown` are both excluded
+    // from this literal comparison, not just Cinder: both ranges move
+    // across releases (Cinder moved on cinder#879's reconciliation, Markdown
+    // on this repo's own `reconcile-internal-peers.ts`, which post-#1330
+    // widened this range to `^0.3.0` on `changeset-release/main` the moment
+    // this test's PR merged) and each has its own dynamic guard below
+    // ("...covering the current ... version") that actually tracks the
+    // released version instead of hardcoding one. A previous version of
+    // this test hardcoded `@lostgradient/markdown: '^0.2.0'` here anyway,
+    // which is exactly the kind of drift the dynamic guards exist to
+    // prevent -- it went stale the first time this range moved, and failed
+    // CI on the version-packages PR that moved it for a reason unrelated to
+    // any actual regression.
     const remainingPeerDependencies = Object.fromEntries(
       Object.entries(editorManifest.peerDependencies ?? {}).filter(
-        ([peer]) => peer !== '@lostgradient/cinder',
+        ([peer]) => peer !== '@lostgradient/cinder' && peer !== '@lostgradient/markdown',
       ),
     );
     expect(remainingPeerDependencies).toEqual({
-      '@lostgradient/markdown': '^0.2.0',
       '@milkdown/ctx': '^7.17.3',
       '@milkdown/kit': '^7.17.3',
       '@milkdown/prose': '^7.17.3',
@@ -72,6 +84,10 @@ describe('Editor package ownership boundary', () => {
       'prosemirror-view': '^1.41.3',
       svelte: '>=5.56.0 <6',
     });
+    // Still pins the peer *set* (that Markdown must be declared at all),
+    // just not its exact range -- that's what the dynamic guard below
+    // checks.
+    expect(Object.keys(editorManifest.peerDependencies ?? {})).toContain('@lostgradient/markdown');
     expect(runtimeExternalSpecifiers(editorManifest)).toEqual([
       '@lostgradient/cinder',
       '@lostgradient/cinder/*',


### PR DESCRIPTION
## Summary

`packages/editor/scripts/package-boundary.test.ts` and its `packages/chat` twin hardcoded `'@lostgradient/markdown': '^0.2.0'` in a literal `toEqual` comparison, duplicating a value each file's own dynamic guard test two blocks down (`keeps Editor's/Chat's Markdown peer range covering the current Markdown version`, via `Bun.semver.satisfies`) already checks correctly. The Cinder peer is excluded from the same literal comparison for exactly this reason — its range moves across releases — but Markdown wasn't, even though #1330 put it in the identical situation: `reconcile-internal-peers.ts` widened both packages' Markdown peer range to `^0.3.0` on `changeset-release/main` the moment #1330 merged, and the stale literal failed real CI on #1332 (`chore: version packages`) for a reason unrelated to any actual regression — [reproduced locally against a worktree of `origin/changeset-release/main`](#verification-not-just-ci), matching #1332's actual failed run.

## Fix

Excludes `'@lostgradient/markdown'` from the literal comparison the same way `'@lostgradient/cinder'` already is, and adds a separate assertion that the peer *set* still includes `'@lostgradient/markdown'` — so the test still pins that Markdown must be declared as a peer, just not its exact range, which the dynamic guard two blocks down already owns. Applied identically to both `packages/editor/scripts/package-boundary.test.ts` and `packages/chat/scripts/package-boundary.test.ts` (same literal, same bug, same fix).

## Verification (not just CI)

- Confirmed the failure is real: `origin/changeset-release/main`'s actual `package.json`s currently have `'@lostgradient/markdown': '^0.3.0'` for both Editor and Chat.
- Reproduced #1332's exact failure locally: ran the *unfixed* (pre-this-PR) test file against a `git worktree` of `origin/changeset-release/main` — fails with `Expected "@lostgradient/markdown": "^0.2.0", Received "^0.3.0"`, byte-identical to the CI log from #1332's failed run.
- Confirmed the fix goes green there: overlaid this PR's fixed test file in the same worktree — 9/9 (Editor) and 10/10 (Chat) pass.
- Confirmed the fix also stays green on this branch's own base (`origin/main`, where the peer range is still `^0.2.0` since #1330 deliberately didn't hand-edit `package.json` — see #1330's PR body) — so this fix is correct now and remains correct once `changeset-release/main` regenerates after merge.
- Full `bunx turbo run test typecheck lint --filter=@lostgradient/editor --filter=@lostgradient/chat --force`: all green (`@lostgradient/editor`: 829 pass, 1 pre-existing skip; `@lostgradient/chat`: 779 pass), 0 typecheck/lint errors.
- `bunx prettier --check` on both touched files — OK.

## Changeset

None. This changes no package's runtime behavior (test-only), and `bun packages/components/scripts/check-changeset-prerelease-bumps.ts` passes with zero changesets present (verified locally) — confirmed this is the actual rule the "Pre-1.0 changeset bump guard" required check enforces, not "a changeset must exist."

## Test plan

- [x] Reproduced #1332's failure locally against `origin/changeset-release/main`
- [x] Fix verified green against both `origin/changeset-release/main` (`^0.3.0`) and `origin/main` (`^0.2.0`)
- [x] `bunx turbo run test typecheck lint --filter=@lostgradient/editor --filter=@lostgradient/chat --force` — all green
- [x] `bunx prettier --check` — OK
- [x] `bun packages/components/scripts/check-changeset-prerelease-bumps.ts` — OK, no changeset needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)