### PR TITLE
fix(editor): memoize ReviewEditor's normalized diff baseline (cinder#1336)

### DIFF
--- a/.changeset/review-editor-diff-stats-memoize-original.md
+++ b/.changeset/review-editor-diff-stats-memoize-original.md
@@ -1,0 +1,39 @@
+---
+'@lostgradient/editor': patch
+---
+
+Fix `ReviewEditor`'s live toolbar diff badge costing ~30ms per recompute on a realistic large
+document — about 1.8x the 16.67ms (60fps) frame budget — by no longer re-normalizing the review
+session's fixed `original` baseline on every edit (cinder#1336).
+
+`review-editor-impl.svelte`'s `diffStats` (`const diffStats = $derived.by(() =>
+computeReviewEditorDiffStats(original, value))`) recomputes on every settled edit — roughly
+2-3x/second while typing, once `MarkdownEditor`'s debounce chain is accounted for. A stage-level
+breakdown, measured with `performance.now()` in a real Chromium production build against a
+304-line/8,255-word document, attributed >99% of the ~30ms median cost to two calls to
+`normalizeDocument` inside `computeReviewEditorDiffStats` — one for `original`, one for `current`
+— that were "essentially identical in cost." `original` is a review session's fixed diff baseline:
+it only changes if the consumer passes a new `original` prop, yet it was fully re-parsed from
+scratch alongside `current` on every single call.
+
+`computeReviewEditorDiffStats` now keeps a small, bounded (8-entry), LRU-evicted cache of
+`original -> normalizeDocument(original)`, keyed by value rather than a single slot: the function
+is shared, stateless, and has no per-instance identity to key off, and a page can legitimately
+host more than one `ReviewEditor` with a different `original` each. A single-slot cache would stay
+correct under that interleaving but would hit 0% of the time; the bounded LRU lets an `original` in
+active use keep surviving cache pressure from other instances' unrelated `current` recomputations,
+while an abandoned instance's entry ages out instead of growing the cache without bound. `current`
+is intentionally left unmemoized — it changes on essentially every call, so caching it wouldn't
+help and would just add overhead.
+
+Re-measured (Node, against the built `dist` function directly, on a synthetic 428-line/13k-word
+document — larger than the issue's own repro, so the absolute numbers move but the relative
+comparison holds): median cost dropped ~48%, in line with removing one of two near-identical
+normalization passes. Deliberately scoped to the toolbar's live `diffStats` path only —
+`generateUnifiedDiff` and `generateMarkdownSummary` share `normalizeDocument` via the same module
+but run per export action rather than per edit, and cinder#1336 scoped itself to the per-edit path
+for that reason; extending this memoization to those call sites is a separate change, not bundled
+here.
+
+This is a performance fix only: `computeReviewEditorDiffStats`'s return value for any given
+`(original, current)` pair is unchanged, cache hit or miss.

--- a/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.test.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.test.ts
@@ -12,7 +12,8 @@
  * rather than reintroducing a direct `normalize()` call that would make the
  * bug come back invisibly to this test file.
  */
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, spyOn, test } from 'bun:test';
+import * as normalizeDocumentModule from '../../export/normalize-document.ts';
 import { computeReviewEditorDiffStats } from './review-editor-diff-stats.ts';
 
 describe('computeReviewEditorDiffStats', () => {
@@ -78,6 +79,112 @@ describe('computeReviewEditorDiffStats', () => {
       removed: 0,
       modified: 0,
     });
+  });
+});
+
+describe('computeReviewEditorDiffStats normalization cost (cinder#1336)', () => {
+  // review-editor-impl.svelte's toolbar badge recomputes this on every settled
+  // edit while `original` — the review session's fixed baseline — never
+  // changes. cinder#1336 measured that re-normalizing `original` from scratch
+  // on every call, alongside `current`, accounted for >99% of a ~30ms-median
+  // recompute on a realistic document: the two normalizeDocument calls were
+  // "essentially identical in cost," and one of them (original's) was pure
+  // waste once original stopped moving.
+  //
+  // This spies on the real normalizeDocument (call-through preserved, so the
+  // returned stats stay correct — see the assertion below) rather than timing
+  // wall-clock cost, per this repo's own stance against timing-threshold
+  // assertions: a call-count assertion is deterministic and can't flake the
+  // way a duration budget can.
+  test('does not re-normalize an unchanged original across repeated calls', () => {
+    // Unique per test run (not just per test in this file): the cache this
+    // pins is module-global and never cleared, so a fixed literal here would
+    // make `callsAfterFirst` depend on process history — cold under a single
+    // run, warm (and wrong) under `--rerun-each` or if an earlier test in
+    // this file happens to reuse the same string. A nonce keeps this test's
+    // `original` guaranteed cache-cold regardless of what ran before it.
+    const nonce = `${Date.now()}-${Math.random()}`;
+    const original = `# Title ${nonce}\n\nOne paragraph.\n\nAnother paragraph.\n`;
+    const normalizeSpy = spyOn(normalizeDocumentModule, 'normalizeDocument');
+
+    const first = computeReviewEditorDiffStats(original, `${original}Edit one.\n`);
+    const callsAfterFirst = normalizeSpy.mock.calls.length;
+    // The very first call for a given `original` must still normalize it —
+    // there's nothing to reuse yet.
+    expect(callsAfterFirst).toBe(2); // original once, current once
+
+    const second = computeReviewEditorDiffStats(original, `${original}Edit two.\n`);
+    const callsAfterSecond = normalizeSpy.mock.calls.length;
+    // A second call with the SAME original and a DIFFERENT current must only
+    // normalize current. Without the fix, this call count matches the first
+    // call's exactly (original gets re-normalized every time); with the fix,
+    // it grows by exactly one (current only).
+    expect(callsAfterSecond - callsAfterFirst).toBe(1);
+
+    // Reusing the cached normalized original must not change the result:
+    // this is a performance fix, not a behavior change.
+    expect(first).toEqual({ added: 1, removed: 0, modified: 0 });
+    expect(second).toEqual({ added: 1, removed: 0, modified: 0 });
+
+    normalizeSpy.mockRestore();
+  });
+
+  test('still produces correct results when original changes between calls', () => {
+    // A cache keyed on the wrong thing (or a single slot that goes stale)
+    // would be invisible in the call-count assertion above if it also
+    // silently returned wrong stats. Interleave two different originals —
+    // as two concurrent ReviewEditor instances on the same page would — and
+    // confirm each is diffed against ITS OWN original, not a leftover cached
+    // one from the other instance.
+    const originalA = '# Doc A\n\nOriginal A body.\n';
+    const originalB = '# Doc B\n\nOriginal B body.\n';
+
+    const statsA1 = computeReviewEditorDiffStats(originalA, '# Doc A\n\nEdited A body.\n');
+    const statsB1 = computeReviewEditorDiffStats(originalB, '# Doc B\n\nEdited B body.\n');
+    // Re-visit A after B interleaved — this must still diff against
+    // originalA, not originalB.
+    const statsA2 = computeReviewEditorDiffStats(originalA, '# Doc A\n\nEdited A again.\n');
+
+    expect(statsA1).toEqual({ added: 0, removed: 0, modified: 1 });
+    expect(statsB1).toEqual({ added: 0, removed: 0, modified: 1 });
+    expect(statsA2).toEqual({ added: 0, removed: 0, modified: 1 });
+  });
+
+  test('recomputes correctly once an original ages out of the bounded cache', () => {
+    // The cache is intentionally bounded (a page can hold more than one
+    // ReviewEditor, but not an unbounded number forever) and evicts the
+    // least-recently-used entry once over capacity. That eviction path has
+    // no other coverage: push enough distinct originals through to guarantee
+    // the first one has been evicted by the time it's revisited, and confirm
+    // the eviction recomputes correctly rather than corrupting anything (a
+    // stale-cache bug here would still return SOME normalized string, so
+    // this checks the returned stats are right, not just that nothing
+    // throws).
+    const nonce = `${Date.now()}-${Math.random()}`;
+    const originals = Array.from(
+      { length: 20 },
+      (_, i) => `# Doc ${nonce}-${i}\n\nOriginal body ${i}.\n`,
+    );
+    const [firstOriginal] = originals;
+    if (firstOriginal === undefined) throw new Error('expected at least one generated original');
+
+    for (const [i, original] of originals.entries()) {
+      const stats = computeReviewEditorDiffStats(
+        original,
+        `# Doc ${nonce}-${i}\n\nEdited body ${i}.\n`,
+      );
+      expect(stats).toEqual({ added: 0, removed: 0, modified: 1 });
+    }
+
+    // firstOriginal is long since evicted (20 distinct originals pushed
+    // through a cache far smaller than that) — revisiting it must still
+    // diff correctly against ITS OWN original, not throw, and not return a
+    // stale/wrong result from whatever now occupies that cache slot.
+    const revisited = computeReviewEditorDiffStats(
+      firstOriginal,
+      `# Doc ${nonce}-0\n\nRevisited edit.\n`,
+    );
+    expect(revisited).toEqual({ added: 0, removed: 0, modified: 1 });
   });
 });
 

--- a/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.test.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.test.ts
@@ -12,8 +12,14 @@
  * rather than reintroducing a direct `normalize()` call that would make the
  * bug come back invisibly to this test file.
  */
-import { describe, expect, spyOn, test } from 'bun:test';
-import * as normalizeDocumentModule from '../../export/normalize-document.ts';
+import { afterEach, describe, expect, mock, spyOn, test } from 'bun:test';
+// Imported with the SAME specifier extension (`.js`) `review-editor-diff-stats.ts` itself uses to
+// import `normalizeDocument` — confirmed by a standalone check that both specifiers resolve to
+// the identical module instance (`viaJsImport.normalizeDocument === viaTsImport.normalizeDocument`
+// via `toBe`), but matching the production import's own specifier removes any doubt for a reader,
+// and matches this package's own convention for spying on a sibling module's export (see
+// `editor/attach.test.ts`'s `import * as editorRuntime from './editor.js'`).
+import * as normalizeDocumentModule from '../../export/normalize-document.js';
 import { computeReviewEditorDiffStats } from './review-editor-diff-stats.ts';
 
 describe('computeReviewEditorDiffStats', () => {
@@ -96,6 +102,17 @@ describe('computeReviewEditorDiffStats normalization cost (cinder#1336)', () => 
   // wall-clock cost, per this repo's own stance against timing-threshold
   // assertions: a call-count assertion is deterministic and can't flake the
   // way a duration budget can.
+  //
+  // `mock.restore()` runs after every test in this describe block, not just
+  // the one that creates the spy: restoring only at the end of that test's
+  // own body would leak the spy into every subsequent test if an assertion
+  // above it throws first (review finding on the initial version of this
+  // file, which restored manually and only reached that call on the happy
+  // path).
+  afterEach(() => {
+    mock.restore();
+  });
+
   test('does not re-normalize an unchanged original across repeated calls', () => {
     // Unique per test run (not just per test in this file): the cache this
     // pins is module-global and never cleared, so a fixed literal here would
@@ -125,8 +142,6 @@ describe('computeReviewEditorDiffStats normalization cost (cinder#1336)', () => 
     // this is a performance fix, not a behavior change.
     expect(first).toEqual({ added: 1, removed: 0, modified: 0 });
     expect(second).toEqual({ added: 1, removed: 0, modified: 0 });
-
-    normalizeSpy.mockRestore();
   });
 
   test('still produces correct results when original changes between calls', () => {

--- a/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-diff-stats.ts
@@ -17,6 +17,52 @@ export interface ReviewEditorDiffStats {
 }
 
 /**
+ * Bounded cache of `original` -> `normalizeDocument(original)` (cinder#1336).
+ *
+ * `computeReviewEditorDiffStats` is re-invoked on every settled edit —
+ * roughly every 300-500ms while typing, per the debounce chain documented on
+ * `review-editor-impl.svelte`'s `diffStats` — but `original` is a review
+ * session's fixed baseline: it only ever changes if the consumer passes a
+ * new `original` prop. Re-normalizing it from scratch on every call was the
+ * entire cost cinder#1336 measured: a stage-level breakdown attributed >99%
+ * of a ~30ms recompute, on a realistic 304-line document, to two
+ * near-identical `normalizeDocument` calls, one of which (original's) never
+ * needed to run more than once per baseline.
+ *
+ * Keyed by value (a `Map`, not a `WeakMap` — strings aren't `WeakMap`-eligible
+ * keys) and bounded to a handful of entries rather than a single slot: this
+ * is a shared, stateless, pure function with no per-instance identity to key
+ * off, and a page can legitimately hold more than one `ReviewEditor`, each
+ * with its own `original`. A single-slot cache would still be *correct*
+ * under that interleaving — a miss just recomputes — but it would hit 0% of
+ * the time and deliver none of the win this exists for. LRU eviction (bump
+ * an entry to most-recently-used on every hit, evict the least-recently-used
+ * entry once over capacity) means an `original` in active use keeps
+ * surviving even while other instances' unrelated `current` recomputations
+ * interleave, while an abandoned instance's entry ages out instead of
+ * growing this cache without bound.
+ */
+const ORIGINAL_NORMALIZE_CACHE_SIZE = 8;
+const normalizedOriginalCache = new Map<string, string>();
+
+function getNormalizedOriginal(original: string): string {
+  const cached = normalizedOriginalCache.get(original);
+  if (cached !== undefined) {
+    normalizedOriginalCache.delete(original);
+    normalizedOriginalCache.set(original, cached);
+    return cached;
+  }
+
+  const normalized = normalizeDocument(original);
+  normalizedOriginalCache.set(original, normalized);
+  if (normalizedOriginalCache.size > ORIGINAL_NORMALIZE_CACHE_SIZE) {
+    const oldestKey = normalizedOriginalCache.keys().next().value;
+    if (oldestKey !== undefined) normalizedOriginalCache.delete(oldestKey);
+  }
+  return normalized;
+}
+
+/**
  * Compute the toolbar's added/removed/modified counts for a document pair.
  *
  * Must use the same front-matter-aware {@link normalizeDocument} the diff
@@ -36,7 +82,7 @@ export function computeReviewEditorDiffStats(
     return { added: 0, removed: 0, modified: 0 };
   }
 
-  const normalizedOriginal = normalizeDocument(original);
+  const normalizedOriginal = getNormalizedOriginal(original);
   const normalizedCurrent = normalizeDocument(current);
   const lineDiffs = computeLineDiff(normalizedOriginal, normalizedCurrent);
   return getDiffStats(lineDiffs);


### PR DESCRIPTION
## Summary

Fixes #1336. `ReviewEditor`'s live toolbar diff badge — `computeReviewEditorDiffStats(original, current)` — cost ~30ms median per recompute on a realistic 304-line/8,255-word document, about 1.8x the 16.67ms (60fps) frame budget. A stage-level breakdown in the issue attributed >99% of that cost to two near-identical `normalizeDocument` calls, one for `original` and one for `current`. `original` is a review session's fixed baseline — it never changes within a session, yet it was re-parsed from scratch on every single settled edit alongside `current`, which does change.

## Fix

`computeReviewEditorDiffStats` now keeps a small (8-entry), LRU-evicted, value-keyed cache of `original -> normalizeDocument(original)`. `current` is intentionally left unmemoized (it changes almost every call, so caching it wouldn't help).

This is scoped to a `Map` rather than a single slot deliberately: the function is shared and stateless with no per-instance identity to key off, and a page can legitimately host more than one `ReviewEditor` with different `original` values. A single-slot cache would stay correct under that interleaving (a miss just recomputes) but would hit 0% of the time and deliver none of the win. Bounded LRU eviction means an `original` in active use survives other instances' interleaved calls, while an idle instance's entry ages out instead of leaking.

Deliberately scoped to only the toolbar's `diffStats` path, matching how the issue scoped itself — `generateUnifiedDiff` and `generateMarkdownSummary` share `normalizeDocument` via the same module but run per export action, not per edit, so the same memoization opportunity there is a separate change.

## Testing

- Added a call-count spy test (`spyOn` the real `normalizeDocument`, call-through preserved) asserting `computeReviewEditorDiffStats` normalizes an unchanged `original` exactly once across repeated calls, not once per call. Reverted the fix and confirmed this test fails (`Expected: 1, Received: 2`); restored and confirmed it passes.
- Added a correctness test interleaving two different `original` values (simulating two concurrent `ReviewEditor` instances) to confirm the cache never returns a stale/wrong result.
- Added an eviction test pushing 20 distinct originals through the bounded cache and revisiting the first (long evicted) to confirm it recomputes correctly rather than corrupting.
- Existing behavioral suite for this function (front-matter handling, cinder#1307) is unchanged and still green.

## Performance

Re-measured after the fix (Node, against the built `dist` function directly — not the issue's original Chromium/Playwright methodology, since that lives in the downstream `chatroom` repo's own repro route and isn't rerun here; a synthetic 428-line/13k-word document, larger than the issue's 304-line repro):

| | median | p95 | max |
|---|---|---|---|
| before (both `normalizeDocument` calls every time) | 56.53ms | 65.47ms | 69.63ms |
| after (fix, same `original` held across calls) | 29.44ms | 36.31ms | 40.55ms |

~48% median reduction — consistent with removing one of two near-identical normalization passes, as the issue's own stage breakdown predicted.

## Test plan

- [x] `bun run --filter=@lostgradient/editor test` — 867 pass, 1 skip, 0 fail
- [x] `bun run --filter=@lostgradient/editor typecheck` — 0 errors
- [x] `bun run --filter=@lostgradient/editor lint` — 0 warnings/errors
- [x] `bun run --filter=@lostgradient/editor components:check` — OK
- [x] Break-and-restore: reverted the fix, watched the new spy test fail with the exact expected diff, restored, watched it pass again (verified byte-identical restore via `diff` against a backup)
- [x] Changeset added (`@lostgradient/editor` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)