### PR TITLE
Fix Playground documentation accessibility and layout

### DIFF
--- a/packages/components/src/components/waveform/waveform.css
+++ b/packages/components/src/components/waveform/waveform.css
@@ -3,6 +3,8 @@
   .cinder-waveform {
     display: grid;
     gap: var(--cinder-space-2);
+    min-inline-size: 0;
+    max-inline-size: 100%;
     color: var(--_cinder-chart-foreground, currentColor);
     background: var(--_cinder-chart-background, transparent);
   }

--- a/packages/components/src/components/waveform/waveform.css
+++ b/packages/components/src/components/waveform/waveform.css
@@ -19,6 +19,23 @@
     position: relative;
   }
 
+  .cinder-waveform__table-scroll {
+    inline-size: 100%;
+    max-inline-size: 100%;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .cinder-waveform__table-scroll > table {
+    min-inline-size: max-content;
+  }
+
+  .cinder-waveform__table-scroll:focus-visible {
+    outline: var(--cinder-ring-width) solid transparent;
+    box-shadow: var(--_cinder-focus-ring-shadow);
+  }
+
   .cinder-waveform svg {
     display: block;
     inline-size: 100%;

--- a/packages/components/src/components/waveform/waveform.css
+++ b/packages/components/src/components/waveform/waveform.css
@@ -36,6 +36,14 @@
     box-shadow: var(--_cinder-focus-ring-shadow);
   }
 
+  @media (forced-colors: active) {
+    .cinder-waveform__table-scroll:focus-visible {
+      outline: var(--cinder-ring-width) solid ButtonText;
+      outline-offset: 2px;
+      box-shadow: none;
+    }
+  }
+
   .cinder-waveform svg {
     display: block;
     inline-size: 100%;

--- a/packages/components/src/components/waveform/waveform.svelte
+++ b/packages/components/src/components/waveform/waveform.svelte
@@ -274,9 +274,10 @@
     <div
       class={dataTableVisibility === 'screen-reader-only'
         ? 'cinder-sr-only'
-        : 'cinder-table-scroll'}
-      role="region"
-      aria-label={tableCaption}
+        : 'cinder-waveform__table-scroll'}
+      {...dataTableVisibility === 'visible'
+        ? { role: 'region', 'aria-label': `${label} data table`, tabindex: 0 }
+        : {}}
     >
       <table
         class={dataTableClass(

--- a/packages/components/src/components/waveform/waveform.svelte
+++ b/packages/components/src/components/waveform/waveform.svelte
@@ -271,22 +271,34 @@
     </svg>
   </div>
   {#if hasDataTable}
-    <table class={dataTableClass(dataTableVisibility)}>
-      <caption>{tableCaption}</caption>
-      <thead>
-        <tr>
-          <th scope="col">Sample index</th>
-          <th scope="col">Amplitude</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each tableSamples as sample (sample.index)}
+    <div
+      class={dataTableVisibility === 'screen-reader-only'
+        ? 'cinder-sr-only'
+        : 'cinder-table-scroll'}
+      role="region"
+      aria-label={tableCaption}
+    >
+      <table
+        class={dataTableClass(
+          dataTableVisibility === 'screen-reader-only' ? 'visible' : dataTableVisibility,
+        )}
+      >
+        <caption>{tableCaption}</caption>
+        <thead>
           <tr>
-            <td>{sample.index}</td>
-            <td>{sample.value.toFixed(4)}</td>
+            <th scope="col">Sample index</th>
+            <th scope="col">Amplitude</th>
           </tr>
-        {/each}
-      </tbody>
-    </table>
+        </thead>
+        <tbody>
+          {#each tableSamples as sample (sample.index)}
+            <tr>
+              <td>{sample.index}</td>
+              <td>{sample.value.toFixed(4)}</td>
+            </tr>
+          {/each}
+        </tbody>
+      </table>
+    </div>
   {/if}
 </figure>

--- a/packages/components/src/components/waveform/waveform.test.ts
+++ b/packages/components/src/components/waveform/waveform.test.ts
@@ -181,7 +181,7 @@ describe('Waveform', () => {
       data: sineData,
     });
 
-    expect(container.querySelector('table.cinder-sr-only')).not.toBeNull();
+    expect(container.querySelector('.cinder-sr-only > table')).not.toBeNull();
   });
 
   test('clamps samples outside [-1, 1] range', () => {

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -553,6 +553,7 @@ describe('component-page single-scroll layout', () => {
     await showPlayground();
     const note = document.querySelector('.dx-play__note');
     expect(note?.textContent).toContain('no adjustable props');
+    expect(screen.queryByRole('group', { name: 'Stage width' })).toBeNull();
 
     unmount();
     await tick();

--- a/packages/playground/src/component-page-live-preview.test.ts
+++ b/packages/playground/src/component-page-live-preview.test.ts
@@ -48,6 +48,7 @@ import {
   toMountProps,
 } from './component-page-live-preview.ts';
 import type { PlaygroundControl } from './component-page-playground.ts';
+import { previewRecipeFor } from './component-page-preview-recipes.ts';
 
 setupHappyDom();
 
@@ -84,6 +85,17 @@ describe('toMountProps', () => {
       { name: 'children', kind: 'text', isChildren: true, value: '', hasDefault: false },
     ];
     expect('children' in toMountProps(controls, { children: '' })).toBe(false);
+  });
+
+  test.each([
+    ['floating-action', { 'aria-label': 'Create item' }],
+    ['meter', { ariaLabel: 'Storage usage' }],
+    ['phone-input', { id: 'playground-phone-input', label: 'Phone number' }],
+    ['pin-input', { id: 'playground-pin-input', label: 'Verification code' }],
+    ['progress', { ariaLabel: 'Task progress' }],
+    ['rating', { id: 'playground-rating', label: 'Rating' }],
+  ])('supplies an accessible preview baseline for %s', (componentName, expectedProps) => {
+    expect(toMountProps([], {}, [], previewRecipeFor(componentName))).toMatchObject(expectedProps);
   });
 });
 

--- a/packages/playground/src/component-page-live-preview.ts
+++ b/packages/playground/src/component-page-live-preview.ts
@@ -60,7 +60,9 @@ export function toMountProps(
   seeds: readonly PlaygroundSeed[] = [],
   recipe?: PreviewRecipe,
 ): Record<string, unknown> {
-  const props: Record<string, unknown> = {};
+  // Recipe props establish a valid baseline for the bare preview. Editable
+  // controls still win below, so changing a generated control remains live.
+  const props: Record<string, unknown> = { ...recipe?.props };
   // A recipe's children are a repo constant (placeholder boxes for a layout
   // primitive, a padded block for Surface), so they are inserted as MARKUP —
   // that is the point, since the whole failure being fixed is that one text run

--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -513,6 +513,30 @@ describe('buildSnippet', () => {
     );
   });
 
+  test('keeps an accessible recipe baseline until its empty control changes it', () => {
+    const labelControl = buildPlaygroundModel(
+      manifest([
+        {
+          name: 'ariaLabel',
+          control: { kind: 'text' },
+          bindable: false,
+          optional: true,
+        },
+      ]),
+    ).controls;
+
+    expect(
+      buildSnippet('Progress', labelControl, { ariaLabel: '' }, [], undefined, {
+        ariaLabel: 'Loading progress',
+      }),
+    ).toBe('<Progress ariaLabel="Loading progress" />');
+    expect(
+      buildSnippet('Progress', labelControl, { ariaLabel: 'Upload progress' }, [], undefined, {
+        ariaLabel: 'Loading progress',
+      }),
+    ).toBe('<Progress ariaLabel="Upload progress" />');
+  });
+
   test('renders string attributes and stacks multiple onto separate lines', () => {
     expect(buildSnippet('Accordion', controls, { multiple: true, size: 'sm' })).toBe(
       '<Accordion\n  multiple\n  size="sm"\n/>',

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -574,7 +574,13 @@ export function buildSnippet(
 
   const attributes = [
     ...Object.entries(baselineProps)
-      .filter(([name]) => !controls.some((control) => control.name === name))
+      .filter(([name]) => {
+        const matchingControl = controls.find((control) => control.name === name);
+        return (
+          matchingControl === undefined ||
+          !shouldEmit(matchingControl, values[matchingControl.name] ?? matchingControl.value)
+        );
+      })
       .flatMap(([name, value]) =>
         typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
           ? [attributeFor(name, value)]

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -555,6 +555,7 @@ export function buildSnippet(
   values: Record<string, PlaygroundValue>,
   seeds: readonly PlaygroundSeed[] = [],
   importPath?: string,
+  baselineProps: Readonly<Record<string, unknown>> = {},
 ): string {
   // The synthesized `children` control renders as element CONTENT, not an
   // attribute, so it is partitioned out of the attribute list.
@@ -572,6 +573,13 @@ export function buildSnippet(
   const preambleSeeds = seeds.filter((seed) => seed.source.length > INLINE_SEED_MAX_CHARS);
 
   const attributes = [
+    ...Object.entries(baselineProps)
+      .filter(([name]) => !controls.some((control) => control.name === name))
+      .flatMap(([name, value]) =>
+        typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
+          ? [attributeFor(name, value)]
+          : [],
+      ),
     ...controls
       .filter((control) => !(control.kind === 'text' && control.isChildren))
       .filter((control) => shouldEmit(control, values[control.name] ?? control.value))

--- a/packages/playground/src/component-page-preview-recipes.ts
+++ b/packages/playground/src/component-page-preview-recipes.ts
@@ -25,6 +25,13 @@
 /** Scaffolding for one component's live-preview stage. */
 export type PreviewRecipe = {
   /**
+   * Deterministic props required for a meaningful bare preview but not useful
+   * as editable controls. In particular, controls whose contract requires an
+   * accessible name receive a domain-specific name here rather than mounting
+   * in a warning-producing state.
+   */
+  props?: Readonly<Record<string, unknown>>;
+  /**
    * Raw HTML mounted as the component's `children`, replacing the synthesized
    * name-as-text seed.
    */
@@ -56,6 +63,12 @@ const PLACEHOLDER_BOXES = [1, 2, 3]
 const LAYOUT_RECIPE: PreviewRecipe = { childrenHtml: PLACEHOLDER_BOXES };
 
 export const PREVIEW_RECIPES: Readonly<Record<string, PreviewRecipe>> = {
+  'floating-action': { props: { 'aria-label': 'Create item' } },
+  meter: { props: { ariaLabel: 'Storage usage' } },
+  'phone-input': { props: { id: 'playground-phone-input', label: 'Phone number' } },
+  'pin-input': { props: { id: 'playground-pin-input', label: 'Verification code' } },
+  progress: { props: { ariaLabel: 'Task progress' } },
+  rating: { props: { id: 'playground-rating', label: 'Rating' } },
   container: LAYOUT_RECIPE,
   grid: LAYOUT_RECIPE,
   'grid-item': LAYOUT_RECIPE,

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -604,6 +604,7 @@
           playgroundValues,
           playgroundModel.seeds,
           documentation.propsManifest.importPath,
+          previewRecipe?.props,
         ),
   );
   /**
@@ -1063,23 +1064,25 @@
                 <!-- Stage controls. Width simulation and focus mode used to live on
                      the shell's top bar and act on an iframe; they now sit with the
                      stage they resize, and work by constraining a plain container. -->
-                {#if playgroundModel.controls.length > 0}
+                {#if playgroundModel.controls.length > 0 || isFocusMode}
                   <div class="dx-viewport" role="group" aria-label="Stage width">
-                    <div class="dx-viewport__sizes">
-                      {#each PREVIEW_WIDTHS as option (option.label)}
-                        <button
-                          type="button"
-                          class="dx-viewport__size"
-                          aria-pressed={previewWidth === option.width}
-                          onclick={() => (previewWidth = option.width)}
-                        >
-                          {option.label}
-                        </button>
-                      {/each}
-                    </div>
-                    <span class="dx-viewport__readout" aria-live="polite">
-                      {previewWidth === null ? 'Full' : `${previewWidth}px`}
-                    </span>
+                    {#if playgroundModel.controls.length > 0}
+                      <div class="dx-viewport__sizes">
+                        {#each PREVIEW_WIDTHS as option (option.label)}
+                          <button
+                            type="button"
+                            class="dx-viewport__size"
+                            aria-pressed={previewWidth === option.width}
+                            onclick={() => (previewWidth = option.width)}
+                          >
+                            {option.label}
+                          </button>
+                        {/each}
+                      </div>
+                      <span class="dx-viewport__readout" aria-live="polite">
+                        {previewWidth === null ? 'Full' : `${previewWidth}px`}
+                      </span>
+                    {/if}
                     <button
                       type="button"
                       class="dx-viewport__expand"

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -970,7 +970,7 @@
                   {#if component.tags.length > 0}
                     <div class="dx-tags">
                       {#each component.tags as tag (tag)}
-                        <Badge variant="accent" size="sm">{tag}</Badge>
+                        <Badge variant="neutral" size="sm">{tag}</Badge>
                       {/each}
                     </div>
                   {/if}
@@ -1063,31 +1063,33 @@
                 <!-- Stage controls. Width simulation and focus mode used to live on
                      the shell's top bar and act on an iframe; they now sit with the
                      stage they resize, and work by constraining a plain container. -->
-                <div class="dx-viewport" role="group" aria-label="Stage width">
-                  <div class="dx-viewport__sizes">
-                    {#each PREVIEW_WIDTHS as option (option.label)}
-                      <button
-                        type="button"
-                        class="dx-viewport__size"
-                        aria-pressed={previewWidth === option.width}
-                        onclick={() => (previewWidth = option.width)}
-                      >
-                        {option.width === null ? 'Full' : `${option.width}`}
-                      </button>
-                    {/each}
+                {#if playgroundModel.controls.length > 0}
+                  <div class="dx-viewport" role="group" aria-label="Stage width">
+                    <div class="dx-viewport__sizes">
+                      {#each PREVIEW_WIDTHS as option (option.label)}
+                        <button
+                          type="button"
+                          class="dx-viewport__size"
+                          aria-pressed={previewWidth === option.width}
+                          onclick={() => (previewWidth = option.width)}
+                        >
+                          {option.label}
+                        </button>
+                      {/each}
+                    </div>
+                    <span class="dx-viewport__readout" aria-live="polite">
+                      {previewWidth === null ? 'Full' : `${previewWidth}px`}
+                    </span>
+                    <button
+                      type="button"
+                      class="dx-viewport__expand"
+                      aria-pressed={isFocusMode}
+                      onclick={() => (isFocusMode = !isFocusMode)}
+                    >
+                      {isFocusMode ? 'Exit' : 'Expand'}
+                    </button>
                   </div>
-                  <span class="dx-viewport__readout" aria-live="polite">
-                    {previewWidth === null ? 'Full' : `${previewWidth}px`}
-                  </span>
-                  <button
-                    type="button"
-                    class="dx-viewport__expand"
-                    aria-pressed={isFocusMode}
-                    onclick={() => (isFocusMode = !isFocusMode)}
-                  >
-                    {isFocusMode ? 'Exit' : 'Expand'}
-                  </button>
-                </div>
+                {/if}
                 <!-- Single wrapper: a branch with several top-level children trips
                        happy-dom's fragment handling in the documentation tests.
 
@@ -2161,6 +2163,7 @@
     max-width: var(--dx-max);
     margin-inline: auto;
     padding-inline: var(--dx-gutter);
+    min-width: 0;
   }
 
   /* ===== Top bar ===== */
@@ -2385,6 +2388,7 @@
       'docs';
     padding-block: clamp(1.25rem, 2vw, 1.75rem) clamp(3rem, 6vw, 5rem);
     align-items: start;
+    min-width: 0;
   }
 
   /* View switcher. */
@@ -2479,6 +2483,7 @@
   }
   .dx-content {
     grid-area: docs;
+    min-width: 0;
   }
 
   .dx-landing-cta {
@@ -2590,6 +2595,14 @@
   .dx-playground__stage .dx-stage__canvas {
     min-height: 18rem;
   }
+  /* Examples and demos may intentionally have a minimum usable width (a
+     permission matrix or sortable row cannot collapse into 200px). Keep that
+     width reachable inside its own stage instead of letting it widen the page. */
+  .dx-stage__canvas {
+    max-width: 100%;
+    min-width: 0;
+    overflow-x: auto;
+  }
   .dx.is-focus-mode .dx-playground__stage .dx-stage {
     flex: 1;
   }
@@ -2691,6 +2704,7 @@
      * fully transparent. */
     background: color-mix(in oklch, var(--cinder-surface-raised), transparent 8%);
     backdrop-filter: blur(8px);
+    min-width: 0;
   }
   .dx-toc__list {
     list-style: none;
@@ -3194,6 +3208,7 @@
   .dx-examples {
     display: flex;
     flex-direction: column;
+    min-width: 0;
     gap: var(--cinder-space-6);
   }
   .dx-example {
@@ -3309,11 +3324,14 @@
     gap: var(--cinder-space-0-5, 0.125rem);
     align-items: flex-start;
     max-inline-size: 40rem;
+    min-inline-size: 0;
     overflow-wrap: break-word;
   }
   .props-type__member {
     white-space: pre-wrap;
     max-width: 28rem;
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
   }
   .props-type--union .props-type__member {
     display: flex;
@@ -3421,7 +3439,10 @@
   /* Narrow container → stacked cards (same ::before-label pattern as before). */
   @container props-section (max-width: 34rem) {
     .props-table-scroll {
-      overflow-x: visible;
+      /* Some generated TypeScript signatures remain wider than a phone-sized
+       * card. Keep that overflow on the table's own scroll surface instead of
+       * allowing it to widen the whole documentation page. */
+      overflow-x: auto;
     }
     .props-table-scroll.is-scrollable::after {
       display: none;
@@ -3447,11 +3468,14 @@
     }
     .props-section :global(.cinder-table td) {
       display: grid;
-      grid-template-columns: minmax(4.5rem, max-content) 1fr;
+      grid-template-columns: minmax(4.5rem, max-content) minmax(0, 1fr);
       gap: var(--cinder-space-3);
       padding-block: var(--cinder-space-1);
       border: none;
       text-align: start;
+    }
+    .props-section :global(.cinder-table td > *) {
+      min-inline-size: 0;
     }
     /* Labels come from each cell's own `data-label`, which the template emits
        from `PROP_COLUMNS`. The previous `nth-child` rules encoded column

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1064,7 +1064,13 @@
                      the shell's top bar and act on an iframe; they now sit with the
                      stage they resize, and work by constraining a plain container. -->
                 {#if playgroundModel.controls.length > 0 || isFocusMode}
-                  <div class="dx-viewport" role="group" aria-label="Stage width">
+                  <div
+                    class="dx-viewport"
+                    role="group"
+                    aria-label={playgroundModel.controls.length > 0
+                      ? 'Stage width'
+                      : 'Preview controls'}
+                  >
                     {#if playgroundModel.controls.length > 0}
                       <div class="dx-viewport__sizes">
                         {#each PREVIEW_WIDTHS as option (option.label)}
@@ -1419,7 +1425,7 @@
                         <span class="dx-stage__dot" aria-hidden="true"></span>
                         <span class="dx-stage__label">Live preview</span>
                       </div>
-                      <div class="dx-stage__canvas">
+                      <div class="dx-stage__canvas" role="region" aria-label="Preview" tabindex="0">
                         {#if mountErrors[`overview-mount-${overviewExample.scenario}`] !== undefined}
                           {@const error = mountErrors[`overview-mount-${overviewExample.scenario}`]}
                           <Callout variant="danger" title="This preview failed to render">
@@ -1522,7 +1528,12 @@
                             </div>
                             <div class="dx-example__body">
                               <div class="dx-stage">
-                                <div class="dx-stage__canvas">
+                                <div
+                                  class="dx-stage__canvas"
+                                  role="region"
+                                  aria-label="Preview"
+                                  tabindex="0"
+                                >
                                   <div
                                     class="example-preview"
                                     id="example-mount-{scenario}"

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1425,7 +1425,12 @@
                         <span class="dx-stage__dot" aria-hidden="true"></span>
                         <span class="dx-stage__label">Live preview</span>
                       </div>
-                      <div class="dx-stage__canvas" role="region" aria-label="Preview" tabindex="0">
+                      <div
+                        class="dx-stage__canvas"
+                        role="region"
+                        aria-label="Overview preview"
+                        tabindex="0"
+                      >
                         {#if mountErrors[`overview-mount-${overviewExample.scenario}`] !== undefined}
                           {@const error = mountErrors[`overview-mount-${overviewExample.scenario}`]}
                           <Callout variant="danger" title="This preview failed to render">
@@ -1531,7 +1536,7 @@
                                 <div
                                   class="dx-stage__canvas"
                                   role="region"
-                                  aria-label="Preview"
+                                  aria-label={`${title} preview`}
                                   tabindex="0"
                                 >
                                   <div

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -1129,7 +1129,7 @@
                       <span class="dx-stage__dot" aria-hidden="true"></span>
                       <span class="dx-stage__label">Live preview</span>
                     </div>
-                    <div class="dx-stage__canvas">
+                    <div class="dx-stage__canvas" role="region" aria-label="Preview" tabindex="0">
                       {#if previewRecipe?.referenceHtml !== undefined}
                         <!-- A styling primitive is invisible without something to
                                be compared against. -->
@@ -1171,7 +1171,7 @@
                       <span class="dx-stage__dot" aria-hidden="true"></span>
                       <span class="dx-stage__label">Featured example</span>
                     </div>
-                    <div class="dx-stage__canvas">
+                    <div class="dx-stage__canvas" role="region" aria-label="Preview" tabindex="0">
                       {#if mountErrors[`playground-mount-${overviewExample.scenario}`] !== undefined}
                         {@const error = mountErrors[`playground-mount-${overviewExample.scenario}`]}
                         <Callout variant="danger" title="This preview failed to render">
@@ -1199,7 +1199,7 @@
                       <span class="dx-stage__dot" aria-hidden="true"></span>
                       <span class="dx-stage__label">Composed component</span>
                     </div>
-                    <div class="dx-stage__canvas">
+                    <div class="dx-stage__canvas" role="region" aria-label="Preview" tabindex="0">
                       <p class="dx-stage__compose">
                         {documentation.component.name} is composed inside
                         <a href={buildComponentHref(composesInto)} target="_top">
@@ -1228,7 +1228,12 @@
                       <span class="dx-stage__dot" aria-hidden="true"></span>
                       <span class="dx-stage__label">Live preview</span>
                     </div>
-                    <div class="dx-stage__canvas"></div>
+                    <div
+                      class="dx-stage__canvas"
+                      role="region"
+                      aria-label="Preview"
+                      tabindex="0"
+                    ></div>
                     <p class="dx-stage__note">
                       Renders with the props below. Adjust the controls to update it live.
                     </p>

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -583,6 +583,14 @@
         }
       : buildPlaygroundModel(documentation.propsManifest),
   );
+  /**
+   * Stage scaffolding for components no amount of prop seeding makes legible —
+   * layout primitives, Surface, and the behavior-only wrappers. See
+   * `component-page-preview-recipes.ts`.
+   */
+  const previewRecipe = $derived(
+    documentation === null ? undefined : previewRecipeFor(documentation.propsManifest.kebabName),
+  );
   // Live control values, keyed by prop name. Seeded from each control's default
   // the first time the model resolves.
   const playgroundValues: Record<string, PlaygroundValue> = $state({});
@@ -667,15 +675,6 @@
   const canMountBare = $derived(
     documentation !== null &&
       canBareMount(documentation.propsManifest.kebabName, documentation.propsManifest.isCompound),
-  );
-
-  /**
-   * Stage scaffolding for components no amount of prop seeding makes legible —
-   * layout primitives, Surface, and the behavior-only wrappers. See
-   * `component-page-preview-recipes.ts`.
-   */
-  const previewRecipe = $derived(
-    documentation === null ? undefined : previewRecipeFor(documentation.propsManifest.kebabName),
   );
 
   const bareComponent = $derived(

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { runAxe } from '../src/helpers/axe.ts';
+
 /**
  * The component documentation page is a single scrolling reference (the
  * three-tab Documentation / Examples / Raw Artifacts layout was removed). Every
@@ -153,4 +155,74 @@ test.describe('canonical page preview controls', () => {
     await page.getByRole('tab', { name: 'Playground' }).click();
     await expect(page.getByRole('group', { name: 'Stage width' })).toContainText('768px');
   });
+});
+
+test.describe('generated Playground accessibility', () => {
+  for (const name of [
+    'floating-action',
+    'meter',
+    'phone-input',
+    'pin-input',
+    'progress',
+    'rating',
+  ]) {
+    test(`mounts ${name} without accessibility warnings at desktop and mobile widths`, async ({
+      page,
+    }) => {
+      for (const [viewport, width] of [
+        ['desktop', 1440],
+        ['mobile', 390],
+      ] as const) {
+        const errors: string[] = [];
+        page.removeAllListeners('console');
+        page.on('console', (message) => {
+          if (message.type() === 'error' || message.type() === 'warning')
+            errors.push(message.text());
+        });
+        await page.setViewportSize({ width, height: 844 });
+        await page.goto(`/page/${name}?view=playground`, { waitUntil: 'load' });
+        await expect(page.locator('#playground-live-mount')).toBeVisible();
+
+        const buckets = await runAxe(page, {
+          slug: name,
+          theme: 'light',
+          viewport,
+          fixture: 'generated-playground',
+        });
+        expect(buckets.critical, `${name} at ${viewport}`).toEqual([]);
+        expect(buckets.serious, `${name} at ${viewport}`).toEqual([]);
+        expect(
+          errors.filter((message) => /accessible name|aria-label|ariaLabel/i.test(message)),
+          `${name} at ${viewport}`,
+        ).toEqual([]);
+      }
+    });
+  }
+});
+
+test.describe('narrow documentation layout', () => {
+  for (const name of [
+    'autocomplete',
+    'chat-composer-popover',
+    'checkbox',
+    'permission-matrix',
+    'pin-input',
+    'sortable-list',
+    'table',
+    'waveform',
+  ]) {
+    test(`${name} does not widen the document`, async ({ page }) => {
+      for (const width of [320, 375, 390, 430]) {
+        await page.setViewportSize({ width, height: 844 });
+        await page.goto(`/page/${name}`, { waitUntil: 'load' });
+        const dimensions = await page.evaluate(() => ({
+          clientWidth: document.documentElement.clientWidth,
+          scrollWidth: document.documentElement.scrollWidth,
+        }));
+        expect(dimensions.scrollWidth, `${name} at ${width}px`).toBeLessThanOrEqual(
+          dimensions.clientWidth,
+        );
+      }
+    });
+  }
 });


### PR DESCRIPTION
Resolves CIN-400, CIN-53, CIN-325, CIN-324, CIN-322, CIN-321, and CIN-402.\n\n- supplies accessible baseline props for generated Playground previews\n- removes decorative hero-tag emphasis and redundant zero-control stage chrome\n- preserves preview fallbacks and verifies the existing inline documentation path\n- prevents narrow-page overflow while retaining local table and code scrolling\n\nValidation:\n- bun test packages/components/src/components/waveform/waveform.test.ts packages/playground/src/component-page-live-preview.test.ts packages/playground/src/component-page-documentation.test.ts\n- bun run --filter='@cinder/playground' typecheck\n- bun run lint\n- bun run test:browser -- tests/playground-documentation.playwright.ts -g 'generated Playground accessibility|narrow documentation layout'