### PR TITLE
Fix Playground documentation structure

### DIFF
--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from 'bun:test';
 
 import {
   assertDocumentationPagesArePreRendered,
+  assertExactlyOneH1,
   assetUrlsFromHtml,
   runStaticExport,
 } from './static-export.ts';
@@ -237,6 +238,21 @@ describe('assertDocumentationPagesArePreRendered', () => {
     expect(error?.message).toContain('2 of 3');
     expect(error?.message).toContain('badge');
     expect(error?.message).toContain('card');
+  });
+});
+
+describe('assertExactlyOneH1', () => {
+  test('accepts one semantic top-level heading', () => {
+    expect(() => assertExactlyOneH1('landing', '<main><h1>cinder</h1></main>')).not.toThrow();
+  });
+
+  test('rejects duplicate or missing top-level headings', () => {
+    expect(() => assertExactlyOneH1('landing', '<h1>cinder</h1><h1>cinder</h1>')).toThrow(
+      'landing: expected exactly one h1, found 2',
+    );
+    expect(() => assertExactlyOneH1('landing', '<main></main>')).toThrow(
+      'landing: expected exactly one h1, found 0',
+    );
   });
 });
 

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -284,7 +284,10 @@ export async function runStaticExport(options: StaticExportOptions = {}): Promis
 
   // Root landing page + the shell bundle graph (shared by every shell page).
   const rootHtml = await render('/', context);
-  if (rootHtml !== null) collect(rootHtml);
+  if (rootHtml !== null) {
+    assertExactlyOneH1('landing page', rootHtml);
+    collect(rootHtml);
+  }
   await renderJsBundleGraph('/shell-bundle/shell.js', context);
   await render('/ping', context);
   // NOTE: the full `/api/manifest` array is intentionally NOT rendered. The UI
@@ -353,6 +356,11 @@ const PRE_RENDER_MARKERS = ['data-component-page', '<h1'] as const;
 /** An `#app` with no children is the exact shape of the regression guarded here. */
 const EMPTY_MOUNT_ROOT = '<div id="app"></div>';
 
+export function assertExactlyOneH1(name: string, html: string): void {
+  const count = html.match(/<h1\b/gi)?.length ?? 0;
+  if (count !== 1) throw new Error(`${name}: expected exactly one h1, found ${count}`);
+}
+
 /**
  * Fail the build when a documentation page exported without server-rendered
  * content.
@@ -381,6 +389,12 @@ export function assertDocumentationPagesArePreRendered(
     const missing = PRE_RENDER_MARKERS.filter((marker) => !html.includes(marker));
     if (missing.length > 0) {
       failures.push(`${name}: missing ${missing.join(', ')}`);
+      continue;
+    }
+    try {
+      assertExactlyOneH1(name, html);
+    } catch (error) {
+      failures.push(error instanceof Error ? error.message : `${name}: invalid h1 count`);
     }
   }
 

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -2861,6 +2861,13 @@
   .readme-content :global(h3:first-child) {
     margin-top: 0;
   }
+  /* Component README titles are removed in the documentation transform; keep
+     this defensive rule for fixture and malformed-content paths. The landing
+     README title is instead omitted structurally in the server renderer, so it
+     never contributes a duplicate H1 to exported or hydrated markup. */
+  .readme-content :global(h1:first-child) {
+    display: none;
+  }
   /*
    * ONE prose scale, for both surfaces.
    *

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -2861,9 +2861,6 @@
   .readme-content :global(h3:first-child) {
     margin-top: 0;
   }
-  .readme-content :global(h1:first-child) {
-    display: none;
-  }
   /*
    * ONE prose scale, for both surfaces.
    *

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -344,7 +344,7 @@ describe('/', () => {
     expect(match).not.toBeNull();
     const payload = JSON.parse(match![1]!) as { component: string; readmeHtml: string };
     expect(payload.component).toBe('');
-    expect(payload.readmeHtml).not.toContain('<h1>cinder</h1>');
+    expect(payload.readmeHtml).not.toMatch(/<h1\b/i);
     expect(payload.readmeHtml).toContain('<h2>Install</h2>');
     expect(payload.readmeHtml).not.toContain('href="./docs/');
     expect(payload.readmeHtml).not.toContain('href="docs/');

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -344,7 +344,7 @@ describe('/', () => {
     expect(match).not.toBeNull();
     const payload = JSON.parse(match![1]!) as { component: string; readmeHtml: string };
     expect(payload.component).toBe('');
-    expect(payload.readmeHtml).toContain('<h1>cinder</h1>');
+    expect(payload.readmeHtml).not.toContain('<h1>cinder</h1>');
     expect(payload.readmeHtml).toContain('<h2>Install</h2>');
     expect(payload.readmeHtml).not.toContain('href="./docs/');
     expect(payload.readmeHtml).not.toContain('href="docs/');

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -648,6 +648,16 @@ export function rewriteRepositoryRelativeReadmeLinks(html: string): string {
   return rewriteRelativeRenderedMarkdownLinks(html, (href) => repositorySourceHref('', href));
 }
 
+/**
+ * The landing hero owns the document's sole top-level heading. The root README
+ * starts with the same title, so leaving its rendered H1 in the prose would
+ * expose duplicate H1s before and after hydration. Remove that leading source
+ * title structurally rather than concealing it with CSS.
+ */
+export function omitLandingReadmeTitle(html: string): string {
+  return html.replace(/^\s*<h1\b[^>]*>[\s\S]*?<\/h1>\s*/, '');
+}
+
 async function renderLandingReadmeHtml(): Promise<string> {
   await initializeHighlighter();
   const markdown = await Bun.file(join(PLAYGROUND_ROOT, '..', '..', 'README.md')).text();
@@ -657,7 +667,7 @@ async function renderLandingReadmeHtml(): Promise<string> {
       'Root README rendering stripped unsafe content. Update README.md to remove raw HTML, unsafe URLs, or other sanitizer-blocked content.',
     );
   }
-  return rewriteRepositoryRelativeReadmeLinks(rendered.html);
+  return omitLandingReadmeTitle(rewriteRepositoryRelativeReadmeLinks(rendered.html));
 }
 
 /**

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -655,7 +655,7 @@ export function rewriteRepositoryRelativeReadmeLinks(html: string): string {
  * title structurally rather than concealing it with CSS.
  */
 export function omitLandingReadmeTitle(html: string): string {
-  return html.replace(/^\s*<h1\b[^>]*>[\s\S]*?<\/h1>\s*/, '');
+  return html.replace(/^\s*<h1\b[^>]*>.*?<\/h1>\s*/is, '');
 }
 
 async function renderLandingReadmeHtml(): Promise<string> {

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -28,7 +28,7 @@ test.describe('playground landing page', () => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
-    await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
+    await expect(page.getByRole('heading', { level: 1, includeHidden: true })).toHaveCount(1);
     await expect(page.getByText('Svelte 5 components for product interfaces')).toHaveCount(0);
     await expect(page.locator('.dx-content--landing .readme-content')).toContainText('Install');
     await expect(page.locator('iframe')).toHaveCount(0);
@@ -61,7 +61,7 @@ test.describe('playground landing page', () => {
     await expect.poll(() => readShellMarker(page)).toBeUndefined();
     await expect(page.locator('#sidebar-filter')).toHaveValue('button');
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
-    await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
+    await expect(page.getByRole('heading', { level: 1, includeHidden: true })).toHaveCount(1);
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
     // The landing page shares the documentation chrome now, rather than a

--- a/packages/testing/tests/playground-landing.playwright.ts
+++ b/packages/testing/tests/playground-landing.playwright.ts
@@ -28,6 +28,7 @@ test.describe('playground landing page', () => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
     await expect(page.getByText('Svelte 5 components for product interfaces')).toHaveCount(0);
     await expect(page.locator('.dx-content--landing .readme-content')).toContainText('Install');
     await expect(page.locator('iframe')).toHaveCount(0);
@@ -60,6 +61,7 @@ test.describe('playground landing page', () => {
     await expect.poll(() => readShellMarker(page)).toBeUndefined();
     await expect(page.locator('#sidebar-filter')).toHaveValue('button');
     await expect(page.getByRole('heading', { name: 'cinder', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toHaveCount(1);
     await expect(page.locator('iframe')).toHaveCount(0);
     await expect(page.locator('#viewport-preset')).toHaveCount(0);
     // The landing page shares the documentation chrome now, rather than a


### PR DESCRIPTION
Closes CIN-395, CIN-79, CIN-77, CIN-75, CIN-74, CIN-73, CIN-71, and CIN-70.