### PR TITLE
Fix JSON Schema Editor diffs and validation

### DIFF
--- a/.changeset/bright-rules-dream.md
+++ b/.changeset/bright-rules-dream.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix JSON Schema Editor property reorder diffs, inline validation indicators, and email-format validation.

--- a/bun.lock
+++ b/bun.lock
@@ -61,6 +61,7 @@
         "@shikijs/types": "^3.21.0",
         "@tanstack/virtual-core": "^3.17.1",
         "ajv": "^8",
+        "ajv-formats": "^3.0.1",
         "esm-env": "^1.2.0",
         "libphonenumber-js": "^1.13.3",
         "lucide-svelte": "0.503.0",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5876,6 +5876,7 @@
     "@shikijs/types": "^3.21.0",
     "@tanstack/virtual-core": "^3.17.1",
     "ajv": "^8",
+    "ajv-formats": "^3.0.1",
     "esm-env": "^1.2.0",
     "libphonenumber-js": "^1.13.3",
     "lucide-svelte": "0.503.0",

--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -191,6 +191,8 @@ const runtimeDependencyExternals = [
   'shiki/*',
   'ajv',
   'ajv/*',
+  'ajv-formats',
+  'ajv-formats/*',
   'shiki',
 ];
 

--- a/packages/components/src/components/json-schema-editor/diff-view.svelte
+++ b/packages/components/src/components/json-schema-editor/diff-view.svelte
@@ -49,7 +49,7 @@
     </Alert>
   {/if}
 
-  {#if !state.hasChanges}
+  {#if !state.hasDiffChanges}
     <EmptyState title="No changes yet" description="Edit the schema to see a diff here." />
   {:else}
     <div class="cinder-jse-diff-lines" role="group" aria-label="JSON diff">

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-impl.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-impl.svelte
@@ -242,9 +242,9 @@
       <Tab value="form">Form</Tab>
       <Tab value="json">JSON</Tab>
       <Tab value="diff">
-        Diff{#if editorState.hasChanges}<span class="cinder-sr-only">, has changes</span>{/if}
+        Diff{#if editorState.hasDiffChanges}<span class="cinder-sr-only">, has changes</span>{/if}
         {#snippet trailing()}
-          {#if editorState.hasChanges}
+          {#if editorState.hasDiffChanges}
             <Badge variant="neutral" aria-hidden="true">●</Badge>
           {/if}
         {/snippet}

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
@@ -246,6 +246,13 @@ describe('createEditorState — diff and copy values', () => {
     expect(state.hasDiffChanges).toBe(true);
   });
 
+  test('hasDiffChanges is false for an unchanged malformed initial schema', () => {
+    const state = createEditorState({ schema: '{not-valid' });
+
+    expect(state.hasChanges).toBe(false);
+    expect(state.hasDiffChanges).toBe(false);
+  });
+
   test('separate `original` overrides the diff baseline', () => {
     const state = createEditorState({
       schema: { type: 'number' },

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.test.ts
@@ -229,6 +229,23 @@ describe('createEditorState — diff and copy values', () => {
     expect(state.hasChanges).toBe(true);
   });
 
+  test('hasDiffChanges tracks property reordering while hasChanges remains semantic', () => {
+    const state = createEditorState({
+      schema: {
+        type: 'object',
+        properties: { first: { type: 'string' }, second: { type: 'number' } },
+      },
+    });
+
+    state.commitFromForm({
+      type: 'object',
+      properties: { second: { type: 'number' }, first: { type: 'string' } },
+    });
+
+    expect(state.hasChanges).toBe(false);
+    expect(state.hasDiffChanges).toBe(true);
+  });
+
   test('separate `original` overrides the diff baseline', () => {
     const state = createEditorState({
       schema: { type: 'number' },

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -376,9 +376,10 @@ export function createEditorState(options: CreateEditorStateOptions) {
   // `hasChanges` intentionally treats object-key order as semantically equal.
   // The Diff view, however, presents the emitted JSON text, where property
   // order is observable (for example in generated forms and documentation).
-  const hasDiffChanges = $derived(
-    (originalCanonicalText || originalRawText) !== committedCanonicalText,
-  );
+  const hasDiffChanges = $derived.by(() => {
+    if (originalSchema === null && committedSchema === null) return false;
+    return (originalCanonicalText || originalRawText) !== committedCanonicalText;
+  });
   const isFormEditable = $derived(committedSchema !== null && !readonly && !jsonDraftIsDirty);
 
   // ===== Public API =====

--- a/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor-state.svelte.ts
@@ -51,6 +51,22 @@ function serialise(value: JsonSchemaValue): string {
   return JSON.stringify(value, null, PRETTY_INDENT);
 }
 
+function createSchemaHistory(initial: JsonSchemaValue, maxDepth?: number) {
+  const options: {
+    initial: JsonSchemaValue;
+    maxDepth?: number;
+    equals: (left: JsonSchemaValue, right: JsonSchemaValue) => boolean;
+  } = {
+    initial,
+    // Schema property order is observable in the editor's emitted JSON and
+    // diff. History must retain a reorder even though `hasChanges` keeps its
+    // documented key-order-insensitive semantic comparison.
+    equals: (left, right) => JSON.stringify(left) === JSON.stringify(right),
+  };
+  if (maxDepth !== undefined) options.maxDepth = maxDepth;
+  return useHistory<JsonSchemaValue>(options);
+}
+
 function isPlainRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -329,11 +345,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     }
 
     if (schemaResult.ok) {
-      const useHistoryOptions: { initial: JsonSchemaValue; maxDepth?: number } = {
-        initial: schemaResult.schema,
-      };
-      if (options.maxHistory !== undefined) useHistoryOptions.maxDepth = options.maxHistory;
-      history = useHistory<JsonSchemaValue>(useHistoryOptions);
+      history = createSchemaHistory(schemaResult.schema, options.maxHistory);
       jsonDraftText = schemaResult.canonicalText;
     } else {
       history = null;
@@ -361,6 +373,12 @@ export function createEditorState(options: CreateEditorStateOptions) {
     if (committedSchema === null) return originalRawText.length > 0;
     return stableSerialise(originalSchema) !== stableSerialise(committedSchema);
   });
+  // `hasChanges` intentionally treats object-key order as semantically equal.
+  // The Diff view, however, presents the emitted JSON text, where property
+  // order is observable (for example in generated forms and documentation).
+  const hasDiffChanges = $derived(
+    (originalCanonicalText || originalRawText) !== committedCanonicalText,
+  );
   const isFormEditable = $derived(committedSchema !== null && !readonly && !jsonDraftIsDirty);
 
   // ===== Public API =====
@@ -401,6 +419,9 @@ export function createEditorState(options: CreateEditorStateOptions) {
     },
     get hasChanges() {
       return hasChanges;
+    },
+    get hasDiffChanges() {
+      return hasDiffChanges;
     },
     get isFormEditable() {
       return isFormEditable;
@@ -503,9 +524,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
       if (history) {
         history.commit(schema, { label: 'apply JSON' });
       } else {
-        const applyOptions: { initial: JsonSchemaValue; maxDepth?: number } = { initial: schema };
-        if (options.maxHistory !== undefined) applyOptions.maxDepth = options.maxHistory;
-        history = useHistory<JsonSchemaValue>(applyOptions);
+        history = createSchemaHistory(schema, options.maxHistory);
       }
       jsonDraftText = serialise(history.current);
       metaResult = meta;
@@ -557,11 +576,7 @@ export function createEditorState(options: CreateEditorStateOptions) {
     revert() {
       if (readonly) return;
       if (originalSchema !== null) {
-        const revertOptions: { initial: JsonSchemaValue; maxDepth?: number } = {
-          initial: originalSchema,
-        };
-        if (options.maxHistory !== undefined) revertOptions.maxDepth = options.maxHistory;
-        history = useHistory<JsonSchemaValue>(revertOptions);
+        history = createSchemaHistory(originalSchema, options.maxHistory);
         jsonDraftText = originalCanonicalText;
         emitChange();
         const epoch = beginValidationCycle();

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.css
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.css
@@ -174,6 +174,10 @@
     border-top: 0;
   }
 
+  .cinder-jse-property-row[data-cinder-invalid] {
+    border-inline-start: 2px solid var(--cinder-color-danger-border);
+  }
+
   .cinder-jse-property-row__summary {
     display: flex;
     align-items: center;

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.test.ts
@@ -157,6 +157,43 @@ describe('JsonSchemaEditor — Diff tab Badge indicator', () => {
     expect(badge?.textContent).toBe('●');
     expect(badge?.getAttribute('aria-hidden')).toBe('true');
   });
+
+  test('renders the Diff badge and lines for a committed property reordering', async () => {
+    render(JsonSchemaEditorImplementation, {
+      props: {
+        id: 'jse-reorder-diff-badge',
+        schema: {
+          type: 'object',
+          properties: { first: { type: 'string' }, second: { type: 'number' } },
+        },
+        view: 'json' as const,
+      },
+    });
+    await flushEffects();
+
+    const textarea = screen.getByRole('textbox', { name: 'JSON' });
+    await fireEvent.input(textarea, {
+      target: {
+        value: JSON.stringify({
+          type: 'object',
+          properties: { second: { type: 'number' }, first: { type: 'string' } },
+        }),
+      },
+    });
+    await flushEffects();
+    const applyButton = screen
+      .getAllByRole('button')
+      .find((button) => button.textContent?.trim() === 'Apply');
+    await fireEvent.click(applyButton as HTMLElement);
+    await flushEffects();
+
+    const diffTab = screen.getByRole('tab', { name: /Diff/ });
+    await fireEvent.click(diffTab);
+    await flushEffects();
+
+    expect(diffTab.querySelector('.cinder-badge')).not.toBeNull();
+    expect(screen.getByRole('group', { name: 'JSON diff' })).not.toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
+++ b/packages/components/src/components/json-schema-editor/json-schema-toolbar.svelte
@@ -85,7 +85,7 @@
     // when participation changes.
     void editorState.canUndo;
     void editorState.canRedo;
-    void editorState.hasChanges;
+    void editorState.hasDiffChanges;
     void editorState.readonly;
     void editorState.copyValue;
     // Track `rovingIndex` too so a keydown/focusin handler moving the roved
@@ -204,7 +204,7 @@
       size="sm"
       iconOnly
       label="Revert"
-      disabled={!editorState.hasChanges || editorState.readonly}
+      disabled={!editorState.hasDiffChanges || editorState.readonly}
       onclick={() => onRevert?.()}
     >
       <RotateCcw class="cinder-icon-sm" />

--- a/packages/components/src/components/json-schema-editor/json-schema-toolbar.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-toolbar.test.ts
@@ -24,6 +24,7 @@ function makeFakeState(
     canUndo: boolean;
     canRedo: boolean;
     hasChanges: boolean;
+    hasDiffChanges: boolean;
     readonly: boolean;
     copyValue: string;
     validationStatus: 'valid' | 'invalid' | 'pending';
@@ -35,6 +36,7 @@ function makeFakeState(
     canUndo: false,
     canRedo: false,
     hasChanges: false,
+    hasDiffChanges: overrides.hasDiffChanges ?? overrides.hasChanges ?? false,
     readonly: false,
     copyValue: '{}',
     validationStatus: 'valid' as const,
@@ -57,6 +59,9 @@ function makeFakeState(
     },
     get hasChanges() {
       return merged.hasChanges;
+    },
+    get hasDiffChanges() {
+      return merged.hasDiffChanges;
     },
     get readonly() {
       return merged.readonly;
@@ -177,7 +182,7 @@ describe('JsonSchemaToolbar — ARIA structure', () => {
 describe('JsonSchemaToolbar — roving tabindex participants', () => {
   test('the rendered .cinder-copy-button is included in the roving participant set', async () => {
     const { container } = render(JsonSchemaToolbar, {
-      props: { state: makeFakeState({ canUndo: true, canRedo: true, hasChanges: true }) },
+      props: { state: makeFakeState({ canUndo: true, canRedo: true, hasDiffChanges: true }) },
     });
     await tick();
 
@@ -358,9 +363,11 @@ describe('JsonSchemaToolbar — tabindex recomputation on state change', () => {
     // First button (Undo) should have tabindex=0 initially
     expect(actionButtons[0]?.tabIndex).toBe(0);
 
-    // Rerender with canUndo=false, canRedo=false, hasChanges=false
+    // Rerender with canUndo=false, canRedo=false, hasDiffChanges=false
     // → Undo, Redo, and Revert become disabled; only CopyButton remains
-    await rerender({ state: makeFakeState({ canUndo: false, canRedo: false, hasChanges: false }) });
+    await rerender({
+      state: makeFakeState({ canUndo: false, canRedo: false, hasDiffChanges: false }),
+    });
     await tick();
 
     actionButtons = getActionButtons(container);

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.test.ts
@@ -117,6 +117,18 @@ describe('tryCompile', () => {
     expect(result.ok).toBe(true);
   });
 
+  test('registers the standard email format before compiling', async () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...values: unknown[]) => warnings.push(values);
+    try {
+      expect(await tryCompile({ type: 'string', format: 'email' })).toEqual({ ok: true });
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings).toEqual([]);
+  });
+
   test('flags an unresolved $ref even when meta-schema validation passes', async () => {
     const schema = { $ref: '#/$defs/missing' };
     const metaResult = await validateMetaSchema(schema);

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.ts
@@ -19,7 +19,7 @@
  */
 
 import type Ajv from 'ajv';
-import type addFormats from 'ajv-formats';
+import type { FormatsPlugin } from 'ajv-formats';
 import type Ajv2019 from 'ajv/dist/2019.js';
 import type Ajv2020 from 'ajv/dist/2020.js';
 
@@ -89,7 +89,7 @@ const loadAjvFormats = createRetryingLoaderCache(() =>
 );
 
 async function registerStandardFormats(ajv: Ajv | Ajv2019 | Ajv2020) {
-  const formats: typeof addFormats = await loadAjvFormats();
+  const formats: FormatsPlugin = await loadAjvFormats();
   formats(ajv);
   return ajv;
 }

--- a/packages/components/src/components/json-schema-editor/json-schema-validator.ts
+++ b/packages/components/src/components/json-schema-editor/json-schema-validator.ts
@@ -19,6 +19,7 @@
  */
 
 import type Ajv from 'ajv';
+import type addFormats from 'ajv-formats';
 import type Ajv2019 from 'ajv/dist/2019.js';
 import type Ajv2020 from 'ajv/dist/2020.js';
 
@@ -83,6 +84,15 @@ const loadAjv2019 = createRetryingLoaderCache(() =>
 const loadAjv2020 = createRetryingLoaderCache(() =>
   import('ajv/dist/2020.js').then((module) => module.default),
 );
+const loadAjvFormats = createRetryingLoaderCache(() =>
+  import('ajv-formats').then((module) => module.default),
+);
+
+async function registerStandardFormats(ajv: Ajv | Ajv2019 | Ajv2020) {
+  const formats: typeof addFormats = await loadAjvFormats();
+  formats(ajv);
+  return ajv;
+}
 
 // Long-lived meta-schema validators. Safe to share — they don't compile the
 // user's schema, only validate against the meta-schema.
@@ -192,13 +202,17 @@ export async function tryCompile(
     let ajv: Ajv | Ajv2020 | Ajv2019;
     if (resolved === '2020-12') {
       const Ajv2020Class = await loadAjv2020();
-      ajv = new Ajv2020Class({ strict: false, addUsedSchema: false });
+      ajv = await registerStandardFormats(
+        new Ajv2020Class({ strict: false, addUsedSchema: false }),
+      );
     } else if (resolved === '2019-09') {
       const Ajv2019Class = await loadAjv2019();
-      ajv = new Ajv2019Class({ strict: false, addUsedSchema: false });
+      ajv = await registerStandardFormats(
+        new Ajv2019Class({ strict: false, addUsedSchema: false }),
+      );
     } else {
       const AjvClass = await loadAjv();
-      ajv = new AjvClass({ strict: false, addUsedSchema: false });
+      ajv = await registerStandardFormats(new AjvClass({ strict: false, addUsedSchema: false }));
     }
 
     ajv.compile(schema);

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -17,6 +17,7 @@
   import ChevronDown from 'lucide-svelte/icons/chevron-down';
   import { onDestroy } from 'svelte';
   import Alert from '../alert/alert.svelte';
+  import Badge from '../badge/badge.svelte';
   import Button from '../button/button.svelte';
   import Chip from '../chip/chip.svelte';
   import Collapsible from '@lostgradient/cinder/collapsible';
@@ -217,6 +218,7 @@
   {#each propertyNames as key (key)}
     {@const isRequired = required.includes(key)}
     {@const isOpen = expanded[key] === true}
+    {@const childValidationErrorCount = childValidationCounts[key] ?? 0}
     {@const panelId = `${idPrefix}-${key}-panel`}
     <!--
       Custom disclosure (not <details>/<summary>) so the action buttons can
@@ -224,7 +226,11 @@
       <button> inside <summary> creates an ARIA "interactive within
       interactive" violation.
     -->
-    <div class="cinder-jse-property-row" data-cinder-required={isRequired ? '' : undefined}>
+    <div
+      class="cinder-jse-property-row"
+      data-cinder-required={isRequired ? '' : undefined}
+      data-cinder-invalid={childValidationErrorCount > 0 ? '' : undefined}
+    >
       <div class="cinder-jse-property-row__summary" style={`--cinder-jse-property-depth: ${depth}`}>
         <button
           type="button"
@@ -242,6 +248,15 @@
           />
           <span class="cinder-jse-property-row__name">{key}</span>
           <span class="cinder-jse-property-row__type">{summariseType(properties[key] ?? {})}</span>
+          {#if childValidationErrorCount > 0}
+            <Badge
+              variant="danger"
+              aria-label={`${childValidationErrorCount} validation ${childValidationErrorCount === 1 ? 'error' : 'errors'} in ${key}`}
+            >
+              {childValidationErrorCount}
+              {childValidationErrorCount === 1 ? 'error' : 'errors'}
+            </Badge>
+          {/if}
         </button>
         <span class="cinder-jse-property-row__spacer"></span>
         <Button

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -17,9 +17,9 @@
   import ChevronDown from 'lucide-svelte/icons/chevron-down';
   import { onDestroy } from 'svelte';
   import Alert from '../alert/alert.svelte';
-  import Badge from '../badge/badge.svelte';
   import Button from '../button/button.svelte';
   import Chip from '../chip/chip.svelte';
+  import Badge from '@lostgradient/cinder/badge';
   import Collapsible from '@lostgradient/cinder/collapsible';
   import Input from '../input/input.svelte';
   import PropertyEditor from './property-editor.svelte';
@@ -235,7 +235,7 @@
         <button
           type="button"
           class="cinder-jse-property-row__trigger"
-          aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${key} property`}
+          aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${key} property${childValidationErrorCount > 0 ? `, ${childValidationErrorCount} validation ${childValidationErrorCount === 1 ? 'error' : 'errors'}` : ''}`}
           aria-expanded={isOpen}
           aria-controls={panelId}
           onclick={() => toggleExpanded(key, isOpen)}
@@ -253,7 +253,7 @@
               variant="danger"
               aria-label={`${childValidationErrorCount} validation ${childValidationErrorCount === 1 ? 'error' : 'errors'} in ${key}`}
             >
-              {childValidationErrorCount}
+              {childValidationErrorCount}{' '}
               {childValidationErrorCount === 1 ? 'error' : 'errors'}
             </Badge>
           {/if}

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -90,6 +90,15 @@ describe('PropertyList', () => {
     ).toBe(4);
   });
 
+  test('renders a danger indicator on the row with nested validation errors', async () => {
+    const source = await Bun.file(new URL('./property-list.svelte', import.meta.url)).text();
+
+    expect(source).toContain("import Badge from '../badge/badge.svelte'");
+    expect(source).toContain('data-cinder-invalid={childValidationErrorCount > 0');
+    expect(source).toContain('<Badge\n              variant="danger"');
+    expect(source).toContain('validation ${childValidationErrorCount');
+  });
+
   test('property-list.svelte clears nested validation counts on collapse and unmount', async () => {
     const source = await Bun.file(new URL('./property-list.svelte', import.meta.url)).text();
 

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -93,9 +93,9 @@ describe('PropertyList', () => {
   test('renders a danger indicator on the row with nested validation errors', async () => {
     const source = await Bun.file(new URL('./property-list.svelte', import.meta.url)).text();
 
-    expect(source).toContain("import Badge from '../badge/badge.svelte'");
+    expect(source).toContain("import Badge from '@lostgradient/cinder/badge'");
     expect(source).toContain('data-cinder-invalid={childValidationErrorCount > 0');
-    expect(source).toContain('<Badge\n              variant="danger"');
+    expect(source).toMatch(/<Badge\s+variant="danger"/);
     expect(source).toContain('validation ${childValidationErrorCount');
   });
 


### PR DESCRIPTION
## Summary

Fix the JSON Schema Editor follow-up issues:

- retain property-order edits in editor history while preserving semantic `hasChanges`, and show them in the Diff tab and Revert control
- mark property rows with nested validation errors using an inline danger badge and border
- register AJV's standard formats at the compilation boundary, eliminating unknown-email-format warnings
- document the completed toolbar/disclosure sweep already present on mainline

## Validation

- `bun run --filter=@lostgradient/cinder test -- json-schema-editor-state.svelte.test.ts json-schema-editor.test.ts property-list.test.ts json-schema-validator.test.ts json-schema-toolbar.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run format:check`
- `bun run test:browser -- tests/playground-documentation.playwright.ts` (20 passed, 0 Axe violations)