### PR TITLE
Detect CSS duplication in compound child rules

### DIFF
--- a/.changeset/guard-child-component-css.md
+++ b/.changeset/guard-child-component-css.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Detect CSS duplication for compound child components authored in parent stylesheets.

--- a/packages/components/scripts/check-css-duplication.test.ts
+++ b/packages/components/scripts/check-css-duplication.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { parse } from 'postcss';
 
 import {
+  componentClassNamesFromMarkup,
   compoundFamilies,
   declarationMultiset,
   declarationMultisetForComponent,
@@ -85,6 +86,14 @@ describe('declarationMultiset', () => {
     const multiset = declarationMultisetForComponent(stylesheet, 'grid-item');
 
     expect([...multiset.keys()]).toEqual(['|color:red', '|font-weight:600']);
+  });
+
+  test('discovers compound-leaf selectors from rendered markup', () => {
+    expect(
+      componentClassNamesFromMarkup(
+        `<tr class="cinder-table__row"><td class:cinder-table__row--selected={selected}></td></tr>`,
+      ),
+    ).toEqual(['cinder-table__row', 'cinder-table__row--selected']);
   });
 
   test('keeps keyframe declarations in their owning component stylesheet', () => {

--- a/packages/components/scripts/check-css-duplication.test.ts
+++ b/packages/components/scripts/check-css-duplication.test.ts
@@ -3,6 +3,7 @@ import { parse } from 'postcss';
 
 import {
   componentClassNamesFromMarkup,
+  componentClassNamesFromStylesheet,
   compoundFamilies,
   declarationMultiset,
   declarationMultisetForComponent,
@@ -94,6 +95,14 @@ describe('declarationMultiset', () => {
         `<tr class="cinder-table__row"><td class:cinder-table__row--selected={selected}></td></tr>`,
       ),
     ).toEqual(['cinder-table__row', 'cinder-table__row--selected']);
+  });
+
+  test('discovers compound-leaf selectors from sidecar CSS', () => {
+    expect(
+      componentClassNamesFromStylesheet(
+        parse('.cinder-table__row--selected { color: var(--cinder-accent); }'),
+      ),
+    ).toEqual(['cinder-table__row--selected']);
   });
 
   test('keeps keyframe declarations in their owning component stylesheet', () => {

--- a/packages/components/scripts/check-css-duplication.test.ts
+++ b/packages/components/scripts/check-css-duplication.test.ts
@@ -103,8 +103,29 @@ describe('declarationMultiset', () => {
       componentClassNamesForComponent(
         `<tr class="cinder-table__row"><td class="cinder-table__header-cell cinder-table__cell"></td></tr>`,
         'table-row',
+        ['table'],
       ),
     ).toEqual(['cinder-table__row']);
+  });
+
+  test('keeps a shared compound leaf root while ignoring parent script queries', () => {
+    expect(
+      componentClassNamesForComponent(
+        `<script>panel.querySelectorAll('.cinder-speed-dial-action');</script><button class="cinder-speed-dial-action"></button>`,
+        'speed-dial-action',
+        ['speed-dial'],
+      ),
+    ).toEqual(['cinder-speed-dial-action']);
+  });
+
+  test('keeps a BEM compound leaf root rendered by its parent and other composites', () => {
+    expect(
+      componentClassNamesForComponent(
+        `<td class="cinder-table__cell cinder-table__cell--selection"></td>`,
+        'table-cell',
+        ['table'],
+      ),
+    ).toEqual(['cinder-table__cell', 'cinder-table__cell--selection']);
   });
 
   test('discovers compound-leaf selectors from sidecar CSS', () => {

--- a/packages/components/scripts/check-css-duplication.test.ts
+++ b/packages/components/scripts/check-css-duplication.test.ts
@@ -75,6 +75,28 @@ describe('declarationMultiset', () => {
     expect(multisetSize(gridItem.multiset)).toBeGreaterThanOrEqual(MINIMUM_DECLARATIONS);
     expect(findDuplicatePairs([gridItem, duplicate], [])).toHaveLength(1);
   });
+
+  test('attributes BEM modifier rules without absorbing unrelated selectors', () => {
+    const stylesheet = parse(`
+      .cinder-grid-item--active { color: red; }
+      .cinder-grid-item__label { font-weight: 600; }
+      .cinder-grid { display: grid; }
+    `);
+    const multiset = declarationMultisetForComponent(stylesheet, 'grid-item');
+
+    expect([...multiset.keys()]).toEqual(['|color:red', '|font-weight:600']);
+  });
+
+  test('keeps keyframe declarations in their owning component stylesheet', () => {
+    const stylesheet = parse(`
+      @keyframes cinder-jse-pulse { from { opacity: 0; } to { opacity: 1; } }
+      .cinder-jse { animation: cinder-jse-pulse 1s; }
+    `);
+    const multiset = declarationMultisetForComponent(stylesheet, 'json-schema-editor', () => true);
+
+    expect(multisetSize(multiset)).toBe(3);
+    expect([...multiset.keys()]).toContain('@keyframes cinder-jse-pulse|opacity:0');
+  });
 });
 
 describe('multisetSimilarity', () => {

--- a/packages/components/scripts/check-css-duplication.test.ts
+++ b/packages/components/scripts/check-css-duplication.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { parse } from 'postcss';
 
 import {
+  componentClassNamesForComponent,
   componentClassNamesFromMarkup,
   componentClassNamesFromStylesheet,
   compoundFamilies,
@@ -95,6 +96,15 @@ describe('declarationMultiset', () => {
         `<tr class="cinder-table__row"><td class:cinder-table__row--selected={selected}></td></tr>`,
       ),
     ).toEqual(['cinder-table__row', 'cinder-table__row--selected']);
+  });
+
+  test('does not claim sibling primitive classes rendered by a compound leaf', () => {
+    expect(
+      componentClassNamesForComponent(
+        `<tr class="cinder-table__row"><td class="cinder-table__header-cell cinder-table__cell"></td></tr>`,
+        'table-row',
+      ),
+    ).toEqual(['cinder-table__row']);
   });
 
   test('discovers compound-leaf selectors from sidecar CSS', () => {

--- a/packages/components/scripts/check-css-duplication.test.ts
+++ b/packages/components/scripts/check-css-duplication.test.ts
@@ -90,6 +90,15 @@ describe('declarationMultiset', () => {
     expect([...multiset.keys()]).toEqual(['|color:red', '|font-weight:600']);
   });
 
+  test('attributes descendant rules to their rightmost component target', () => {
+    const stylesheet = parse(`
+      .cinder-tab-list .cinder-tab[data-cinder-active]::after { height: 2px; }
+    `);
+
+    expect(multisetSize(declarationMultisetForComponent(stylesheet, 'tab-list'))).toBe(0);
+    expect([...declarationMultisetForComponent(stylesheet, 'tab').keys()]).toEqual(['|height:2px']);
+  });
+
   test('discovers compound-leaf selectors from rendered markup', () => {
     expect(
       componentClassNamesFromMarkup(

--- a/packages/components/scripts/check-css-duplication.test.ts
+++ b/packages/components/scripts/check-css-duplication.test.ts
@@ -4,6 +4,7 @@ import { parse } from 'postcss';
 import {
   compoundFamilies,
   declarationMultiset,
+  declarationMultisetForComponent,
   findDuplicatePairs,
   MINIMUM_DECLARATIONS,
   multisetSimilarity,
@@ -50,6 +51,29 @@ describe('declarationMultiset', () => {
   test('keeps shared public tokens verbatim — token reuse is not duplication evidence', () => {
     const multiset = multisetFor(`.a { gap: var(--cinder-space-2); }`, 'a');
     expect(multiset.get('|gap:var(--cinder-space-2)')).toBe(1);
+  });
+
+  test('attributes child rules in a parent stylesheet to the child component', () => {
+    const parentStylesheet = parse(`
+      .cinder-grid { display: grid; gap: 1rem; }
+      .cinder-grid-item { grid-column-start: auto; grid-column-end: span 1; grid-row-start: auto; padding: 1rem; margin: 0; border: 0; background: transparent; min-width: 0; min-height: 0; position: relative; outline: 0; box-sizing: border-box; }
+    `);
+    const bentoCell = parse(`
+      .cinder-bento-cell { grid-column-start: auto; grid-column-end: span 1; grid-row-start: auto; padding: 1rem; margin: 0; border: 0; background: transparent; min-width: 0; min-height: 0; position: relative; outline: 0; box-sizing: border-box; }
+    `);
+    const gridItem = {
+      name: 'grid-item',
+      multiset: declarationMultisetForComponent(parentStylesheet, 'grid-item'),
+      familyRoot: 'grid',
+    };
+    const duplicate = {
+      name: 'bento-cell',
+      multiset: declarationMultisetForComponent(bentoCell, 'bento-cell'),
+      familyRoot: 'bento-cell',
+    };
+
+    expect(multisetSize(gridItem.multiset)).toBeGreaterThanOrEqual(MINIMUM_DECLARATIONS);
+    expect(findDuplicatePairs([gridItem, duplicate], [])).toHaveLength(1);
   });
 });
 

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -137,6 +137,13 @@ function selectorContainsComponent(rule: Rule, className: string): boolean {
   return new RegExp(`(^|[^a-z0-9-])\\.${className}(?:$|--|__|[^a-z0-9-])`, 'i').test(rule.selector);
 }
 
+/** Extract Cinder classes rendered by a component, including declaration-free leaves. */
+export function componentClassNamesFromMarkup(source: string): string[] {
+  return [
+    ...new Set([...source.matchAll(/\bcinder-[a-z0-9_-]+/gi)].map((match) => match[0])),
+  ].toSorted();
+}
+
 /**
  * Build a declaration multiset from rules owned by one component. This lets a
  * compound parent keep leaf rules in its stylesheet without hiding that leaf
@@ -262,6 +269,14 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
     const multiset: DeclarationMultiset = new Map();
     const componentSources = sources.get(component.name) ?? [];
     const classNames = new Set([`cinder-${component.name}`]);
+    for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.svelte')) continue;
+      for (const className of componentClassNamesFromMarkup(
+        readFileSync(join(component.directory, entry.name), 'utf8'),
+      )) {
+        classNames.add(className);
+      }
+    }
     for (const source of componentSources) {
       source.walkRules((rule) => {
         for (const match of rule.selector.matchAll(/\\.([a-z][a-z0-9-]*)/gi)) {

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -144,6 +144,22 @@ export function componentClassNamesFromMarkup(source: string): string[] {
   ].toSorted();
 }
 
+/** Extract only the rendered classes owned by a component, not sibling primitives it composes. */
+export function componentClassNamesForComponent(source: string, componentName: string): string[] {
+  const [block, ...element] = componentName.split('-');
+  const roots = [`cinder-${componentName}`];
+  if (block !== undefined && element.length > 0)
+    roots.push(`cinder-${block}__${element.join('-')}`);
+  return componentClassNamesFromMarkup(source).filter((className) =>
+    roots.some(
+      (root) =>
+        className === root ||
+        className.startsWith(`${root}--`) ||
+        className.startsWith(`${root}__`),
+    ),
+  );
+}
+
 /** Extract Cinder classes from component CSS when markup computes them dynamically. */
 export function componentClassNamesFromStylesheet(stylesheet: Root): string[] {
   const classNames = new Set<string>();
@@ -282,8 +298,9 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
     const classNames = new Set([`cinder-${component.name}`]);
     for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
       if (!entry.isFile() || !entry.name.endsWith('.svelte')) continue;
-      for (const className of componentClassNamesFromMarkup(
+      for (const className of componentClassNamesForComponent(
         readFileSync(join(component.directory, entry.name), 'utf8'),
+        component.name,
       )) {
         classNames.add(className);
       }

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -144,6 +144,17 @@ export function componentClassNamesFromMarkup(source: string): string[] {
   ].toSorted();
 }
 
+/** Extract Cinder classes from component CSS when markup computes them dynamically. */
+export function componentClassNamesFromStylesheet(stylesheet: Root): string[] {
+  const classNames = new Set<string>();
+  stylesheet.walkRules((rule) => {
+    for (const match of rule.selector.matchAll(/\.([a-z][a-z0-9_-]*)/gi)) {
+      if (match[1]?.startsWith('cinder-')) classNames.add(match[1]);
+    }
+  });
+  return [...classNames].toSorted();
+}
+
 /**
  * Build a declaration multiset from rules owned by one component. This lets a
  * compound parent keep leaf rules in its stylesheet without hiding that leaf
@@ -278,11 +289,7 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
       }
     }
     for (const source of componentSources) {
-      source.walkRules((rule) => {
-        for (const match of rule.selector.matchAll(/\\.([a-z][a-z0-9-]*)/gi)) {
-          if (match[1]?.startsWith('cinder-')) classNames.add(match[1]);
-        }
-      });
+      for (const className of componentClassNamesFromStylesheet(source)) classNames.add(className);
       for (const [key, count] of declarationMultisetForComponent(
         source,
         component.name,

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -11,6 +11,7 @@ import {
   type Root,
   type Rule,
 } from 'postcss';
+import selectorParser from 'postcss-selector-parser';
 
 import { discoverComponentDirectories } from './discover-component-directories.ts';
 
@@ -134,7 +135,26 @@ function declarationBelongsToClasses(
 }
 
 function selectorContainsComponent(rule: Rule, className: string): boolean {
-  return new RegExp(`(^|[^a-z0-9-])\\.${className}(?:$|--|__|[^a-z0-9-])`, 'i').test(rule.selector);
+  let matches = false;
+  selectorParser((selectors) => {
+    selectors.each((selector) => {
+      const lastCombinator = selector.nodes.reduce(
+        (index, node, nodeIndex) => (node.type === 'combinator' ? nodeIndex : index),
+        -1,
+      );
+      for (const node of selector.nodes.slice(lastCombinator + 1)) {
+        if (node.type !== 'class') continue;
+        if (
+          node.value === className ||
+          node.value.startsWith(`${className}--`) ||
+          node.value.startsWith(`${className}__`)
+        ) {
+          matches = true;
+        }
+      }
+    });
+  }).processSync(rule.selector);
+  return matches;
 }
 
 /** Extract Cinder classes rendered by a component, including declaration-free leaves. */

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -277,6 +277,24 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
     sources.set(component.name, componentSources);
   }
 
+  const renderedClasses = new Map<string, Set<string>>();
+  const renderedClassOwners = new Map<string, Set<string>>();
+  for (const component of components) {
+    const classNames = new Set<string>();
+    for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.svelte')) continue;
+      for (const className of componentClassNamesFromMarkup(
+        readFileSync(join(component.directory, entry.name), 'utf8'),
+      )) {
+        classNames.add(className);
+        const owners = renderedClassOwners.get(className) ?? new Set<string>();
+        owners.add(component.name);
+        renderedClassOwners.set(className, owners);
+      }
+    }
+    renderedClasses.set(component.name, classNames);
+  }
+
   const edges: Array<readonly [string, string]> = [];
   const compoundParents = new Map<string, Set<string>>();
   for (const component of components) {
@@ -296,14 +314,8 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
     const multiset: DeclarationMultiset = new Map();
     const componentSources = sources.get(component.name) ?? [];
     const classNames = new Set([`cinder-${component.name}`]);
-    for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
-      if (!entry.isFile() || !entry.name.endsWith('.svelte')) continue;
-      for (const className of componentClassNamesForComponent(
-        readFileSync(join(component.directory, entry.name), 'utf8'),
-        component.name,
-      )) {
-        classNames.add(className);
-      }
+    for (const className of renderedClasses.get(component.name) ?? []) {
+      if (renderedClassOwners.get(className)?.size === 1) classNames.add(className);
     }
     for (const source of componentSources) {
       for (const className of componentClassNamesFromStylesheet(source)) classNames.add(className);

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -9,6 +9,7 @@ import {
   type Document,
   parse,
   type Root,
+  type Rule,
 } from 'postcss';
 
 import { discoverComponentDirectories } from './discover-component-directories.ts';
@@ -106,8 +107,36 @@ function atRuleContext(node: Declaration): string {
  * not the layer wrapper) prefixes each key so responsive clones count.
  */
 export function declarationMultiset(root: Root, componentName: string): DeclarationMultiset {
+  return declarationMultisetForComponent(root, componentName, () => true);
+}
+
+function declarationBelongsToComponent(declaration: Declaration, componentName: string): boolean {
+  const className = `cinder-${componentName}`;
+  let current: Container | Document | undefined = declaration.parent;
+  while (current && current.type !== 'root') {
+    if (current.type === 'rule' && selectorContainsComponent(current, className)) return true;
+    current = current.parent;
+  }
+  return false;
+}
+
+function selectorContainsComponent(rule: Rule, className: string): boolean {
+  return new RegExp(`(^|[^a-z0-9-])\\.${className}($|[^a-z0-9-])`, 'i').test(rule.selector);
+}
+
+/**
+ * Build a declaration multiset from rules owned by one component. This lets a
+ * compound parent keep leaf rules in its stylesheet without hiding that leaf
+ * from cross-component duplication detection.
+ */
+export function declarationMultisetForComponent(
+  root: Root,
+  componentName: string,
+  belongsToComponent = declarationBelongsToComponent,
+): DeclarationMultiset {
   const multiset: DeclarationMultiset = new Map();
   root.walkDecls((declaration) => {
+    if (!belongsToComponent(declaration, componentName)) return;
     const context = atRuleContext(declaration);
     const key = `${context}|${normalizeProperty(declaration.prop, componentName)}:${normalizeValue(
       declaration.value,
@@ -190,11 +219,13 @@ type ComponentCss = {
 
 async function collectComponentCss(): Promise<ComponentCss[]> {
   const components = await discoverComponentDirectories();
-  const sources = new Map<string, string>();
+  const sources: Root[] = [];
   for (const component of components) {
-    const sidecarPath = join(component.directory, `${component.name}.css`);
-    if (!existsSync(sidecarPath)) continue;
-    sources.set(component.name, readFileSync(sidecarPath, 'utf8'));
+    for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.css')) continue;
+      const sourcePath = join(component.directory, entry.name);
+      sources.push(parse(readFileSync(sourcePath, 'utf8'), { from: sourcePath }));
+    }
   }
 
   const edges: Array<readonly [string, string]> = [];
@@ -208,12 +239,18 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
   const families = compoundFamilies(edges);
 
   const results: ComponentCss[] = [];
-  for (const [name, source] of sources) {
-    const root = parse(source, { from: name });
+  for (const component of components) {
+    const multiset: DeclarationMultiset = new Map();
+    for (const source of sources) {
+      for (const [key, count] of declarationMultisetForComponent(source, component.name)) {
+        multiset.set(key, (multiset.get(key) ?? 0) + count);
+      }
+    }
+    if (multiset.size === 0) continue;
     results.push({
-      name,
-      multiset: declarationMultiset(root, name),
-      familyRoot: families.get(name) ?? name,
+      name: component.name,
+      multiset,
+      familyRoot: families.get(component.name) ?? component.name,
     });
   }
   return results;

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -86,6 +86,10 @@ function isAtRule(node: Container | Document): node is AtRule {
   return node.type === 'atrule';
 }
 
+function isRule(node: Container | Document): node is Rule {
+  return node.type === 'rule';
+}
+
 function atRuleContext(node: Declaration): string {
   const parts: string[] = [];
   // Climb through every container (rules included) to the root, collecting
@@ -114,7 +118,7 @@ function declarationBelongsToComponent(declaration: Declaration, componentName: 
   const className = `cinder-${componentName}`;
   let current: Container | Document | undefined = declaration.parent;
   while (current && current.type !== 'root') {
-    if (current.type === 'rule' && selectorContainsComponent(current, className)) return true;
+    if (isRule(current) && selectorContainsComponent(current, className)) return true;
     current = current.parent;
   }
   return false;

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -115,17 +115,26 @@ export function declarationMultiset(root: Root, componentName: string): Declarat
 }
 
 function declarationBelongsToComponent(declaration: Declaration, componentName: string): boolean {
-  const className = `cinder-${componentName}`;
+  return declarationBelongsToClasses(declaration, [`cinder-${componentName}`]);
+}
+
+function declarationBelongsToClasses(
+  declaration: Declaration,
+  classNames: readonly string[],
+): boolean {
   let current: Container | Document | undefined = declaration.parent;
   while (current && current.type !== 'root') {
-    if (isRule(current) && selectorContainsComponent(current, className)) return true;
+    if (isRule(current)) {
+      const rule = current;
+      if (classNames.some((className) => selectorContainsComponent(rule, className))) return true;
+    }
     current = current.parent;
   }
   return false;
 }
 
 function selectorContainsComponent(rule: Rule, className: string): boolean {
-  return new RegExp(`(^|[^a-z0-9-])\\.${className}($|[^a-z0-9-])`, 'i').test(rule.selector);
+  return new RegExp(`(^|[^a-z0-9-])\\.${className}(?:$|--|__|[^a-z0-9-])`, 'i').test(rule.selector);
 }
 
 /**
@@ -223,21 +232,27 @@ type ComponentCss = {
 
 async function collectComponentCss(): Promise<ComponentCss[]> {
   const components = await discoverComponentDirectories();
-  const sources: Root[] = [];
+  const sources = new Map<string, Root[]>();
   for (const component of components) {
+    const componentSources: Root[] = [];
     for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
       if (!entry.isFile() || !entry.name.endsWith('.css')) continue;
       const sourcePath = join(component.directory, entry.name);
-      sources.push(parse(readFileSync(sourcePath, 'utf8'), { from: sourcePath }));
+      componentSources.push(parse(readFileSync(sourcePath, 'utf8'), { from: sourcePath }));
     }
+    sources.set(component.name, componentSources);
   }
 
   const edges: Array<readonly [string, string]> = [];
+  const compoundParents = new Map<string, Set<string>>();
   for (const component of components) {
     const indexPath = join(component.directory, 'index.ts');
     if (!existsSync(indexPath)) continue;
     for (const leaf of siblingLeafImports(readFileSync(indexPath, 'utf8'))) {
       edges.push([component.name, leaf]);
+      const parents = compoundParents.get(leaf) ?? new Set<string>();
+      parents.add(component.name);
+      compoundParents.set(leaf, parents);
     }
   }
   const families = compoundFamilies(edges);
@@ -245,9 +260,31 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
   const results: ComponentCss[] = [];
   for (const component of components) {
     const multiset: DeclarationMultiset = new Map();
-    for (const source of sources) {
-      for (const [key, count] of declarationMultisetForComponent(source, component.name)) {
+    const componentSources = sources.get(component.name) ?? [];
+    const classNames = new Set([`cinder-${component.name}`]);
+    for (const source of componentSources) {
+      source.walkRules((rule) => {
+        for (const match of rule.selector.matchAll(/\\.([a-z][a-z0-9-]*)/gi)) {
+          if (match[1]?.startsWith('cinder-')) classNames.add(match[1]);
+        }
+      });
+      for (const [key, count] of declarationMultisetForComponent(
+        source,
+        component.name,
+        () => true,
+      )) {
         multiset.set(key, (multiset.get(key) ?? 0) + count);
+      }
+    }
+    for (const parent of compoundParents.get(component.name) ?? []) {
+      for (const source of sources.get(parent) ?? []) {
+        for (const [key, count] of declarationMultisetForComponent(
+          source,
+          component.name,
+          (declaration) => declarationBelongsToClasses(declaration, [...classNames]),
+        )) {
+          multiset.set(key, (multiset.get(key) ?? 0) + count);
+        }
       }
     }
     if (multiset.size === 0) continue;

--- a/packages/components/scripts/check-css-duplication.ts
+++ b/packages/components/scripts/check-css-duplication.ts
@@ -139,17 +139,23 @@ function selectorContainsComponent(rule: Rule, className: string): boolean {
 
 /** Extract Cinder classes rendered by a component, including declaration-free leaves. */
 export function componentClassNamesFromMarkup(source: string): string[] {
+  const markup = source.replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, '');
   return [
-    ...new Set([...source.matchAll(/\bcinder-[a-z0-9_-]+/gi)].map((match) => match[0])),
+    ...new Set([...markup.matchAll(/\bcinder-[a-z0-9_-]+/gi)].map((match) => match[0])),
   ].toSorted();
 }
 
 /** Extract only the rendered classes owned by a component, not sibling primitives it composes. */
-export function componentClassNamesForComponent(source: string, componentName: string): string[] {
-  const [block, ...element] = componentName.split('-');
+export function componentClassNamesForComponent(
+  source: string,
+  componentName: string,
+  compoundParents: readonly string[] = [],
+): string[] {
   const roots = [`cinder-${componentName}`];
-  if (block !== undefined && element.length > 0)
-    roots.push(`cinder-${block}__${element.join('-')}`);
+  for (const parent of compoundParents) {
+    if (!componentName.startsWith(`${parent}-`)) continue;
+    roots.push(`cinder-${parent}__${componentName.slice(parent.length + 1)}`);
+  }
   return componentClassNamesFromMarkup(source).filter((className) =>
     roots.some(
       (root) =>
@@ -277,24 +283,6 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
     sources.set(component.name, componentSources);
   }
 
-  const renderedClasses = new Map<string, Set<string>>();
-  const renderedClassOwners = new Map<string, Set<string>>();
-  for (const component of components) {
-    const classNames = new Set<string>();
-    for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
-      if (!entry.isFile() || !entry.name.endsWith('.svelte')) continue;
-      for (const className of componentClassNamesFromMarkup(
-        readFileSync(join(component.directory, entry.name), 'utf8'),
-      )) {
-        classNames.add(className);
-        const owners = renderedClassOwners.get(className) ?? new Set<string>();
-        owners.add(component.name);
-        renderedClassOwners.set(className, owners);
-      }
-    }
-    renderedClasses.set(component.name, classNames);
-  }
-
   const edges: Array<readonly [string, string]> = [];
   const compoundParents = new Map<string, Set<string>>();
   for (const component of components) {
@@ -314,8 +302,15 @@ async function collectComponentCss(): Promise<ComponentCss[]> {
     const multiset: DeclarationMultiset = new Map();
     const componentSources = sources.get(component.name) ?? [];
     const classNames = new Set([`cinder-${component.name}`]);
-    for (const className of renderedClasses.get(component.name) ?? []) {
-      if (renderedClassOwners.get(className)?.size === 1) classNames.add(className);
+    for (const entry of readdirSync(component.directory, { withFileTypes: true })) {
+      if (!entry.isFile() || !entry.name.endsWith('.svelte')) continue;
+      for (const className of componentClassNamesForComponent(
+        readFileSync(join(component.directory, entry.name), 'utf8'),
+        component.name,
+        [...(compoundParents.get(component.name) ?? [])],
+      )) {
+        classNames.add(className);
+      }
     }
     for (const source of componentSources) {
       for (const className of componentClassNamesFromStylesheet(source)) classNames.add(className);

--- a/packages/components/scripts/css-duplication-baseline.json
+++ b/packages/components/scripts/css-duplication-baseline.json
@@ -13,10 +13,5 @@
     "a": "bar-chart",
     "b": "line-chart",
     "reason": "Same SVG chart-family shared plot-frame chrome as the area-chart/bar-chart pair — distinct mark types over common axis/grid/overlay styling."
-  },
-  {
-    "a": "checkbox-group",
-    "b": "radio-group",
-    "reason": "Both are native fieldset wrappers with the same legend, hint, and validation layout; their child controls retain distinct multiple-selection and single-selection behavior, keyboard models, and semantics."
   }
 ]

--- a/packages/components/scripts/css-duplication-baseline.json
+++ b/packages/components/scripts/css-duplication-baseline.json
@@ -13,5 +13,10 @@
     "a": "bar-chart",
     "b": "line-chart",
     "reason": "Same SVG chart-family shared plot-frame chrome as the area-chart/bar-chart pair — distinct mark types over common axis/grid/overlay styling."
+  },
+  {
+    "a": "checkbox-group",
+    "b": "radio-group",
+    "reason": "Both are native fieldset wrappers with the same legend, hint, and validation layout; their child controls retain distinct multiple-selection and single-selection behavior, keyboard models, and semantics."
   }
 ]


### PR DESCRIPTION
Closes CIN-373

## Summary
- inspect every component CSS file rather than a conventional sidecar name
- attribute parent-authored child rules to their matching component
- baseline the legitimate CheckboxGroup and RadioGroup shared fieldset layout

## Validation
- bun run --filter=@lostgradient/cinder test -- scripts/check-css-duplication.test.ts
- bun run --filter=@lostgradient/cinder check:css-duplication
- bun run --filter=@lostgradient/cinder lint:invariants