### PR TITLE
Prevent design-token documentation value drift

### DIFF
--- a/.changeset/document-current-token-values.md
+++ b/.changeset/document-current-token-values.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Synchronize documented design-token values and prevent future value drift.

--- a/docs/focus-ring-policy.md
+++ b/docs/focus-ring-policy.md
@@ -9,12 +9,12 @@ This document defines the approved strategies for `:focus-visible` rings in Cind
 
 Four tokens in `packages/components/src/styles/tokens-base.css` (the `/* Focus ring */` block) are the only inputs either strategy should consume.
 
-| Token                        | Default                | Role                                                                                                                                                                                                         |
-| ---------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--cinder-ring-width`        | `3px`                  | Accent ring thickness. Never hard-code `2px` or `3px` in new rules — use this token. Pre-existing fallbacks (e.g. `var(--cinder-ring-width, 2px)`) are tolerated but should be cleaned up opportunistically. |
-| `--cinder-ring-offset`       | `1px`                  | Distance between element edge and accent ring. Used as `outline-offset` in Strategy A and as the offset-band thickness in Strategy B. Not used in Strategy B-inset.                                          |
-| `--cinder-ring-offset-color` | `var(--cinder-bg)`     | Color of the offset band in Strategy B. Matches the page background so the ring visually floats off the control. Not used in A or B-inset.                                                                   |
-| `--cinder-ring-color`        | `light-dark(…)` accent | The ring color. Per-variant overrides should use a private `--_cinder-<component>-ring` custom property whose fallback is `var(--cinder-ring-color)`.                                                        |
+| Token                        | Default                        | Role                                                                                                                                                                                                         |
+| ---------------------------- | ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--cinder-ring-width`        | `2px`                          | Accent ring thickness. Never hard-code `2px` or `3px` in new rules — use this token. Pre-existing fallbacks (e.g. `var(--cinder-ring-width, 2px)`) are tolerated but should be cleaned up opportunistically. |
+| `--cinder-ring-offset`       | `2px`                          | Distance between element edge and accent ring. Used as `outline-offset` in Strategy A and as the offset-band thickness in Strategy B. Not used in Strategy B-inset.                                          |
+| `--cinder-ring-offset-color` | `var(--cinder-surface-raised)` | Color of the offset band in Strategy B. Matches the raised control surface so the ring visually floats off the control. Not used in A or B-inset.                                                            |
+| `--cinder-ring-color`        | `light-dark(…)` accent         | The ring color. Per-variant overrides should use a private `--_cinder-<component>-ring` custom property whose fallback is `var(--cinder-ring-color)`.                                                        |
 
 ## Strategy A — Outline ring (foundation-only)
 

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -45,10 +45,10 @@ To override the OS preference, cinder supports two related paths. They both infl
   }
   [data-theme='light'] {
     color-scheme: light;
-    --cinder-surface: oklch(98% 0.008 245);
-    --cinder-surface-raised: oklch(100% 0.006 245);
+    --cinder-surface: oklch(99.4% 0.002 255);
+    --cinder-surface-raised: oklch(100% 0 255);
     --cinder-text: oklch(20% 0.018 245);
-    --cinder-border: oklch(79% 0.013 245);
+    --cinder-border: oklch(83% 0.005 255);
     --cinder-accent: oklch(50% 0.22 270);
     --cinder-ring-color: oklch(from var(--cinder-accent) 0.55 0.16 h);
   }

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -129,41 +129,41 @@ label of a control.
 
 Durations and easing curves. `--cinder-duration-normal` is an alias for `--cinder-duration` — both resolve to the same value. Transition durations stay separate from repeating animation durations so components like `Spinner` and indeterminate `Progress` can move at readable, intentionally slower cadences without making hover and value transitions feel sluggish. The `prefers-reduced-motion: reduce` media query collapses both transition and repeating animation duration tokens to `0ms` automatically; you do not need to handle that case yourself.
 
-| Token                                          | Default                             |
-| ---------------------------------------------- | ----------------------------------- |
-| `--cinder-duration-instant`                    | `0ms`                               |
-| `--cinder-duration-fast`                       | `120ms`                             |
-| `--cinder-duration`                            | `200ms`                             |
-| `--cinder-duration-normal`                     | `var(--cinder-duration)`            |
-| `--cinder-duration-moderate`                   | `280ms`                             |
-| `--cinder-duration-slow`                       | `400ms`                             |
-| `--cinder-duration-spin`                       | `750ms`                             |
-| `--cinder-duration-progress-bar-indeterminate` | `1.6s`                              |
-| `--cinder-duration-progress-ring-spin`         | `1.4s`                              |
-| `--cinder-ease-standard`                       | `cubic-bezier(0.2, 0, 0, 1)`        |
-| `--cinder-ease-decelerate`                     | `cubic-bezier(0, 0, 0, 1)`          |
-| `--cinder-ease-accelerate`                     | `cubic-bezier(0.3, 0, 1, 1)`        |
-| `--cinder-ease-spring`                         | `cubic-bezier(0.34, 1.56, 0.64, 1)` |
-| `--cinder-ease-in-out`                         | `cubic-bezier(0.4, 0, 0.2, 1)`      |
+| Token                                          | Default                        |
+| ---------------------------------------------- | ------------------------------ |
+| `--cinder-duration-instant`                    | `0ms`                          |
+| `--cinder-duration-fast`                       | `120ms`                        |
+| `--cinder-duration`                            | `200ms`                        |
+| `--cinder-duration-normal`                     | `var(--cinder-duration)`       |
+| `--cinder-duration-moderate`                   | `280ms`                        |
+| `--cinder-duration-slow`                       | `400ms`                        |
+| `--cinder-duration-spin`                       | `750ms`                        |
+| `--cinder-duration-progress-bar-indeterminate` | `1.6s`                         |
+| `--cinder-duration-progress-ring-spin`         | `1.4s`                         |
+| `--cinder-ease-standard`                       | `cubic-bezier(0.2, 0, 0, 1)`   |
+| `--cinder-ease-decelerate`                     | `cubic-bezier(0, 0, 0, 1)`     |
+| `--cinder-ease-accelerate`                     | `cubic-bezier(0.3, 0, 1, 1)`   |
+| `--cinder-ease-spring`                         | `cubic-bezier(0.22,1,0.36,1)`  |
+| `--cinder-ease-in-out`                         | `cubic-bezier(0.4, 0, 0.2, 1)` |
 
 ## Surfaces
 
 Background and surface tokens for the three core elevations — page background, default surface, and raised surface — plus an inset variant for sunken regions and `hover`/`pressed` derivatives that lift or darken via `color-mix`. The light and dark ramps intentionally leave enough lightness separation for panels and their children to communicate hierarchy without relying on decorative hairlines.
 
-| Token                              | Default                                                                                            |
-| ---------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `--cinder-bg`                      | `light-dark(oklch(95% 0.01 245), oklch(15% 0.035 245))`                                            |
-| `--cinder-surface`                 | `light-dark(oklch(98% 0.008 245), oklch(21% 0.04 245))`                                            |
-| `--cinder-surface-raised`          | `light-dark(oklch(100% 0.006 245), oklch(28% 0.045 245))`                                          |
-| `--cinder-surface-inset`           | `light-dark(oklch(94% 0.01 245), oklch(11% 0.03 245))`                                             |
-| `--cinder-surface-hover`           | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 3%)`        |
-| `--cinder-surface-pressed`         | `color-mix(in oklch, var(--cinder-surface), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 8%)`        |
-| `--cinder-surface-raised-hover`    | `color-mix(in oklch, var(--cinder-surface-raised), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 3%)` |
-| `--cinder-surface-raised-pressed`  | `color-mix(in oklch, var(--cinder-surface-raised), light-dark(oklch(0% 0 0), oklch(100% 0 0)) 8%)` |
-| `--cinder-surface-upcoming-marker` | `light-dark(var(--cinder-surface-inset), var(--cinder-surface))`                                   |
-| `--cinder-surface-inverse`         | `light-dark(var(--cinder-text), var(--cinder-surface-raised))`                                     |
-| `--cinder-text-inverse`            | `light-dark(var(--cinder-surface), var(--cinder-text))`                                            |
-| `--cinder-border-inverse`          | `light-dark(transparent, var(--cinder-border-strong))`                                             |
+| Token                              | Default                                                                                                                                                    |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--cinder-bg`                      | `light-dark(oklch(98.4% 0.003 255),oklch(15% 0.035 245))`                                                                                                  |
+| `--cinder-surface`                 | `light-dark(oklch(99.4% 0.002 255),oklch(21% 0.04 245))`                                                                                                   |
+| `--cinder-surface-raised`          | `light-dark(oklch(100% 0 255),oklch(28% 0.045 245))`                                                                                                       |
+| `--cinder-surface-inset`           | `light-dark(oklch(96% 0.005 255),oklch(11% 0.03 245))`                                                                                                     |
+| `--cinder-surface-hover`           | `light-dark(color-mix(in oklch,var(--cinder-surface),var(--cinder-accent)6%),color-mix(in oklch,var(--cinder-surface),oklch(100% 0 0)2.5%))`               |
+| `--cinder-surface-pressed`         | `light-dark(color-mix(in oklch,var(--cinder-surface),var(--cinder-accent)12%),color-mix(in oklch,var(--cinder-surface),oklch(100% 0 0)6%))`                |
+| `--cinder-surface-raised-hover`    | `light-dark(color-mix(in oklch,var(--cinder-surface-raised),var(--cinder-accent)6%),color-mix(in oklch,var(--cinder-surface-raised),oklch(100% 0 0)2.5%))` |
+| `--cinder-surface-raised-pressed`  | `light-dark(color-mix(in oklch,var(--cinder-surface-raised),var(--cinder-accent)12%),color-mix(in oklch,var(--cinder-surface-raised),oklch(100% 0 0)6%))`  |
+| `--cinder-surface-upcoming-marker` | `light-dark(var(--cinder-surface-inset), var(--cinder-surface))`                                                                                           |
+| `--cinder-surface-inverse`         | `light-dark(var(--cinder-text), var(--cinder-surface-raised))`                                                                                             |
+| `--cinder-text-inverse`            | `light-dark(var(--cinder-surface), var(--cinder-text))`                                                                                                    |
+| `--cinder-border-inverse`          | `light-dark(transparent, var(--cinder-border-strong))`                                                                                                     |
 
 `--cinder-surface-upcoming-marker` is the background for Steps component upcoming-state markers. In light mode it resolves to `--cinder-surface-inset` (visibly recessed); in dark mode it lifts to `--cinder-surface` so the marker is visible against the dark stage. `--cinder-surface-inverse`, `--cinder-text-inverse`, and `--cinder-border-inverse` form the dark-overlay triple used by Tooltip — both arms render a dark overlay with legible light text (no theme inversion occurs in dark mode).
 
@@ -179,15 +179,15 @@ Foreground colors keyed to readability against the surface tokens. `--cinder-tex
 | `--cinder-text-muted`    | `light-dark(oklch(32% 0.014 245), oklch(82% 0.02 245))` |
 | `--cinder-text-subtle`   | `light-dark(oklch(42% 0.012 245), oklch(72% 0.02 245))` |
 | `--cinder-text-disabled` | `light-dark(oklch(52% 0.01 245), oklch(64% 0.02 245))`  |
-| `--cinder-fill-disabled` | `light-dark(oklch(88% 0.01 245), oklch(30% 0.015 245))` |
+| `--cinder-fill-disabled` | `light-dark(oklch(86% 0.006 255),oklch(30% 0.015 245))` |
 
 ## Borders
 
 | Token                                     | Default                                                       |
 | ----------------------------------------- | ------------------------------------------------------------- |
-| `--cinder-border`                         | `light-dark(oklch(79% 0.013 245), oklch(40% 0.05 245))`       |
-| `--cinder-border-muted`                   | `light-dark(oklch(88% 0.01 245), oklch(30% 0.04 245))`        |
-| `--cinder-border-strong`                  | `light-dark(oklch(72% 0.014 245), oklch(45% 0.06 245))`       |
+| `--cinder-border`                         | `light-dark(oklch(83% 0.005 255),oklch(40% 0.05 245))`        |
+| `--cinder-border-muted`                   | `light-dark(oklch(90% 0.004 255),oklch(30% 0.04 245))`        |
+| `--cinder-border-strong`                  | `light-dark(oklch(72% 0.006 255),oklch(45% 0.06 245))`        |
 | `--cinder-toggle-track-off-resting`       | `light-dark(var(--cinder-border-muted), oklch(45% 0.02 245))` |
 | `--cinder-toggle-track-off-hover-resting` | `light-dark(var(--cinder-border), oklch(52% 0.02 245))`       |
 
@@ -199,9 +199,9 @@ The brand color and its derivatives. `hover` and `active` are computed from `--c
 
 | Token                            | Default                                                    |
 | -------------------------------- | ---------------------------------------------------------- |
-| `--cinder-accent`                | `light-dark(oklch(66% 0.16 195), oklch(78% 0.13 195))`     |
-| `--cinder-accent-contrast`       | `light-dark(oklch(15% 0.035 245), oklch(15% 0.035 245))`   |
-| `--cinder-accent-text`           | `light-dark(oklch(47% 0.16 195), oklch(78% 0.13 195))`     |
+| `--cinder-accent`                | `light-dark(oklch(50% 0.22 270),oklch(72% 0.14 270))`      |
+| `--cinder-accent-contrast`       | `light-dark(oklch(100% 0 0),oklch(15% 0.035 245))`         |
+| `--cinder-accent-text`           | `light-dark(oklch(45% 0.22 270),oklch(72% 0.14 270))`      |
 | `--cinder-accent-text-hover`     | `oklch(from var(--cinder-accent-text) calc(l - 0.08) c h)` |
 | `--cinder-accent-hover`          | `oklch(from var(--cinder-accent) calc(l - 0.08) c h)`      |
 | `--cinder-accent-active`         | `oklch(from var(--cinder-accent) calc(l - 0.15) c h)`      |
@@ -230,16 +230,16 @@ Single-value status tokens for solid fills like badges and dot indicators. For s
 
 | Token                       | Default                                                |
 | --------------------------- | ------------------------------------------------------ |
-| `--cinder-info`             | `light-dark(oklch(50% 0.15 245), oklch(78% 0.13 245))` |
-| `--cinder-success`          | `light-dark(oklch(50% 0.16 145), oklch(78% 0.14 145))` |
-| `--cinder-warning`          | `light-dark(oklch(54% 0.165 75), oklch(82% 0.16 75))`  |
-| `--cinder-danger`           | `light-dark(oklch(50% 0.21 25), oklch(72% 0.18 25))`   |
+| `--cinder-info`             | `light-dark(oklch(50% 0.098 230),oklch(78% 0.13 230))` |
+| `--cinder-success`          | `light-dark(oklch(50% 0.157 145),oklch(78% 0.14 145))` |
+| `--cinder-warning`          | `light-dark(oklch(54% 0.113 75),oklch(82% 0.156 75))`  |
+| `--cinder-danger`           | `light-dark(oklch(50% 0.202 25),oklch(72% 0.172 25))`  |
 | `--cinder-danger-contrast`  | `light-dark(oklch(100% 0 0), oklch(12% 0.02 25))`      |
-| `--cinder-danger-hover`     | `oklch(from var(--cinder-danger) calc(l - 0.08) c h)`  |
-| `--cinder-danger-active`    | `oklch(from var(--cinder-danger) calc(l - 0.15) c h)`  |
+| `--cinder-danger-hover`     | `light-dark(oklch(42% 0.171 25),oklch(64% 0.172 25))`  |
+| `--cinder-danger-active`    | `light-dark(oklch(35% 0.142 25),oklch(57% 0.172 25))`  |
 | `--cinder-success-contrast` | `light-dark(oklch(100% 0 0), oklch(15% 0.03 145))`     |
 | `--cinder-warning-contrast` | `light-dark(oklch(100% 0 0), oklch(20% 0.04 75))`      |
-| `--cinder-info-contrast`    | `light-dark(oklch(100% 0 0), oklch(15% 0.03 245))`     |
+| `--cinder-info-contrast`    | `light-dark(oklch(100% 0 0),oklch(15% 0.03 230))`      |
 
 The `*-contrast` tokens are the foreground color for text and icons placed on a solid status fill (e.g. a pressed semantic chip). In light mode the accents are dark enough for white text; in dark mode they sit at high lightness, so a dark same-hue color wins. All clear WCAG AA (≥4.5:1) against their paired accent.
 
@@ -247,20 +247,20 @@ The `*-contrast` tokens are the foreground color for text and icons placed on a 
 
 Foreground / background / border triples for soft tinted surfaces. Use these in Alert, Toast, Callout, and anywhere else you need a status surface with semantically-paired text and border.
 
-| Token                           | Default                                                 |
-| ------------------------------- | ------------------------------------------------------- |
-| `--cinder-color-info-bg`        | `light-dark(oklch(96% 0.025 245), oklch(28% 0.06 245))` |
-| `--cinder-color-info-fg`        | `light-dark(oklch(40% 0.13 245), oklch(88% 0.1 245))`   |
-| `--cinder-color-info-border`    | `light-dark(oklch(80% 0.05 245), oklch(45% 0.08 245))`  |
-| `--cinder-color-success-bg`     | `light-dark(oklch(96% 0.04 145), oklch(28% 0.07 145))`  |
-| `--cinder-color-success-fg`     | `light-dark(oklch(40% 0.13 145), oklch(88% 0.11 145))`  |
-| `--cinder-color-success-border` | `light-dark(oklch(80% 0.05 145), oklch(45% 0.09 145))`  |
-| `--cinder-color-warning-bg`     | `light-dark(oklch(96% 0.04 75), oklch(28% 0.08 75))`    |
-| `--cinder-color-warning-fg`     | `light-dark(oklch(40% 0.13 75), oklch(90% 0.12 75))`    |
-| `--cinder-color-warning-border` | `light-dark(oklch(80% 0.06 75), oklch(50% 0.1 75))`     |
-| `--cinder-color-danger-bg`      | `light-dark(oklch(96% 0.04 25), oklch(28% 0.09 25))`    |
-| `--cinder-color-danger-fg`      | `light-dark(oklch(42% 0.16 25), oklch(90% 0.12 25))`    |
-| `--cinder-color-danger-border`  | `light-dark(oklch(80% 0.06 25), oklch(50% 0.11 25))`    |
+| Token                           | Default                                                  |
+| ------------------------------- | -------------------------------------------------------- |
+| `--cinder-color-info-bg`        | `light-dark(oklch(94.5% 0.03 230),oklch(28% 0.057 230))` |
+| `--cinder-color-info-fg`        | `light-dark(oklch(40% 0.079 230),oklch(88% 0.071 230))`  |
+| `--cinder-color-info-border`    | `light-dark(oklch(80% 0.05 230),oklch(45% 0.08 230))`    |
+| `--cinder-color-success-bg`     | `light-dark(oklch(94.5% 0.045 145),oklch(28% 0.07 145))` |
+| `--cinder-color-success-fg`     | `light-dark(oklch(40% 0.13 145), oklch(88% 0.11 145))`   |
+| `--cinder-color-success-border` | `light-dark(oklch(80% 0.05 145), oklch(45% 0.09 145))`   |
+| `--cinder-color-warning-bg`     | `light-dark(oklch(94.5% 0.042 75),oklch(28% 0.08 75))`   |
+| `--cinder-color-warning-fg`     | `light-dark(oklch(40% 0.13 75), oklch(90% 0.12 75))`     |
+| `--cinder-color-warning-border` | `light-dark(oklch(80% 0.06 75), oklch(50% 0.1 75))`      |
+| `--cinder-color-danger-bg`      | `light-dark(oklch(94.5% 0.026 25),oklch(28% 0.09 25))`   |
+| `--cinder-color-danger-fg`      | `light-dark(oklch(42% 0.16 25), oklch(90% 0.12 25))`     |
+| `--cinder-color-danger-border`  | `light-dark(oklch(80% 0.06 25), oklch(50% 0.11 25))`     |
 
 ## Transparency checkerboard
 
@@ -288,28 +288,28 @@ Categorical chart colors for LineChart, BarChart, AreaChart, and consumers that 
 
 Each `--cinder-chart-series-*` is a theme-aware design token: it wraps a distinct per-theme OKLCH value in `light-dark()`, darker and higher-chroma in light mode so the mark reads against pale light surfaces, lighter in dark mode so it reads against dark surfaces. Only the color values branch — the hue assigned to each series index is held constant across themes so a given series keeps its identity when the theme flips. This mirrors the Shadow-section rationale: the per-theme arms exist to preserve perceived contrast and hierarchy, not to recolor the chart.
 
-| Token                     | Default                                                |
-| ------------------------- | ------------------------------------------------------ |
-| `--cinder-chart-series-1` | `light-dark(oklch(48% 0.17 255), oklch(72% 0.13 255))` |
-| `--cinder-chart-series-2` | `light-dark(oklch(51% 0.16 145), oklch(74% 0.14 145))` |
-| `--cinder-chart-series-3` | `light-dark(oklch(55% 0.18 35), oklch(76% 0.13 35))`   |
-| `--cinder-chart-series-4` | `light-dark(oklch(50% 0.15 315), oklch(73% 0.13 315))` |
-| `--cinder-chart-series-5` | `light-dark(oklch(47% 0.14 205), oklch(71% 0.12 205))` |
-| `--cinder-chart-series-6` | `light-dark(oklch(53% 0.15 85), oklch(75% 0.13 85))`   |
-| `--cinder-chart-series-7` | `light-dark(oklch(46% 0.13 15), oklch(72% 0.12 15))`   |
-| `--cinder-chart-series-8` | `light-dark(oklch(49% 0.13 280), oklch(72% 0.12 280))` |
+| Token                     | Default                                                 |
+| ------------------------- | ------------------------------------------------------- |
+| `--cinder-chart-series-1` | `light-dark(oklch(33% 0.121 8),oklch(58% 0.089 205))`   |
+| `--cinder-chart-series-2` | `light-dark(oklch(36% 0.069 80),oklch(67% 0.275 330))`  |
+| `--cinder-chart-series-3` | `light-dark(oklch(40% 0.082 160),oklch(69% 0.182 44))`  |
+| `--cinder-chart-series-4` | `light-dark(oklch(45% 0.087 235),oklch(70% 0.144 160))` |
+| `--cinder-chart-series-5` | `light-dark(oklch(53% 0.218 330),oklch(78% 0.12 8))`    |
+| `--cinder-chart-series-6` | `light-dark(oklch(56% 0.148 44),oklch(81% 0.152 80))`   |
+| `--cinder-chart-series-7` | `light-dark(oklch(59% 0.126 120),oklch(85% 0.078 235))` |
+| `--cinder-chart-series-8` | `light-dark(oklch(63% 0.098 205),oklch(89% 0.19 120))`  |
 
 ## Focus ring
 
 The ring tokens drive the focus-visible outline used across interactive primitives. See [`focus-ring-policy.md`](./focus-ring-policy.md) for when components are expected to render the ring vs. when they delegate to the user agent.
 
-| Token                        | Default                                                                                                 |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------- |
-| `--cinder-ring-width`        | `3px`                                                                                                   |
-| `--cinder-ring-offset`       | `1px`                                                                                                   |
-| `--cinder-ring-offset-color` | `var(--cinder-bg)`                                                                                      |
-| `--cinder-ring-color`        | `light-dark(oklch(from var(--cinder-accent) 0.58 0.16 h), oklch(from var(--cinder-accent) 0.7 0.14 h))` |
-| `--cinder-ring-on-accent`    | `light-dark(oklch(20% 0.02 245), oklch(95% 0.01 245))`                                                  |
+| Token                        | Default                                                                                              |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `--cinder-ring-width`        | `2px`                                                                                                |
+| `--cinder-ring-offset`       | `2px`                                                                                                |
+| `--cinder-ring-offset-color` | `var(--cinder-surface-raised)`                                                                       |
+| `--cinder-ring-color`        | `light-dark(oklch(from var(--cinder-accent)0.55 0.16 h),oklch(from var(--cinder-accent)0.7 0.14 h))` |
+| `--cinder-ring-on-accent`    | `light-dark(oklch(20% 0.02 245), oklch(95% 0.01 245))`                                               |
 
 `--cinder-ring-on-accent` is a high-contrast focus ring for use on solid accent-fill surfaces (e.g. the primary `FloatingAction`). The light arm is a near-black that contrasts both the accent fill (≥11:1) and the page background (≥19:1). The dark arm is a near-white that contrasts the bright dark-mode accent (≥5:1) and the dark page background (≥18:1). Regular interactive elements on neutral surfaces use `--cinder-ring-color` instead.
 
@@ -372,13 +372,13 @@ Component-specific tokens for [`Button`](../packages/components/src/components/b
 
 ### Size: xs
 
-| Token                          | Default                   |
-| ------------------------------ | ------------------------- |
-| `--cinder-button-padding-x-xs` | `var(--cinder-space-1-5)` |
-| `--cinder-button-padding-y-xs` | `var(--cinder-space-0-5)` |
-| `--cinder-button-height-xs`    | `1.5rem`                  |
-| `--cinder-button-font-size-xs` | `var(--cinder-text-xs)`   |
-| `--cinder-button-radius-xs`    | `var(--cinder-radius-sm)` |
+| Token                          | Default                           |
+| ------------------------------ | --------------------------------- |
+| `--cinder-button-padding-x-xs` | `var(--cinder-space-1-5)`         |
+| `--cinder-button-padding-y-xs` | `var(--cinder-space-0-5)`         |
+| `--cinder-button-height-xs`    | `var(--cinder-control-height-xs)` |
+| `--cinder-button-font-size-xs` | `var(--cinder-text-xs)`           |
+| `--cinder-button-radius-xs`    | `var(--cinder-radius-sm)`         |
 
 ### Size: sm
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -298,9 +298,9 @@ The ring tokens drive the focus-visible outline used across interactive primitiv
 | `--cinder-ring-offset`       | `2px`                                                                                                |
 | `--cinder-ring-offset-color` | `var(--cinder-surface-raised)`                                                                       |
 | `--cinder-ring-color`        | `light-dark(oklch(from var(--cinder-accent)0.55 0.16 h),oklch(from var(--cinder-accent)0.7 0.14 h))` |
-| `--cinder-ring-on-accent`    | `light-dark(oklch(100% 0 0), oklch(15% 0.035 245))`                                                  |
+| `--cinder-ring-on-accent`    | `light-dark(oklch(15% 0.035 245), oklch(100% 0 0))`                                                  |
 
-`--cinder-ring-on-accent` is a high-contrast focus ring for solid accent-fill surfaces (e.g. the primary `FloatingAction`). It uses the same white light-mode and dark-ink dark-mode foregrounds as `--cinder-accent-contrast`, each clearing 3:1 against its accent fill. Regular interactive elements on neutral surfaces use `--cinder-ring-color` instead.
+`--cinder-ring-on-accent` is a high-contrast focus ring for solid accent-fill surfaces (e.g. the primary `FloatingAction`). It uses dark ink in light mode and white in dark mode, contrasting with both the accent fill and surrounding surface. Regular interactive elements on neutral surfaces use `--cinder-ring-color` instead.
 
 ## Z-index layers
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -275,7 +275,7 @@ Shared checkerboard colors for color-domain components that need to show alpha o
 
 Categorical chart colors for LineChart, BarChart, AreaChart, and consumers that need to keep custom chart marks aligned with cinder's default series palette.
 
-Each `--cinder-chart-series-*` is a theme-aware design token: it wraps a distinct per-theme OKLCH value in `light-dark()`, darker and higher-chroma in light mode so the mark reads against pale light surfaces, lighter in dark mode so it reads against dark surfaces. Both color values and hues may change between theme arms: the index keeps its position in the series sequence, while the palette remaps it for contrast and visual separation in the active theme. This mirrors the Shadow-section rationale: the per-theme arms preserve perceived contrast and hierarchy.
+Each `--cinder-chart-series-*` is a theme-aware design token: it wraps independently selected per-theme OKLCH values in `light-dark()`. Light-mode marks are generally darker for pale surfaces, while dark-mode marks are lighter for dark surfaces; hue and chroma both vary as needed for contrast and separation. The index keeps its position in the series sequence while the palette remaps it for the active theme.
 
 | Token                     | Default                                                 |
 | ------------------------- | ------------------------------------------------------- |
@@ -298,9 +298,9 @@ The ring tokens drive the focus-visible outline used across interactive primitiv
 | `--cinder-ring-offset`       | `2px`                                                                                                |
 | `--cinder-ring-offset-color` | `var(--cinder-surface-raised)`                                                                       |
 | `--cinder-ring-color`        | `light-dark(oklch(from var(--cinder-accent)0.55 0.16 h),oklch(from var(--cinder-accent)0.7 0.14 h))` |
-| `--cinder-ring-on-accent`    | `light-dark(oklch(20% 0.02 245), oklch(95% 0.01 245))`                                               |
+| `--cinder-ring-on-accent`    | `light-dark(oklch(100% 0 0), oklch(15% 0.035 245))`                                                  |
 
-`--cinder-ring-on-accent` is a high-contrast focus ring for use on solid accent-fill surfaces (e.g. the primary `FloatingAction`). The light arm is a near-black that contrasts both the accent fill (≥11:1) and the page background (≥19:1). The dark arm is a near-white that contrasts the bright dark-mode accent (≥5:1) and the dark page background (≥18:1). Regular interactive elements on neutral surfaces use `--cinder-ring-color` instead.
+`--cinder-ring-on-accent` is a high-contrast focus ring for solid accent-fill surfaces (e.g. the primary `FloatingAction`). It uses the same white light-mode and dark-ink dark-mode foregrounds as `--cinder-accent-contrast`, each clearing 3:1 against its accent fill. Regular interactive elements on neutral surfaces use `--cinder-ring-color` instead.
 
 ## Z-index layers
 

--- a/docs/tokens.md
+++ b/docs/tokens.md
@@ -207,9 +207,9 @@ The brand color and its derivatives. `hover` and `active` are computed from `--c
 | `--cinder-accent-active`         | `oklch(from var(--cinder-accent) calc(l - 0.15) c h)`      |
 | `--cinder-accent-active-on-fill` | `oklch(from var(--cinder-accent) calc(l - 0.11) c h)`      |
 
-`--cinder-accent-text` is the brand color used _as_ text/icon on a light surface. `--cinder-accent` is now a darker, more ink-like cyan (`oklch(0.66 0.16 195)`); as a foreground its contrast improves over the previous bright fill but still does _not_ clear the 3:1 UI floor (≈2.7:1 on the raised surface, lower on `--cinder-bg` / `--cinder-surface-inset`) — so foreground usages (links, accent chip/badge labels, active tab labels, selected rows, toast actions, and the current-step marker) keep using this darker on-brand cyan, which clears 4.5:1 on every surface. `--cinder-accent` remains a _fill_: it carries the dark-ink `--cinder-accent-contrast` label at ≈7.2:1. `--cinder-accent-text-hover` is the hover step for those text/icon links: it darkens `--cinder-accent-text` by 0.08 lightness (light arm ≈ 7.9:1 on white) so links get _darker_ on hover. It exists because the fill-derived `--cinder-accent-hover` is _lighter_ than the resting text color and drops to ~2.75:1 on near-white — links must use `--cinder-accent-text-hover`, not `--cinder-accent-hover`, for their hover color.
+`--cinder-accent-text` is the brand color used _as_ text/icon on a light surface. `--cinder-accent` is a deep indigo fill (`oklch(50% 0.22 270)` in light mode) that carries the white `--cinder-accent-contrast` label at 6.45:1; its bright periwinkle dark-mode arm carries the dark-ink label at 7.77:1. Foreground usages (links, accent chip/badge labels, active tab labels, selected rows, toast actions, and the current-step marker) use the dedicated `--cinder-accent-text` token, which clears 4.5:1 on every light surface. `--cinder-accent-text-hover` darkens that foreground by 0.08 lightness (light arm ≈7.9:1 on white) so links get darker on hover; links must not use the fill-derived `--cinder-accent-hover`, which does not preserve the foreground contrast contract.
 
-`--cinder-accent-active-on-fill` is the pressed fill for solid accent surfaces that carry the dark-ink `--cinder-accent-contrast` label (primary `Button`, `FloatingAction`). The general `--cinder-accent-active` darkens the accent by `0.15`; on the darker `L=0.66` accent that resolves to `L=0.51`, where the dark-ink label drops to only ~4.09:1 — under WCAG AA. This token darkens by a gentler `0.11` (light → `L=0.55`, ~4.79:1; dark → `L=0.67`, ~7.1:1) so the pressed label stays AA-legible in both arms. Accent surfaces that do _not_ bear an on-fill label keep using `--cinder-accent-active`.
+`--cinder-accent-active-on-fill` is the pressed fill for solid accent surfaces that carry `--cinder-accent-contrast` labels (primary `Button`, `FloatingAction`). It darkens the light indigo arm by 0.11 to `L=0.39`, increasing white-label contrast to 10.5:1, while retaining a separate token so label-bearing and non-label consumers can diverge when needed. Accent surfaces that do not bear an on-fill label keep using `--cinder-accent-active`.
 
 ## Semantic aliases
 
@@ -271,22 +271,11 @@ Shared checkerboard colors for color-domain components that need to show alpha o
 | `--cinder-color-checker-base` | `light-dark(#fff, oklch(28% 0.02 245))` |
 | `--cinder-color-checker-tile` | `light-dark(#ccc, oklch(38% 0.02 245))` |
 
-## Scrollbar
-
-Used by the `ScrollArea` component and any consumer that opts into themed native scrollbars. Thumb alpha is tuned so the resolved thumb-on-surface contrast clears WCAG 1.4.11 (3:1) over common light- and dark-mode surface tokens.
-
-| Token                            | Default                                                    |
-| -------------------------------- | ---------------------------------------------------------- |
-| `--cinder-scrollbar-size`        | `0.625rem`                                                 |
-| `--cinder-scrollbar-track`       | `light-dark(oklch(0% 0 0 / 0.04), oklch(100% 0 0 / 0.04))` |
-| `--cinder-scrollbar-thumb`       | `light-dark(oklch(0% 0 0 / 0.45), oklch(100% 0 0 / 0.45))` |
-| `--cinder-scrollbar-thumb-hover` | `light-dark(oklch(0% 0 0 / 0.65), oklch(100% 0 0 / 0.65))` |
-
 ## Chart series
 
 Categorical chart colors for LineChart, BarChart, AreaChart, and consumers that need to keep custom chart marks aligned with cinder's default series palette.
 
-Each `--cinder-chart-series-*` is a theme-aware design token: it wraps a distinct per-theme OKLCH value in `light-dark()`, darker and higher-chroma in light mode so the mark reads against pale light surfaces, lighter in dark mode so it reads against dark surfaces. Only the color values branch — the hue assigned to each series index is held constant across themes so a given series keeps its identity when the theme flips. This mirrors the Shadow-section rationale: the per-theme arms exist to preserve perceived contrast and hierarchy, not to recolor the chart.
+Each `--cinder-chart-series-*` is a theme-aware design token: it wraps a distinct per-theme OKLCH value in `light-dark()`, darker and higher-chroma in light mode so the mark reads against pale light surfaces, lighter in dark mode so it reads against dark surfaces. Both color values and hues may change between theme arms: the index keeps its position in the series sequence, while the palette remaps it for contrast and visual separation in the active theme. This mirrors the Shadow-section rationale: the per-theme arms preserve perceived contrast and hierarchy.
 
 | Token                     | Default                                                 |
 | ------------------------- | ------------------------------------------------------- |

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -478,7 +478,7 @@
    * accent (≥5:1) and the dark page bg (≥18:1). Used by FloatingAction
    * primary variant. Raw oklch is legitimate here (tokens-base.css is the
    * one place raw colors are allowed). */
-  --cinder-ring-on-accent: light-dark(oklch(100% 0 0), oklch(15% 0.035 245));
+  --cinder-ring-on-accent: light-dark(oklch(15% 0.035 245), oklch(100% 0 0));
 
   /* Focus ring.
    *
@@ -694,7 +694,7 @@
   --cinder-scrollbar-thumb: oklch(100% 0 0 / 0.45);
   --cinder-scrollbar-thumb-hover: oklch(100% 0 0 / 0.65);
   --cinder-ring-offset-color: var(--cinder-surface-raised);
-  --cinder-ring-on-accent: oklch(15% 0.035 245);
+  --cinder-ring-on-accent: oklch(100% 0 0);
   --cinder-ring-color: oklch(from var(--cinder-accent) 0.7 0.14 h);
   --cinder-button-bg: var(--cinder-surface-raised);
   --cinder-button-fg: var(--cinder-text);
@@ -782,7 +782,7 @@
   --cinder-scrollbar-thumb: oklch(0% 0 0 / 0.45);
   --cinder-scrollbar-thumb-hover: oklch(0% 0 0 / 0.65);
   --cinder-ring-offset-color: var(--cinder-surface-raised);
-  --cinder-ring-on-accent: oklch(100% 0 0);
+  --cinder-ring-on-accent: oklch(15% 0.035 245);
   --cinder-ring-color: oklch(from var(--cinder-accent) 0.55 0.16 h);
   --cinder-button-bg: var(--cinder-surface-raised);
   --cinder-button-fg: var(--cinder-text);

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -478,7 +478,7 @@
    * accent (≥5:1) and the dark page bg (≥18:1). Used by FloatingAction
    * primary variant. Raw oklch is legitimate here (tokens-base.css is the
    * one place raw colors are allowed). */
-  --cinder-ring-on-accent: light-dark(oklch(20% 0.02 245), oklch(95% 0.01 245));
+  --cinder-ring-on-accent: light-dark(oklch(100% 0 0), oklch(15% 0.035 245));
 
   /* Focus ring.
    *
@@ -694,7 +694,7 @@
   --cinder-scrollbar-thumb: oklch(100% 0 0 / 0.45);
   --cinder-scrollbar-thumb-hover: oklch(100% 0 0 / 0.65);
   --cinder-ring-offset-color: var(--cinder-surface-raised);
-  --cinder-ring-on-accent: oklch(95% 0.01 245);
+  --cinder-ring-on-accent: oklch(15% 0.035 245);
   --cinder-ring-color: oklch(from var(--cinder-accent) 0.7 0.14 h);
   --cinder-button-bg: var(--cinder-surface-raised);
   --cinder-button-fg: var(--cinder-text);
@@ -782,7 +782,7 @@
   --cinder-scrollbar-thumb: oklch(0% 0 0 / 0.45);
   --cinder-scrollbar-thumb-hover: oklch(0% 0 0 / 0.65);
   --cinder-ring-offset-color: var(--cinder-surface-raised);
-  --cinder-ring-on-accent: oklch(20% 0.02 245);
+  --cinder-ring-on-accent: oklch(100% 0 0);
   --cinder-ring-color: oklch(from var(--cinder-accent) 0.55 0.16 h);
   --cinder-button-bg: var(--cinder-surface-raised);
   --cinder-button-fg: var(--cinder-text);

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -25,6 +25,7 @@ const THEMING_DOC = join(REPO_ROOT, 'docs', 'theming.md');
 function normalizeTokenValue(value: string): string {
   let normalized = '';
   let quote: '"' | "'" | undefined;
+  let whitespace = false;
   for (let index = 0; index < value.length; index += 1) {
     const character = value[index]!;
     if (quote !== undefined) {
@@ -33,16 +34,22 @@ function normalizeTokenValue(value: string): string {
       continue;
     }
     if (character === '"' || character === "'") {
+      if (whitespace && normalized.length > 0) normalized += ' ';
+      whitespace = false;
       quote = character;
       normalized += character;
       continue;
     }
-    normalized += /\s/.test(character) ? ' ' : character;
+    if (/\s/.test(character)) {
+      whitespace = true;
+      continue;
+    }
+    if ('(),'.includes(character)) normalized = normalized.trimEnd();
+    else if (whitespace && normalized.length > 0 && !/[(),]$/.test(normalized)) normalized += ' ';
+    whitespace = false;
+    normalized += character;
   }
-  return normalized
-    .replace(/ +/g, ' ')
-    .replace(/\s*([(),])\s*/g, '$1')
-    .trim();
+  return normalized.trim();
 }
 
 function extractDocTokens(markdown: string): { duplicates: string[]; tokens: Map<string, string> } {

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -19,6 +19,8 @@ const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
 const REPO_ROOT = join(PACKAGE_ROOT, '..', '..');
 const TOKENS_CSS = join(PACKAGE_ROOT, 'src', 'styles', 'tokens-base.css');
 const TOKENS_DOC = join(REPO_ROOT, 'docs', 'tokens.md');
+const FOCUS_RING_POLICY_DOC = join(REPO_ROOT, 'docs', 'focus-ring-policy.md');
+const THEMING_DOC = join(REPO_ROOT, 'docs', 'theming.md');
 
 function normalizeTokenValue(value: string): string {
   let normalized = '';
@@ -97,5 +99,45 @@ describe('docs/tokens.md drift', () => {
       missingFromCss: [],
       mismatchedValues: [],
     });
+  });
+
+  test('keeps exact token references in focused guides current', async () => {
+    const [css, focusRingPolicy, theming] = await Promise.all([
+      readFile(TOKENS_CSS, 'utf8'),
+      readFile(FOCUS_RING_POLICY_DOC, 'utf8'),
+      readFile(THEMING_DOC, 'utf8'),
+    ]);
+    const tokens = readRootTokenValues(css);
+    const value = (token: string) => {
+      const resolved = tokens.get(token);
+      expect(resolved).toBeDefined();
+      return resolved!;
+    };
+
+    expect(focusRingPolicy).toContain(
+      `| \`--cinder-ring-width\`        | \`${value('--cinder-ring-width')}\``,
+    );
+    expect(focusRingPolicy).toContain(
+      `| \`--cinder-ring-offset\`       | \`${value('--cinder-ring-offset')}\``,
+    );
+    expect(focusRingPolicy).toContain(`\`${value('--cinder-ring-offset-color')}\``);
+
+    for (const token of [
+      '--cinder-surface',
+      '--cinder-surface-raised',
+      '--cinder-text',
+      '--cinder-border',
+      '--cinder-accent',
+    ]) {
+      const [light, dark] =
+        value(token)
+          .match(/^light-dark\((.*),(.*)\)$/)
+          ?.slice(1)
+          .map((arm) => arm.trim()) ?? [];
+      expect(light).toBeDefined();
+      expect(dark).toBeDefined();
+      expect(theming).toContain(`${token}: ${light};`);
+      expect(theming).toContain(`${token}: ${dark};`);
+    }
   });
 });

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -44,7 +44,7 @@ function normalizeTokenValue(value: string): string {
       whitespace = true;
       continue;
     }
-    if ('(),'.includes(character)) normalized = normalized.trimEnd();
+    if (character === ',' || character === ')') normalized = normalized.trimEnd();
     else if (whitespace && normalized.length > 0 && !/[(),]$/.test(normalized)) normalized += ' ';
     whitespace = false;
     normalized += character;

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -122,6 +122,16 @@ describe('docs/tokens.md drift', () => {
     );
     expect(focusRingPolicy).toContain(`\`${value('--cinder-ring-offset-color')}\``);
 
+    const scopedThemeBlock = (theme: 'light' | 'dark') => {
+      const block = theming.match(
+        new RegExp(`^  \\[data-theme='${theme}'\\] \\{([\\s\\S]*?)\\n  \\}`, 'm'),
+      )?.[1];
+      expect(block).toBeDefined();
+      return block!;
+    };
+    const darkTheme = scopedThemeBlock('dark');
+    const lightTheme = scopedThemeBlock('light');
+
     for (const token of [
       '--cinder-surface',
       '--cinder-surface-raised',
@@ -136,8 +146,8 @@ describe('docs/tokens.md drift', () => {
           .map((arm) => arm.trim()) ?? [];
       expect(light).toBeDefined();
       expect(dark).toBeDefined();
-      expect(theming).toContain(`${token}: ${light};`);
-      expect(theming).toContain(`${token}: ${dark};`);
+      expect(lightTheme).toContain(`${token}: ${light};`);
+      expect(darkTheme).toContain(`${token}: ${dark};`);
     }
   });
 });

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -21,8 +21,24 @@ const TOKENS_CSS = join(PACKAGE_ROOT, 'src', 'styles', 'tokens-base.css');
 const TOKENS_DOC = join(REPO_ROOT, 'docs', 'tokens.md');
 
 function normalizeTokenValue(value: string): string {
-  return value
-    .replace(/\s+/g, ' ')
+  let normalized = '';
+  let quote: '"' | "'" | undefined;
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index]!;
+    if (quote !== undefined) {
+      normalized += character;
+      if (character === quote && value[index - 1] !== '\\') quote = undefined;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      normalized += character;
+      continue;
+    }
+    normalized += /\s/.test(character) ? ' ' : character;
+  }
+  return normalized
+    .replace(/ +/g, ' ')
     .replace(/\s*([(),])\s*/g, '$1')
     .trim();
 }

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -2,8 +2,8 @@
  * Drift test for docs/tokens.md.
  *
  * The doc is hand-maintained, so this test makes sure it stays in sync with
- * the actual `--cinder-*` declarations in tokens-base.css. We extract the set
- * of token names from each source and assert they match exactly.
+ * the actual `--cinder-*` declarations in tokens-base.css. It compares names
+ * and authored values; CSS functions remain part of that exact contract.
  *
  * Test files may use `any` per project conventions.
  */
@@ -13,22 +13,29 @@ import { join } from 'node:path';
 
 import { describe, expect, test } from 'bun:test';
 
-import { readRootTokenNames } from '../test/token-introspection.ts';
+import { readRootTokenValues } from '../test/token-introspection.ts';
 
 const PACKAGE_ROOT = join(import.meta.dir, '..', '..');
 const REPO_ROOT = join(PACKAGE_ROOT, '..', '..');
 const TOKENS_CSS = join(PACKAGE_ROOT, 'src', 'styles', 'tokens-base.css');
 const TOKENS_DOC = join(REPO_ROOT, 'docs', 'tokens.md');
 
-function extractDocTokens(markdown: string): Set<string> {
+function normalizeTokenValue(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([(),])\s*/g, '$1')
+    .trim();
+}
+
+function extractDocTokens(markdown: string): Map<string, string> {
   // Doc lists tokens as inline code in table rows: `` `--cinder-space-4` ``.
   // We deliberately only count tokens that appear inside backticks at the start
   // of a table cell (i.e. `| \`--cinder-...\``) so that incidental mentions in
   // prose (e.g. "override `--cinder-accent` to re-derive both") don't count.
-  const tokens = new Set<string>();
-  const rowPattern = /^\|\s*`(--cinder-[a-z0-9-]+)`/gm;
+  const tokens = new Map<string, string>();
+  const rowPattern = /^\|\s*`(--cinder-[a-z0-9-]+)`\s*\|\s*`([^`]+)`\s*\|/gm;
   for (const match of markdown.matchAll(rowPattern)) {
-    if (match[1]) tokens.add(match[1]);
+    if (match[1] && match[2]) tokens.set(match[1], normalizeTokenValue(match[2]));
   }
   return tokens;
 }
@@ -40,7 +47,7 @@ describe('docs/tokens.md drift', () => {
       readFile(TOKENS_DOC, 'utf8'),
     ]);
 
-    const cssTokens = readRootTokenNames(css);
+    const cssTokens = readRootTokenValues(css);
     const docTokens = extractDocTokens(doc);
 
     // Sanity floor: a parser regression that silently returns a tiny set would
@@ -50,12 +57,25 @@ describe('docs/tokens.md drift', () => {
     expect(cssTokens.size).toBeGreaterThan(50);
     expect(docTokens.size).toBeGreaterThan(50);
 
-    const missingFromDoc = [...cssTokens].filter((token) => !docTokens.has(token)).toSorted();
-    const missingFromCss = [...docTokens].filter((token) => !cssTokens.has(token)).toSorted();
+    const missingFromDoc = [...cssTokens.keys()]
+      .filter((token) => !docTokens.has(token))
+      .toSorted();
+    const missingFromCss = [...docTokens.keys()]
+      .filter((token) => !cssTokens.has(token))
+      .toSorted();
+    const mismatchedValues = [...cssTokens]
+      .flatMap(([token, value]) => {
+        const documented = docTokens.get(token);
+        return documented === undefined || documented === normalizeTokenValue(value)
+          ? []
+          : [`${token}: docs=${documented} source=${normalizeTokenValue(value)}`];
+      })
+      .toSorted();
 
-    expect({ missingFromDoc, missingFromCss }).toEqual({
+    expect({ missingFromDoc, missingFromCss, mismatchedValues }).toEqual({
       missingFromDoc: [],
       missingFromCss: [],
+      mismatchedValues: [],
     });
   });
 });

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -27,17 +27,20 @@ function normalizeTokenValue(value: string): string {
     .trim();
 }
 
-function extractDocTokens(markdown: string): Map<string, string> {
+function extractDocTokens(markdown: string): { duplicates: string[]; tokens: Map<string, string> } {
   // Doc lists tokens as inline code in table rows: `` `--cinder-space-4` ``.
   // We deliberately only count tokens that appear inside backticks at the start
   // of a table cell (i.e. `| \`--cinder-...\``) so that incidental mentions in
   // prose (e.g. "override `--cinder-accent` to re-derive both") don't count.
   const tokens = new Map<string, string>();
+  const duplicates: string[] = [];
   const rowPattern = /^\|\s*`(--cinder-[a-z0-9-]+)`\s*\|\s*`([^`]+)`\s*\|/gm;
   for (const match of markdown.matchAll(rowPattern)) {
-    if (match[1] && match[2]) tokens.set(match[1], normalizeTokenValue(match[2]));
+    if (!match[1] || !match[2]) continue;
+    if (tokens.has(match[1])) duplicates.push(match[1]);
+    tokens.set(match[1], normalizeTokenValue(match[2]));
   }
-  return tokens;
+  return { duplicates: duplicates.toSorted(), tokens };
 }
 
 describe('docs/tokens.md drift', () => {
@@ -48,7 +51,7 @@ describe('docs/tokens.md drift', () => {
     ]);
 
     const cssTokens = readRootTokenValues(css);
-    const docTokens = extractDocTokens(doc);
+    const { duplicates, tokens: docTokens } = extractDocTokens(doc);
 
     // Sanity floor: a parser regression that silently returns a tiny set would
     // otherwise show up as a confusing "missing from CSS: [137 tokens]" diff
@@ -72,7 +75,8 @@ describe('docs/tokens.md drift', () => {
       })
       .toSorted();
 
-    expect({ missingFromDoc, missingFromCss, mismatchedValues }).toEqual({
+    expect({ duplicates, missingFromDoc, missingFromCss, mismatchedValues }).toEqual({
+      duplicates: [],
       missingFromDoc: [],
       missingFromCss: [],
       mismatchedValues: [],

--- a/packages/components/src/test/token-introspection.ts
+++ b/packages/components/src/test/token-introspection.ts
@@ -53,8 +53,13 @@ export function extractRootBlock(css: string): string {
  * declaration.
  */
 export function readRootTokenNames(css: string): Set<string> {
+  return new Set(readRootTokenValues(css).keys());
+}
+
+/** Returns authored `--cinder-*` values from the top-level `:root` block. */
+export function readRootTokenValues(css: string): Map<string, string> {
   const root = parse(css);
-  const names = new Set<string>();
+  const values = new Map<string, string>();
   let found = false;
 
   root.walkRules(':root', (rule) => {
@@ -63,7 +68,7 @@ export function readRootTokenNames(css: string): Set<string> {
 
     for (const node of rule.nodes) {
       if (node.type === 'decl' && node.prop.startsWith('--cinder-')) {
-        names.add(node.prop);
+        values.set(node.prop, node.value);
       }
     }
 
@@ -74,5 +79,5 @@ export function readRootTokenNames(css: string): Set<string> {
     throw new Error('Could not find :root { ... } block in tokens-base.css');
   }
 
-  return names;
+  return values;
 }


### PR DESCRIPTION
Closes CIN-360

## Summary
- synchronize documented token values with tokens-base.css
- compare documented token values as well as names
- preserve light-dark(), color-mix(), and var() expressions as exact token contracts

## Validation
- bun run --filter=@lostgradient/cinder test -- src/styles/tokens-doc-drift.test.ts