### PR TITLE
Cover FileUpload dropzone accessibility

### DIFF
--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -131,6 +131,22 @@ describe('FileUpload rendering', () => {
     );
   });
 
+  test('exposes the dropzone as a group and keeps the native picker keyboard reachable', async () => {
+    const { container } = render(FileUpload, { props: { id: 'resume-upload' } });
+    const dropzone = container.querySelector('.cinder-file-upload__dropzone') as HTMLDivElement;
+    const input = container.querySelector('#resume-upload') as HTMLInputElement;
+    const button = container.querySelector('.cinder-file-upload__button') as HTMLButtonElement;
+    const inputClick = mock(() => {});
+    input.click = inputClick;
+
+    expect(dropzone.getAttribute('role')).toBe('group');
+    button.focus();
+    expect(document.activeElement).toBe(button);
+
+    await fireEvent.click(button);
+    expect(inputClick).toHaveBeenCalledTimes(1);
+  });
+
   test('renders custom picker trigger text', () => {
     const { container } = render(FileUpload, {
       props: { id: 'history-import', browseLabel: 'Import history JSON' },
@@ -253,6 +269,20 @@ describe('FileUpload validation and events', () => {
     expect(onFilesChange.mock.calls[0]?.[0]).toEqual([
       expect.objectContaining({ file, status: 'pending' }),
     ]);
+  });
+
+  test('adds files through the native picker without a drag event', async () => {
+    const onFilesAccepted = mock((_files: File[]) => {});
+    const file = createFile('resume.pdf', 'application/pdf', 512_000);
+    const { container } = render(FileUpload, {
+      props: { id: 'resume-upload', onFilesAccepted },
+    });
+    const input = container.querySelector('#resume-upload') as HTMLInputElement;
+
+    attachInputFiles(input, [file]);
+    await fireEvent.change(input);
+
+    expect(onFilesAccepted).toHaveBeenCalledWith([file]);
   });
 
   test('maxSize rejection reports reason and message', async () => {

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -136,7 +136,7 @@ describe('FileUpload rendering', () => {
     const input = container.querySelector('#resume-upload') as HTMLInputElement;
     const button = screen.getByRole('button', { name: 'Browse files' });
     const inputClick = mock(() => {});
-    input.click = inputClick;
+    input.click = inputClick as unknown as typeof input.click;
 
     expect(screen.getByRole('group', { name: 'File upload' })).toBe(
       container.querySelector('.cinder-file-upload__dropzone')!,

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -139,7 +139,7 @@ describe('FileUpload rendering', () => {
     input.click = inputClick;
 
     expect(screen.getByRole('group', { name: 'File upload' })).toBe(
-      container.querySelector('.cinder-file-upload__dropzone'),
+      container.querySelector('.cinder-file-upload__dropzone')!,
     );
     expect(button.hasAttribute('tabindex')).toBe(false);
     button.focus();

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -7,7 +7,7 @@ setupHappyDom();
 
 const nativeDataTransfer = globalThis.DataTransfer;
 
-const { render, fireEvent, cleanup } = await import('@testing-library/svelte');
+const { render, fireEvent, cleanup, screen } = await import('@testing-library/svelte');
 
 // Unmount renders between tests; shared document.body otherwise leaks activeElement/nodes.
 afterEach(() => {
@@ -131,15 +131,17 @@ describe('FileUpload rendering', () => {
     );
   });
 
-  test('exposes the dropzone as a group and keeps the native picker keyboard reachable', async () => {
+  test('exposes a named dropzone group and keeps the native picker keyboard reachable', async () => {
     const { container } = render(FileUpload, { props: { id: 'resume-upload' } });
-    const dropzone = container.querySelector('.cinder-file-upload__dropzone') as HTMLDivElement;
     const input = container.querySelector('#resume-upload') as HTMLInputElement;
-    const button = container.querySelector('.cinder-file-upload__button') as HTMLButtonElement;
+    const button = screen.getByRole('button', { name: 'Browse files' });
     const inputClick = mock(() => {});
     input.click = inputClick;
 
-    expect(dropzone.getAttribute('role')).toBe('group');
+    expect(screen.getByRole('group', { name: 'File upload' })).toBe(
+      container.querySelector('.cinder-file-upload__dropzone'),
+    );
+    expect(button.hasAttribute('tabindex')).toBe(false);
     button.focus();
     expect(document.activeElement).toBe(button);
 
@@ -237,6 +239,16 @@ describe('FileUpload rendering', () => {
     );
   });
 
+  test('uses the FormField label as the dropzone group name', () => {
+    render(FormFieldFileUploadFixture, {
+      props: { fieldId: 'resume', fieldLabel: 'Resume' },
+    });
+
+    expect(screen.getByRole('group', { name: 'Resume' }).classList).toContain(
+      'cinder-file-upload__dropzone',
+    );
+  });
+
   test('inherits required and disabled from FormField context', () => {
     const { container } = render(FormFieldFileUploadFixture, {
       props: {
@@ -282,6 +294,7 @@ describe('FileUpload validation and events', () => {
     attachInputFiles(input, [file]);
     await fireEvent.change(input);
 
+    expect(onFilesAccepted).toHaveBeenCalledTimes(1);
     expect(onFilesAccepted).toHaveBeenCalledWith([file]);
   });
 


### PR DESCRIPTION
Closes CIN-183

## Summary
- assert the dropzone exposes group semantics
- assert the browse control receives focus and opens the native picker
- assert the native picker adds files without drag-and-drop

## Validation
- bun run --filter=@lostgradient/cinder test -- src/components/file-upload/file-upload.test.ts