### PR TITLE
Enforce Cinder authoring obligations

### DIFF
--- a/.agents/skills/cinder-component-authoring/SKILL.md
+++ b/.agents/skills/cinder-component-authoring/SKILL.md
@@ -18,6 +18,9 @@ links generated READMEs back to the live package guidance.
 - [ ] Apply the `cinder-_floating-surface` class to floating panels (defined in `_floating-surface.css`), and compose form controls from `Input` and `FormField`. (#921, #923)
 - [ ] Use a rotating chevron for disclosure controls that render an indicator; use direction-aware lateral chevrons for nested submenus, keep intentionally text-only disclosures icon-free, and use icons from the lucide-svelte set. (#957)
 - [ ] Add tests for resulting state and resting appearance, not only transitions. (#931)
+- [ ] For every leaf, add a substantive test, README skeleton, stylesheet registration in src/styles/components.css, generated exports, and the sidebar count-gate update. (#310)
+- [ ] For every new token, add check-token-contrast.test.ts coverage and its docs/tokens.md entry; tokens-doc-drift.test.ts must stay green. (#310)
+- [ ] Register every new guard script in check-pipeline-coverage.ts in the same change. (#310)
 - [ ] Get a design review for every new component; record its nearest neighbours, why it exists, and the review outcome in `*.a11y.md`. (#968)
 - [ ] For a novel interaction model, get an accessibility review covering focus management, the keyboard matrix, and assistive-technology announcements; record the outcome in `*.a11y.md`. (#968)
 <!-- component-authoring-checklist:end -->

--- a/.claude/skills/cinder-component-authoring/SKILL.md
+++ b/.claude/skills/cinder-component-authoring/SKILL.md
@@ -18,6 +18,9 @@ links generated READMEs back to the live package guidance.
 - [ ] Apply the `cinder-_floating-surface` class to floating panels (defined in `_floating-surface.css`), and compose form controls from `Input` and `FormField`. (#921, #923)
 - [ ] Use a rotating chevron for disclosure controls that render an indicator; use direction-aware lateral chevrons for nested submenus, keep intentionally text-only disclosures icon-free, and use icons from the lucide-svelte set. (#957)
 - [ ] Add tests for resulting state and resting appearance, not only transitions. (#931)
+- [ ] For every leaf, add a substantive test, README skeleton, stylesheet registration in src/styles/components.css, generated exports, and the sidebar count-gate update. (#310)
+- [ ] For every new token, add check-token-contrast.test.ts coverage and its docs/tokens.md entry; tokens-doc-drift.test.ts must stay green. (#310)
+- [ ] Register every new guard script in check-pipeline-coverage.ts in the same change. (#310)
 - [ ] Get a design review for every new component; record its nearest neighbours, why it exists, and the review outcome in `*.a11y.md`. (#968)
 - [ ] For a novel interaction model, get an accessibility review covering focus management, the keyboard matrix, and assistive-technology announcements; record the outcome in `*.a11y.md`. (#968)
 <!-- component-authoring-checklist:end -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,9 @@ checklist:
 - [ ] Apply the `cinder-_floating-surface` class to floating panels (defined in `_floating-surface.css`), and compose form controls from `Input` and `FormField`. (#921, #923)
 - [ ] Use a rotating chevron for disclosure controls that render an indicator; use direction-aware lateral chevrons for nested submenus, keep intentionally text-only disclosures icon-free, and use icons from the lucide-svelte set. (#957)
 - [ ] Add tests for resulting state and resting appearance, not only transitions. (#931)
+- [ ] For every leaf, add a substantive test, README skeleton, stylesheet registration in src/styles/components.css, generated exports, and the sidebar count-gate update. (#310)
+- [ ] For every new token, add check-token-contrast.test.ts coverage and its docs/tokens.md entry; tokens-doc-drift.test.ts must stay green. (#310)
+- [ ] Register every new guard script in check-pipeline-coverage.ts in the same change. (#310)
 - [ ] Get a design review for every new component; record its nearest neighbours, why it exists, and the review outcome in `*.a11y.md`. (#968)
 - [ ] For a novel interaction model, get an accessibility review covering focus management, the keyboard matrix, and assistive-technology announcements; record the outcome in `*.a11y.md`. (#968)
 <!-- component-authoring-checklist:end -->

--- a/packages/components/AGENTS.md
+++ b/packages/components/AGENTS.md
@@ -21,6 +21,9 @@ Before creating a component, load the repository-local
 - [ ] Apply the `cinder-_floating-surface` class to floating panels (defined in `_floating-surface.css`), and compose form controls from `Input` and `FormField`. (#921, #923)
 - [ ] Use a rotating chevron for disclosure controls that render an indicator; use direction-aware lateral chevrons for nested submenus, keep intentionally text-only disclosures icon-free, and use icons from the lucide-svelte set. (#957)
 - [ ] Add tests for resulting state and resting appearance, not only transitions. (#931)
+- [ ] For every leaf, add a substantive test, README skeleton, stylesheet registration in src/styles/components.css, generated exports, and the sidebar count-gate update. (#310)
+- [ ] For every new token, add check-token-contrast.test.ts coverage and its docs/tokens.md entry; tokens-doc-drift.test.ts must stay green. (#310)
+- [ ] Register every new guard script in check-pipeline-coverage.ts in the same change. (#310)
 - [ ] Get a design review for every new component; record its nearest neighbours, why it exists, and the review outcome in `*.a11y.md`. (#968)
 - [ ] For a novel interaction model, get an accessibility review covering focus management, the keyboard matrix, and assistive-technology announcements; record the outcome in `*.a11y.md`. (#968)
 <!-- component-authoring-checklist:end -->

--- a/packages/components/scripts/component-conventions.ts
+++ b/packages/components/scripts/component-conventions.ts
@@ -92,6 +92,21 @@ export const COMPONENT_AUTHORING_CHECKLIST = [
     references: ['#931'],
   },
   {
+    id: 'component-delivery-artifacts',
+    text: 'For every leaf, add a substantive test, README skeleton, stylesheet registration in src/styles/components.css, generated exports, and the sidebar count-gate update.',
+    references: ['#310'],
+  },
+  {
+    id: 'token-delivery-artifacts',
+    text: 'For every new token, add check-token-contrast.test.ts coverage and its docs/tokens.md entry; tokens-doc-drift.test.ts must stay green.',
+    references: ['#310'],
+  },
+  {
+    id: 'guard-pipeline-registration',
+    text: 'Register every new guard script in check-pipeline-coverage.ts in the same change.',
+    references: ['#310'],
+  },
+  {
     id: 'human-design-review',
     text: 'Get a design review for every new component; record its nearest neighbours, why it exists, and the review outcome in `*.a11y.md`.',
     references: ['#968'],

--- a/packages/components/scripts/create-component.test.ts
+++ b/packages/components/scripts/create-component.test.ts
@@ -64,6 +64,9 @@ describe('component authoring guidance', () => {
     expect(canonicalChecklist).toContain('accessibility review');
     expect(canonicalChecklist).toContain('`*.a11y.md`');
     expect(canonicalChecklist).toContain('#968');
+    expect(canonicalChecklist).toContain('sidebar count-gate');
+    expect(canonicalChecklist).toContain('check-token-contrast.test.ts');
+    expect(canonicalChecklist).toContain('check-pipeline-coverage.ts');
 
     for (const relativePath of CHECKLIST_MIRRORS) {
       const source = await readFile(join(REPOSITORY_ROOT, relativePath), 'utf8');


### PR DESCRIPTION
Closes CIN-310

## Summary
- add leaf, token, and guard-delivery requirements to the canonical authoring checklist
- synchronize every checklist mirror
- assert the new requirements in scaffold guidance tests

## Validation
- bun run --filter=@lostgradient/cinder test -- scripts/create-component.test.ts
- bun run --filter=@lostgradient/cinder lint:invariants