### PR TITLE
fix(cinder): surface enum metadata and name reorder controls

### DIFF
--- a/.changeset/quiet-enums-move.md
+++ b/.changeset/quiet-enums-move.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Surface unsupported JSON Schema enum metadata and clarify property reorder controls for assistive technology.

--- a/packages/components/src/components/json-schema-editor/property-editor.constants.ts
+++ b/packages/components/src/components/json-schema-editor/property-editor.constants.ts
@@ -18,7 +18,6 @@ export const EDITABLE_KEYWORDS = new Set([
   'default',
   'examples',
   'const',
-  'enum',
   'minLength',
   'maxLength',
   'pattern',

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -30,7 +30,6 @@
   import Checkbox from '../checkbox/checkbox.svelte';
   import Collapsible from '@lostgradient/cinder/collapsible';
   import Input from '../input/input.svelte';
-  import Tooltip from '../tooltip/tooltip.svelte';
 
   import { reconcileCompositionBranchKeys } from './composition-branch-keys.ts';
   import {
@@ -472,19 +471,14 @@
         >
           Add $ref
         </Button>
-        {#if preservedKeys.length > 0}
-          <Tooltip text={`Preserved keys: ${preservedKeys.join(', ')}`}>
-            <Badge variant="info">+{preservedKeys.length} preserved</Badge>
-          </Tooltip>
-        {/if}
       </div>
     {/if}
 
-    <!-- Preserved-keywords badge for the readonly case (Add $ref is hidden). -->
-    {#if readonly && objectValue.$ref === undefined && preservedKeys.length > 0}
-      <Tooltip text={`Preserved keys: ${preservedKeys.join(', ')}`}>
+    {#if preservedKeys.length > 0}
+      <div class="cinder-jse-advanced-row">
         <Badge variant="info">+{preservedKeys.length} preserved</Badge>
-      </Tooltip>
+        <span>Preserved keywords: {preservedKeys.join(', ')}</span>
+      </div>
     {/if}
   {/if}
 </div>

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -273,7 +273,7 @@
           variant="ghost"
           size="xs"
           disabled={readonly}
-          aria-label="Move up"
+          aria-label={`Move ${key} up`}
           onclick={() => moveProperty(key, -1)}
         >
           ↑
@@ -282,7 +282,7 @@
           variant="ghost"
           size="xs"
           disabled={readonly}
-          aria-label="Move down"
+          aria-label={`Move ${key} down`}
           onclick={() => moveProperty(key, 1)}
         >
           ↓

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -102,6 +102,12 @@ describe('PropertyList', () => {
     expect(preservedKeys).toEqual(['enum']);
   });
 
+  test('renders preserved keywords visibly beside a $ref editor', async () => {
+    const source = await Bun.file(new URL('./property-editor.svelte', import.meta.url)).text();
+
+    expect(source).toContain("Preserved keywords: {preservedKeys.join(', ')}");
+  });
+
   test('aggregates local and nested validation error counts', async () => {
     expect(
       calculatePropertyValidationErrorCount(

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -5,8 +5,9 @@ import { setupHappyDom } from '../../test/happy-dom.ts';
 
 setupHappyDom();
 
-const { cleanup, fireEvent, render } = await import('@testing-library/svelte');
+const { cleanup, fireEvent, render, screen } = await import('@testing-library/svelte');
 const { default: PropertyList } = await import('./property-list.svelte');
+const { EDITABLE_KEYWORDS } = await import('./property-editor.constants.ts');
 const { calculatePropertyValidationErrorCount } = await import('./property-list-validation.ts');
 
 // @testing-library/svelte v5's auto-cleanup does not register under bun:test (no
@@ -74,6 +75,31 @@ describe('PropertyList', () => {
     await fireEvent.click(addButton!);
 
     expect(latestRequired).toEqual(['missingSchema']);
+  });
+
+  test('identifies each property in the accessible names of its reorder controls', () => {
+    render(PropertyList, {
+      idPrefix: 'properties',
+      path: '/properties',
+      properties: {
+        email: { type: 'string' },
+        age: { type: 'integer' },
+      },
+      required: [],
+      onValueChange: () => {},
+    });
+
+    expect(screen.getByRole('button', { name: 'Move email up' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Move email down' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Move age up' })).not.toBeNull();
+    expect(screen.getByRole('button', { name: 'Move age down' })).not.toBeNull();
+  });
+
+  test('keeps enum in the preserved-keywords count when a schema is loaded', () => {
+    const loadedSchema = { type: 'string', enum: ['draft', 'published'] };
+    const preservedKeys = Object.keys(loadedSchema).filter((key) => !EDITABLE_KEYWORDS.has(key));
+
+    expect(preservedKeys).toEqual(['enum']);
   });
 
   test('aggregates local and nested validation error counts', async () => {


### PR DESCRIPTION
## Summary

- preserve unsupported JSON Schema `enum` values in the visible preserved-keyword count
- name each property reorder control with its property key for screen-reader clarity
- add focused regression coverage and a patch changeset

## Root cause

`enum` was marked as editable without a matching control, while every reorder button reused the same static accessible name.

## Validation

- `bun run --filter=@lostgradient/cinder components:check`
- `bun run --filter=@lostgradient/cinder test -- src/components/json-schema-editor`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder lint`
- `bun run --filter=@lostgradient/cinder check:changeset-prerelease-bumps`

Closes CIN-368
Closes CIN-165