### PR TITLE
fix(editor): preserve live edits during debounce

### DIFF
--- a/.changeset/fresh-edit-ownership.md
+++ b/.changeset/fresh-edit-ownership.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/editor': patch
+---
+
+Keep one-way MarkdownEditor consumers from overwriting a settled user edit while the public change callback is debounced.

--- a/packages/editor/src/lib/components/markdown-editor/markdown-editor-onewaysync-harness.svelte
+++ b/packages/editor/src/lib/components/markdown-editor/markdown-editor-onewaysync-harness.svelte
@@ -55,6 +55,16 @@
     if (!view) return;
     view.dispatch(view.state.tr.insertText(suffix, view.state.doc.content.size - 1));
   }
+
+  export function applyUserEditWithoutHistory(suffix: string): void {
+    const view = editorRef?.getView();
+    if (!view) return;
+    view.dispatch(
+      view.state.tr
+        .insertText(suffix, view.state.doc.content.size - 1)
+        .setMeta('addToHistory', false),
+    );
+  }
 </script>
 
 <MarkdownEditor

--- a/packages/editor/src/lib/components/markdown-editor/markdown-editor-onewaysync-harness.svelte
+++ b/packages/editor/src/lib/components/markdown-editor/markdown-editor-onewaysync-harness.svelte
@@ -49,6 +49,12 @@
   export function getLiveMarkdown(): string {
     return editorRef?.getMarkdown() ?? '';
   }
+
+  export function applyUserEdit(suffix: string): void {
+    const view = editorRef?.getView();
+    if (!view) return;
+    view.dispatch(view.state.tr.insertText(suffix, view.state.doc.content.size - 1));
+  }
 </script>
 
 <MarkdownEditor

--- a/packages/editor/src/lib/components/markdown-editor/markdown-editor.setmarkdown-onewaysync.test.ts
+++ b/packages/editor/src/lib/components/markdown-editor/markdown-editor.setmarkdown-onewaysync.test.ts
@@ -211,3 +211,39 @@ describe('MarkdownEditor.setMarkdown() vs. a one-way value prop (cinder#1328)', 
     }
   });
 });
+
+describe('MarkdownEditor live value ownership (CIN-406)', () => {
+  test('does not reconcile a stale one-way parent value over a settled user edit', async () => {
+    const clock = installFakeClock();
+    const result = render(OneWaySyncHarness, {
+      props: { initialValue: 'Original content.' },
+    });
+
+    try {
+      await pollUntil(() => isReady(result.container), clock);
+      const component = result.component as unknown as {
+        applyUserEdit: (suffix: string) => void;
+        setOuterValue: (content: string) => void;
+        getLiveMarkdown: () => string;
+      };
+
+      // Let the editor's initial one-way value reconciliation release its
+      // external-update guard before simulating live user input.
+      await tick();
+      await Promise.resolve();
+      component.applyUserEdit(' User edit.');
+      expect(component.getLiveMarkdown().trim()).toBe('Original content. User edit.');
+
+      // A one-way parent update can still contain the value from immediately
+      // before this edit while the public onchange callback is debounced.
+      component.setOuterValue('Stale parent value.');
+      await tick();
+
+      expect(component.getLiveMarkdown().trim()).toBe('Original content. User edit.');
+    } finally {
+      clock.restore();
+      result.unmount();
+      cleanup();
+    }
+  });
+});

--- a/packages/editor/src/lib/components/markdown-editor/markdown-editor.setmarkdown-onewaysync.test.ts
+++ b/packages/editor/src/lib/components/markdown-editor/markdown-editor.setmarkdown-onewaysync.test.ts
@@ -213,7 +213,40 @@ describe('MarkdownEditor.setMarkdown() vs. a one-way value prop (cinder#1328)', 
 });
 
 describe('MarkdownEditor live value ownership (CIN-406)', () => {
-  test('does not reconcile a stale one-way parent value over a settled user edit', async () => {
+  test('does not reconcile the previously observed one-way parent value over a pending user edit', async () => {
+    const clock = installFakeClock();
+    const result = render(OneWaySyncHarness, {
+      props: { initialValue: 'Original content.' },
+    });
+
+    try {
+      await pollUntil(() => isReady(result.container), clock);
+      const component = result.component as unknown as {
+        applyUserEdit: (suffix: string) => void;
+        getLiveMarkdown: () => string;
+      };
+
+      // Let the editor's initial one-way value reconciliation release its
+      // external-update guard before simulating live user input.
+      await tick();
+      await Promise.resolve();
+      component.applyUserEdit(' User edit.');
+      expect(component.getLiveMarkdown().trim()).toBe('Original content. User edit.');
+
+      // The component's bindable value can react while the one-way parent
+      // still owns the previously observed value. Let Svelte flush that
+      // propagation without advancing either debounce.
+      await tick();
+
+      expect(component.getLiveMarkdown().trim()).toBe('Original content. User edit.');
+    } finally {
+      clock.restore();
+      result.unmount();
+      cleanup();
+    }
+  });
+
+  test('applies a genuinely new parent value while a user edit is pending', async () => {
     const clock = installFakeClock();
     const result = render(OneWaySyncHarness, {
       props: { initialValue: 'Original content.' },
@@ -227,19 +260,72 @@ describe('MarkdownEditor live value ownership (CIN-406)', () => {
         getLiveMarkdown: () => string;
       };
 
-      // Let the editor's initial one-way value reconciliation release its
-      // external-update guard before simulating live user input.
       await tick();
       await Promise.resolve();
       component.applyUserEdit(' User edit.');
-      expect(component.getLiveMarkdown().trim()).toBe('Original content. User edit.');
-
-      // A one-way parent update can still contain the value from immediately
-      // before this edit while the public onchange callback is debounced.
-      component.setOuterValue('Stale parent value.');
+      component.setOuterValue('Authoritative reset.');
       await tick();
 
-      expect(component.getLiveMarkdown().trim()).toBe('Original content. User edit.');
+      expect(component.getLiveMarkdown().trim()).toBe('Authoritative reset.');
+
+      // The external replacement cancels the pending internal callback, so
+      // advancing both debounce boundaries cannot resurrect the user edit.
+      clock.advance(1000);
+      await tick();
+      expect(component.getLiveMarkdown().trim()).toBe('Authoritative reset.');
+    } finally {
+      clock.restore();
+      result.unmount();
+      cleanup();
+    }
+  });
+
+  test('protects document changes excluded from undo history as internal edits', async () => {
+    const clock = installFakeClock();
+    const result = render(OneWaySyncHarness, {
+      props: { initialValue: 'Original content.' },
+    });
+
+    try {
+      await pollUntil(() => isReady(result.container), clock);
+      const component = result.component as unknown as {
+        applyUserEditWithoutHistory: (suffix: string) => void;
+        getLiveMarkdown: () => string;
+      };
+
+      await tick();
+      await Promise.resolve();
+      component.applyUserEditWithoutHistory(' Normalized.');
+      await tick();
+
+      expect(component.getLiveMarkdown().trim()).toBe('Original content. Normalized.');
+    } finally {
+      clock.restore();
+      result.unmount();
+      cleanup();
+    }
+  });
+
+  test('protects multiple internal transactions until their debounced publication', async () => {
+    const clock = installFakeClock();
+    const result = render(OneWaySyncHarness, {
+      props: { initialValue: 'Original content.' },
+    });
+
+    try {
+      await pollUntil(() => isReady(result.container), clock);
+      const component = result.component as unknown as {
+        applyUserEdit: (suffix: string) => void;
+        getLiveMarkdown: () => string;
+      };
+
+      await tick();
+      await Promise.resolve();
+      component.applyUserEdit(' First.');
+      component.applyUserEdit(' Second.');
+      await tick();
+
+      expect(component.getLiveMarkdown().trim()).toBe('Original content. First. Second.');
     } finally {
       clock.restore();
       result.unmount();

--- a/packages/editor/src/lib/components/markdown-editor/markdown-editor.svelte
+++ b/packages/editor/src/lib/components/markdown-editor/markdown-editor.svelte
@@ -594,6 +594,7 @@
         // Editor may be in the middle of teardown; fail open to avoid crashing.
         return;
       }
+      if (editorState.getPendingInternalMarkdown() === currentMarkdown) return;
       // Only update if actually different
       if (externalValue !== currentMarkdown) {
         try {

--- a/packages/editor/src/lib/components/markdown-editor/markdown-editor.svelte
+++ b/packages/editor/src/lib/components/markdown-editor/markdown-editor.svelte
@@ -104,6 +104,7 @@
   // ring or blinking caret at an arbitrary position. We target the wrapper
   // element via a reactive reference set during rendering.
   let wrapperElement = $state<HTMLDivElement | null>(null);
+  let lastObservedExternalValue: string | undefined;
 
   $effect(() => {
     if (!snapshotMode) return;
@@ -587,6 +588,10 @@
     const externalValue = value;
 
     if (editorState && !isInternalUpdate) {
+      if (editorState.hasPendingInternalChange() && externalValue === lastObservedExternalValue) {
+        return;
+      }
+      lastObservedExternalValue = externalValue;
       let currentMarkdown: string;
       try {
         currentMarkdown = editorState.getMarkdown();
@@ -594,7 +599,6 @@
         // Editor may be in the middle of teardown; fail open to avoid crashing.
         return;
       }
-      if (editorState.getPendingInternalMarkdown() === currentMarkdown) return;
       // Only update if actually different
       if (externalValue !== currentMarkdown) {
         try {

--- a/packages/editor/src/lib/components/review-editor/review-editor-state.test.ts
+++ b/packages/editor/src/lib/components/review-editor/review-editor-state.test.ts
@@ -70,4 +70,55 @@ describe('createReviewEditorState diffStats', () => {
 
     expect(state.diffStats).toEqual({ added: 0, removed: 0, modified: 0 });
   });
+
+  test('exposes view controls, visible comment count, and summary content', () => {
+    const state = createReviewEditorState({
+      getOriginal: () => 'Original content.\n',
+      getValue: () => 'Updated content.\n',
+      getThreads: () => [
+        {
+          id: 'thread-1',
+          createdAt: '2026-08-18T00:00:00.000Z',
+          anchor: {
+            quote: 'Updated',
+            prefix: '',
+            suffix: ' content.',
+            status: 'anchored',
+            from: 0,
+            to: 7,
+            originalPosition: { offset: 0, line: 1, column: 1 },
+          },
+          comments: [
+            {
+              id: 'comment-1',
+              threadId: 'thread-1',
+              authorId: 'reviewer',
+              body: 'Visible comment',
+              createdAt: '2026-08-18T00:00:00.000Z',
+            },
+            {
+              id: 'comment-2',
+              threadId: 'thread-1',
+              authorId: 'reviewer',
+              body: 'Deleted comment',
+              createdAt: '2026-08-18T00:00:00.000Z',
+              deletedAt: '2026-08-18T00:01:00.000Z',
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(state.activeView).toBe('editor');
+    state.setActiveView('summary');
+    expect(state.activeView).toBe('summary');
+
+    expect(state.diffViewMode).toBe('unified');
+    state.setDiffViewMode('final');
+    expect(state.diffViewMode).toBe('final');
+
+    expect(state.commentCount).toBe(1);
+    expect(state.summaryContent).toContain('Visible comment');
+    expect(state.summaryContent).not.toContain('# Review Summary');
+  });
 });

--- a/packages/editor/src/lib/editor/attach.test.ts
+++ b/packages/editor/src/lib/editor/attach.test.ts
@@ -22,7 +22,7 @@ function createEditorState(): EditorState {
     view: {} as EditorState['view'],
     focus: mock(() => {}),
     getMarkdown: mock(() => ''),
-    getPendingInternalMarkdown: mock(() => null),
+    hasPendingInternalChange: mock(() => false),
     setMarkdown: mock((_content: string) => {}),
     clearPendingTimers: mock(() => {}),
     markDestroyed: mock(() => {}),

--- a/packages/editor/src/lib/editor/attach.test.ts
+++ b/packages/editor/src/lib/editor/attach.test.ts
@@ -22,6 +22,7 @@ function createEditorState(): EditorState {
     view: {} as EditorState['view'],
     focus: mock(() => {}),
     getMarkdown: mock(() => ''),
+    getPendingInternalMarkdown: mock(() => null),
     setMarkdown: mock((_content: string) => {}),
     clearPendingTimers: mock(() => {}),
     markDestroyed: mock(() => {}),

--- a/packages/editor/src/lib/editor/editor.selection.test.ts
+++ b/packages/editor/src/lib/editor/editor.selection.test.ts
@@ -1,6 +1,10 @@
 /// <reference lib="dom" />
+import { editorViewOptionsCtx } from '@milkdown/kit/core';
+import type { MilkdownPlugin } from '@milkdown/kit/ctx';
+import type { Transaction } from '@milkdown/prose/state';
 import { TextSelection } from '@milkdown/prose/state';
-import { afterEach, describe, expect, test } from 'bun:test';
+import type { EditorView } from '@milkdown/prose/view';
+import { afterEach, describe, expect, spyOn, test } from 'bun:test';
 import type { FakeClock } from '../test/fake-clock.js';
 import { installFakeClock } from '../test/fake-clock.js';
 import { setupHappyDom } from '../test/happy-dom.js';
@@ -69,6 +73,71 @@ describe('createEditor selection notifications', () => {
     // the document-change listener is still inside its debounce window.
     expect(selections.at(-1)).toEqual({ from: 3, to: 9, isCollapsed: false });
     clock.advance(200);
+    container.remove();
+  });
+});
+
+describe('createEditor transaction ownership', () => {
+  test('preserves the EditorView receiver of a configured transaction dispatcher', async () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    let expectedView: EditorView | undefined;
+    let receiverWasExpected = false;
+    const receiverAwareDispatcher: MilkdownPlugin = (context) => async () => {
+      context.update(editorViewOptionsCtx, (previous) => ({
+        ...previous,
+        dispatchTransaction(this: EditorView, transaction: Transaction) {
+          receiverWasExpected = this === expectedView;
+          this.updateState(this.state.apply(transaction));
+        },
+      }));
+    };
+
+    editorState = await createEditor(container, {
+      initialContent: 'receiver regression',
+      plugins: [receiverAwareDispatcher],
+    });
+    expectedView = editorState.view;
+    clock = installFakeClock();
+    editorState.view.dispatch(editorState.view.state.tr.insertText('x', 1));
+
+    expect(receiverWasExpected).toBe(true);
+    expect(editorState.getMarkdown()).toContain('xreceiver regression');
+    container.remove();
+  });
+
+  test('does not serialize Markdown synchronously at the transaction boundary', async () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    editorState = await createEditor(container, {
+      initialContent: 'serialization regression',
+    });
+    const editorAction = spyOn(editorState.editor, 'action');
+    clock = installFakeClock();
+    editorState.view.dispatch(editorState.view.state.tr.insertText('x', 1));
+
+    // Milkdown's listener remains the serialization boundary and has not
+    // reached its 200ms debounce yet.
+    expect(editorAction).not.toHaveBeenCalled();
+    container.remove();
+  });
+
+  test('marks history-excluded document transactions as internal until an external replacement', async () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    editorState = await createEditor(container, {
+      initialContent: 'ownership regression',
+    });
+    clock = installFakeClock();
+
+    editorState.view.dispatch(
+      editorState.view.state.tr.insertText('x', 1).setMeta('addToHistory', false),
+    );
+    expect(editorState.hasPendingInternalChange()).toBe(true);
+
+    editorState.setMarkdown('Authoritative replacement.');
+    expect(editorState.hasPendingInternalChange()).toBe(false);
+    expect(editorState.getMarkdown().trim()).toBe('Authoritative replacement.');
     container.remove();
   });
 });

--- a/packages/editor/src/lib/editor/editor.ts
+++ b/packages/editor/src/lib/editor/editor.ts
@@ -89,7 +89,7 @@ export async function createEditor(
   // Track if editor is destroyed to prevent accessing context after cleanup
   let isDestroyed = false;
   let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
-  let pendingInternalMarkdown: string | null = null;
+  let hasPendingInternalChange = false;
   // Build the editor
   let builder = Editor.make()
     .config((ctx) => {
@@ -125,7 +125,7 @@ export async function createEditor(
         if (debounceTimeout) clearTimeout(debounceTimeout);
         debounceTimeout = setTimeout(() => {
           if (isDestroyed) return; // Guard after debounce
-          pendingInternalMarkdown = null;
+          hasPendingInternalChange = false;
           onchange?.(markdown);
         }, changeDebounceMs);
       });
@@ -259,17 +259,12 @@ export async function createEditor(
   view.setProps({
     dispatchTransaction: (transaction) => {
       if (dispatchTransaction) {
-        dispatchTransaction(transaction);
+        dispatchTransaction.call(view, transaction);
       } else {
         view.updateState(view.state.apply(transaction));
       }
-      if (
-        transaction.docChanged &&
-        transaction.getMeta('addToHistory') !== false &&
-        !isDestroyed &&
-        !isExternalUpdate
-      ) {
-        pendingInternalMarkdown = editor.action(getMarkdown());
+      if (transaction.docChanged && !isDestroyed && !isExternalUpdate) {
+        hasPendingInternalChange = true;
       }
     },
   });
@@ -298,8 +293,8 @@ export async function createEditor(
       return editor.action(getMarkdown());
     },
 
-    getPendingInternalMarkdown() {
-      return pendingInternalMarkdown;
+    hasPendingInternalChange() {
+      return hasPendingInternalChange;
     },
 
     setMarkdown(content: string) {
@@ -309,7 +304,7 @@ export async function createEditor(
         debounceTimeout = null;
       }
 
-      pendingInternalMarkdown = null;
+      hasPendingInternalChange = false;
       isExternalUpdate = true;
       try {
         editor.action(replaceAll(content));

--- a/packages/editor/src/lib/editor/editor.ts
+++ b/packages/editor/src/lib/editor/editor.ts
@@ -89,7 +89,7 @@ export async function createEditor(
   // Track if editor is destroyed to prevent accessing context after cleanup
   let isDestroyed = false;
   let debounceTimeout: ReturnType<typeof setTimeout> | null = null;
-
+  let pendingInternalMarkdown: string | null = null;
   // Build the editor
   let builder = Editor.make()
     .config((ctx) => {
@@ -125,6 +125,7 @@ export async function createEditor(
         if (debounceTimeout) clearTimeout(debounceTimeout);
         debounceTimeout = setTimeout(() => {
           if (isDestroyed) return; // Guard after debounce
+          pendingInternalMarkdown = null;
           onchange?.(markdown);
         }, changeDebounceMs);
       });
@@ -251,6 +252,28 @@ export async function createEditor(
   // Get the view for direct access
   const view = editor.ctx.get(editorViewCtx);
 
+  // ProseMirror's transaction dispatch is the first synchronous point at
+  // which the live document is authoritative. Keep the component's value
+  // owner current there, while leaving the public onchange callback debounced.
+  const dispatchTransaction = view.props.dispatchTransaction;
+  view.setProps({
+    dispatchTransaction: (transaction) => {
+      if (dispatchTransaction) {
+        dispatchTransaction(transaction);
+      } else {
+        view.updateState(view.state.apply(transaction));
+      }
+      if (
+        transaction.docChanged &&
+        transaction.getMeta('addToHistory') !== false &&
+        !isDestroyed &&
+        !isExternalUpdate
+      ) {
+        pendingInternalMarkdown = editor.action(getMarkdown());
+      }
+    },
+  });
+
   // Apply readonly state
   if (readonly && view) {
     view.setProps({ editable: () => false });
@@ -275,6 +298,10 @@ export async function createEditor(
       return editor.action(getMarkdown());
     },
 
+    getPendingInternalMarkdown() {
+      return pendingInternalMarkdown;
+    },
+
     setMarkdown(content: string) {
       // Clear any pending debounce to prevent stale callbacks
       if (debounceTimeout) {
@@ -282,12 +309,13 @@ export async function createEditor(
         debounceTimeout = null;
       }
 
+      pendingInternalMarkdown = null;
       isExternalUpdate = true;
-      editor.action(replaceAll(content));
-      // Reset flag after microtask
-      queueMicrotask(() => {
+      try {
+        editor.action(replaceAll(content));
+      } finally {
         isExternalUpdate = false;
-      });
+      }
     },
 
     clearPendingTimers() {

--- a/packages/editor/src/lib/editor/types.ts
+++ b/packages/editor/src/lib/editor/types.ts
@@ -132,6 +132,8 @@ export interface EditorState {
   view: EditorView;
   focus(): void;
   getMarkdown(): string;
+  /** Live user-authored value awaiting the debounced onchange callback. */
+  getPendingInternalMarkdown(): string | null;
   setMarkdown(content: string): void;
   /** Clear any pending debounce timers (called on destroy) */
   clearPendingTimers(): void;

--- a/packages/editor/src/lib/editor/types.ts
+++ b/packages/editor/src/lib/editor/types.ts
@@ -132,8 +132,8 @@ export interface EditorState {
   view: EditorView;
   focus(): void;
   getMarkdown(): string;
-  /** Live user-authored value awaiting the debounced onchange callback. */
-  getPendingInternalMarkdown(): string | null;
+  /** Whether a live document change is awaiting the debounced onchange callback. */
+  hasPendingInternalChange(): boolean;
   setMarkdown(content: string): void;
   /** Clear any pending debounce timers (called on destroy) */
   clearPendingTimers(): void;

--- a/packages/editor/src/lib/utilities/reactive-utilities.test.ts
+++ b/packages/editor/src/lib/utilities/reactive-utilities.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'bun:test';
+import { flushSync } from 'svelte';
+// `$effect.root` is a rune, and plain test files are not compiled by the
+// Svelte plugin. The rune compiles to this untyped runtime primitive.
+// @ts-expect-error -- untyped internal entry point
+import { effect_root as untypedEffectRoot } from 'svelte/internal/client';
+import { createChangeTracker } from './change-tracker.svelte.ts';
+import { useReducedMotion } from './use-reduced-motion.svelte.ts';
+
+const effectRoot = untypedEffectRoot as (run: () => void) => () => void;
+
+describe('reactive editor utilities', () => {
+  test('change tracker reports clean and changed content synchronously', () => {
+    let tracker: ReturnType<typeof createChangeTracker> | undefined;
+    const destroyRoot = effectRoot(() => {
+      tracker = createChangeTracker();
+    });
+
+    try {
+      if (!tracker) throw new Error('Change tracker did not initialize.');
+      tracker.setBaseline('Original content.');
+      tracker.setCurrent('Original content.');
+      flushSync();
+      expect(tracker.hasChanges).toBe(false);
+
+      tracker.setCurrent('Updated content.');
+      flushSync();
+      expect(tracker.hasChanges).toBe(true);
+      expect(tracker.verifyNow()).toBe(true);
+    } finally {
+      tracker?.destroy();
+      destroyRoot();
+    }
+  });
+
+  test('reduced-motion watcher is false when no browser media query is available', () => {
+    const previousWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+    Object.defineProperty(globalThis, 'window', { value: undefined, configurable: true });
+
+    try {
+      expect(useReducedMotion().current).toBe(false);
+    } finally {
+      if (previousWindow) {
+        Object.defineProperty(globalThis, 'window', previousWindow);
+      } else {
+        Reflect.deleteProperty(globalThis, 'window');
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- prevent pending internal MarkdownEditor edits from being mistaken for stale external values
- scope external-update suppression to the synchronous replacement it protects
- add a one-way binding regression test and coverage for the affected reactive utilities
- publish a patch changeset for @lostgradient/editor

## Validation

- with-turborepo-cache bun run --filter=@lostgradient/editor validate
- mutation proof: breaking the pending-edit capture makes the regression test fail with the stale parent value; restoring both files by hash makes it pass
- exact origin/main independently reproduced the existing Svelte function-coverage ratchet failure; the added behavioral tests restore the threshold without lowering it

Linear: CIN-406