### PR TITLE
ci: deduplicate post-merge browser validation

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -29,36 +29,6 @@ on:
   # is deliberately unscoped: it pays the full Playwright cost in exchange for
   # testing the exact merged result.
   merge_group: {}
-  push:
-    branches:
-      - main
-    paths:
-      - 'packages/components/src/**'
-      - 'packages/components/components.json'
-      - 'packages/components/package.json'
-      - 'packages/components/scripts/**'
-      - 'packages/chat/**'
-      - 'packages/*/package.json'
-      - 'packages/*/scripts/**'
-      - 'packages/*/tsconfig*.json'
-      - 'packages/editor/src/**'
-      - 'packages/editor/components.json'
-      - 'packages/markdown/src/**'
-      - 'packages/playground/src/**'
-      - 'packages/playground/scripts/**'
-      - 'packages/testing/**'
-      - '.github/workflows/browser-tests.yaml'
-      - 'package.json'
-      - 'bun.lock'
-      - 'bun.lockb'
-      - 'bunfig.toml'
-      - 'packages/*/bunfig.toml'
-      - 'turbo.json'
-      - '.npmrc'
-      - 'tsconfig*.json'
-      - '!packages/**/*.md'
-      - '!packages/**/README*'
-      - '!packages/**/CHANGELOG*'
   workflow_dispatch:
     inputs:
       mode:

--- a/packages/components/scripts/check-pipeline-coverage.test.ts
+++ b/packages/components/scripts/check-pipeline-coverage.test.ts
@@ -64,7 +64,7 @@ describe('Turbo input topology', () => {
     );
     expect(browserWorkflow).toContain('playwright-visual:');
     expect(browserWorkflow).toContain('test:browser:docker');
-    expect(browserWorkflow).not.toMatch(/^  push:/m);
+    expect(browserWorkflow).not.toMatch(/^\s*push:/m);
     expect(browserWorkflow).toContain('echo "browser_relevant=true" >> "$GITHUB_OUTPUT"');
     expect(browserWorkflow).toContain('CLASSIFIER_BROWSER_RELEVANT');
     expect(browserWorkflow).toContain('Merge visual-report fragments');

--- a/packages/components/scripts/check-pipeline-coverage.test.ts
+++ b/packages/components/scripts/check-pipeline-coverage.test.ts
@@ -64,6 +64,7 @@ describe('Turbo input topology', () => {
     );
     expect(browserWorkflow).toContain('playwright-visual:');
     expect(browserWorkflow).toContain('test:browser:docker');
+    expect(browserWorkflow).not.toMatch(/^  push:/m);
     expect(browserWorkflow).toContain('echo "browser_relevant=true" >> "$GITHUB_OUTPUT"');
     expect(browserWorkflow).toContain('CLASSIFIER_BROWSER_RELEVANT');
     expect(browserWorkflow).toContain('Merge visual-report fragments');


### PR DESCRIPTION
Closes CIN-412.\n\nRemoves the redundant main-push browser workflow trigger while retaining merge-queue and manual visual coverage. `main-green` remains the post-merge validation workflow, with scheduled and explicitly forced audits using `TURBO_FORCE`.\n\nValidation: `bun test packages/components/scripts/check-pipeline-coverage.test.ts`; `bun run --filter=@lostgradient/cinder check:pipeline-coverage`.