### PR TITLE
Suspend Chat auto-scroll while editing

### DIFF
--- a/.changeset/quiet-editing-scroll.md
+++ b/.changeset/quiet-editing-scroll.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Keep active message edit controls stationary while another message streams.

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -1164,6 +1164,80 @@ describe('ChatAdapter — command equivalence', () => {
     }
   });
 
+  test('conversation growth recomputes scroll state without moving active edit controls', async () => {
+    const frames: FrameRequestCallback[] = [];
+    const originalRaf = globalThis.requestAnimationFrame;
+    const originalCancelRaf = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((handle: number) => {
+      if (handle >= 1 && handle <= frames.length) frames[handle - 1] = () => {};
+    }) as typeof cancelAnimationFrame;
+    const flushFrames = (): void => {
+      const pending = frames.splice(0);
+      for (const frame of pending) frame(performance.now());
+      flushSync();
+    };
+    const initial = conversationFromMessages('adapter-edit-conversation-growth', [
+      message('user-1', 'user', 'Original text', 0),
+    ]);
+    const target = document.createElement('div');
+    document.body.append(target);
+    const instance = mount(AdapterSwitchFixture, {
+      target,
+      props: {
+        initial,
+        adapter: { sendMessage: async () => {}, editMessage: async () => {} },
+      },
+    }) as SwitchFixtureInstance;
+
+    try {
+      flushSync();
+      target.querySelector<HTMLButtonElement>('.chat-message-edit-button')!.click();
+      flushSync();
+      const editor = target.querySelector<HTMLTextAreaElement>('.chat-message-edit-textarea');
+      expect(editor).not.toBeNull();
+      const timeline = target.querySelector<HTMLElement>('.chat-timeline')!;
+      let scrollHeight = 100;
+      Object.defineProperties(timeline, {
+        clientHeight: { configurable: true, value: 100 },
+        scrollHeight: { configurable: true, get: () => scrollHeight },
+      });
+      timeline.scrollTop = 0;
+      const scrollCalls: ScrollToOptions[] = [];
+      timeline.scrollTo = ((options: ScrollToOptions) => {
+        scrollCalls.push(options);
+      }) as HTMLElement['scrollTo'];
+
+      scrollHeight = 500;
+      instance.setConversation(
+        conversationFromMessages('adapter-edit-conversation-growth', [
+          message('user-1', 'user', 'Original text', 0),
+          message('assistant-1', 'assistant', 'A new response', 1),
+        ]),
+      );
+      flushSync();
+      await tick();
+      await Promise.resolve();
+      expect(frames.length).toBeGreaterThan(0);
+      flushFrames();
+      await tick();
+      await Promise.resolve();
+      flushSync();
+
+      expect(target.querySelector('.chat-message-edit-textarea')).toBe(editor);
+      expect(scrollCalls).toEqual([]);
+      expect(target.querySelector('.chat-jump-button')).not.toBeNull();
+    } finally {
+      globalThis.requestAnimationFrame = originalRaf;
+      globalThis.cancelAnimationFrame = originalCancelRaf;
+      unmount(instance);
+      target.remove();
+    }
+  });
+
   test('file drag overlay is container state and empty file drops do not touch the transcript', () => {
     const conversation = conversationFromMessages('adapter-file-drag', [
       message('user-1', 'user', 'Keep this transcript stable', 0),

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -1086,11 +1086,14 @@ describe('ChatAdapter — command equivalence', () => {
       message('user-1', 'user', 'Original text', 0),
       message('assistant-1', 'assistant', 'Streaming reply', 1),
     ]);
+    const sent: MessageInput[] = [];
     const { container, instance } = mountChat({
       id: 'chat-adapter-edit-stream',
       conversation,
       adapter: {
-        sendMessage: async () => {},
+        sendMessage: async (message) => {
+          sent.push(message);
+        },
         editMessage: async () => {},
       } satisfies ChatAdapter,
     });
@@ -1105,6 +1108,12 @@ describe('ChatAdapter — command equivalence', () => {
       expect(save).not.toBeNull();
       expect(cancel).not.toBeNull();
       const timeline = container.querySelector<HTMLElement>('.chat-timeline')!;
+      let scrollHeight = 500;
+      Object.defineProperties(timeline, {
+        clientHeight: { configurable: true, value: 100 },
+        scrollHeight: { configurable: true, get: () => scrollHeight },
+      });
+      timeline.scrollTop = 0;
       const scrollCalls: ScrollToOptions[] = [];
       timeline.scrollTo = ((options: ScrollToOptions) => {
         scrollCalls.push(options);
@@ -1121,7 +1130,26 @@ describe('ChatAdapter — command equivalence', () => {
       expect(container.querySelector('.chat-message-edit-save')).toBe(save);
       expect(container.querySelector('.chat-message-edit-cancel')).toBe(cancel);
       expect(scrollCalls).toEqual([]);
+      expect(container.querySelector('.chat-jump-button')).not.toBeNull();
 
+      const composer = container.querySelector<HTMLTextAreaElement>('.chat-input-editor')!;
+      composer.value = 'A new message';
+      composer.dispatchEvent(new Event('input', { bubbles: true }));
+      flushSync();
+      container.querySelector<HTMLButtonElement>('.chat-input-send')!.click();
+      await tick();
+      flushSync();
+
+      expect(sent).toEqual([{ content: 'A new message', role: 'user' }]);
+      expect(container.querySelector('.chat-message-edit-textarea')).toBe(editor);
+      expect(scrollCalls).toEqual([]);
+
+      timeline.scrollTop = 400;
+      timeline.dispatchEvent(new Event('scroll'));
+      flushFrames();
+      await tick();
+      flushSync();
+      scrollHeight = 600;
       cancel!.click();
       flushSync();
       chat.pushToken(' after editing');

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -1180,6 +1180,15 @@ describe('ChatAdapter — command equivalence', () => {
       for (const frame of pending) frame(performance.now());
       flushSync();
     };
+    const finishConversationGrowth = async (): Promise<void> => {
+      await tick();
+      await Promise.resolve();
+      expect(frames.length).toBeGreaterThan(0);
+      flushFrames();
+      await tick();
+      await Promise.resolve();
+      flushSync();
+    };
     const initial = conversationFromMessages('adapter-edit-conversation-growth', [
       message('user-1', 'user', 'Original text', 0),
     ]);
@@ -1211,7 +1220,7 @@ describe('ChatAdapter — command equivalence', () => {
         scrollCalls.push(options);
       }) as HTMLElement['scrollTo'];
 
-      scrollHeight = 500;
+      scrollHeight = 270;
       instance.setConversation(
         conversationFromMessages('adapter-edit-conversation-growth', [
           message('user-1', 'user', 'Original text', 0),
@@ -1219,13 +1228,22 @@ describe('ChatAdapter — command equivalence', () => {
         ]),
       );
       flushSync();
-      await tick();
-      await Promise.resolve();
-      expect(frames.length).toBeGreaterThan(0);
-      flushFrames();
-      await tick();
-      await Promise.resolve();
+      await finishConversationGrowth();
+
+      expect(target.querySelector('.chat-message-edit-textarea')).toBe(editor);
+      expect(scrollCalls).toEqual([]);
+      expect(target.querySelector('.chat-jump-button')).toBeNull();
+
+      scrollHeight = 500;
+      instance.setConversation(
+        conversationFromMessages('adapter-edit-conversation-growth', [
+          message('user-1', 'user', 'Original text', 0),
+          message('assistant-1', 'assistant', 'A new response', 1),
+          message('assistant-2', 'assistant', 'Another response', 2),
+        ]),
+      );
       flushSync();
+      await finishConversationGrowth();
 
       expect(target.querySelector('.chat-message-edit-textarea')).toBe(editor);
       expect(scrollCalls).toEqual([]);

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -1066,6 +1066,57 @@ describe('ChatAdapter — command equivalence', () => {
     unmount(instance);
   });
 
+  test('streaming another message preserves edit controls and suspends auto-scroll', async () => {
+    const conversation = conversationFromMessages('adapter-edit-stream', [
+      message('user-1', 'user', 'Original text', 0),
+      message('assistant-1', 'assistant', 'Streaming reply', 1),
+    ]);
+    const { container, instance } = mountChat({
+      id: 'chat-adapter-edit-stream',
+      conversation,
+      adapter: {
+        sendMessage: async () => {},
+        editMessage: async () => {},
+      } satisfies ChatAdapter,
+    });
+
+    container.querySelector<HTMLButtonElement>('.chat-message-edit-button')!.click();
+    flushSync();
+    const editor = container.querySelector<HTMLTextAreaElement>('.chat-message-edit-textarea');
+    const save = container.querySelector<HTMLButtonElement>('.chat-message-edit-save');
+    const cancel = container.querySelector<HTMLButtonElement>('.chat-message-edit-cancel');
+    expect(editor).not.toBeNull();
+    expect(save).not.toBeNull();
+    expect(cancel).not.toBeNull();
+    const timeline = container.querySelector<HTMLElement>('.chat-timeline')!;
+    const scrollCalls: ScrollToOptions[] = [];
+    timeline.scrollTo = ((options: ScrollToOptions) => {
+      scrollCalls.push(options);
+    }) as HTMLElement['scrollTo'];
+
+    const chat = instance as unknown as ChatImperative;
+    chat.beginStreaming('assistant-1');
+    chat.pushToken('Partial streaming reply');
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await tick();
+    flushSync();
+
+    expect(container.querySelector('.chat-message-edit-textarea')).toBe(editor);
+    expect(container.querySelector('.chat-message-edit-save')).toBe(save);
+    expect(container.querySelector('.chat-message-edit-cancel')).toBe(cancel);
+    expect(scrollCalls).toEqual([]);
+
+    cancel!.click();
+    flushSync();
+    chat.pushToken(' after editing');
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+    await tick();
+    flushSync();
+    expect(scrollCalls.length).toBeGreaterThan(0);
+
+    unmount(instance);
+  });
+
   test('file drag overlay is container state and empty file drops do not touch the transcript', () => {
     const conversation = conversationFromMessages('adapter-file-drag', [
       message('user-1', 'user', 'Keep this transcript stable', 0),

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -1067,6 +1067,21 @@ describe('ChatAdapter — command equivalence', () => {
   });
 
   test('streaming another message preserves edit controls and suspends auto-scroll', async () => {
+    const frames: FrameRequestCallback[] = [];
+    const originalRaf = globalThis.requestAnimationFrame;
+    const originalCancelRaf = globalThis.cancelAnimationFrame;
+    globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+      frames.push(callback);
+      return frames.length;
+    }) as typeof requestAnimationFrame;
+    globalThis.cancelAnimationFrame = ((handle: number) => {
+      if (handle >= 1 && handle <= frames.length) frames[handle - 1] = () => {};
+    }) as typeof cancelAnimationFrame;
+    const flushFrames = (): void => {
+      const pending = frames.splice(0);
+      for (const frame of pending) frame(performance.now());
+      flushSync();
+    };
     const conversation = conversationFromMessages('adapter-edit-stream', [
       message('user-1', 'user', 'Original text', 0),
       message('assistant-1', 'assistant', 'Streaming reply', 1),
@@ -1080,41 +1095,45 @@ describe('ChatAdapter — command equivalence', () => {
       } satisfies ChatAdapter,
     });
 
-    container.querySelector<HTMLButtonElement>('.chat-message-edit-button')!.click();
-    flushSync();
-    const editor = container.querySelector<HTMLTextAreaElement>('.chat-message-edit-textarea');
-    const save = container.querySelector<HTMLButtonElement>('.chat-message-edit-save');
-    const cancel = container.querySelector<HTMLButtonElement>('.chat-message-edit-cancel');
-    expect(editor).not.toBeNull();
-    expect(save).not.toBeNull();
-    expect(cancel).not.toBeNull();
-    const timeline = container.querySelector<HTMLElement>('.chat-timeline')!;
-    const scrollCalls: ScrollToOptions[] = [];
-    timeline.scrollTo = ((options: ScrollToOptions) => {
-      scrollCalls.push(options);
-    }) as HTMLElement['scrollTo'];
+    try {
+      container.querySelector<HTMLButtonElement>('.chat-message-edit-button')!.click();
+      flushSync();
+      const editor = container.querySelector<HTMLTextAreaElement>('.chat-message-edit-textarea');
+      const save = container.querySelector<HTMLButtonElement>('.chat-message-edit-save');
+      const cancel = container.querySelector<HTMLButtonElement>('.chat-message-edit-cancel');
+      expect(editor).not.toBeNull();
+      expect(save).not.toBeNull();
+      expect(cancel).not.toBeNull();
+      const timeline = container.querySelector<HTMLElement>('.chat-timeline')!;
+      const scrollCalls: ScrollToOptions[] = [];
+      timeline.scrollTo = ((options: ScrollToOptions) => {
+        scrollCalls.push(options);
+      }) as HTMLElement['scrollTo'];
 
-    const chat = instance as unknown as ChatImperative;
-    chat.beginStreaming('assistant-1');
-    chat.pushToken('Partial streaming reply');
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    await tick();
-    flushSync();
+      const chat = instance as unknown as ChatImperative;
+      chat.beginStreaming('assistant-1');
+      chat.pushToken('Partial streaming reply');
+      flushFrames();
+      await tick();
+      flushSync();
 
-    expect(container.querySelector('.chat-message-edit-textarea')).toBe(editor);
-    expect(container.querySelector('.chat-message-edit-save')).toBe(save);
-    expect(container.querySelector('.chat-message-edit-cancel')).toBe(cancel);
-    expect(scrollCalls).toEqual([]);
+      expect(container.querySelector('.chat-message-edit-textarea')).toBe(editor);
+      expect(container.querySelector('.chat-message-edit-save')).toBe(save);
+      expect(container.querySelector('.chat-message-edit-cancel')).toBe(cancel);
+      expect(scrollCalls).toEqual([]);
 
-    cancel!.click();
-    flushSync();
-    chat.pushToken(' after editing');
-    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
-    await tick();
-    flushSync();
-    expect(scrollCalls.length).toBeGreaterThan(0);
-
-    unmount(instance);
+      cancel!.click();
+      flushSync();
+      chat.pushToken(' after editing');
+      flushFrames();
+      await tick();
+      flushSync();
+      expect(scrollCalls.length).toBeGreaterThan(0);
+    } finally {
+      globalThis.requestAnimationFrame = originalRaf;
+      globalThis.cancelAnimationFrame = originalCancelRaf;
+      unmount(instance);
+    }
   });
 
   test('file drag overlay is container state and empty file drops do not touch the transcript', () => {

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -780,13 +780,11 @@
       let cancelled = false;
       const waitForBottomTarget = isTranscriptAppend ? waitForLayoutFrame() : tick();
       void waitForBottomTarget.then(() => {
-        if (
-          cancelled ||
-          !viewport ||
-          pendingHistoryScroll ||
-          historyAnchorMessageId !== null ||
-          editingMessageIds.size > 0
-        ) {
+        if (cancelled || !viewport || pendingHistoryScroll || historyAnchorMessageId !== null) {
+          return;
+        }
+        if (editingMessageIds.size > 0) {
+          scrollState.recomputeFromViewport(viewport);
           return;
         }
         // Re-check the guard at execution time: a guarded scroll (e.g.

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -214,6 +214,7 @@
   // part re-derives to show the resolved state.
   let approvedToolCallIds = $state(new Set<string>());
   let deniedToolCallIds = $state(new Set<string>());
+  let editingMessageIds = $state(new Set<string>());
   let pendingRetryMessageTokens = $state(new Map<string, symbol>());
 
   // Per-message disclosure state (reasoning blocks + tool-call cards). UI-only;
@@ -257,6 +258,7 @@
     approvedToolCallIds = new Set();
     pendingRetryMessageTokens = new Map();
     deniedToolCallIds = new Set();
+    editingMessageIds = new Set();
     reasoningState.reset();
     toolCallState.reset();
     typingIndicatorState.reset();
@@ -783,7 +785,7 @@
           !viewport ||
           pendingHistoryScroll ||
           historyAnchorMessageId !== null ||
-          hasActiveMessageEdit()
+          editingMessageIds.size > 0
         ) {
           return;
         }
@@ -2374,7 +2376,7 @@
           });
         }
         // Auto-scroll if at bottom
-        if (scrollState.atBottom && viewport && !hasActiveMessageEdit()) {
+        if (scrollState.atBottom && viewport && editingMessageIds.size === 0) {
           if (isVirtualized) {
             chatVirtualizer.scrollToOffset(chatVirtualizer.scrollSize, { behavior: 'instant' });
           } else {
@@ -2385,8 +2387,11 @@
     }
   }
 
-  function hasActiveMessageEdit(): boolean {
-    return Boolean(viewport?.querySelector('.chat-message-edit'));
+  function handleEditingChange(messageId: string, editing: boolean): void {
+    const next = new Set(editingMessageIds);
+    if (editing) next.add(messageId);
+    else next.delete(messageId);
+    editingMessageIds = next;
   }
 
   /**
@@ -2531,6 +2536,7 @@
         {messagePart}
         onretry={allowRetry && canRetry ? handleRetry : undefined}
         onedit={allowEditing && canEdit ? handleEdit : undefined}
+        oneditingchange={(editing) => handleEditingChange(message.id, editing)}
         showDefaultActions={allowCopy}
         {onExpandedChange}
         streaming={isStreamingMessage}

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -1639,6 +1639,7 @@
   function handleSubmit(message: MessageInput, attachments: ChatAttachment[]): void {
     cancelNonVirtualHistoryAnchorStabilization();
     invalidatePendingHistoryRestoration();
+    const autoScrollSuppressed = editingMessageIds.size > 0;
     // Fire-and-forget the command (the dispatcher owns awaiting + error routing);
     // scroll immediately so the round-trip latency never delays the auto-scroll.
     // `Promise.resolve(...)` normalizes a sync-returning method to a promise so
@@ -1655,9 +1656,15 @@
     // atBottom=true state immediately — scrollState.setAtBottom() only
     // updates the internal helper state; the bindable must be written explicitly
     // (matching the pattern in handleScrollStateChange and onReachBottom).
-    scrollState.setAtBottom(true);
-    updateAtBottomBinding(true);
+    if (!autoScrollSuppressed) {
+      scrollState.setAtBottom(true);
+      updateAtBottomBinding(true);
+    }
     tick().then(() => {
+      if (autoScrollSuppressed) {
+        scrollState.recomputeFromViewport(viewport);
+        return;
+      }
       if (isVirtualized) {
         chatVirtualizer.scrollToOffset(chatVirtualizer.scrollSize, { behavior: 'instant' });
       } else {
@@ -2366,17 +2373,20 @@
     if (streamingScrollRaf === undefined) {
       streamingScrollRaf = requestAnimationFrame(() => {
         streamingScrollRaf = undefined;
+        const autoScrollSuppressed = editingMessageIds.size > 0;
         // Flush: join the entire buffer once per frame
         streamingContent = tokenBuffer.join('');
-        if (streamingRowElement) {
-          tick().then(() => {
-            if (streamingRowElement) {
-              chatVirtualizer.measureElementNode(streamingRowElement);
-            }
-          });
-        }
+        void tick().then(async () => {
+          if (streamingRowElement) {
+            chatVirtualizer.measureElementNode(streamingRowElement);
+            if (isVirtualized) await tick();
+          }
+          if (autoScrollSuppressed) {
+            scrollState.recomputeFromViewport(viewport);
+          }
+        });
         // Auto-scroll if at bottom
-        if (scrollState.atBottom && viewport && editingMessageIds.size === 0) {
+        if (scrollState.atBottom && viewport && !autoScrollSuppressed) {
           if (isVirtualized) {
             chatVirtualizer.scrollToOffset(chatVirtualizer.scrollSize, { behavior: 'instant' });
           } else {

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -776,7 +776,9 @@
     // below and snaps a stale-true viewport to the bottom (#1237).
     if (!isTranscriptGrowth && autoStickSuppressedByPrepend) return undefined;
 
-    if (atBottom && currentCount > 0) {
+    const activeEditNeedsScrollRecompute =
+      isTranscriptAppend && untrack(() => editingMessageIds.size > 0);
+    if ((atBottom || activeEditNeedsScrollRecompute) && currentCount > 0) {
       let cancelled = false;
       const waitForBottomTarget = isTranscriptAppend ? waitForLayoutFrame() : tick();
       void waitForBottomTarget.then(() => {

--- a/packages/chat/src/lib/components/chat/container/chat.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat.svelte
@@ -778,7 +778,13 @@
       let cancelled = false;
       const waitForBottomTarget = isTranscriptAppend ? waitForLayoutFrame() : tick();
       void waitForBottomTarget.then(() => {
-        if (cancelled || !viewport || pendingHistoryScroll || historyAnchorMessageId !== null) {
+        if (
+          cancelled ||
+          !viewport ||
+          pendingHistoryScroll ||
+          historyAnchorMessageId !== null ||
+          hasActiveMessageEdit()
+        ) {
           return;
         }
         // Re-check the guard at execution time: a guarded scroll (e.g.
@@ -2368,7 +2374,7 @@
           });
         }
         // Auto-scroll if at bottom
-        if (scrollState.atBottom && viewport) {
+        if (scrollState.atBottom && viewport && !hasActiveMessageEdit()) {
           if (isVirtualized) {
             chatVirtualizer.scrollToOffset(chatVirtualizer.scrollSize, { behavior: 'instant' });
           } else {
@@ -2377,6 +2383,10 @@
         }
       });
     }
+  }
+
+  function hasActiveMessageEdit(): boolean {
+    return Boolean(viewport?.querySelector('.chat-message-edit'));
   }
 
   /**

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -57,6 +57,8 @@ export interface UseChatScrollStateReturn {
   readonly isUserScrolling: boolean;
   /** Set atBottom state directly */
   setAtBottom(value: boolean): void;
+  /** Recompute bottom and jump-button state from the viewport's current geometry. */
+  recomputeFromViewport(viewport: HTMLElement | null): void;
   /** Create a scroll event listener attachment for the viewport */
   createScrollAttachment(): Attachment<HTMLElement>;
   /**
@@ -340,7 +342,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * scroll-to-top). State is refreshed from final geometry, and reaching the
    * bottom fires `onReachBottom` when the state transitions there.
    */
-  function recomputeAtBottomAtSettlement(viewport: HTMLElement | null): void {
+  function recomputeFromViewport(viewport: HTMLElement | null): void {
     if (viewport === null) return;
     const state = {
       scrollTop: viewport.scrollTop,
@@ -575,7 +577,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
       // listener's next rAF recompute can re-fire the auto-stick effect
       // against a stale `atBottom: true` and yank a just-completed top-scroll
       // back to the bottom (#1236).
-      recomputeAtBottomAtSettlement(viewport);
+      recomputeFromViewport(viewport);
       applyPendingSentinelEntry(viewport);
       onSettled?.();
     }
@@ -761,6 +763,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
       return showJumpButton;
     },
     setAtBottom,
+    recomputeFromViewport,
     createScrollAttachment,
     createSentinelObserver,
     handleSentinelEntry,

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -38,6 +38,8 @@
     onretry?: ((messageId: string) => void) | undefined;
     /** Called when user edits a message (fires with new content). Only applies to user messages. */
     onedit?: ((event: { messageId: string; content: string }) => void) | undefined;
+    /** Called when this message enters or leaves edit mode. */
+    oneditingchange?: ((editing: boolean) => void) | undefined;
     /** The set of approved tool call IDs for deriving approval state. */
     approvedToolCallIds?: ReadonlySet<string> | undefined;
     /** The set of denied tool call IDs for deriving denial state. */
@@ -83,6 +85,7 @@
 </script>
 
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { classNames } from '../../../utilities/class-names.ts';
   import {
     deriveMessageParts,
@@ -108,6 +111,7 @@
     onExpandedChange,
     onretry,
     onedit,
+    oneditingchange,
     approvedToolCallIds,
     deniedToolCallIds,
     onapprove,
@@ -132,11 +136,13 @@
   function startEditing() {
     editContent = textContent;
     isEditing = true;
+    oneditingchange?.(true);
   }
 
   function cancelEditing() {
     isEditing = false;
     editContent = '';
+    oneditingchange?.(false);
   }
 
   function saveEdit() {
@@ -146,7 +152,12 @@
     }
     isEditing = false;
     editContent = '';
+    oneditingchange?.(false);
   }
+
+  onDestroy(() => {
+    if (isEditing) oneditingchange?.(false);
+  });
 
   function handleEditKeyDown(event: KeyboardEvent) {
     if (event.key === 'Escape') {


### PR DESCRIPTION
## Summary

- suspend both automatic streaming scroll paths while a message edit form is active
- restore existing auto-scroll behavior as soon as edit mode ends
- add a regression test covering edit-control identity, scroll suppression, and resume behavior

## Validation

- with-turborepo-cache bun run --filter=@lostgradient/chat validate
- with-turborepo-cache bun run --filter=@lostgradient/chat validate:consumer
- with-turborepo-cache bun run lint
- with-turborepo-cache bun run typecheck
- git diff --check
- Prettier check
- independent correctness/test review: PASS
- independent interaction/accessibility review: PASS

Linear: CIN-414