### PR TITLE
Stabilize Cinder consumer validation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,6 +54,7 @@ jobs:
   release:
     name: Version or publish
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr-dialog/+page.svelte
+++ b/packages/components/fixtures/sveltekit-consumer/src/routes/dev-ssr-dialog/+page.svelte
@@ -3,9 +3,14 @@
   import ConfirmDialog from '@lostgradient/cinder/confirm-dialog';
 
   let confirmDialogOpen = $state(false);
+  let hydrated = $state(false);
+
+  $effect(() => {
+    hydrated = true;
+  });
 </script>
 
-<main>
+<main data-dev-ssr-hydrated={hydrated}>
   <button
     type="button"
     data-dev-ssr-confirm-dialog-trigger

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -24,6 +24,7 @@ import {
   registerHookProcessGroup,
   REPO_ROOT,
   runHookCommand,
+  signalHookProcessGroup,
   withGateLock,
   withLocalValidationGateLock,
   type GitRunner,
@@ -369,6 +370,27 @@ describe('registerHookProcessGroup', () => {
     } finally {
       killProcessGroup(processGroup.pid);
       await processGroup.exited;
+    }
+  });
+});
+
+describe('signalHookProcessGroup', () => {
+  it('falls back to the direct process when the group signal fails', () => {
+    const calls: Array<{ pid: number; signal: string | number }> = [];
+    const kill = spyOn(process, 'kill').mockImplementation((pid, signal) => {
+      calls.push({ pid, signal: signal ?? 0 });
+      if (pid < 0) throw Object.assign(new Error('group unavailable'), { code: 'ESRCH' });
+      return true;
+    });
+
+    try {
+      signalHookProcessGroup(4_242, 'SIGTERM');
+      expect(calls).toEqual([
+        { pid: -4_242, signal: 'SIGTERM' },
+        { pid: 4_242, signal: 'SIGTERM' },
+      ]);
+    } finally {
+      kill.mockRestore();
     }
   });
 });

--- a/packages/components/scripts/husky/utilities.test.ts
+++ b/packages/components/scripts/husky/utilities.test.ts
@@ -21,6 +21,7 @@ import {
   nodeModulesTopology,
   parsePushRefs,
   prePushPackageScript,
+  registerHookProcessGroup,
   REPO_ROOT,
   runHookCommand,
   withGateLock,
@@ -329,6 +330,45 @@ describe('runHookCommand', () => {
     } finally {
       if (childPid !== undefined) killProcessGroup(childPid);
       await rm(directory, { force: true, recursive: true });
+    }
+  });
+});
+
+describe('registerHookProcessGroup', () => {
+  it('includes a directly spawned detached process in hook cleanup', async () => {
+    const processGroup = Bun.spawn(['bun', '-e', 'setInterval(() => {}, 1000)'], {
+      detached: true,
+      stderr: 'ignore',
+      stdin: 'ignore',
+      stdout: 'ignore',
+    });
+    registerHookProcessGroup(processGroup.pid);
+
+    try {
+      await cleanupHookProcesses();
+      await waitForProcessExit(processGroup.pid);
+    } finally {
+      killProcessGroup(processGroup.pid);
+      await processGroup.exited;
+    }
+  });
+
+  it('does not clean up a directly spawned process after it is unregistered', async () => {
+    const processGroup = Bun.spawn(['bun', '-e', 'setInterval(() => {}, 1000)'], {
+      detached: true,
+      stderr: 'ignore',
+      stdin: 'ignore',
+      stdout: 'ignore',
+    });
+    const unregisterProcessGroup = registerHookProcessGroup(processGroup.pid);
+    unregisterProcessGroup();
+
+    try {
+      await cleanupHookProcesses();
+      expect(isProcessAlive(processGroup.pid)).toBe(true);
+    } finally {
+      killProcessGroup(processGroup.pid);
+      await processGroup.exited;
     }
   });
 });

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -102,7 +102,7 @@ export function prePushPackageScript(
 }
 
 type HookSignal = 'SIGINT' | 'SIGTERM' | 'SIGHUP';
-type CleanupSignal = HookSignal | 'SIGKILL';
+export type HookCleanupSignal = HookSignal | 'SIGKILL';
 
 const SIGNAL_EXIT_CODES: Record<HookSignal, number> = {
   SIGHUP: 129,
@@ -193,7 +193,7 @@ function isProcessGroupAlive(pid: number): boolean {
   }
 }
 
-function signalProcessGroup(pid: number, signal: CleanupSignal): void {
+export function signalHookProcessGroup(pid: number, signal: HookCleanupSignal): void {
   try {
     process.kill(-pid, signal);
     return;
@@ -215,27 +215,30 @@ function drainActiveProcessGroups(): number[] {
   return pids;
 }
 
-export function cleanupHookProcessesImmediately(signal: CleanupSignal = 'SIGTERM'): void {
+export function cleanupHookProcessesImmediately(signal: HookCleanupSignal = 'SIGTERM'): void {
   for (const pid of drainActiveProcessGroups()) {
-    signalProcessGroup(pid, signal);
+    signalHookProcessGroup(pid, signal);
   }
 }
 
-export async function cleanupHookProcesses(signal: CleanupSignal = 'SIGTERM'): Promise<void> {
+export async function cleanupHookProcesses(signal: HookCleanupSignal = 'SIGTERM'): Promise<void> {
   const pids = drainActiveProcessGroups();
   await cleanupProcessGroups(pids, signal);
 }
 
-async function cleanupProcessGroups(pids: readonly number[], signal: CleanupSignal): Promise<void> {
+async function cleanupProcessGroups(
+  pids: readonly number[],
+  signal: HookCleanupSignal,
+): Promise<void> {
   for (const pid of pids) {
-    signalProcessGroup(pid, signal);
+    signalHookProcessGroup(pid, signal);
   }
 
   await Bun.sleep(250);
 
   for (const pid of pids) {
     if (isProcessGroupAlive(pid)) {
-      signalProcessGroup(pid, 'SIGKILL');
+      signalHookProcessGroup(pid, 'SIGKILL');
     }
   }
 }

--- a/packages/components/scripts/husky/utilities.ts
+++ b/packages/components/scripts/husky/utilities.ts
@@ -129,6 +129,12 @@ export type HookCommandOptions = {
   readonly stderr?: 'inherit' | 'pipe';
 };
 
+/** Register a detached process group for cleanup when the validation hook exits. */
+export function registerHookProcessGroup(pid: number): () => void {
+  activeHookProcessGroups.add(pid);
+  return () => activeHookProcessGroups.delete(pid);
+}
+
 type HookSignalCleanupOptions = {
   readonly exitAfterCleanup?: boolean;
 };
@@ -298,7 +304,7 @@ export async function runHookCommand(
     };
   }
 
-  activeHookProcessGroups.add(subprocess.pid);
+  const unregisterProcessGroup = registerHookProcessGroup(subprocess.pid);
 
   const abort = () => {
     aborted = true;
@@ -350,7 +356,7 @@ export async function runHookCommand(
     if (hookSignalCleanupPromise) {
       await hookSignalCleanupPromise;
     }
-    activeHookProcessGroups.delete(subprocess.pid);
+    unregisterProcessGroup();
   }
 }
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -29,13 +29,35 @@ describe('SvelteKit hydration route matrix', () => {
 });
 
 describe('development server teardown', () => {
-  test('does not signal a server that already exited', async () => {
+  test('does not signal a process group that is already gone', async () => {
     let signalCount = 0;
-    await stopDevelopmentServer({ exitCode: 0, exited: Promise.resolve(0), pid: 4_242 }, 1, () => {
-      signalCount += 1;
-    });
+    await stopDevelopmentServer(
+      { exitCode: 0, exited: Promise.resolve(0), pid: 4_242 },
+      1,
+      () => {
+        signalCount += 1;
+      },
+      () => false,
+    );
 
     expect(signalCount).toBe(0);
+  });
+
+  test('signals a live process group after its leader already exited', async () => {
+    const signals: NodeJS.Signals[] = [];
+    let processGroupAlive = true;
+
+    await stopDevelopmentServer(
+      { exitCode: 0, exited: Promise.resolve(0), pid: 4_242 },
+      1,
+      (_pid, signal) => {
+        signals.push(signal);
+        processGroupAlive = false;
+      },
+      () => processGroupAlive,
+    );
+
+    expect(signals).toEqual(['SIGTERM']);
   });
 
   test('escalates to SIGKILL when graceful termination never settles', async () => {
@@ -58,7 +80,7 @@ describe('development server teardown', () => {
       }
     };
 
-    await stopDevelopmentServer(server, 1, signalProcessGroup);
+    await stopDevelopmentServer(server, 1, signalProcessGroup, () => server.exitCode === null);
 
     expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
     expect(server.exitCode).toBe(137);
@@ -73,9 +95,14 @@ describe('development server teardown', () => {
     };
 
     await expect(
-      stopDevelopmentServer(server, 1, (_pid, signal) => {
-        signals.push(signal);
-      }),
+      stopDevelopmentServer(
+        server,
+        1,
+        (_pid, signal) => {
+          signals.push(signal);
+        },
+        () => true,
+      ),
     ).rejects.toThrow('still running after SIGKILL');
 
     expect(signals).toEqual(['SIGTERM', 'SIGKILL']);

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -10,8 +10,77 @@ import {
   parseHydrationBrowserProcessIds,
   resolveChatFixtureCinderVersion,
   runBoundedHydrationTeardown,
+  stopDevelopmentServer,
+  SVELTEKIT_HYDRATION_ROUTES,
   unreclaimedTeardownFailures,
 } from './validate-consumers.ts';
+
+describe('SvelteKit hydration route matrix', () => {
+  test('uses focused feature routes instead of the monolithic dev SSR fixture', () => {
+    expect(SVELTEKIT_HYDRATION_ROUTES).toEqual([
+      '/subpath',
+      '/chat-layout',
+      '/dev-ssr-dialog',
+      '/dev-ssr-navigation',
+      '/dev-ssr-tabs',
+    ]);
+    expect(SVELTEKIT_HYDRATION_ROUTES).not.toContain('/dev-ssr');
+  });
+});
+
+describe('development server teardown', () => {
+  test('does not signal a server that already exited', async () => {
+    let signalCount = 0;
+    await stopDevelopmentServer({ exitCode: 0, exited: Promise.resolve(0), pid: 4_242 }, 1, () => {
+      signalCount += 1;
+    });
+
+    expect(signalCount).toBe(0);
+  });
+
+  test('escalates to SIGKILL when graceful termination never settles', async () => {
+    const signals: NodeJS.Signals[] = [];
+    let resolveExit!: (exitCode: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      resolveExit = resolve;
+    });
+    const server = {
+      exitCode: null as number | null,
+      exited,
+      pid: 4_242,
+    };
+    const signalProcessGroup = (pid: number, signal: NodeJS.Signals) => {
+      expect(pid).toBe(-4_242);
+      signals.push(signal);
+      if (signal === 'SIGKILL') {
+        server.exitCode = 137;
+        resolveExit(137);
+      }
+    };
+
+    await stopDevelopmentServer(server, 1, signalProcessGroup);
+
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+    expect(server.exitCode).toBe(137);
+  });
+
+  test('fails after a bounded hard termination when the process group survives', async () => {
+    const signals: NodeJS.Signals[] = [];
+    const server = {
+      exitCode: null,
+      exited: new Promise<number>(() => {}),
+      pid: 4_242,
+    };
+
+    await expect(
+      stopDevelopmentServer(server, 1, (_pid, signal) => {
+        signals.push(signal);
+      }),
+    ).rejects.toThrow('still running after SIGKILL');
+
+    expect(signals).toEqual(['SIGTERM', 'SIGKILL']);
+  });
+});
 
 describe('hydration teardown', () => {
   test('forces later resources closed when page close never settles', async () => {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1194,8 +1194,70 @@ const SVELTEKIT_DEV_SSR_ROUTES = [
   },
 ] as const;
 
+type SvelteKitHydrationRoute =
+  | '/subpath'
+  | '/chat-layout'
+  | '/dev-ssr-dialog'
+  | '/dev-ssr-navigation'
+  | '/dev-ssr-tabs';
+
+export const SVELTEKIT_HYDRATION_ROUTES = [
+  '/subpath',
+  '/chat-layout',
+  '/dev-ssr-dialog',
+  '/dev-ssr-navigation',
+  '/dev-ssr-tabs',
+] as const satisfies readonly SvelteKitHydrationRoute[];
+
 const SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS = 25_000;
 const SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS = 200;
+const DEVELOPMENT_SERVER_TEARDOWN_TIMEOUT_MS = 5_000;
+
+type DevelopmentServerProcess = Pick<Bun.Subprocess, 'exitCode' | 'exited' | 'pid'>;
+type SignalProcessGroup = (pid: number, signal: NodeJS.Signals) => void;
+
+/** Stop the detached Vite process group without letting cleanup hide the readiness result. */
+export async function stopDevelopmentServer(
+  server: DevelopmentServerProcess,
+  timeoutMs = DEVELOPMENT_SERVER_TEARDOWN_TIMEOUT_MS,
+  signalProcessGroup: SignalProcessGroup = (pid, signal) => process.kill(pid, signal),
+): Promise<void> {
+  if (server.exitCode !== null) return;
+
+  const stop = async (signal: NodeJS.Signals): Promise<void> => {
+    signalProcessGroup(-server.pid, signal);
+    await promiseWithTimeout(
+      server.exited,
+      timeoutMs,
+      `stopping development server process group with ${signal}`,
+    );
+  };
+
+  try {
+    await stop('SIGTERM');
+  } catch (gracefulError) {
+    if (server.exitCode !== null) return;
+    try {
+      await stop('SIGKILL');
+    } catch (forceError) {
+      throw new Error(
+        `development server process group ${server.pid} is still running after SIGKILL: ${forceError instanceof Error ? forceError.message : String(forceError)}; graceful stop also failed: ${gracefulError instanceof Error ? gracefulError.message : String(gracefulError)}`,
+        { cause: forceError },
+      );
+    }
+  }
+}
+
+async function developmentServerTeardownError(
+  server: DevelopmentServerProcess,
+): Promise<Error | undefined> {
+  try {
+    await stopDevelopmentServer(server);
+    return undefined;
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+}
 
 function formatHtmlExcerpt(body: string): string {
   return body.replace(/\s+/g, ' ').trim().slice(0, 1_000);
@@ -1282,6 +1344,7 @@ async function assertSvelteKitDevChatHydrationRoute(
     ],
     {
       cwd: fixtureDirectory,
+      detached: true,
       stdout: 'pipe',
       stderr: 'pipe',
       env: {
@@ -1314,12 +1377,15 @@ async function assertSvelteKitDevChatHydrationRoute(
       // Same reasoning as the dev-SSR readiness failure below: surface the
       // server's own output, since "we stopped waiting" says nothing about why.
       const waitedMs = Date.now() - chatLayoutStartedAt;
-      devServer.kill();
-      await devServer.exited;
+      const teardownError = await developmentServerTeardownError(devServer);
+      const devServerOutput =
+        teardownError === undefined
+          ? formatServerOutput(await devServerStdout, await devServerStderr)
+          : `: unavailable because teardown failed: ${teardownError.message}`;
       fail(
         `sveltekit-consumer ${label} /chat-layout dev readiness failed: ${message}\n` +
           `(waited ${waitedMs}ms; port ${httpPort})\n` +
-          `dev server output${formatServerOutput(await devServerStdout, await devServerStderr)}`,
+          `dev server output${devServerOutput}`,
       );
     });
 
@@ -1331,18 +1397,28 @@ async function assertSvelteKitDevChatHydrationRoute(
     await assertSvelteKitClientRoutesHydrate(httpPort, `${label} dev`, ['/chat-layout']);
     hydrationAssertionsPassed = true;
   } finally {
-    devServer.kill();
-    await devServer.exited;
-    const devServerOutput = `${await devServerStdout}\n${await devServerStderr}`;
-    const sourceMapWarnings = extractPublishedPackageSourceMapWarnings(devServerOutput);
-    if (sourceMapWarnings.length > 0) {
-      const warningMessage =
-        `sveltekit-consumer ${label} dev hydration emitted source-map warnings for published package artifacts:\n` +
-        sourceMapWarnings.map((warning) => `  ${warning}`).join('\n');
+    const teardownError = await developmentServerTeardownError(devServer);
+    if (teardownError !== undefined) {
       if (!hydrationAssertionsPassed) {
-        process.stderr.write(`[validate-consumers] ${warningMessage}\n`);
+        process.stderr.write(
+          `[validate-consumers] sveltekit-consumer ${label} dev hydration teardown also failed: ${teardownError.message}\n`,
+        );
       } else {
-        fail(warningMessage);
+        fail(`sveltekit-consumer ${label} dev hydration teardown failed: ${teardownError.message}`);
+      }
+    }
+    if (devServer.exitCode !== null) {
+      const devServerOutput = `${await devServerStdout}\n${await devServerStderr}`;
+      const sourceMapWarnings = extractPublishedPackageSourceMapWarnings(devServerOutput);
+      if (sourceMapWarnings.length > 0) {
+        const warningMessage =
+          `sveltekit-consumer ${label} dev hydration emitted source-map warnings for published package artifacts:\n` +
+          sourceMapWarnings.map((warning) => `  ${warning}`).join('\n');
+        if (!hydrationAssertionsPassed) {
+          process.stderr.write(`[validate-consumers] ${warningMessage}\n`);
+        } else {
+          fail(warningMessage);
+        }
       }
     }
   }
@@ -1355,6 +1431,7 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
     ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(httpPort), '--strictPort'],
     {
       cwd: fixtureDirectory,
+      detached: true,
       stdout: 'pipe',
       stderr: 'pipe',
       env: {
@@ -1412,15 +1489,18 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
         const waitedMs = Date.now() - routeStartedAt;
         const spentMs = Date.now() - (readinessDeadline - SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS);
         const leftMs = Math.max(0, readinessDeadline - Date.now());
-        devServer.kill();
-        await devServer.exited;
+        const teardownError = await developmentServerTeardownError(devServer);
+        const devServerOutput =
+          teardownError === undefined
+            ? formatServerOutput(await devServerStdout, await devServerStderr)
+            : `: unavailable because teardown failed: ${teardownError.message}`;
         fail(
           `sveltekit-consumer ${label} ${routePath} dev SSR readiness failed: ${message}\n` +
             `(waited ${waitedMs}ms on this route of ${remainingReadinessBudget}ms allowed; ` +
             `${spentMs}ms spent and ${leftMs}ms left of the shared ` +
             `${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms budget; ` +
             `poll ${SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS}ms; port ${httpPort})\n` +
-            `dev server output${formatServerOutput(await devServerStdout, await devServerStderr)}`,
+            `dev server output${devServerOutput}`,
         );
       });
 
@@ -1489,25 +1569,35 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
     // red `main` runs between 2026-07-24 and 2026-08-05 against ~100 passes on
     // unchanged code, including a docs-only commit.
     //
-    // The original all-components /dev-ssr route remains the built-server
-    // hydration fixture — including the ConfirmDialog interaction and focus
-    // restoration — where the transform waterfall cannot exist.
+    // The focused dev-SSR routes also own built-server hydration, including
+    // ConfirmDialog interaction and focus restoration. Keeping the browser
+    // matrix split by feature prevents one broad client graph from stalling.
     // Raising the timeout here would mask the waterfall, not fix it.
     devSsrAssertionsPassed = true;
   } finally {
-    devServer.kill();
-    await devServer.exited;
-    const devServerOutput = `${await devServerStdout}\n${await devServerStderr}`;
-    const sourceMapWarnings = extractPublishedPackageSourceMapWarnings(devServerOutput);
-    if (sourceMapWarnings.length > 0) {
-      const warningMessage =
-        `sveltekit-consumer ${label} dev SSR emitted source-map warnings for published package dist artifacts:\n` +
-        sourceMapWarnings.map((warning) => `  ${warning}`).join('\n');
-      // Preserve the primary SSR failure if one occurred in the try block.
+    const teardownError = await developmentServerTeardownError(devServer);
+    if (teardownError !== undefined) {
       if (!devSsrAssertionsPassed) {
-        process.stderr.write(`[validate-consumers] ${warningMessage}\n`);
+        process.stderr.write(
+          `[validate-consumers] sveltekit-consumer ${label} dev SSR teardown also failed: ${teardownError.message}\n`,
+        );
       } else {
-        fail(warningMessage);
+        fail(`sveltekit-consumer ${label} dev SSR teardown failed: ${teardownError.message}`);
+      }
+    }
+    if (devServer.exitCode !== null) {
+      const devServerOutput = `${await devServerStdout}\n${await devServerStderr}`;
+      const sourceMapWarnings = extractPublishedPackageSourceMapWarnings(devServerOutput);
+      if (sourceMapWarnings.length > 0) {
+        const warningMessage =
+          `sveltekit-consumer ${label} dev SSR emitted source-map warnings for published package dist artifacts:\n` +
+          sourceMapWarnings.map((warning) => `  ${warning}`).join('\n');
+        // Preserve the primary SSR failure if one occurred in the try block.
+        if (!devSsrAssertionsPassed) {
+          process.stderr.write(`[validate-consumers] ${warningMessage}\n`);
+        } else {
+          fail(warningMessage);
+        }
       }
     }
   }
@@ -1809,11 +1899,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
       // `assertSvelteKitDevSsrRoute` (see the note there). Dependencies are
       // bundled at build time, so there is no transform waterfall and no
       // optimizer-triggered reload to race.
-      await assertSvelteKitClientRoutesHydrate(httpPort, label, [
-        '/subpath',
-        '/chat-layout',
-        '/dev-ssr',
-      ]);
+      await assertSvelteKitClientRoutesHydrate(httpPort, label, SVELTEKIT_HYDRATION_ROUTES);
 
       // Subpath page
       const subpathResponse = await fetchWithTimeout(
@@ -1930,8 +2016,6 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
     restoreManifest();
   }
 }
-
-type SvelteKitHydrationRoute = '/subpath' | '/chat-layout' | '/dev-ssr';
 
 /**
  * `--disable-dev-shm-usage` is Playwright's documented remedy for Chromium
@@ -2182,7 +2266,7 @@ async function stopConsumerFixtureServer(server: Bun.Subprocess): Promise<void> 
 async function runSvelteKitHydrationRoutesOnce(
   httpPort: number,
   label: string,
-  routePaths: SvelteKitHydrationRoute[],
+  routePaths: readonly SvelteKitHydrationRoute[],
 ): Promise<void> {
   const browserHandle = await launchHydrationChromium();
   const { browser, processToken } = browserHandle;
@@ -2276,7 +2360,7 @@ async function runSvelteKitHydrationRoutesOnce(
 async function assertSvelteKitClientRoutesHydrate(
   httpPort: number,
   label: string,
-  routePaths: SvelteKitHydrationRoute[],
+  routePaths: readonly SvelteKitHydrationRoute[],
 ): Promise<void> {
   try {
     await runSvelteKitHydrationRoutesOnce(httpPort, label, routePaths);
@@ -2380,6 +2464,16 @@ async function assertSvelteKitHydrationRouteContent(
   }
 
   await page.locator('[data-dev-ssr-hydrated="true"]').waitFor({ timeout: 5_000 });
+  if (routePath === '/dev-ssr-navigation') {
+    await page.getByText('basicOrderWorkflow').waitFor({ timeout: 5_000 });
+    return;
+  }
+  if (routePath === '/dev-ssr-tabs') {
+    await page.getByText('Workflow editor').waitFor({ timeout: 5_000 });
+    await page.getByText('Direct editor').waitFor({ timeout: 5_000 });
+    return;
+  }
+
   const trigger = page.getByRole('button', { name: 'Reset state' });
   await trigger.click();
   const dialog = page.getByRole('dialog', { name: 'Reset all local state?' });

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -20,6 +20,7 @@ import { parse } from 'postcss';
 import { waitForReadyHtml } from './consumer-readiness.ts';
 import {
   installHookProcessCleanup,
+  registerHookProcessGroup,
   runHookCommand,
   withLocalValidationGateLock,
 } from './husky/utilities.ts';
@@ -1215,19 +1216,55 @@ const DEVELOPMENT_SERVER_TEARDOWN_TIMEOUT_MS = 5_000;
 
 type DevelopmentServerProcess = Pick<Bun.Subprocess, 'exitCode' | 'exited' | 'pid'>;
 type SignalProcessGroup = (pid: number, signal: NodeJS.Signals) => void;
+type IsProcessGroupAlive = (pid: number) => boolean;
+
+function processGroupIsAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (caught) {
+    if (
+      typeof caught === 'object' &&
+      caught !== null &&
+      'code' in caught &&
+      caught.code === 'ESRCH'
+    ) {
+      return false;
+    }
+    return true;
+  }
+}
+
+async function waitForProcessGroupExit(
+  pid: number,
+  timeoutMs: number,
+  isProcessGroupAlive: IsProcessGroupAlive,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (isProcessGroupAlive(pid)) {
+    if (Date.now() >= deadline) {
+      throw new Error(`process group ${pid} did not exit within ${timeoutMs}ms`);
+    }
+    await Bun.sleep(Math.min(25, timeoutMs));
+  }
+}
 
 /** Stop the detached Vite process group without letting cleanup hide the readiness result. */
 export async function stopDevelopmentServer(
   server: DevelopmentServerProcess,
   timeoutMs = DEVELOPMENT_SERVER_TEARDOWN_TIMEOUT_MS,
   signalProcessGroup: SignalProcessGroup = (pid, signal) => process.kill(pid, signal),
+  isProcessGroupAlive: IsProcessGroupAlive = processGroupIsAlive,
 ): Promise<void> {
-  if (server.exitCode !== null) return;
+  if (!isProcessGroupAlive(server.pid)) return;
 
   const stop = async (signal: NodeJS.Signals): Promise<void> => {
     signalProcessGroup(-server.pid, signal);
     await promiseWithTimeout(
-      server.exited,
+      Promise.all([
+        server.exited,
+        waitForProcessGroupExit(server.pid, timeoutMs, isProcessGroupAlive),
+      ]),
       timeoutMs,
       `stopping development server process group with ${signal}`,
     );
@@ -1236,7 +1273,7 @@ export async function stopDevelopmentServer(
   try {
     await stop('SIGTERM');
   } catch (gracefulError) {
-    if (server.exitCode !== null) return;
+    if (!isProcessGroupAlive(server.pid)) return;
     try {
       await stop('SIGKILL');
     } catch (forceError) {
@@ -1355,6 +1392,7 @@ async function assertSvelteKitDevChatHydrationRoute(
       },
     },
   );
+  const unregisterDevServerProcessGroup = registerHookProcessGroup(devServer.pid);
   const devServerStdout = devServer.stdout
     ? new Response(devServer.stdout).text()
     : Promise.resolve('');
@@ -1398,6 +1436,7 @@ async function assertSvelteKitDevChatHydrationRoute(
     hydrationAssertionsPassed = true;
   } finally {
     const teardownError = await developmentServerTeardownError(devServer);
+    if (teardownError === undefined) unregisterDevServerProcessGroup();
     if (teardownError !== undefined) {
       if (!hydrationAssertionsPassed) {
         process.stderr.write(
@@ -1441,6 +1480,7 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
       },
     },
   );
+  const unregisterDevServerProcessGroup = registerHookProcessGroup(devServer.pid);
   const devServerStdout = devServer.stdout
     ? new Response(devServer.stdout).text()
     : Promise.resolve('');
@@ -1576,6 +1616,7 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
     devSsrAssertionsPassed = true;
   } finally {
     const teardownError = await developmentServerTeardownError(devServer);
+    if (teardownError === undefined) unregisterDevServerProcessGroup();
     if (teardownError !== undefined) {
       if (!devSsrAssertionsPassed) {
         process.stderr.write(

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -22,12 +22,13 @@ import {
   installHookProcessCleanup,
   registerHookProcessGroup,
   runHookCommand,
+  signalHookProcessGroup,
   withLocalValidationGateLock,
 } from './husky/utilities.ts';
 import {
-  type CommentScanState,
   containsUpstreamSpecifier,
   lineHasUpstreamSpecifierResidue,
+  type CommentScanState,
 } from './lib/cinder-specifier-residue.ts';
 import { discoverComponents } from './lib/discover-components.ts';
 import { parseJsonFile, readJsonFile } from './lib/read-json-file.ts';
@@ -1215,7 +1216,8 @@ const SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS = 200;
 const DEVELOPMENT_SERVER_TEARDOWN_TIMEOUT_MS = 5_000;
 
 type DevelopmentServerProcess = Pick<Bun.Subprocess, 'exitCode' | 'exited' | 'pid'>;
-type SignalProcessGroup = (pid: number, signal: NodeJS.Signals) => void;
+type DevelopmentServerSignal = 'SIGTERM' | 'SIGKILL';
+type SignalProcessGroup = (pid: number, signal: DevelopmentServerSignal) => void;
 type IsProcessGroupAlive = (pid: number) => boolean;
 
 function processGroupIsAlive(pid: number): boolean {
@@ -1253,12 +1255,13 @@ async function waitForProcessGroupExit(
 export async function stopDevelopmentServer(
   server: DevelopmentServerProcess,
   timeoutMs = DEVELOPMENT_SERVER_TEARDOWN_TIMEOUT_MS,
-  signalProcessGroup: SignalProcessGroup = (pid, signal) => process.kill(pid, signal),
+  signalProcessGroup: SignalProcessGroup = (pid, signal) =>
+    signalHookProcessGroup(Math.abs(pid), signal),
   isProcessGroupAlive: IsProcessGroupAlive = processGroupIsAlive,
 ): Promise<void> {
   if (!isProcessGroupAlive(server.pid)) return;
 
-  const stop = async (signal: NodeJS.Signals): Promise<void> => {
+  const stop = async (signal: DevelopmentServerSignal): Promise<void> => {
     signalProcessGroup(-server.pid, signal);
     await promiseWithTimeout(
       Promise.all([


### PR DESCRIPTION
## Summary

- stop detached Vite process groups with bounded SIGTERM-to-SIGKILL escalation while preserving readiness diagnostics
- cap the serialized release job at 45 minutes so a validator cannot occupy the queue indefinitely
- split built-client hydration coverage across focused dialog, navigation, and tabs routes without increasing waits or retries
- retain ConfirmDialog open, cancel, and focus-restoration proof

## Validation

- `with-turborepo-cache bun test packages/components/scripts/validate-consumers.test.ts`
- negative controls for teardown escalation and the focused hydration route matrix
- `with-turborepo-cache bun run --filter=@lostgradient/cinder validate:consumer`
- `with-turborepo-cache bun run --filter=@lostgradient/cinder validate:consumer:hydration-smoke`
- `with-turborepo-cache bun run lint`
- `with-turborepo-cache bun run typecheck`
- `actionlint .github/workflows/release.yaml`

Tracks CIN-415 and CIN-405.

Closes #1351