### PR TITLE
Normalize the Ubuntu mirror before Playwright setup

### DIFF
--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -174,7 +174,7 @@ jobs:
       # When that mirror is unreachable, apt can fetch release metadata from
       # its fallback but then hang indefinitely on package indexes. Select the
       # canonical archive explicitly before Playwright invokes apt.
-      - name: Normalize Ubuntu mirror for hydration smoke
+      - name: Normalize Ubuntu mirror for Playwright dependencies
         run: >-
           sudo sed -i
           's|http://azure.archive.ubuntu.com/ubuntu/|https://archive.ubuntu.com/ubuntu/|g'

--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -169,6 +169,17 @@ jobs:
       # before the release (which waits for this same-SHA main-green run) can
       # publish. NOT continue-on-error: a crash here must go red so the release
       # never publishes on top of a broken hydration path.
+      #
+      # GitHub's Ubuntu runner mirror list prefers azure.archive.ubuntu.com.
+      # When that mirror is unreachable, apt can fetch release metadata from
+      # its fallback but then hang indefinitely on package indexes. Select the
+      # canonical archive explicitly before Playwright invokes apt.
+      - name: Normalize Ubuntu mirror for hydration smoke
+        run: >-
+          sudo sed -i
+          's|http://azure.archive.ubuntu.com/ubuntu/|https://archive.ubuntu.com/ubuntu/|g'
+          /etc/apt/apt-mirrors.txt
+
       - name: Install Chromium for hydration smoke
         run: bunx playwright install --with-deps chromium
 

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -220,6 +220,12 @@ jobs:
             echo "Published ${peer} satisfies Editor peer ${peer_range}: ${published_versions}"
           done
 
+      - name: Normalize Ubuntu mirror for Playwright dependencies
+        run: >-
+          sudo sed -i
+          's|http://azure.archive.ubuntu.com/ubuntu/|https://archive.ubuntu.com/ubuntu/|g'
+          /etc/apt/apt-mirrors.txt
+
       - name: Install Chromium for consumer validation
         run: bunx playwright install --with-deps chromium
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,6 +120,13 @@ jobs:
 
       # Chromium is only needed by validate:consumer — gate it identically so
       # the no-publish path skips the browser download too.
+      - name: Normalize Ubuntu mirror for Playwright dependencies
+        if: github.event_name != 'push' || steps.pending-changesets.outputs.pending == 'false'
+        run: >-
+          sudo sed -i
+          's|http://azure.archive.ubuntu.com/ubuntu/|https://archive.ubuntu.com/ubuntu/|g'
+          /etc/apt/apt-mirrors.txt
+
       - name: Install Chromium for consumer validation
         if: github.event_name != 'push' || steps.pending-changesets.outputs.pending == 'false'
         run: bunx playwright install --with-deps chromium

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -196,27 +196,42 @@ describe('workflow-level env block scanning', () => {
   });
 });
 
-describe('main-green hydration browser setup', () => {
-  test('normalizes the hosted-runner Ubuntu mirror before installing Playwright dependencies', () => {
-    const workspaceRoot = resolve(import.meta.dirname, '../../..');
-    const workflow = readFileSync(
-      join(workspaceRoot, '.github', 'workflows', 'main-green.yaml'),
-      'utf8',
-    );
-    const mirrorNormalizationIndex = workflow.indexOf(
-      'Normalize Ubuntu mirror for hydration smoke',
-    );
-    const runnerMirrorIndex = workflow.indexOf('/etc/apt/apt-mirrors.txt');
-    const azureMirrorIndex = workflow.indexOf('http://azure.archive.ubuntu.com/ubuntu/');
-    const canonicalMirrorIndex = workflow.indexOf('https://archive.ubuntu.com/ubuntu/');
-    const playwrightInstallIndex = workflow.indexOf('bunx playwright install --with-deps chromium');
+describe('Playwright dependency setup', () => {
+  test.each(['main-green.yaml', 'release.yaml', 'release-manual.yaml'])(
+    '%s normalizes the hosted-runner Ubuntu mirror before installing Playwright dependencies',
+    (workflowName) => {
+      const workspaceRoot = resolve(import.meta.dirname, '../../..');
+      const workflow = readFileSync(
+        join(workspaceRoot, '.github', 'workflows', workflowName),
+        'utf8',
+      );
+      const mirrorNormalizationIndex = workflow.indexOf(
+        'Normalize Ubuntu mirror for Playwright dependencies',
+      );
+      const runnerMirrorIndex = workflow.indexOf(
+        '/etc/apt/apt-mirrors.txt',
+        mirrorNormalizationIndex,
+      );
+      const azureMirrorIndex = workflow.indexOf(
+        'http://azure.archive.ubuntu.com/ubuntu/',
+        mirrorNormalizationIndex,
+      );
+      const canonicalMirrorIndex = workflow.indexOf(
+        'https://archive.ubuntu.com/ubuntu/',
+        azureMirrorIndex,
+      );
+      const playwrightInstallIndex = workflow.indexOf(
+        'bunx playwright install --with-deps chromium',
+        canonicalMirrorIndex,
+      );
 
-    expect(mirrorNormalizationIndex).toBeGreaterThan(-1);
-    expect(runnerMirrorIndex).toBeGreaterThan(mirrorNormalizationIndex);
-    expect(azureMirrorIndex).toBeGreaterThan(mirrorNormalizationIndex);
-    expect(canonicalMirrorIndex).toBeGreaterThan(azureMirrorIndex);
-    expect(playwrightInstallIndex).toBeGreaterThan(canonicalMirrorIndex);
-  });
+      expect(mirrorNormalizationIndex).toBeGreaterThan(-1);
+      expect(runnerMirrorIndex).toBeGreaterThan(mirrorNormalizationIndex);
+      expect(azureMirrorIndex).toBeGreaterThan(mirrorNormalizationIndex);
+      expect(canonicalMirrorIndex).toBeGreaterThan(azureMirrorIndex);
+      expect(playwrightInstallIndex).toBeGreaterThan(canonicalMirrorIndex);
+    },
+  );
 });
 
 describe('validate-release-workflow changeset guards', () => {

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -196,6 +196,29 @@ describe('workflow-level env block scanning', () => {
   });
 });
 
+describe('main-green hydration browser setup', () => {
+  test('normalizes the hosted-runner Ubuntu mirror before installing Playwright dependencies', () => {
+    const workspaceRoot = resolve(import.meta.dirname, '../../..');
+    const workflow = readFileSync(
+      join(workspaceRoot, '.github', 'workflows', 'main-green.yaml'),
+      'utf8',
+    );
+    const mirrorNormalizationIndex = workflow.indexOf(
+      'Normalize Ubuntu mirror for hydration smoke',
+    );
+    const runnerMirrorIndex = workflow.indexOf('/etc/apt/apt-mirrors.txt');
+    const azureMirrorIndex = workflow.indexOf('http://azure.archive.ubuntu.com/ubuntu/');
+    const canonicalMirrorIndex = workflow.indexOf('https://archive.ubuntu.com/ubuntu/');
+    const playwrightInstallIndex = workflow.indexOf('bunx playwright install --with-deps chromium');
+
+    expect(mirrorNormalizationIndex).toBeGreaterThan(-1);
+    expect(runnerMirrorIndex).toBeGreaterThan(mirrorNormalizationIndex);
+    expect(azureMirrorIndex).toBeGreaterThan(mirrorNormalizationIndex);
+    expect(canonicalMirrorIndex).toBeGreaterThan(azureMirrorIndex);
+    expect(playwrightInstallIndex).toBeGreaterThan(canonicalMirrorIndex);
+  });
+});
+
 describe('validate-release-workflow changeset guards', () => {
   test('requires artifact and publish commands for every public package', () => {
     const workflow = {


### PR DESCRIPTION
## Summary

- replace the hosted runner Azure Ubuntu mirror entry with the canonical archive before Playwright installs browser dependencies
- preserve `--with-deps` and every hydration/source validation gate
- pin the mirror path and pre-install ordering in workflow regression coverage

## Evidence

Exact-main run 32215754622 attempts 1 and 2 independently hung after `azure.archive.ubuntu.com` stopped serving package indexes. The last successful run completed the same install in 21 seconds.

## Verification

- `bun test packages/components/scripts/validate-release-workflow.test.ts`
- `with-turborepo-cache bun run --filter=@lostgradient/cinder validate:workflow`
- `with-turborepo-cache bun run lint`
- `with-turborepo-cache bun run typecheck`
- `bunx prettier --check .github/workflows/main-green.yaml packages/components/scripts/validate-release-workflow.test.ts`
- `git diff --check`

Tracks CIN-416 and GitHub issue #1362.