### PR TITLE
JSON Schema editor: render properties as a semantic table

### DIFF
--- a/.changeset/json-schema-property-table.md
+++ b/.changeset/json-schema-property-table.md
@@ -1,0 +1,5 @@
+---
+"@lostgradient/cinder": patch
+---
+
+Rework the JSON Schema editor's form view from stacked disclosure rows into a semantic table (Property key / Type / Description / Actions columns), with nested tables for expanded object properties. The required toggle is now a checkbox named for the property key rather than a button whose name changed on every press.

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
@@ -60,7 +60,7 @@ All property-table controls use their native button, checkbox, and input keyboar
 - `Tab` and `Shift+Tab` move through enabled controls in reading order: disclosure, required, move up, move down, delete — then, if the row is expanded, its detail controls (including any nested table) — then the next row. Disabled controls, and all controls in read-only or dirty-JSON form state, are skipped by native sequential navigation.
 - `Enter` and `Space` activate the disclosure, move, and delete buttons.
 - `Space` toggles the required checkbox. `Enter` does not — that's native checkbox behavior and isn't overridden.
-- `Enter` and `Space` also move through the enabled enum value input and its move or remove controls. The first Up and last Down controls are disabled and skipped.
+- `Tab` and `Shift+Tab` also move through the enabled enum value input and its move or remove controls. The first Up and last Down controls are disabled and skipped.
 - Editable property names commit when their input loses focus. Text-entry keys remain native input behavior.
 - `Cmd+Z`, `Shift+Cmd+Z`, and `Cmd+Y` undo and redo on macOS. `Ctrl+Z`, `Shift+Ctrl+Z`, and `Ctrl+Y` provide the corresponding shortcuts elsewhere. They act only outside editable text controls, so native text-editing shortcuts remain available while focus is in an input.
 
@@ -71,7 +71,7 @@ All property-table controls use their native button, checkbox, and input keyboar
 | Property table | `table` | `Schema properties` (root) or `Properties of <key>` (nested) | — |
 | Enum table | `table` | `Enum values` | — |
 | Disclosure | `button` | `Expand <key> property` / `Collapse <key> property`, suffixed with `, N validation errors` when the row has nested errors | `aria-expanded`; `aria-controls` present only while the detail row is rendered |
-| Required | `checkbox` | `<key>` — the column header supplies the word "Required" | `checked` |
+| Required | `checkbox` | `<key>` | `checked` |
 | Move up / down | `button` | `Move <key> up` / `Move <key> down` | `disabled` at the ends of the table, in read-only mode, and while a JSON draft is dirty |
 | Delete | `button` | `Delete <key>` | `disabled` in read-only mode and while a JSON draft is dirty |
 | Validation badge | — | `N validation errors in <key>` | — |
@@ -80,7 +80,7 @@ All property-table controls use their native button, checkbox, and input keyboar
 
 Reorder and delete controls repeat identically on every row, so each one carries the property key in its name — without that, a screen-reader control list reads as a column of indistinguishable "Move up" entries.
 
-The required control's accessible name is the bare property key, not `<key>: Required (toggle off)`. Naming it after the next action would make the name change on every toggle, which announces the change twice and breaks a reference a screen-reader user just built by name; the column header already supplies "Required" as context, matching how the reorder and delete controls rely on their own column position plus name.
+The required control's accessible name is the bare property key, not `<key>: Required (toggle off)`. Naming it after the next action would make the name change on every toggle, which announces the change twice and breaks a reference a screen-reader user just built by name. It lives in the same visually-hidden `Actions` column as the reorder and delete buttons; a `checkbox` role already announces as "checkbox," so nothing else in the name needs to say "required" for it to be understood in context, and the row-header key told the user which row they're in before they got there.
 
 Do not rely on color, icon shape, placeholder text, or a control's column position as the only way to communicate state or available actions.
 

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
@@ -2,7 +2,7 @@
 
 ## Pattern
 
-JsonSchemaEditor is a multi-view editor for authoring JSON Schema documents with form, raw JSON, and diff modes, undo history, and validation. The form view presents schema properties as a nested list of disclosure rows, not as a data table.
+JsonSchemaEditor is a multi-view editor for authoring JSON Schema documents with form, raw JSON, and diff modes, undo history, and validation. The form view presents schema properties as a semantic `table` whose rows expand into nested tables — one nesting level per object depth.
 
 ## Use when
 
@@ -13,47 +13,111 @@ JsonSchemaEditor is a multi-view editor for authoring JSON Schema documents with
 
 - Editing arbitrary free-form JSON with no schema semantics — use a plain code editor instead.
 
-## Property-list interaction model
+## Why a table and not a grid
 
-Each property is a `div` row containing a native disclosure button and sibling action buttons. The disclosure is intentionally not `details`/`summary`: the sibling controls would otherwise create interactive controls inside `summary`. Expanding a row reveals the property-name input and its nested `PropertyEditor`; nested object properties render another `PropertyList` within that panel.
+The property list is a native `table`, not `role="grid"`. Every interactive control inside a cell stays in the natural tab order; no roving tabindex is layered on top. This follows the pattern the enum table already established in this component: cells hold text inputs, checkboxes, and buttons, and a spreadsheet-style two-dimensional arrow-key model would take `ArrowLeft`/`ArrowRight` away from editing inside those controls in exchange for a navigation style this editor doesn't otherwise use.
 
-The disclosure button has an explicit name such as `Expand address property` or `Collapse address property`, plus `aria-expanded` and `aria-controls` pointing to the revealed panel. Required, reorder, and delete actions remain separate native buttons. Reorder labels include the affected property name, for example `Move address up`, so identical icon-only controls remain distinguishable in a screen-reader rotor.
+The cost is a long tab sequence on a wide schema. That's mitigated by collapsing: a collapsed row contributes five tab stops (disclosure, required checkbox, move up, move down, delete); nested rows contribute none until expanded. The other accepted cost is that screen-reader table-navigation commands (for example JAWS/NVDA's table cell movement) don't cross the nesting boundary — reaching a nested table's cells means entering it explicitly, the same way entering any nested table does.
 
-## Enum values
+## Structure
 
-The `Enum values` checkbox enables an editable semantic table. Each row contains a labelled JSON-value input plus move and remove buttons. The table has the accessible name `Enum values`; row controls identify their one-based value position, such as `Move enum value 2 up`, rather than relying on the visible icon or its table position. Invalid JSON stays in its input and is announced as an alert until it can be committed.
+The property table has the accessible name `Schema properties`. A nested table takes the name of its owning property, for example `Properties of address`, so a screen-reader table list distinguishes nested tables from the root and from each other without depending on nesting depth.
 
-## Keyboard and focus
+| Column | Header | Contents |
+| ------ | ------ | -------- |
+| 1 | `Property key` | `<th scope="row">` holding the disclosure button, whose own text is the property key. |
+| 2 | `Type` | The type summary text (for example `string`, `object`, `array of string`). |
+| 3 | `Description` | The schema's `description`, when present. |
+| 4 | (visually hidden) `Actions` | Required checkbox, move up, move down, and delete. |
 
-All property-list controls use their native button and input keyboard behavior.
+Every header cell uses `<th scope="col">`, so a screen reader announcing a cell also announces its column ("Type: object"). A row with nested validation errors carries `data-cinder-invalid` and shows a danger badge in the key cell, labelled with the error count and the property key.
 
-- `Tab` and `Shift+Tab` move through enabled disclosure, required-toggle, reorder, and delete controls, then the revealed editor controls when a row is expanded. The unavailable direction on the first or last row, and all disabled controls in read-only or dirty-JSON form state, are skipped by native sequential navigation.
-- `Enter` and `Space` activate the disclosure, required, reorder, and delete buttons.
-- `Tab` and `Shift+Tab` also move through the enabled enum value input and its move or remove controls. The first Up and last Down controls are disabled and skipped.
-- Expanding or collapsing leaves focus on the disclosure button; it does not move focus into or out of the panel.
-- Editable property names commit when their input loses focus. Text-entry keys remain native input behavior.
-- `Cmd+Z`, `Shift+Cmd+Z`, and `Cmd+Y` undo and redo on macOS. `Ctrl+Z`, `Shift+Ctrl+Z`, and `Ctrl+Y` provide the corresponding shortcuts elsewhere. They act only outside editable text controls, so native text-editing shortcuts remain available while focus is in an input.
+Below depth 0, the `<thead>` stays in the DOM — so `<th scope="col">` associations still hold for every cell — but is visually hidden. Nesting a header band inside every expanded row would repeat the same four column names at every depth for no benefit; the table's `aria-label` already carries the identifying information a nested table needs.
+
+An expanded row's detail is a sibling `<tr>` whose single `<td>` spans all four columns (`colspan="4"`). That cell holds the property-name input, the type and constraint editors, and — for an object property — the nested `Properties of <key>` table. The `aria-live` announcement paragraph, the rename error `Alert`, and the `Add property` button all render outside the `<table>` element; a `<table>` only validly contains `<caption>`/`<thead>`/`<tbody>`/`<tfoot>`/`<tr>`, and a stray child would be silently reparented by the HTML parser.
+
+## Focus management
+
+Focus is never moved on mount, on SSR, or on any change originating outside the user's own action.
+
+| Action | Where focus goes |
+| ------ | ----------------- |
+| Expand a row | Stays on the disclosure button, which is now `Collapse <key> property` with `aria-expanded="true"`. Focus does not enter the revealed row. |
+| Collapse a row | Stays on the disclosure button. |
+| Move a row up or down | Stays on the pressed control, which travels with the row to its new position. A move that lands the row first or last disables that direction's control; focus does not jump elsewhere. |
+| Delete a row | Moves to the next row's disclosure button; if the deleted row was last, to the previous row's; if the table is now empty, to the `Add property` button. |
+| Add a property | The new row opens expanded, with focus placed in its property-name input. |
+| Rename a property | Stays in the name input. The rename commits on blur. |
+
+Whenever a focused element disappears (delete, undo/redo shrinking the table), focus is placed explicitly rather than allowed to fall to `document.body` — a silent drop to `body` would send the next `Tab` back to the top of the page.
 
 Keep focus indicators visible. If you wrap or restyle JsonSchemaEditor, verify the focused element remains visually apparent in default and forced-colors modes.
 
+## Keyboard
+
+All property-table controls use their native button, checkbox, and input keyboard behavior. No key is intercepted inside the table except the two undo shortcuts, and those are suppressed while focus is in an editable text control.
+
+- `Tab` and `Shift+Tab` move through enabled controls in reading order: disclosure, required, move up, move down, delete — then, if the row is expanded, its detail controls (including any nested table) — then the next row. Disabled controls, and all controls in read-only or dirty-JSON form state, are skipped by native sequential navigation.
+- `Enter` and `Space` activate the disclosure, move, and delete buttons.
+- `Space` toggles the required checkbox. `Enter` does not — that's native checkbox behavior and isn't overridden.
+- `Enter` and `Space` also move through the enabled enum value input and its move or remove controls. The first Up and last Down controls are disabled and skipped.
+- Editable property names commit when their input loses focus. Text-entry keys remain native input behavior.
+- `Cmd+Z`, `Shift+Cmd+Z`, and `Cmd+Y` undo and redo on macOS. `Ctrl+Z`, `Shift+Ctrl+Z`, and `Ctrl+Y` provide the corresponding shortcuts elsewhere. They act only outside editable text controls, so native text-editing shortcuts remain available while focus is in an input.
+
 ## Names, roles, and state
 
-The disclosure’s accessible name includes the property key and, when present, its nested validation-error count. Its `aria-expanded` state conveys whether its controlled panel is visible. The required toggle exposes its pressed state and an accessible name that explains the next action. Disabled controls communicate the read-only and dirty-JSON states through their native disabled state.
+| Control | Role | Accessible name | State |
+| ------- | ---- | ---------------- | ----- |
+| Property table | `table` | `Schema properties` (root) or `Properties of <key>` (nested) | — |
+| Enum table | `table` | `Enum values` | — |
+| Disclosure | `button` | `Expand <key> property` / `Collapse <key> property`, suffixed with `, N validation errors` when the row has nested errors | `aria-expanded`; `aria-controls` present only while the detail row is rendered |
+| Required | `checkbox` | `<key>` — the column header supplies the word "Required" | `checked` |
+| Move up / down | `button` | `Move <key> up` / `Move <key> down` | `disabled` at the ends of the table, in read-only mode, and while a JSON draft is dirty |
+| Delete | `button` | `Delete <key>` | `disabled` in read-only mode and while a JSON draft is dirty |
+| Validation badge | — | `N validation errors in <key>` | — |
+| Enum value input | `textbox` | `Enum value <n>` | `aria-invalid` and `aria-describedby` while the draft is unparseable or duplicate |
+| Enum move / remove | `button` | `Move enum value <n> up` / `down`, `Remove enum value <n>` | `disabled` at the ends, while any enum draft is invalid, and when one value remains |
 
-Nested validation is announced through the disclosure name and a danger badge labelled with the error count and property key. Reordering commits the new schema order, updates the form/JSON/diff views, leaves focus on the named control, and announces the property’s resulting position. Deleting a property announces the deletion and moves focus to the next property, previous property, or Add property when the list becomes empty.
+Reorder and delete controls repeat identically on every row, so each one carries the property key in its name — without that, a screen-reader control list reads as a column of indistinguishable "Move up" entries.
 
-The enum editor keeps an invalid raw value local so it cannot corrupt the committed schema. A valid JSON value, an enum reorder, or a removal commits through the same form-state path as every other form edit, keeping JSON and diff views synchronized.
+The required control's accessible name is the bare property key, not `<key>: Required (toggle off)`. Naming it after the next action would make the name change on every toggle, which announces the change twice and breaks a reference a screen-reader user just built by name; the column header already supplies "Required" as context, matching how the reorder and delete controls rely on their own column position plus name.
 
-Do not rely on color, icon shape, placeholder text, or layout position as the only way to communicate state or available actions.
+Do not rely on color, icon shape, placeholder text, or a control's column position as the only way to communicate state or available actions.
 
 When JsonSchemaEditor accepts snippets or arbitrary children, the caller owns the semantics inside those children. Prefer native elements first, and add ARIA only when it matches the rendered behavior.
 
+## Assistive-technology announcements
+
+The property list owns one polite live region, rendered as a visually hidden paragraph outside the table. The enum table owns a separate one of its own.
+
+- Reordering a property announces `Moved <key> property to position <n> of <total>.`
+- Deleting a property announces `Deleted <key> property.`
+- Adding a property is not announced through the live region — focus moves into the new row's name input, which is self-announcing.
+- Expanding or collapsing is not announced through the live region; `aria-expanded` on the button already carries the state.
+- Reordering, removing, or adding an enum value announces through the enum table's own live region (see the enum-editor test suite for exact wording).
+- A row's validation error is announced assertively by that row's own `role="alert"` message when it appears, not routed through the polite region — a validation error is about the control being edited right now and should interrupt.
+- Nested validation errors on a collapsed row are not announced; the count is folded into the disclosure button's accessible name and shown as a badge, discoverable on navigation rather than interrupting.
+
+Reordering commits the new schema order and updates the form, JSON, and diff views together, so a subsequent read of any view reflects the same state.
+
 ## Verification
 
-- Automated: `bun run --filter=@lostgradient/cinder test -- property-list.test.ts` verifies disclosure resting semantics, property-specific reorder names, and resulting order.
-- Automated: `bun run --filter=@lostgradient/cinder test -- enum-editor.test.ts` verifies the enum table’s resting state, JSON-value validation, and resulting reorder state.
-- Automated: `bun run --filter=@cinder/testing test:playwright -- editors-complex-residual.playwright.ts --grep "JSON commits surface editable enum values"` verifies JSON-to-form synchronization in a browser.
-- Automated: `bun run --filter=@lostgradient/cinder test -- json-schema-editor-state.svelte.test.ts` verifies form and JSON commits, validation hooks, undo/redo history, diff baselines, dirty-draft handling, and `draftOverride` behavior.
-- Manual browser check: tab through a nested object row, expand and collapse it with `Enter` and `Space`, then confirm focus remains on the disclosure and the nested panel controls join the tab order.
-- Manual browser check: use a screen reader to confirm property-specific disclosure and reorder names, expanded state, nested-validation counts, and disabled controls in read-only or dirty-JSON form state.
-- Manual browser check: check forced-colors mode when the component adds borders, focus rings, selected state, or status color.
+### Automated
+
+- `bun run --filter=@lostgradient/cinder test -- property-list.test.ts` verifies the table's resting state (row count, column headers, per-row key/type), property-scoped control names, first/last and unrepresentable-move disabling, resulting key order after a reorder, the live-region reorder and delete messages, focus restoration after delete, nested-table reveal on expand, and `aria-controls` present only while the detail row is rendered.
+- `bun run --filter=@lostgradient/cinder test -- enum-editor.test.ts` verifies the enum table's resting state, JSON-value validation, resulting reorder state, and its move/remove/add announcements and focus targets.
+- `bun run --filter=@lostgradient/cinder test -- json-schema-editor.test.ts` verifies the diff-tab changed-state indicator, the toolbar's role and labels, nested validation-count aggregation, and undo/redo via keyboard shortcut on the editor region.
+- `bun run --filter=@lostgradient/cinder test -- json-schema-editor-state.svelte.test.ts` verifies form and JSON commits, validation hooks, undo/redo history, diff baselines, dirty-draft handling, and `draftOverride` behavior — this module has no DOM dependency and is unaffected by the table structure.
+- `bun run --filter=@cinder/testing test:playwright -- editors-complex-residual.playwright.ts --grep "JSON schema editor"` verifies JSON-to-form and form-to-JSON synchronization in a browser, the toolbar's roving tabindex, and the diff tab's accessible markup.
+
+### Manual verification only
+
+These are not covered by any automated check and should be re-walked when the interaction model changes.
+
+- Tab from the top of the editor to the bottom of a schema with two nesting levels and confirm the order is sequential, that collapsed rows contribute no hidden stops, and that no visibly-disabled control is reachable.
+- Expand and collapse a nested object row with `Enter` and then with `Space`, and confirm focus stays on the disclosure button both times.
+- Delete the last row of a table with a screen reader running, and confirm focus lands on the previous row's disclosure button and the deletion is announced.
+- Reorder a row repeatedly and confirm each move announces, including two identical consecutive moves.
+- Navigate into a nested table with a screen reader and confirm it announces entering a new table named for the owning property, with row/column counts scoped to that nested table rather than the parent's.
+- Confirm a row-level validation alert interrupts, and that several simultaneous row errors don't produce an unusable cascade of assertive announcements.
+- Check forced-colors mode for the table's row borders, the expanded-row background, focus rings, the danger badge, and disabled control state.

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.css
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.css
@@ -160,17 +160,17 @@
     color: var(--cinder-text-subtle);
   }
 
-  /* Each property is a custom disclosure (not <details>/<summary> — putting the
-   action buttons inside <summary> creates an ARIA "interactive within
-   interactive" violation). One top divider per row; no per-row card chrome.
-   The Required pill's primary/ghost variant conveys required state, so we
-   don't render a separate text marker. */
-  .cinder-jse-property-row {
+  .cinder-jse-property-table {
+    inline-size: 100%;
+    border-collapse: collapse;
+  }
+
+  .cinder-jse-property-row > .cinder-table__cell {
     border-top: 1px solid var(--cinder-border-muted);
     background: transparent;
   }
 
-  .cinder-jse-property-row:first-child {
+  .cinder-jse-property-row:first-child > .cinder-table__cell {
     border-top: 0;
   }
 
@@ -208,25 +208,34 @@
     margin-block: var(--cinder-space-1) 0;
   }
 
-  .cinder-jse-property-row[data-cinder-invalid] {
+  .cinder-jse-property-row[data-cinder-invalid] > .cinder-table__cell:first-child {
     border-inline-start: 2px solid var(--cinder-color-danger-border);
   }
 
-  .cinder-jse-property-row__summary {
-    display: flex;
-    align-items: center;
-    gap: var(--cinder-space-2);
-    padding-block: var(--cinder-space-1-5);
-    padding-inline-end: var(--cinder-space-3);
+  .cinder-jse-property-row__key {
     padding-inline-start: calc(
       var(--cinder-space-3) + var(--cinder-jse-property-depth, 0) * var(--cinder-space-4)
     );
-    min-height: var(--cinder-button-height-md);
+    white-space: nowrap;
   }
 
-  /* The chevron + name + type form a single clickable disclosure trigger.
-   Action buttons live as siblings inside __summary so they keep the
-   single-baseline layout without nesting interactive elements. */
+  .cinder-jse-property-row__type,
+  .cinder-jse-property-row__description {
+    font-size: var(--cinder-text-xs);
+    color: var(--cinder-text-subtle);
+  }
+
+  .cinder-jse-property-row__actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--cinder-space-1);
+    text-align: end;
+  }
+
+  /* The chevron + name form a single clickable disclosure trigger. Action
+   buttons live in their own cell so they keep the single-baseline layout
+   without nesting interactive elements inside the trigger. */
   .cinder-jse-property-row__trigger {
     display: inline-flex;
     align-items: center;
@@ -272,33 +281,27 @@
     color: var(--cinder-text);
   }
 
-  .cinder-jse-property-row__type {
-    font-size: var(--cinder-text-xs);
-    color: var(--cinder-text-subtle);
-    padding: 0 var(--cinder-space-1-5);
-  }
-
-  .cinder-jse-property-row__spacer {
-    flex: 1 1 auto;
-  }
-
-  .cinder-jse-property-row__panel {
-    display: flex;
-    flex-direction: column;
-    gap: var(--cinder-space-3);
+  .cinder-jse-property-row__detail-cell {
+    display: table-cell;
     padding: var(--cinder-space-3) var(--cinder-space-3) var(--cinder-space-4);
-    margin-inline-start: calc(var(--cinder-jse-property-depth, 0) * var(--cinder-space-4));
+    padding-inline-start: calc(
+      var(--cinder-space-3) + var(--cinder-jse-property-depth, 0) * var(--cinder-space-4)
+    );
     background: transparent;
   }
 
+  .cinder-jse-property-row__detail-cell > * + * {
+    margin-block-start: var(--cinder-space-3);
+  }
+
   /* The nested PropertyEditor inside an open property panel doesn't get a card. */
-  .cinder-jse-property-row__panel > .cinder-jse-property-editor[data-cinder-jse-depth] {
+  .cinder-jse-property-row__detail-cell > .cinder-jse-property-editor[data-cinder-jse-depth] {
     border: 0;
     background: transparent;
     border-radius: 0;
   }
 
-  .cinder-jse-property-row__panel > .cinder-jse-property-editor > .cinder-jse-section {
+  .cinder-jse-property-row__detail-cell > .cinder-jse-property-editor > .cinder-jse-section {
     padding-inline: 0;
   }
 

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -7,6 +7,8 @@
     value: JsonSchemaValue;
     path: string;
     depth?: number;
+    /** The property key this editor renders, when nested under a PropertyList row. Threaded to a nested PropertyList so it can label its table. */
+    propertyKey?: string | undefined;
     readonly?: boolean;
     enumDrafts?: Record<string, Record<number, EnumDraft>>;
     historyRevision?: number;
@@ -53,6 +55,7 @@
     value,
     path,
     depth = 0,
+    propertyKey,
     readonly = false,
     enumDrafts = {},
     historyRevision = 0,
@@ -433,6 +436,7 @@
           {depth}
           {enumDrafts}
           {historyRevision}
+          parentKey={propertyKey}
           path={`${path}/properties`}
           properties={objectValue.properties ?? {}}
           required={objectValue.required ?? []}

--- a/packages/components/src/components/json-schema-editor/property-list.svelte
+++ b/packages/components/src/components/json-schema-editor/property-list.svelte
@@ -11,6 +11,8 @@
     readonly?: boolean;
     enumDrafts?: Record<string, Record<number, EnumDraft>>;
     historyRevision?: number;
+    /** The owning property's key, when this list renders a nested object's properties. Used to give the nested table a distinguishing accessible name. */
+    parentKey?: string | undefined;
     onvalidationErrorcount?: ((count: number) => void) | undefined;
     onEnumDraftsChange?: ((next: Record<string, Record<number, EnumDraft>>) => void) | undefined;
     onValueChange: (properties: Record<string, JsonSchemaValue>, required: string[]) => void;
@@ -20,12 +22,15 @@
 <script lang="ts">
   import ChevronDown from 'lucide-svelte/icons/chevron-down';
   import { onDestroy, tick } from 'svelte';
+  import { classNames } from '../../utilities/class-names.ts';
   import Alert from '../alert/alert.svelte';
   import Button from '../button/button.svelte';
+  import Checkbox from '../checkbox/checkbox.svelte';
   import Chip from '../chip/chip.svelte';
   import Badge from '@lostgradient/cinder/badge';
   import Collapsible from '@lostgradient/cinder/collapsible';
   import Input from '../input/input.svelte';
+  import Table from '@lostgradient/cinder/table';
   import PropertyEditor from './property-editor.svelte';
   import { calculatePropertyValidationErrorCount } from './property-list-validation.ts';
 
@@ -38,6 +43,7 @@
     readonly = false,
     enumDrafts = {},
     historyRevision = 0,
+    parentKey,
     onvalidationErrorcount,
     onEnumDraftsChange,
     onValueChange,
@@ -237,11 +243,11 @@
     return Object.keys(next).every((name, nextIndex) => name === reordered[nextIndex]);
   }
 
-  function toggleRequired(key: string) {
+  function setRequired(key: string, isRequired: boolean) {
     if (readonly) return;
     const set = new Set(required);
-    if (set.has(key)) set.delete(key);
-    else set.add(key);
+    if (isRequired) set.add(key);
+    else set.delete(key);
     onValueChange(properties, [...set]);
   }
 
@@ -294,128 +300,155 @@
 
 <p class="cinder-sr-only" aria-live="polite">{actionAnnouncement}</p>
 
-<div class="cinder-jse-property-list">
-  {#if renameError}
-    <Alert variant="danger">{renameError}</Alert>
-  {/if}
+{#if renameError}
+  <Alert variant="danger">{renameError}</Alert>
+{/if}
 
+<div class="cinder-jse-property-list">
   {#if propertyNames.length === 0}
     <p class="cinder-jse-property-list__empty">No properties yet.</p>
-  {/if}
-
-  {#each propertyNames as key, index (key)}
-    {@const isRequired = required.includes(key)}
-    {@const isOpen = expanded[key] === true}
-    {@const childValidationErrorCount = Math.max(
-      childValidationCounts[key] ?? 0,
-      retainedDraftCount(key),
-    )}
-    {@const panelId = `${idPrefix}-${key}-panel`}
-    <!--
-      Custom disclosure (not <details>/<summary>) so the action buttons can
-      live as siblings of the trigger rather than nested inside it.
-      <button> inside <summary> creates an ARIA "interactive within
-      interactive" violation.
-    -->
-    <div
-      class="cinder-jse-property-row"
-      data-cinder-required={isRequired ? '' : undefined}
-      data-cinder-invalid={childValidationErrorCount > 0 ? '' : undefined}
+  {:else}
+    <Table
+      class="cinder-jse-property-table"
+      aria-label={parentKey ? `Properties of ${parentKey}` : 'Schema properties'}
     >
-      <div class="cinder-jse-property-row__summary" style={`--cinder-jse-property-depth: ${depth}`}>
-        <button
-          use:propertyTrigger={key}
-          type="button"
-          class="cinder-jse-property-row__trigger"
-          aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${key} property${childValidationErrorCount > 0 ? `, ${childValidationErrorCount} validation ${childValidationErrorCount === 1 ? 'error' : 'errors'}` : ''}`}
-          aria-expanded={isOpen}
-          aria-controls={isOpen ? panelId : undefined}
-          onclick={() => toggleExpanded(key, isOpen)}
-        >
-          <ChevronDown
-            class="cinder-jse-property-row__chevron"
-            size={14}
-            strokeWidth={2}
-            aria-hidden="true"
-          />
-          <span class="cinder-jse-property-row__name">{key}</span>
-          <span class="cinder-jse-property-row__type">{summariseType(properties[key] ?? {})}</span>
-          {#if childValidationErrorCount > 0}
-            <Badge
-              variant="danger"
-              aria-label={`${childValidationErrorCount} validation ${childValidationErrorCount === 1 ? 'error' : 'errors'} in ${key}`}
+      <Table.Header class={classNames(depth > 0 && 'cinder-sr-only')}>
+        <Table.Row>
+          <Table.HeaderCell>Property key</Table.HeaderCell>
+          <Table.HeaderCell>Type</Table.HeaderCell>
+          <Table.HeaderCell>Description</Table.HeaderCell>
+          <Table.HeaderCell><span class="cinder-sr-only">Actions</span></Table.HeaderCell>
+        </Table.Row>
+      </Table.Header>
+      <Table.Body>
+        {#each propertyNames as key, index (key)}
+          {@const isRequired = required.includes(key)}
+          {@const isOpen = expanded[key] === true}
+          {@const childValidationErrorCount = Math.max(
+            childValidationCounts[key] ?? 0,
+            retainedDraftCount(key),
+          )}
+          {@const panelId = `${idPrefix}-${key}-panel`}
+          {@const propertySchema = properties[key] ?? {}}
+          {@const description =
+            typeof propertySchema === 'object' ? (propertySchema.description ?? '') : ''}
+          <Table.Row
+            class="cinder-jse-property-row"
+            data-cinder-required={isRequired ? '' : undefined}
+            data-cinder-invalid={childValidationErrorCount > 0 ? '' : undefined}
+          >
+            <Table.Cell
+              as="th"
+              class="cinder-jse-property-row__key"
+              style={`--cinder-jse-property-depth: ${depth}`}
             >
-              {childValidationErrorCount}{' '}
-              {childValidationErrorCount === 1 ? 'error' : 'errors'}
-            </Badge>
-          {/if}
-        </button>
-        <span class="cinder-jse-property-row__spacer"></span>
-        <Button
-          variant={isRequired ? 'primary' : 'ghost'}
-          size="xs"
-          disabled={readonly}
-          aria-pressed={isRequired}
-          aria-label={`${key}: ${isRequired ? 'Required (toggle off)' : 'Optional (toggle required)'}`}
-          onclick={() => toggleRequired(key)}
-        >
-          {isRequired ? 'Required' : 'Optional'}
-        </Button>
-        <Button
-          variant="ghost"
-          size="xs"
-          disabled={readonly || !canMoveProperty(index, -1)}
-          aria-label={`Move ${key} up`}
-          onclick={() => moveProperty(key, -1, index)}
-        >
-          ↑
-        </Button>
-        <Button
-          variant="ghost"
-          size="xs"
-          disabled={readonly || !canMoveProperty(index, 1)}
-          aria-label={`Move ${key} down`}
-          onclick={() => moveProperty(key, 1, index)}
-        >
-          ↓
-        </Button>
-        <Button
-          variant="ghost-danger"
-          size="xs"
-          disabled={readonly}
-          aria-label={`Delete ${key}`}
-          onclick={() => deleteProperty(key, index)}
-        >
-          Delete
-        </Button>
-      </div>
+              <button
+                use:propertyTrigger={key}
+                type="button"
+                class="cinder-jse-property-row__trigger"
+                aria-label={`${isOpen ? 'Collapse' : 'Expand'} ${key} property${childValidationErrorCount > 0 ? `, ${childValidationErrorCount} validation ${childValidationErrorCount === 1 ? 'error' : 'errors'}` : ''}`}
+                aria-expanded={isOpen}
+                aria-controls={isOpen ? panelId : undefined}
+                onclick={() => toggleExpanded(key, isOpen)}
+              >
+                <ChevronDown
+                  class="cinder-jse-property-row__chevron"
+                  size={14}
+                  strokeWidth={2}
+                  aria-hidden="true"
+                />
+                <span class="cinder-jse-property-row__name">{key}</span>
+                {#if childValidationErrorCount > 0}
+                  <Badge
+                    variant="danger"
+                    aria-label={`${childValidationErrorCount} validation ${childValidationErrorCount === 1 ? 'error' : 'errors'} in ${key}`}
+                  >
+                    {childValidationErrorCount}{' '}
+                    {childValidationErrorCount === 1 ? 'error' : 'errors'}
+                  </Badge>
+                {/if}
+              </button>
+            </Table.Cell>
+            <Table.Cell class="cinder-jse-property-row__type">
+              {summariseType(propertySchema)}
+            </Table.Cell>
+            <Table.Cell class="cinder-jse-property-row__description">
+              {description}
+            </Table.Cell>
+            <Table.Cell class="cinder-jse-property-row__actions">
+              <Checkbox
+                checked={isRequired}
+                disabled={readonly}
+                aria-label={key}
+                onValueChange={(next) => setRequired(key, next)}
+              />
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={readonly || !canMoveProperty(index, -1)}
+                aria-label={`Move ${key} up`}
+                onclick={() => moveProperty(key, -1, index)}
+              >
+                ↑
+              </Button>
+              <Button
+                variant="ghost"
+                size="xs"
+                disabled={readonly || !canMoveProperty(index, 1)}
+                aria-label={`Move ${key} down`}
+                onclick={() => moveProperty(key, 1, index)}
+              >
+                ↓
+              </Button>
+              <Button
+                variant="ghost-danger"
+                size="xs"
+                disabled={readonly}
+                aria-label={`Delete ${key}`}
+                onclick={() => deleteProperty(key, index)}
+              >
+                Delete
+              </Button>
+            </Table.Cell>
+          </Table.Row>
 
-      {#if isOpen}
-        <div id={panelId} class="cinder-jse-property-row__panel">
-          <Input
-            id={`${idPrefix}-${key}-name`}
-            label="Name"
-            value={getDraftName(key)}
-            disabled={readonly}
-            oninput={(event: Event) => (draftNames[key] = (event.target as HTMLInputElement).value)}
-            onblur={() => commitRename(key)}
-          />
-          <PropertyEditor
-            idPrefix={`${idPrefix}-${key}-schema`}
-            path={`${path}/${pointerSegment(key)}`}
-            depth={depth + 1}
-            {readonly}
-            {enumDrafts}
-            {historyRevision}
-            value={properties[key] ?? {}}
-            onvalidationErrorcount={(count) => setChildValidationErrorCount(key, count)}
-            {onEnumDraftsChange}
-            onValueChange={(next) => setPropertySchema(key, next)}
-          />
-        </div>
-      {/if}
-    </div>
-  {/each}
+          {#if isOpen}
+            <Table.Row class="cinder-jse-property-row__detail-row">
+              <Table.Cell
+                id={panelId}
+                colspan={4}
+                class="cinder-jse-property-row__detail-cell"
+                style={`--cinder-jse-property-depth: ${depth}`}
+              >
+                <Input
+                  id={`${idPrefix}-${key}-name`}
+                  label="Name"
+                  value={getDraftName(key)}
+                  disabled={readonly}
+                  oninput={(event: Event) =>
+                    (draftNames[key] = (event.target as HTMLInputElement).value)}
+                  onblur={() => commitRename(key)}
+                />
+                <PropertyEditor
+                  idPrefix={`${idPrefix}-${key}-schema`}
+                  path={`${path}/${pointerSegment(key)}`}
+                  depth={depth + 1}
+                  propertyKey={key}
+                  {readonly}
+                  {enumDrafts}
+                  {historyRevision}
+                  value={properties[key] ?? {}}
+                  onvalidationErrorcount={(count) => setChildValidationErrorCount(key, count)}
+                  {onEnumDraftsChange}
+                  onValueChange={(next) => setPropertySchema(key, next)}
+                />
+              </Table.Cell>
+            </Table.Row>
+          {/if}
+        {/each}
+      </Table.Body>
+    </Table>
+  {/if}
 
   <span class="cinder-jse-property-list__add-property-reference" bind:this={addPropertyElement}>
     <Button variant="secondary" size="sm" disabled={readonly} onclick={addProperty}>

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -105,6 +105,44 @@ describe('PropertyList', () => {
     ).toBeNull();
   });
 
+  test('the required checkbox adds and removes the key from the required array', async () => {
+    let latestRequired: string[] = [];
+    const { rerender } = render(PropertyList, {
+      idPrefix: 'properties',
+      path: '/properties',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'integer' },
+      },
+      required: ['name'],
+      onValueChange: (_properties: unknown, required: string[]) => {
+        latestRequired = required;
+      },
+    });
+
+    expect(screen.getByRole('checkbox', { name: 'name' })).toHaveProperty('checked', true);
+    expect(screen.getByRole('checkbox', { name: 'age' })).toHaveProperty('checked', false);
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'age' }));
+    expect(latestRequired).toEqual(['name', 'age']);
+
+    await rerender({
+      idPrefix: 'properties',
+      path: '/properties',
+      properties: {
+        name: { type: 'string' },
+        age: { type: 'integer' },
+      },
+      required: latestRequired,
+      onValueChange: (_properties: unknown, required: string[]) => {
+        latestRequired = required;
+      },
+    });
+
+    await fireEvent.click(screen.getByRole('checkbox', { name: 'name' }));
+    expect(latestRequired).toEqual(['age']);
+  });
+
   test('reorders properties through the row controls', async () => {
     let latestProperties: Record<string, JsonSchemaValue> = {};
     render(PropertyList, {

--- a/packages/components/src/components/json-schema-editor/property-list.test.ts
+++ b/packages/components/src/components/json-schema-editor/property-list.test.ts
@@ -90,10 +90,8 @@ describe('PropertyList', () => {
       onValueChange: () => {},
     });
 
-    expect(
-      screen.getByRole('button', { name: 'email: Optional (toggle required)' }),
-    ).not.toBeNull();
-    expect(screen.getByRole('button', { name: 'age: Optional (toggle required)' })).not.toBeNull();
+    expect(screen.getByRole('checkbox', { name: 'email' })).not.toBeNull();
+    expect(screen.getByRole('checkbox', { name: 'age' })).not.toBeNull();
     expect(screen.getByRole('button', { name: 'Move email up' })).not.toBeNull();
     expect(screen.getByRole('button', { name: 'Move email down' })).not.toBeNull();
     expect(screen.getByRole('button', { name: 'Move age up' })).not.toBeNull();


### PR DESCRIPTION
Summary:

- Replace `property-list.svelte`'s div-based disclosure rows with a compositional `Table` (Property key / Type / Description / Actions columns, one `<tr>` per property).
- Expanding a row reveals a sibling detail `<tr>` whose `<td colspan="4">` holds the existing `PropertyEditor`; object properties render a nested table named `Properties of <key>`.
- Convert the required control from a toggle `Button` to a `Checkbox` named for the bare property key.
- Fix a pre-existing bug where `--cinder-jse-property-depth` was set on a sibling element the expanded panel's indentation could never actually inherit from.
- Rewrite `json-schema-editor.a11y.md` for the table interaction model.
- Preserve all existing behavior verbatim: JSON-Pointer escaping, enum-draft rebase/prune, `canMoveProperty`'s disabled states, the `propertyTrigger` focus-restoration map, `announceAction`.

Closes CIN-155, CIN-157.

Validation:

- `bun run --filter=@lostgradient/cinder test -- property-list.test.ts enum-editor.test.ts json-schema-editor.test.ts json-schema-editor-state.svelte.test.ts json-schema-toolbar.test.ts json-schema-validator.test.ts composition-branch-keys.test.ts` — 141 pass
- `bun run --filter=@lostgradient/cinder typecheck` — 0 errors
- `bun run --filter=@lostgradient/cinder lint` — 0 errors
- `bun run --filter=@lostgradient/cinder components:check` — OK
- `bun run --filter=@cinder/testing test:playwright -- editors-complex-residual.playwright.ts --grep "JSON schema editor"` — 6/6 pass
- Manually verified in the browser: flat schema, nested object expansion, required checkbox, reorder controls