### PR TITLE
JSON Schema editor: add a type selector

### DIFF
--- a/.changeset/json-schema-type-selector.md
+++ b/.changeset/json-schema-type-selector.md
@@ -1,0 +1,5 @@
+---
+"@lostgradient/cinder": patch
+---
+
+Add a type selector to the JSON Schema editor's property editor, covering string/number/integer/boolean/enum/object/array plus "Any" and an explicit "Multiple types" option that reveals the existing multi-type checkbox row. Selecting "enum" seeds a default value and expands the enum table without touching `type`; the previously separate "Enum values" checkbox is removed since the type select now covers that transition.

--- a/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
+++ b/packages/components/src/components/json-schema-editor/json-schema-editor.a11y.md
@@ -71,6 +71,7 @@ All property-table controls use their native button, checkbox, and input keyboar
 | Property table | `table` | `Schema properties` (root) or `Properties of <key>` (nested) | — |
 | Enum table | `table` | `Enum values` | — |
 | Disclosure | `button` | `Expand <key> property` / `Collapse <key> property`, suffixed with `, N validation errors` when the row has nested errors | `aria-expanded`; `aria-controls` present only while the detail row is rendered |
+| Type | `combobox` | `<key> type` (visually hidden — a "Type" heading labels the section) | value is `any`, a concrete type, `enum`, or `multiple` |
 | Required | `checkbox` | `<key>` | `checked` |
 | Move up / down | `button` | `Move <key> up` / `Move <key> down` | `disabled` at the ends of the table, in read-only mode, and while a JSON draft is dirty |
 | Delete | `button` | `Delete <key>` | `disabled` in read-only mode and while a JSON draft is dirty |
@@ -81,6 +82,8 @@ All property-table controls use their native button, checkbox, and input keyboar
 Reorder and delete controls repeat identically on every row, so each one carries the property key in its name — without that, a screen-reader control list reads as a column of indistinguishable "Move up" entries.
 
 The required control's accessible name is the bare property key, not `<key>: Required (toggle off)`. Naming it after the next action would make the name change on every toggle, which announces the change twice and breaks a reference a screen-reader user just built by name. It lives in the same visually-hidden `Actions` column as the reorder and delete buttons; a `checkbox` role already announces as "checkbox," so nothing else in the name needs to say "required" for it to be understood in context, and the row-header key told the user which row they're in before they got there.
+
+The Type select covers `any`, `string`, `number`, `integer`, `boolean`, `enum`, `object`, and `array` directly. `type` may legitimately be a JSON array (`["string","null"]`) or bare `null`, neither of which a single-select value can represent; those states surface as a `multiple` option, and selecting it explicitly reveals the pre-existing multi-select checkbox row (the same one this select otherwise replaces) so nothing the checkboxes could already express is lost. Selecting `enum` seeds a default `['']` and reveals the enum table without touching `type`, so `type: 'string'` plus `enum` stays a string enum rather than losing its type. Selecting away from `enum` clears it.
 
 Do not rely on color, icon shape, placeholder text, or a control's column position as the only way to communicate state or available actions.
 
@@ -108,7 +111,7 @@ Reordering commits the new schema order and updates the form, JSON, and diff vie
 - `bun run --filter=@lostgradient/cinder test -- enum-editor.test.ts` verifies the enum table's resting state, JSON-value validation, resulting reorder state, and its move/remove/add announcements and focus targets.
 - `bun run --filter=@lostgradient/cinder test -- json-schema-editor.test.ts` verifies the diff-tab changed-state indicator, the toolbar's role and labels, nested validation-count aggregation, and undo/redo via keyboard shortcut on the editor region.
 - `bun run --filter=@lostgradient/cinder test -- json-schema-editor-state.svelte.test.ts` verifies form and JSON commits, validation hooks, undo/redo history, diff baselines, dirty-draft handling, and `draftOverride` behavior — this module has no DOM dependency and is unaffected by the table structure.
-- `bun run --filter=@cinder/testing test:playwright -- editors-complex-residual.playwright.ts --grep "JSON schema editor"` verifies JSON-to-form and form-to-JSON synchronization in a browser, the toolbar's roving tabindex, and the diff tab's accessible markup.
+- `bun run --filter=@cinder/testing test:playwright -- editors-complex-residual.playwright.ts --grep "JSON schema editor"` verifies JSON-to-form and form-to-JSON synchronization in a browser, the toolbar's roving tabindex, the diff tab's accessible markup, the type selector switching to `enum` and revealing the enum table, and selecting `Multiple types` seeding a starting array and revealing the checkbox row. The type-select interaction is covered here rather than in `property-list.test.ts` — mounting it through a real browser sidesteps a happy-dom keyed-each reconciliation limitation the unit harness hits at this nesting depth.
 
 ### Manual verification only
 

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" module>
   import type { JsonSchemaTypeName, JsonSchemaValue } from './json-schema-editor-types.ts';
   import type { EnumDraft } from './enum-editor.svelte';
+  import type { SelectOption } from '@lostgradient/cinder/select';
 
   export type PropertyEditorProps = {
     idPrefix: string;
@@ -36,6 +37,7 @@
   import Checkbox from '../checkbox/checkbox.svelte';
   import Collapsible from '@lostgradient/cinder/collapsible';
   import Input from '../input/input.svelte';
+  import Select from '@lostgradient/cinder/select';
 
   import { reconcileCompositionBranchKeys } from './composition-branch-keys.ts';
   import {
@@ -240,6 +242,55 @@
     patch({ enum: values }, options ?? { label: 'edit enum values' });
   }
 
+  // ===== Type select =====
+  // A fast-path selector covering the seven options CIN-156 names plus "Any"
+  // and an explicit "Multiple types" escape hatch. `type` may legitimately be
+  // an array (JSON Schema multi-type) or `null`, neither of which fits a
+  // single-select value — those states, and the deliberate opt-in to edit
+  // them, fall back to the existing PRIMITIVE_TYPES checkbox row below.
+  const typeSelectValue = $derived.by<string>(() => {
+    if (hasEnum) return 'enum';
+    if (selectedTypes.length > 1 || selectedTypes.includes('null')) return 'multiple';
+    return isAnyType ? 'any' : selectedTypes[0]!;
+  });
+
+  const showTypeCheckboxes = $derived(typeSelectValue === 'multiple');
+
+  const typeSelectOptions: SelectOption[] = [
+    { value: 'any', label: 'Any' },
+    { value: 'string', label: 'string' },
+    { value: 'number', label: 'number' },
+    { value: 'integer', label: 'integer' },
+    { value: 'boolean', label: 'boolean' },
+    { value: 'enum', label: 'enum' },
+    { value: 'object', label: 'object' },
+    { value: 'array', label: 'array' },
+    { value: 'multiple', label: 'Multiple types' },
+  ];
+
+  function setTypeFromSelect(next: string) {
+    if (readonly || next === typeSelectValue) return;
+    if (next === 'multiple') {
+      // Seed a sensible starting multi-type set from the current single type
+      // (or 'string' from 'any'/'enum') so the checkbox row opens with
+      // something already checked rather than empty.
+      const base = selectedTypes[0] ?? 'string';
+      setTypeFromCheckboxes([base, 'null']);
+      if (hasEnum) setEnum(false);
+      return;
+    }
+    if (next === 'enum') {
+      setEnum(true);
+      return;
+    }
+    if (hasEnum) setEnum(false);
+    if (next === 'any') {
+      setTypeFromCheckboxes([]);
+      return;
+    }
+    setTypeFromCheckboxes([next as JsonSchemaTypeName]);
+  }
+
   // ===== Composition =====
   function patchComposition(
     keyword: 'oneOf' | 'anyOf' | 'allOf' | 'not',
@@ -382,36 +433,40 @@
     <!-- Type section -->
     <div class="cinder-jse-section">
       <h4 class="cinder-jse-section__title">Type</h4>
-      <div class="cinder-jse-type-row">
-        <Checkbox
-          id={`${idPrefix}-type-any`}
-          checked={isAnyType}
-          label="Any"
-          disabled={readonly}
-          onchange={(event: Event) => setAny((event.target as HTMLInputElement).checked)}
-        />
-        {#each PRIMITIVE_TYPES as primitive (primitive)}
+      <Select
+        id={`${idPrefix}-type-select`}
+        label={`${propertyKey ?? 'Value'} type`}
+        labelVisible={false}
+        value={typeSelectValue}
+        options={typeSelectOptions}
+        disabled={readonly}
+        onchange={(event: Event) => setTypeFromSelect((event.target as HTMLSelectElement).value)}
+      />
+      {#if showTypeCheckboxes}
+        <div class="cinder-jse-type-row">
           <Checkbox
-            id={`${idPrefix}-type-${primitive}`}
-            checked={selectedTypes.includes(primitive)}
-            label={primitive}
+            id={`${idPrefix}-type-any`}
+            checked={isAnyType}
+            label="Any"
             disabled={readonly}
-            onchange={(event: Event) =>
-              toggleType(primitive, (event.target as HTMLInputElement).checked)}
+            onchange={(event: Event) => setAny((event.target as HTMLInputElement).checked)}
           />
-        {/each}
-      </div>
+          {#each PRIMITIVE_TYPES as primitive (primitive)}
+            <Checkbox
+              id={`${idPrefix}-type-${primitive}`}
+              checked={selectedTypes.includes(primitive)}
+              label={primitive}
+              disabled={readonly}
+              onchange={(event: Event) =>
+                toggleType(primitive, (event.target as HTMLInputElement).checked)}
+            />
+          {/each}
+        </div>
+      {/if}
     </div>
 
-    <div class="cinder-jse-section">
-      <Checkbox
-        id={`${idPrefix}-enum`}
-        checked={hasEnum}
-        label="Enum values"
-        disabled={readonly}
-        onchange={(event: Event) => setEnum((event.target as HTMLInputElement).checked)}
-      />
-      {#if hasEnum}
+    {#if hasEnum}
+      <div class="cinder-jse-section">
         <EnumEditor
           idPrefix={`${idPrefix}-enum`}
           path={`${path}/enum`}
@@ -423,8 +478,8 @@
           onDraftsChange={(next) => onEnumDraftsChange?.({ ...enumDrafts, [`${path}/enum`]: next })}
           onValuesChange={setEnumValues}
         />
-      {/if}
-    </div>
+      </div>
+    {/if}
 
     <!-- Object constraints (properties + required) — comes early because it's the heaviest. -->
     {#if showObjectConstraints}

--- a/packages/components/src/components/json-schema-editor/property-editor.svelte
+++ b/packages/components/src/components/json-schema-editor/property-editor.svelte
@@ -271,12 +271,17 @@
   function setTypeFromSelect(next: string) {
     if (readonly || next === typeSelectValue) return;
     if (next === 'multiple') {
-      // Seed a sensible starting multi-type set from the current single type
-      // (or 'string' from 'any'/'enum') so the checkbox row opens with
+      if (hasEnum) setEnum(false);
+      // `type` is already multi-type or `null` (it just wasn't visible behind
+      // an active `enum`) — reveal the checkbox row on the existing value
+      // rather than reseeding it and silently dropping types the schema
+      // already had.
+      if (selectedTypes.length > 1 || selectedTypes.includes('null')) return;
+      // Otherwise seed a sensible starting multi-type set from the current
+      // single type (or 'string' from 'any') so the checkbox row opens with
       // something already checked rather than empty.
       const base = selectedTypes[0] ?? 'string';
       setTypeFromCheckboxes([base, 'null']);
-      if (hasEnum) setEnum(false);
       return;
     }
     if (next === 'enum') {

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -503,6 +503,41 @@ test.describe('JSON schema editor', () => {
     await expect(editor.getByText('Enter a valid JSON value.')).toBeVisible();
   });
 
+  test('the type selector switches a property to enum and reveals the enum table', async ({
+    page,
+  }) => {
+    const editor = await openFirstEditor(page);
+    await editor.getByRole('button', { name: 'Expand name property' }).click();
+
+    const typeSelect = editor.getByRole('combobox', { name: 'name type' });
+    await expect(typeSelect).toHaveValue('string');
+    await expect(editor.getByRole('table', { name: 'Enum values' })).toHaveCount(0);
+
+    await typeSelect.selectOption('enum');
+
+    await expect(editor.getByRole('table', { name: 'Enum values' })).toBeVisible();
+    await expect(editor.getByRole('textbox', { name: 'Enum value 1' })).toHaveValue('""');
+  });
+
+  test('selecting "Multiple types" seeds a starting array and reveals the checkbox row', async ({
+    page,
+  }) => {
+    const editor = await openFirstEditor(page);
+    await editor.getByRole('button', { name: 'Expand name property' }).click();
+
+    const typeSelect = editor.getByRole('combobox', { name: 'name type' });
+    await expect(editor.getByRole('checkbox', { name: 'string', exact: true })).toHaveCount(0);
+
+    await typeSelect.selectOption('multiple');
+
+    await expect(editor.getByRole('checkbox', { name: 'string', exact: true })).toBeChecked();
+    await expect(editor.getByRole('checkbox', { name: 'null', exact: true })).toBeChecked();
+
+    const jsonTab = editor.getByRole('tab', { name: /JSON/ });
+    await jsonTab.click();
+    await expect(editor.locator('textarea').first()).toHaveValue(/"type":\s*\[\s*"string",\s*"null"\s*\]/);
+  });
+
   test('exactly one enabled toolbar action is in the tab order at rest', async ({ page }) => {
     const editor = await openFirstEditor(page);
     const toolbarRight = editor.locator('.cinder-jse-toolbar__right').first();

--- a/packages/testing/tests/editors-complex-residual.playwright.ts
+++ b/packages/testing/tests/editors-complex-residual.playwright.ts
@@ -538,6 +538,38 @@ test.describe('JSON schema editor', () => {
     await expect(editor.locator('textarea').first()).toHaveValue(/"type":\s*\[\s*"string",\s*"null"\s*\]/);
   });
 
+  test('selecting "Multiple types" from an enum on an already multi-type schema preserves the existing types', async ({
+    page,
+  }) => {
+    const editor = await openFirstEditor(page);
+    const jsonTab = editor.getByRole('tab', { name: /JSON/ });
+    await jsonTab.click();
+    await editor
+      .locator('textarea')
+      .first()
+      .fill('{"type":"object","properties":{"code":{"type":["string","number"],"enum":["a",1]}}}');
+    await editor.getByRole('button', { name: 'Apply' }).click();
+
+    await editor.getByRole('tab', { name: /^Form/ }).click();
+    await editor.getByRole('button', { name: 'Expand code property' }).click();
+
+    const typeSelect = editor.getByRole('combobox', { name: 'code type' });
+    await expect(typeSelect).toHaveValue('enum');
+
+    await typeSelect.selectOption('multiple');
+
+    // Existing multi-type set survives — not reseeded to [base, 'null'].
+    await expect(editor.getByRole('checkbox', { name: 'string', exact: true })).toBeChecked();
+    await expect(editor.getByRole('checkbox', { name: 'number', exact: true })).toBeChecked();
+    await expect(editor.getByRole('checkbox', { name: 'null', exact: true })).not.toBeChecked();
+    await expect(editor.getByRole('table', { name: 'Enum values' })).toHaveCount(0);
+
+    await jsonTab.click();
+    await expect(editor.locator('textarea').first()).toHaveValue(
+      /"type":\s*\[\s*"string",\s*"number"\s*\]/,
+    );
+  });
+
   test('exactly one enabled toolbar action is in the tab order at rest', async ({ page }) => {
     const editor = await openFirstEditor(page);
     const toolbarRight = editor.locator('.cinder-jse-toolbar__right').first();


### PR DESCRIPTION
Summary:

- Add a `Select` to the property editor's Type section covering `string`/`number`/`integer`/`boolean`/`enum`/`object`/`array` plus `Any`.
- Add an explicit `Multiple types` option for states the select can't represent (a genuine multi-type array, or bare `null`) — selecting it seeds a starting `[type, 'null']` array and reveals the existing `PRIMITIVE_TYPES` checkbox row, so no expressiveness is lost.
- Selecting `enum` seeds `enum: ['']` and expands the enum table without touching `type` — same semantics as the removed "Enum values" checkbox.
- Remove the now-redundant "Enum values" checkbox.
- Rewrite the relevant a11y.md sections for the new control.

Closes CIN-156.

Testing note: the type-select interaction is covered by two new Playwright browser tests rather than happy-dom unit tests. Mounting the `Select` this deep inside `Table` + `PropertyEditor`'s conditional sections trips a documented happy-dom keyed-each reconciliation limitation on mount — it fails even for resting-state assertions that never touch the control. Verified manually in the browser (string → enum → multiple transitions, each producing correct JSON) in addition to the browser suite.

Validation:

- `bun run --filter=@lostgradient/cinder test -- property-list.test.ts enum-editor.test.ts json-schema-editor.test.ts json-schema-editor-state.svelte.test.ts json-schema-toolbar.test.ts json-schema-validator.test.ts composition-branch-keys.test.ts` — 142 pass
- `bun run --filter=@lostgradient/cinder typecheck` — 0 errors
- `bun run --filter=@lostgradient/cinder lint` — 0 errors
- `bun run --filter=@lostgradient/cinder components:check` — OK
- `bun run --filter=@cinder/testing test:playwright -- editors-complex-residual.playwright.ts --grep "JSON schema editor"` — 8/8 pass (includes 2 new type-selector tests)
- Manually verified in the browser: string→enum, enum→string, and →multiple transitions