### PR TITLE
fix(chat): settle atBottom correctly through content-visibility churn during scroll

### DIFF
--- a/.changeset/chat-scroll-content-visibility-churn.md
+++ b/.changeset/chat-scroll-content-visibility-churn.md
@@ -1,0 +1,11 @@
+---
+'@lostgradient/chat': patch
+---
+
+Fix `atBottom` sometimes settling wrong after `scrollToTop()`/`scrollToBottom()` when off-screen `.chat-message` rows use `content-visibility: auto` row virtualization and the animation runs long enough for rows to churn mid-flight (rows scrolled past re-collapse to their `contain-intrinsic-size` estimate, newly-visible rows expand to real height, shifting `scrollHeight` by hundreds of px while the scroll is in progress).
+
+Two asymmetries let that churn leave `atBottom` wrong at settlement: `scrollToBottom()` never went through `withUserScrollGuard`, so it had no `scrollend`-driven final geometry recompute — only the passive, rAF-batched `scroll` listener, which can lag or coalesce under load and never fire again after the last geometry change (this was ~80% of the observed failures). `scrollToTop()` did go through the guard but never forced layout for the animation's duration, so a `scrollend` arriving while bottom rows were transiently collapsed could read `scrollHeight <= clientHeight` — indistinguishable from a genuinely short transcript — and settle with `atBottom` stuck `true`.
+
+`scrollToBottom()` now routes through `withUserScrollGuard` (getting the same final recompute `scrollToTop`/`jumpToLatest` already had), and `scrollToTop()` now forces layout for its animation's duration (the same treatment `scrollToBottom`/`jumpToLatest` already had), so both paths hold rows at real height until they settle instead of racing content-visibility's collapse/expand churn.
+
+Reproduced deterministically in `use-chat-scroll-state.test.ts` by driving the hook's public API against a fake viewport whose `scrollHeight` getter models the churn (collapsed unless `data-cinder-force-visible` is set), rather than relying on a CI-timing-dependent real-browser repro — this is a layout-timing race that a real WebKit run only reproduced in ~20% of runs even under CI CPU pressure (0% locally), which is exactly the kind of flake a synthetic harness driving the actual code path under test can pin deterministically.

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -503,7 +503,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * Scroll to the bottom of the viewport.
    *
    * Routed through `withUserScrollGuard` (CIN-418) so it gets the same
-   * `scrollend`-driven final `recomputeAtBottomAtSettlement` that
+   * `scrollend`-driven final `recomputeFromViewport` that
    * `scrollToTop`/`jumpToLatest` already get. Without it, `atBottom` depended
    * solely on the passive `scroll` listener's rAF-batched recompute — under
    * `content-visibility: auto` row virtualization, off-screen rows collapse
@@ -719,7 +719,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
         // estimate as the scroll-to-top animation passes them, which can
         // shrink `scrollHeight` below `clientHeight` right as `scrollend`
         // fires — indistinguishable from a genuinely short transcript to
-        // `recomputeAtBottomAtSettlement`'s `isAtBottom` check, so the guard
+        // `recomputeFromViewport`'s `isAtBottom` check, so the guard
         // settled with `atBottom` stuck `true` instead of `false`.
         withForcedLayout(viewport, () => {
           viewport.scrollTo({ top: 0, behavior: getScrollBehavior() });

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -501,18 +501,31 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
 
   /**
    * Scroll to the bottom of the viewport.
+   *
+   * Routed through `withUserScrollGuard` (CIN-418) so it gets the same
+   * `scrollend`-driven final `recomputeAtBottomAtSettlement` that
+   * `scrollToTop`/`jumpToLatest` already get. Without it, `atBottom` depended
+   * solely on the passive `scroll` listener's rAF-batched recompute — under
+   * `content-visibility: auto` row virtualization, off-screen rows collapse
+   * to their `contain-intrinsic-size` estimate and newly-visible rows expand
+   * to real height continuously during the animation, which can shift
+   * `scrollHeight` by hundreds of px mid-flight and coalesce/lag the passive
+   * listener's last recompute under load (observed on CI WebKit, ~20% of
+   * runs). `withUserScrollGuard`'s own `scrollend` handler is the backstop
+   * that still recomputes from final geometry even if that happens.
    */
   function scrollToBottom(viewport: HTMLElement | null): void {
     if (!viewport) return;
-    // Supersede any stale guard from an earlier top-scroll (scrollToTop) that
-    // hasn't expired yet — this scroll's own target already matches what the
-    // auto-stick-to-bottom effect wants, so it needs no guard of its own, but
-    // an older guard left active would keep suppressing that effect's
-    // correction for messages appended after this call.
-    clearUserScrollGuard();
-    withForcedLayout(viewport, () => {
-      viewport.scrollTo({ top: viewport.scrollHeight, behavior: getScrollBehavior() });
-    });
+    withUserScrollGuard(
+      viewport,
+      () => {
+        withForcedLayout(viewport, () => {
+          viewport.scrollTo({ top: viewport.scrollHeight, behavior: getScrollBehavior() });
+        });
+      },
+      undefined,
+      () => viewport.scrollHeight,
+    );
   }
 
   /**
@@ -700,7 +713,17 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     withUserScrollGuard(
       viewport,
       () => {
-        viewport.scrollTo({ top: 0, behavior: getScrollBehavior() });
+        // Force layout for the duration of the animation (CIN-418), same
+        // treatment scrollToBottom/jumpToLatest already get. Without this,
+        // rows scrolled past re-collapse to their content-visibility
+        // estimate as the scroll-to-top animation passes them, which can
+        // shrink `scrollHeight` below `clientHeight` right as `scrollend`
+        // fires — indistinguishable from a genuinely short transcript to
+        // `recomputeAtBottomAtSettlement`'s `isAtBottom` check, so the guard
+        // settled with `atBottom` stuck `true` instead of `false`.
+        withForcedLayout(viewport, () => {
+          viewport.scrollTo({ top: 0, behavior: getScrollBehavior() });
+        });
       },
       undefined,
       // Destination: only a scrollend AT the top is this scroll's own

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -691,21 +691,37 @@ describe('useChatScrollState — isUserScrolling guard (regression for #774)', (
     expect(state.isUserScrolling).toBe(false);
   });
 
-  test('scrollToBottom supersedes a stale scrollToTop guard instead of leaving it to expire on its own schedule', () => {
-    // Regression guard (Codex review on #787): "Clear stale top-scroll guards
-    // before bottom jumps" — a bottom-directed jump whose own target already
-    // matches the auto-stick effect (so it needs no guard of its own) must
-    // still cancel an EARLIER guard from a top-scroll, or that stale guard
-    // keeps suppressing auto-stick corrections for messages appended after
-    // the user's intent already changed.
+  test('scrollToBottom supersedes a stale scrollToTop guard with its own, rather than leaving the old one to expire on its own schedule', () => {
+    // Regression guard (Codex review on #787), updated for CIN-418: a
+    // bottom-directed scroll must still cancel an EARLIER guard from a
+    // top-scroll, or that stale guard's own timer could clear
+    // `isUserScrolling` out from under the new scrollToBottom animation.
+    // Before CIN-418, scrollToBottom wasn't guarded at all, so superseding
+    // meant clearing to no-guard; scrollToBottom is now itself guarded (so
+    // it gets the same scrollend-driven final recompute scrollToTop/
+    // jumpToLatest already had), so superseding now means its OWN guard
+    // replaces the stale one — proven the same way the other overlapping-
+    // guard regressions in this file are: the OLDER session's original
+    // timer must not fire on its own schedule.
     jest.useFakeTimers();
     const state = useChatScrollState();
     const viewport = createViewport();
 
-    state.scrollToTop(viewport);
+    state.scrollToTop(viewport); // session A: backstop armed for ~500ms from t=0
     expect(state.isUserScrolling).toBe(true);
 
-    state.scrollToBottom(viewport);
+    jest.advanceTimersByTime(50);
+    state.scrollToBottom(viewport); // session B: backstop armed for ~500ms from t=50
+    expect(state.isUserScrolling).toBe(true);
+
+    // At t≈520ms: session A's original (500ms) deadline has passed, but
+    // session B's (550ms) has not. isUserScrolling must still be true —
+    // proving session A's timer was actually cancelled, not just racing.
+    jest.advanceTimersByTime(470);
+    expect(state.isUserScrolling).toBe(true);
+
+    // Session B's own timer eventually settles it.
+    jest.advanceTimersByTime(30);
     expect(state.isUserScrolling).toBe(false);
   });
 
@@ -842,5 +858,93 @@ describe('useChatScrollState — finishUserScrollGuard (regression for #1237)', 
 
     expect(() => jest.advanceTimersByTime(600)).not.toThrow();
     expect(state.isUserScrolling).toBe(false);
+  });
+});
+
+describe('useChatScrollState — content-visibility churn during scroll-to-top/bottom (CIN-418)', () => {
+  // CIN-418: off-screen `.chat-message` rows use `content-visibility: auto`
+  // with a `contain-intrinsic-size` estimate. When a scroll-to-top/bottom
+  // animation runs long enough (CI CPU pressure), rows scrolled past
+  // re-collapse to the estimate and rows newly in view expand to real height,
+  // shifting `scrollHeight` by hundreds of px mid-flight. Two asymmetries in
+  // the settle logic let that churn leave `atBottom` wrong at the end:
+  //
+  // 1. `scrollToBottom()` never went through `withUserScrollGuard`, so it had
+  //    no `scrollend`-driven final `recomputeAtBottomAtSettlement` — only the
+  //    passive, rAF-batched `scroll` listener, which can lag/coalesce under
+  //    load and never fire again after the last geometry change.
+  // 2. `scrollToTop()` went through the guard but never forced layout, so a
+  //    `scrollend` arriving while bottom rows are transiently collapsed
+  //    (content-visibility churn, not a genuinely short transcript) reads a
+  //    collapsed `scrollHeight <= clientHeight` and `isAtBottom` reports
+  //    "fits in viewport" — true — even though the real, expanded transcript
+  //    does not fit and the viewport is actually at the top.
+
+  test('scrollToBottom recomputes atBottom from final geometry after scrollend, not only from the passive scroll listener (regression for CIN-418)', () => {
+    // Reproduces the scrollToBottom side of CIN-418 deterministically: the
+    // animation's own scrollend is the last recompute opportunity if the
+    // final passive `scroll` tick doesn't survive rAF batching before it —
+    // exactly the CI-CPU-pressure scenario the diagnostic run observed
+    // (4/5 flakes were scrollToBottom, atBottom stuck false).
+    const state = useChatScrollState();
+    const viewport = createViewport(); // scrollTop 0, scrollHeight 2000, clientHeight 400
+    state.setAtBottom(false);
+
+    state.scrollToBottom(viewport);
+
+    // The animation actually reaches the bottom, but — simulating a
+    // coalesced/lagged passive scroll listener — no further 'scroll' event
+    // fires before 'scrollend'. Only a scrollend-driven recompute can catch
+    // this.
+    (viewport as { scrollTop: number }).scrollTop = 1600; // scrollHeight(2000) - clientHeight(400)
+    viewport.dispatchEvent(new Event('scrollend'));
+
+    expect(state.atBottom).toBe(true);
+  });
+
+  test('scrollToTop is unaffected by transient content-visibility collapse of bottom rows during the animation (regression for CIN-418)', () => {
+    // Reproduces the scrollToTop side of CIN-418: bottom rows collapse to
+    // their content-visibility estimate mid-scroll (scrollHeight briefly
+    // reads smaller than clientHeight — indistinguishable from a genuinely
+    // short transcript to `isAtBottom` unless layout is forced for the
+    // animation's duration, the same treatment scrollToBottom/jumpToLatest
+    // already get).
+    const state = useChatScrollState();
+    const viewport = document.createElement('div');
+    let churnCollapsed = false;
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get() {
+        // While layout is forced (data-cinder-force-visible set), every row
+        // is held at real height regardless of content-visibility churn —
+        // that's the mechanism under test. Only when the attribute is absent
+        // can a transient collapse be observed.
+        if (viewport.hasAttribute('data-cinder-force-visible')) return 2000;
+        return churnCollapsed ? 350 : 2000;
+      },
+    });
+    Object.defineProperty(viewport, 'scrollTop', {
+      value: 1600,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(viewport, 'clientHeight', { value: 400, configurable: true });
+    viewport.scrollTo = () => {};
+    document.body.appendChild(viewport);
+
+    state.scrollToTop(viewport);
+    expect(state.atBottom).toBe(false);
+
+    // Mid-animation content-visibility churn collapses the (now off-screen)
+    // bottom rows just as the animation reaches the top.
+    churnCollapsed = true;
+    (viewport as { scrollTop: number }).scrollTop = 0;
+    viewport.dispatchEvent(new Event('scrollend'));
+
+    // The transcript never actually got shorter than the viewport — this
+    // must not read as "fits in viewport, therefore at bottom".
+    expect(state.atBottom).toBe(false);
+
+    viewport.remove();
   });
 });

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -870,7 +870,7 @@ describe('useChatScrollState — content-visibility churn during scroll-to-top/b
   // the settle logic let that churn leave `atBottom` wrong at the end:
   //
   // 1. `scrollToBottom()` never went through `withUserScrollGuard`, so it had
-  //    no `scrollend`-driven final `recomputeAtBottomAtSettlement` — only the
+  //    no `scrollend`-driven final `recomputeFromViewport` — only the
   //    passive, rAF-batched `scroll` listener, which can lag/coalesce under
   //    load and never fire again after the last geometry change.
   // 2. `scrollToTop()` went through the guard but never forced layout, so a


### PR DESCRIPTION
## Summary
- CIN-418: `scrollToTop()`/`scrollToBottom()` in `@lostgradient/chat` could settle `atBottom` wrong when off-screen `.chat-message` rows use `content-visibility: auto` and the animation runs long enough for rows to churn mid-flight (scrollHeight shifting by hundreds of px while the scroll is in progress) — observed on real CI WebKit (Linux) at ~20% flake rate, not reproducible locally, and not a headless-DOM artifact.
- Two asymmetries: `scrollToBottom()` never went through `withUserScrollGuard` (no `scrollend`-driven final recompute — only the passive, rAF-batched `scroll` listener), and `scrollToTop()` went through the guard but never forced layout for the animation's duration (a `scrollend` arriving mid-churn could misread `scrollHeight <= clientHeight` as "fits in viewport").
- `scrollToBottom()` now routes through `withUserScrollGuard`; `scrollToTop()` now forces layout for its animation's duration — matching the treatment `jumpToLatest` already had on both counts.

## Test plan
- [x] Added two tests in `use-chat-scroll-state.test.ts` that drive the hook's public API against a fake viewport whose geometry models the content-visibility churn deterministically (no real-browser CI timing dependency).
- [x] Reverted the fix and re-ran: both new tests failed (red), confirming they're load-bearing.
- [x] Restored the fix: full `use-chat-scroll-state.test.ts` suite green (36 pass; 1 pre-existing unrelated flaky test confirmed independent via stash-test on unmodified `origin/main`).
- [x] `bun run test` (full monorepo, all packages): 10474 pass, 0 fail.
- [x] `bun run typecheck` (all packages): clean.
- [x] `bun run lint` (all packages): 0 errors (pre-existing unrelated warnings only).
- [x] `components:check`: OK.
- [x] Changeset added explaining the content-visibility interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)