### PR TITLE
fix(chat): make withUserScrollGuard the sole owner of releasing the forced-layout window (CIN-418, second round)

### DIFF
--- a/.changeset/chat-scroll-forced-layout-release-ownership.md
+++ b/.changeset/chat-scroll-forced-layout-release-ownership.md
@@ -1,0 +1,13 @@
+---
+'@lostgradient/chat': patch
+---
+
+Fix `scrollToTop()`/`scrollToBottom()`/`jumpToLatest()` still occasionally settling `atBottom` wrong after the `@lostgradient/chat@0.11.1` fix for this same symptom (CIN-418), confirmed on real GitHub Actions WebKit CI: `scrollToTop()` failed roughly 20/30 repeats even after that release.
+
+That release made `withForcedLayout`'s `data-cinder-force-visible` window span the whole animation, restoring itself off its own `scrollend` listener with a scroll-quiet timeout backstop. The listener had no destination check, so a **stale** `scrollend` — the tail end of an unrelated, still-settling scroll session (most commonly a mount-time auto-scroll-to-bottom whose `scrollend` was still in flight when a `scrollToTop()` call followed immediately after) — was indistinguishable from the session's own animation completing, and stripped the attribute a few frames into the real animation instead of holding it for the animation's actual duration. Content-visibility churn then resumed mid-flight, WebKit stalled the animation part-way under CI CPU pressure, and the enclosing `withUserScrollGuard` session's settlement logic (which IS destination-aware and stale-event-safe, per #1236) read final geometry against a viewport that never reached its target — landing on the wrong `atBottom`. Measured: `data-cinder-force-visible` was observed present immediately after a `scrollToTop()` click in only ~1/6 of real CI runs.
+
+Ownership of releasing the attribute now belongs solely to the enclosing `withUserScrollGuard` session — its existing destination-aware, stale-event-safe settlement (`settle()`, plus `finishUserScrollGuard`/`clearUserScrollGuard`/`destroy`) is what releases it, not a second, independent listener inside `withForcedLayout` with no way to tell a stale event from its own completion. `withForcedLayout` now only applies the attribute and forces the initial layout; it no longer arms any listener or timer of its own.
+
+Pinned in `use-chat-scroll-state.test.ts` by reproducing the exact race: a guarded `scrollToTop()` session receives a `scrollend` away from its destination (a stale event) and the attribute must survive it, released only by the session's own genuine settlement, its scroll-quiet backstop, or an explicit `finishUserScrollGuard`/`clearUserScrollGuard`/`destroy`. Verified red against the reverted (0.11.1-shipped) implementation and green with the fix.
+
+As with the previous round, the synthetic unit harness is necessary but not sufficient evidence here — this is a real-CI-timing race a synthetic fake-viewport test can pin the _mechanism_ of but not the flake rate. Confirm the actual failure-rate drop against real GitHub Actions WebKit before treating this as closed.

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -248,15 +248,21 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
   // re-read its target geometry at settlement so callback ordering cannot
   // replay a stale intersection snapshot.
   let pendingSentinelEntry: IntersectionObserverEntry | null = null;
-  // Cancel function for the in-flight withForcedLayout session, if any. A new
-  // session cancels the previous one's listeners/timer before starting its
-  // own — see withForcedLayout below for why this matters.
-  let activeForcedLayoutCancel: (() => void) | null = null;
+  // Release function for the currently-applied forced-layout attribute, if
+  // any. Ownership of WHEN this fires belongs to the enclosing
+  // `withUserScrollGuard` session (its `settle`/`finishUserScrollGuard`/
+  // `clearUserScrollGuard`/`destroy`), not to `withForcedLayout` itself — see
+  // withForcedLayout below for why a self-restoring `scrollend` listener was
+  // unsafe (CIN-418, second round).
+  let activeForcedLayoutRelease: (() => void) | null = null;
   // Cancel function for the in-flight withUserScrollGuard session, if any. A
-  // new session cancels the previous one's timer before starting its own —
-  // same rationale as activeForcedLayoutCancel: without it, an earlier
-  // overlapping guarded scroll's timer could flip isUserScrolling back to
-  // false while a later guarded scroll's animation is still in progress.
+  // new session cancels the previous one's timer before starting its own:
+  // without it, an earlier overlapping guarded scroll's timer could flip
+  // isUserScrolling back to false while a later guarded scroll's animation is
+  // still in progress. Note this deliberately does NOT release
+  // activeForcedLayoutRelease — a superseding session reuses/re-applies the
+  // same forced-layout window on the same viewport rather than tearing it
+  // down and reapplying it.
   let activeUserScrollGuardCancel: (() => void) | null = null;
   let activeUserScrollViewport: HTMLElement | null = null;
   // Where the in-flight guarded scroll is headed, when its initiator declared
@@ -426,8 +432,9 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
 
   /**
    * Forces every row to lay out at its real height before a programmatic
-   * scroll-to-bottom, then restores the content-visibility optimization once
-   * the scroll settles.
+   * scroll, for the caller's `withUserScrollGuard` session to release once
+   * ITS settlement logic (not this function's own timers) decides the
+   * animation is really done.
    *
    * Off-screen `.chat-message` rows use `content-visibility: auto` with a
    * 180px estimate (`contain-intrinsic-size`) until they're painted. Calling
@@ -435,66 +442,50 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * target computed from those estimates; as the animation scrolls estimated
    * rows into view, they resize to their real height, which shifts content
    * under the fixed pixel target mid-flight — visible as a jerk right as the
-   * scroll finishes. Forcing layout up front (`data-cinder-force-visible`)
-   * makes the target accurate from the start.
+   * scroll finishes, and (CIN-418) a `scrollHeight` that can read back below
+   * `clientHeight` right as the guard settles, misread as "short transcript,
+   * already at the bottom". Forcing layout up front
+   * (`data-cinder-force-visible`) makes both the initial target and every
+   * later geometry read accurate.
    *
-   * The `scrollend` listener restores the optimization as soon as the
-   * animation actually finishes. The timeout is a backstop for environments
-   * without `scrollend` support and for a zero-distance scroll (already at
-   * the bottom), where neither `scroll` nor `scrollend` ever fires — but it
-   * re-arms on every `scroll` tick rather than firing once on a fixed clock,
-   * so a scroll animation that legitimately runs longer than the backstop
-   * duration (a long transcript, a slower device) can never have the
-   * optimization restored out from under it mid-flight, which would let
-   * off-screen rows resize again before the scroll settles — the exact jerk
-   * this exists to prevent.
+   * This function used to restore the optimization itself, on its own
+   * `scrollend` listener with a scroll-quiet timeout backstop. That was
+   * CIN-418's actual bug (confirmed against real GitHub Actions WebKit,
+   * where the synthetic fake-viewport unit harness below did not reproduce
+   * it): a *stale* `scrollend` — the tail of an unrelated, still-in-flight
+   * scroll session, e.g. a mount-time auto-scroll-to-bottom still settling
+   * when a `scrollToTop()` call fires immediately after — is exactly the
+   * kind of event this listener could not distinguish from its own
+   * animation's completion, because it had no destination check and no
+   * staleness handling the way `withUserScrollGuard`'s own `scrollend`
+   * listener does. `{ once: true }` meant it fired at most once and then
+   * stayed fired: the attribute would get stripped a few frames into the
+   * REAL animation, un-forced `content-visibility: auto` churn would resume
+   * mid-flight, WebKit would stall the animation part-way under CI CPU
+   * pressure, and the guard's own (correct, destination-aware) settlement
+   * logic would then read final geometry against a still-estimated
+   * `scrollHeight` and land on the wrong `atBottom`. Measured: the attribute
+   * was observed present immediately after a `scrollToTop()` click in only
+   * ~1/6 of real CI runs.
    *
-   * A second call before the first session settles (e.g. a double-click on
-   * jump-to-latest, or auto-scroll firing while a prior scroll is still in
-   * flight) cancels the earlier session's listeners/timer first. Without
-   * this, the OLDER session's own scrollend/backstop could still fire and
-   * strip the attribute while the NEWER scroll animation is still running —
-   * the same jerk this whole mechanism exists to prevent, just reintroduced
-   * by an overlapping call instead of a single long one.
+   * There is now exactly one settlement authority — the enclosing guard —
+   * and exactly one release path per session, so a stale event from a
+   * DIFFERENT session can no longer strip this one's forced-layout window.
+   * A caller that applies this more than once within the same guard session
+   * (e.g. `withUserScrollGuard`'s bottom-grew re-issue) is idempotent: the
+   * attribute is already set, and this just re-forces layout for the new
+   * target.
    */
   function withForcedLayout(viewport: HTMLElement, scroll: () => void): void {
-    activeForcedLayoutCancel?.();
-
     viewport.setAttribute('data-cinder-force-visible', '');
     // Force a synchronous layout so scrollHeight (read inside `scroll`)
     // reflects every row's real height, not the content-visibility estimate.
     void viewport.offsetHeight;
 
-    let settled = false;
-    let backstop: ReturnType<typeof setTimeout>;
-    const backstopDuration = reducedMotion.current ? 50 : 500;
-
-    function cancel() {
-      if (settled) return;
-      settled = true;
-      clearTimeout(backstop);
-      viewport.removeEventListener('scrollend', restore);
-      viewport.removeEventListener('scroll', armBackstop);
-    }
-
-    const restore = () => {
-      if (settled) return;
-      cancel();
-      activeForcedLayoutCancel = null;
+    activeForcedLayoutRelease = () => {
+      activeForcedLayoutRelease = null;
       viewport.removeAttribute('data-cinder-force-visible');
     };
-
-    function armBackstop() {
-      clearTimeout(backstop);
-      backstop = setTimeout(restore, backstopDuration);
-    }
-
-    activeForcedLayoutCancel = cancel;
-    viewport.addEventListener('scrollend', restore, { once: true });
-    viewport.addEventListener('scroll', armBackstop, { passive: true });
-    // Covers the zero-distance case (already at bottom): no scroll/scrollend
-    // event will ever fire, so this is the only thing that restores it.
-    armBackstop();
 
     scroll();
   }
@@ -590,7 +581,14 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
       // listener's next rAF recompute can re-fire the auto-stick effect
       // against a stale `atBottom: true` and yank a just-completed top-scroll
       // back to the bottom (#1236).
+      //
+      // Read geometry BEFORE releasing any forced-layout window this session
+      // applied (CIN-418): releasing first snaps `scrollHeight` back to the
+      // content-visibility estimate for whichever rows have since scrolled
+      // off-screen, reintroducing the exact stale-geometry misread this
+      // settlement exists to avoid.
       recomputeFromViewport(viewport);
+      activeForcedLayoutRelease?.();
       applyPendingSentinelEntry(viewport);
       onSettled?.();
     }
@@ -666,6 +664,11 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     activeUserScrollViewport = null;
     activeUserScrollGuardDestination = null;
     isUserScrolling = false;
+    // Release any forced-layout window this (now-cleared) session held. A
+    // no-op for the virtualized callers of this method, which never apply
+    // forced layout in the first place; guards this method against leaving
+    // `data-cinder-force-visible` stuck on the non-virtualized path too.
+    activeForcedLayoutRelease?.();
     applyPendingSentinelEntry(viewport);
   }
 
@@ -678,7 +681,10 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
     if (activeUserScrollGuardCancel === null) return false;
     const viewport = activeUserScrollViewport;
     const destination = activeUserScrollGuardDestination;
-    clearUserScrollGuard();
+    // Read/apply the destination BEFORE clearing: `clearUserScrollGuard`
+    // releases this session's forced-layout window (CIN-418), which would
+    // snap `scrollHeight` back to the content-visibility estimate and make a
+    // bottom-directed `destination()` read short.
     if (viewport) {
       // Either way this instant scroll aborts the browser's in-flight
       // smooth-scroll animation; with a declared destination it also lands
@@ -688,6 +694,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
         behavior: 'instant',
       });
     }
+    clearUserScrollGuard();
     return true;
   }
 
@@ -768,8 +775,7 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * `UseChatScrollStateReturn.destroy` for details.
    */
   function destroy(): void {
-    activeForcedLayoutCancel?.();
-    activeForcedLayoutCancel = null;
+    activeForcedLayoutRelease?.();
     activeUserScrollGuardCancel?.();
     activeUserScrollGuardCancel = null;
     activeUserScrollViewport = null;

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.svelte.ts
@@ -249,12 +249,19 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
   // replay a stale intersection snapshot.
   let pendingSentinelEntry: IntersectionObserverEntry | null = null;
   // Release function for the currently-applied forced-layout attribute, if
-  // any. Ownership of WHEN this fires belongs to the enclosing
-  // `withUserScrollGuard` session (its `settle`/`finishUserScrollGuard`/
-  // `clearUserScrollGuard`/`destroy`), not to `withForcedLayout` itself — see
-  // withForcedLayout below for why a self-restoring `scrollend` listener was
-  // unsafe (CIN-418, second round).
+  // any, and the viewport it applies to. Ownership of WHEN release fires
+  // belongs to the enclosing `withUserScrollGuard` session (its
+  // `settle`/`finishUserScrollGuard`/`clearUserScrollGuard`/`destroy`), not
+  // to `withForcedLayout` itself — see withForcedLayout below for why a
+  // self-restoring `scrollend` listener was unsafe (CIN-418, second round).
+  // Tracking the viewport alongside the release matters because this state
+  // is a single slot, not per-viewport: if `withForcedLayout` is ever called
+  // for a DIFFERENT viewport than the one currently holding a forced-layout
+  // window (this hook's public API accepts a viewport per call; nothing
+  // enforces a single instance's calls all target the same element), simply
+  // overwriting the slot would leak the older viewport's attribute forever.
   let activeForcedLayoutRelease: (() => void) | null = null;
+  let activeForcedLayoutViewport: HTMLElement | null = null;
   // Cancel function for the in-flight withUserScrollGuard session, if any. A
   // new session cancels the previous one's timer before starting its own:
   // without it, an earlier overlapping guarded scroll's timer could flip
@@ -477,13 +484,23 @@ export function useChatScrollState(options?: UseChatScrollStateOptions): UseChat
    * target.
    */
   function withForcedLayout(viewport: HTMLElement, scroll: () => void): void {
+    // A forced-layout window already active for a DIFFERENT viewport would
+    // otherwise have its release closure silently overwritten below, leaking
+    // its `data-cinder-force-visible` attribute with nothing left to remove
+    // it. Release it now, before applying to the new viewport.
+    if (activeForcedLayoutViewport !== null && activeForcedLayoutViewport !== viewport) {
+      activeForcedLayoutRelease?.();
+    }
+
     viewport.setAttribute('data-cinder-force-visible', '');
     // Force a synchronous layout so scrollHeight (read inside `scroll`)
     // reflects every row's real height, not the content-visibility estimate.
     void viewport.offsetHeight;
 
+    activeForcedLayoutViewport = viewport;
     activeForcedLayoutRelease = () => {
       activeForcedLayoutRelease = null;
+      activeForcedLayoutViewport = null;
       viewport.removeAttribute('data-cinder-force-visible');
     };
 

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -79,6 +79,9 @@ describe('useChatScrollState — withForcedLayout release ownership (CIN-418, se
     const viewport = createViewport();
     state.scrollToBottom(viewport);
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
+    // Clean up the in-flight guard explicitly rather than leaving its 500ms
+    // real-timer backstop to fire after this test completes.
+    state.destroy();
     viewport.remove();
   });
 
@@ -158,6 +161,30 @@ describe('useChatScrollState — withForcedLayout release ownership (CIN-418, se
     (viewport as { scrollTop: number }).scrollTop = 0;
     viewport.dispatchEvent(new Event('scrollend'));
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
+  });
+
+  test('a forced-layout window on one viewport does not leak when a later call forces a DIFFERENT viewport', () => {
+    // Regression guard (Copilot review, PR #1374): the release closure lives
+    // in a single slot, not one per viewport. Overwriting it unconditionally
+    // for a different viewport would leave the FIRST viewport's attribute
+    // stuck forever, since nothing would remove it once its own closure is
+    // gone. A single hook instance shouldn't normally be driven against two
+    // different viewports, but nothing in the public API prevents it, and
+    // this must not silently leak `data-cinder-force-visible` if it happens.
+    const state = useChatScrollState();
+    const viewportA = createViewport();
+    const viewportB = createViewport();
+
+    state.scrollToBottom(viewportA);
+    expect(viewportA.hasAttribute('data-cinder-force-visible')).toBe(true);
+
+    state.scrollToBottom(viewportB);
+    expect(viewportA.hasAttribute('data-cinder-force-visible')).toBe(false);
+    expect(viewportB.hasAttribute('data-cinder-force-visible')).toBe(true);
+
+    state.destroy();
+    viewportA.remove();
+    viewportB.remove();
   });
 
   test('destroy releases an in-flight forced-layout window', () => {

--- a/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
+++ b/packages/chat/src/lib/components/chat/container/use-chat-scroll-state.test.ts
@@ -1,12 +1,21 @@
 /**
  * Tests for use-chat-scroll-state.svelte.ts.
  *
- * Focused on the withForcedLayout backstop timing (private helper, exercised
- * through scrollToBottom): a scroll animation that runs LONGER than the
- * backstop duration must never have data-cinder-force-visible restored out
- * from under it mid-flight — that would re-enable content-visibility:auto on
- * off-screen rows before the scroll settles, reproducing the exact jerk the
- * mechanism exists to prevent.
+ * The `withForcedLayout — release ownership (CIN-418, second round)` describe
+ * block below is focused on WHO releases `data-cinder-force-visible` and
+ * WHEN. Release used to be `withForcedLayout`'s own responsibility, armed on
+ * its own `scrollend` listener with a scroll-quiet timeout backstop — that
+ * listener had no destination check, so a STALE `scrollend` from an
+ * unrelated, still-settling scroll session (e.g. a mount-time auto-scroll
+ * whose tail is still in flight when `scrollToTop()` is called immediately
+ * after) would strip the attribute a few frames into the real animation,
+ * long before it actually finished. Confirmed against real GitHub Actions
+ * WebKit: the attribute was observed present immediately after a
+ * `scrollToTop()` click in only ~1/6 of runs. Release now belongs solely to
+ * the enclosing `withUserScrollGuard` session, which already has correct,
+ * destination-aware staleness handling (#1236) — these tests pin that a
+ * stale scrollend can no longer strip the attribute, and that the genuine
+ * one still does.
  */
 
 /// <reference lib="dom" />
@@ -64,101 +73,148 @@ function createIntersectionObserverEntry(
   };
 }
 
-describe('useChatScrollState — withForcedLayout backstop', () => {
-  test('sets data-cinder-force-visible for the duration of scrollToBottom', () => {
+describe('useChatScrollState — withForcedLayout release ownership (CIN-418, second round)', () => {
+  test('sets data-cinder-force-visible synchronously for a scrollToBottom call', () => {
     const state = useChatScrollState();
     const viewport = createViewport();
     state.scrollToBottom(viewport);
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
-    viewport.dispatchEvent(new Event('scrollend'));
     viewport.remove();
   });
 
-  test('a scrollend event removes data-cinder-force-visible immediately', () => {
+  test('a STALE scrollend (not at the guard destination) does not strip the attribute — the CIN-418 race', () => {
+    // Reproduces the mechanism confirmed against real GitHub Actions WebKit:
+    // an unrelated scroll session's tail-end scrollend (e.g. a mount-time
+    // auto-scroll-to-bottom still settling) arrives while THIS session's
+    // forced-layout window is active. Before the fix, withForcedLayout's own
+    // `scrollend` listener had no destination check, so it could not tell
+    // this apart from its own animation completing and stripped the
+    // attribute regardless — measured present in only ~1/6 of real runs.
     const state = useChatScrollState();
-    const viewport = createViewport();
-    state.scrollToBottom(viewport);
+    const viewport = createViewport(); // scrollTop 0, scrollHeight 2000, clientHeight 400
+    (viewport as { scrollTop: number }).scrollTop = 1600;
+
+    state.scrollToTop(viewport); // destination: 0
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
+
+    // Stale scrollend from an unrelated, still-settling session — the
+    // viewport hasn't actually moved toward the top yet.
+    viewport.dispatchEvent(new Event('scrollend'));
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
+    expect(state.isUserScrolling).toBe(true);
+
+    // The real animation reaches the top; its OWN scrollend both settles the
+    // guard and releases the forced-layout window it was holding.
+    (viewport as { scrollTop: number }).scrollTop = 0;
     viewport.dispatchEvent(new Event('scrollend'));
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
-    viewport.remove();
+    expect(state.isUserScrolling).toBe(false);
   });
 
-  test('repeated scroll ticks past the backstop duration keep it set (no premature restore mid-animation)', () => {
-    jest.useFakeTimers();
+  test('a genuine scrollend at the destination releases the attribute', () => {
     const state = useChatScrollState();
     const viewport = createViewport();
     state.scrollToBottom(viewport);
-
-    // Simulate an animation still actively progressing well past the 500ms
-    // non-reduced-motion backstop duration: a scroll tick every 90ms for
-    // 630ms. Each tick re-arms the backstop before the current arm can fire,
-    // so it must never restore the optimization while ticks keep arriving.
-    for (let i = 0; i < 7; i++) {
-      jest.advanceTimersByTime(90);
-      viewport.dispatchEvent(new Event('scroll'));
-      expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
-    }
+    (viewport as { scrollTop: number }).scrollTop = 1600; // scrollHeight(2000) - clientHeight(400)
+    viewport.dispatchEvent(new Event('scrollend'));
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
   });
 
-  test('once scroll ticks stop arriving, the backstop eventually restores it', () => {
+  test('the scroll-quiet backstop still releases the attribute when no scrollend ever arrives at the destination', () => {
+    // A cancelled or never-completing animation must not leave the
+    // attribute (and the content-visibility override it forces) stuck
+    // forever. The guard's own scroll-quiet backstop is the fallback here,
+    // same as it already is for isUserScrolling — this is the ONE place
+    // release still happens off a timer, and it's the guard's timer, not a
+    // separate one withForcedLayout arms for itself.
     jest.useFakeTimers();
     const state = useChatScrollState();
-    const viewport = createViewport();
+    const viewport = createViewport(); // scrollTo is a no-op stub — scrollTop never moves
     state.scrollToBottom(viewport);
-    viewport.dispatchEvent(new Event('scroll'));
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
 
-    // No further ticks — the backstop (500ms, non-reduced-motion) should fire.
     jest.advanceTimersByTime(499);
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
     jest.advanceTimersByTime(1);
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
   });
 
-  test('a zero-distance scroll (already at bottom, no scroll/scrollend events) still restores via the backstop', () => {
+  test('an overlapping scrollToTop supersedes a still-forced scrollToBottom session and keeps the attribute set throughout', () => {
+    // The successor session reuses the same forced-layout window rather than
+    // tearing it down and reapplying it — the attribute must never flicker
+    // off between the two calls, only the successor's own settlement
+    // releases it.
     jest.useFakeTimers();
     const state = useChatScrollState();
     const viewport = createViewport();
+
     state.scrollToBottom(viewport);
-    // No events dispatched at all — only the initial backstop arm can save us.
-    jest.advanceTimersByTime(499);
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
-    jest.advanceTimersByTime(1);
-    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
-  });
 
-  test('a second scrollToBottom before the first settles cancels the first session (no premature restore from the stale backstop)', () => {
-    jest.useFakeTimers();
-    // Regression guard: overlapping calls (e.g. a double-click on jump-to-
-    // latest, or auto-scroll firing mid-animation) used to leave the OLDER
-    // session's listeners/backstop live. When the OLDER session's backstop
-    // fired on its own original schedule, it stripped the attribute even
-    // though the NEWER session's own (later) backstop hadn't fired yet.
-    //
-    // No scroll ticks are dispatched here deliberately: re-arming would mask
-    // the bug, since (without the fix) a tick re-arms BOTH sessions'
-    // listeners identically and neither timer ever gets to fire on its own.
-    // This test instead lets each session's timer run to its own deadline
-    // untouched, so only the fix (cancelling the older session outright)
-    // prevents the stale one from firing.
-    const state = useChatScrollState();
-    const viewport = createViewport();
-
-    state.scrollToBottom(viewport); // session A: backstop armed for ~500ms from t=0
     jest.advanceTimersByTime(50);
-    state.scrollToBottom(viewport); // session B: backstop armed for ~500ms from t=50
-
-    // At t≈520ms: session A's original (500ms) deadline has passed, but
-    // session B's (550ms) has not. The attribute must still be present —
-    // proving session A's backstop was actually cancelled, not just racing.
-    jest.advanceTimersByTime(470);
+    state.scrollToTop(viewport); // supersedes the bottom session; still forced
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
 
-    // Session B's own backstop eventually fires and restores it.
-    jest.advanceTimersByTime(29);
-    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
-    jest.advanceTimersByTime(1);
+    (viewport as { scrollTop: number }).scrollTop = 0;
+    viewport.dispatchEvent(new Event('scrollend'));
     expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
+  });
+
+  test('destroy releases an in-flight forced-layout window', () => {
+    const state = useChatScrollState();
+    const viewport = createViewport();
+    state.scrollToBottom(viewport);
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
+    state.destroy();
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
+  });
+
+  test('clearUserScrollGuard releases an in-flight forced-layout window', () => {
+    const state = useChatScrollState();
+    const viewport = createViewport();
+    state.scrollToTop(viewport);
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(true);
+    state.clearUserScrollGuard();
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
+  });
+
+  test('finishUserScrollGuard reads the destination against forced (real) geometry, then releases the attribute', () => {
+    // Regression guard: releasing the forced-layout window BEFORE reading
+    // the declared destination would snap scrollHeight back to the
+    // content-visibility estimate and make a bottom-directed destination()
+    // read short.
+    const state = useChatScrollState();
+    const viewport = document.createElement('div');
+    Object.defineProperty(viewport, 'scrollTop', {
+      value: 0,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(viewport, 'clientHeight', { value: 400, configurable: true });
+    Object.defineProperty(viewport, 'scrollHeight', {
+      configurable: true,
+      get() {
+        // Only the real (forced) height while the attribute is set — the
+        // content-visibility estimate otherwise.
+        return viewport.hasAttribute('data-cinder-force-visible') ? 2000 : 350;
+      },
+    });
+    const scrollCalls: number[] = [];
+    viewport.scrollTo = ((options?: ScrollToOptions | number) => {
+      const top = typeof options === 'number' ? options : (options?.top ?? 0);
+      scrollCalls.push(top);
+      (viewport as { scrollTop: number }).scrollTop = top;
+    }) as typeof viewport.scrollTo;
+    document.body.appendChild(viewport);
+
+    state.jumpToLatest(viewport);
+    expect(scrollCalls).toEqual([2000]);
+
+    state.finishUserScrollGuard();
+    expect(scrollCalls.at(-1)).toBe(2000);
+    expect(viewport.hasAttribute('data-cinder-force-visible')).toBe(false);
+
+    viewport.remove();
   });
 });
 


### PR DESCRIPTION
## Summary

CIN-418 was reopened: the `@lostgradient/chat@0.11.1` fix (#1373) did not actually fix the real CI-observed failure — chatroom's real-CI diagnostic (30-repeat runs on GitHub Actions WebKit) showed `scrollToTop()` still failing at essentially the same rate after that release.

An iteration-attributed diagnostic run captured the actual mechanism: `withForcedLayout`'s `data-cinder-force-visible` window was restoring itself off its own `scrollend` listener (with a scroll-quiet timeout backstop), and that listener had no destination check. A **stale** `scrollend` from an unrelated, still-settling scroll session (most commonly a mount-time auto-scroll-to-bottom whose tail was still in flight when `scrollToTop()` fired immediately after) was indistinguishable from the session's own animation completing, so the attribute was stripped a few frames into the real animation instead of held for its actual duration. `data-cinder-force-visible` was observed present immediately after a `scrollToTop()` click in only ~1/6 of real CI runs.

- `withForcedLayout` no longer arms any listener or timer of its own — it only applies the attribute and forces the initial layout.
- Releasing the attribute is now solely the job of the enclosing `withUserScrollGuard` session's existing destination-aware, stale-event-safe settlement (`settle()`), plus `finishUserScrollGuard`/`clearUserScrollGuard`/`destroy` for the other ways a guarded session ends — the same settlement logic #1236 already made correct for `isUserScrolling`.
- Reordered `finishUserScrollGuard` to read/apply its declared destination *before* clearing the guard (which now releases forced layout), so a bottom-directed destination is still computed against real (forced), not content-visibility-estimated, geometry.

## Test plan

- [x] New regression test reproduces the exact race (a stale `scrollend` away from the guard's destination must not strip the attribute) — verified **red** against the reverted 0.11.1-shipped implementation, **green** with the fix.
- [x] Extended/rewrote the rest of the `withForcedLayout` test describe block for the new single-owner release model (genuine-scrollend release, scroll-quiet-backstop release, overlapping-session hold-through, `destroy`/`clearUserScrollGuard`/`finishUserScrollGuard` release paths).
- [x] Full `@lostgradient/chat` suite: 798/798 passing.
- [x] `typecheck` and `lint` clean.
- [ ] **Not yet verified against real CI** — per CIN-418's own history, the synthetic fake-viewport harness passed for the *previous* fix too and that did not hold up on real GitHub Actions WebKit. The chatroom-side session will re-run the real-CI diagnostic (`--repeat-each=30` on webkit-5) once this is published, and that result — not this synthetic suite — is the actual release gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)