### PR TITLE
Fix Playground preview contracts and overlay fallbacks

### DIFF
--- a/packages/playground/src/component-page-playground.test.ts
+++ b/packages/playground/src/component-page-playground.test.ts
@@ -188,6 +188,131 @@ describe('buildPlaygroundModel', () => {
     expect(model.skipped).toEqual(['children']);
   });
 
+  test('uses a contract-valid BarChart preview seed instead of disconnected generic values', () => {
+    const model = buildPlaygroundModel({
+      ...manifest([
+        {
+          name: 'data',
+          control: {
+            kind: 'array',
+            rawType: 'BarChartDatum[]',
+            element: { fields: [], degenerate: true },
+          },
+          bindable: false,
+          optional: false,
+        },
+        { name: 'categoryKey', control: { kind: 'text' }, bindable: false, optional: false },
+        {
+          name: 'series',
+          control: {
+            kind: 'array',
+            rawType: 'BarChartSeries[]',
+            element: { fields: [], degenerate: true },
+          },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+      name: 'Bar chart',
+      kebabName: 'bar-chart',
+    });
+
+    expect(model.controls).toContainEqual(
+      expect.objectContaining({ name: 'categoryKey', value: 'month' }),
+    );
+    expect(model.seeds.map(({ name, value }) => ({ name, value }))).toEqual([
+      {
+        name: 'data',
+        value: [
+          { month: 'January', revenue: 42 },
+          { month: 'February', revenue: 58 },
+          { month: 'March', revenue: 73 },
+        ],
+      },
+      {
+        name: 'series',
+        value: [{ id: 'revenue', label: 'Revenue', valueKey: 'revenue' }],
+      },
+    ]);
+  });
+
+  test('uses stable DataTable row identities in its explicit preview seed', () => {
+    const model = buildPlaygroundModel({
+      ...manifest([
+        {
+          name: 'columns',
+          control: {
+            kind: 'array',
+            rawType: 'DataTableColumn[]',
+            element: { fields: [], degenerate: true },
+          },
+          bindable: false,
+          optional: false,
+        },
+        {
+          name: 'rows',
+          control: {
+            kind: 'array',
+            rawType: 'DataTableRow[]',
+            element: { fields: [], degenerate: true },
+          },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+      name: 'Data table',
+      kebabName: 'data-table',
+    });
+
+    expect(model.seeds.map(({ name, value }) => ({ name, value }))).toEqual([
+      {
+        name: 'columns',
+        value: [
+          { key: 'name', label: 'Name', rowHeader: true },
+          { key: 'role', label: 'Role' },
+        ],
+      },
+      {
+        name: 'rows',
+        value: [
+          { id: 'ada', name: 'Ada Lovelace', role: 'Engineer' },
+          { id: 'grace', name: 'Grace Hopper', role: 'Admiral' },
+        ],
+      },
+    ]);
+  });
+
+  test('uses complete shortcut entries in the KeyboardShortcuts preview seed', () => {
+    const model = buildPlaygroundModel({
+      ...manifest([
+        {
+          name: 'groups',
+          control: {
+            kind: 'array',
+            rawType: 'KeyboardShortcutGroup[]',
+            element: { fields: [], degenerate: true },
+          },
+          bindable: false,
+          optional: false,
+        },
+      ]),
+      name: 'Keyboard shortcuts',
+      kebabName: 'keyboard-shortcuts',
+    });
+
+    expect(model.seeds.map(({ name, value }) => ({ name, value }))).toEqual([
+      {
+        name: 'groups',
+        value: [
+          {
+            label: 'General',
+            shortcuts: [{ action: 'Open command palette', keys: ['Meta', 'K'] }],
+          },
+        ],
+      },
+    ]);
+  });
+
   test('a non-children snippet prop stays non-adjustable (skipped)', () => {
     const model = buildPlaygroundModel(
       manifest([{ name: 'header', control: { kind: 'snippet' }, bindable: false, optional: true }]),
@@ -238,6 +363,10 @@ describe('buildPlaygroundModel', () => {
   test.each([
     ['Autocomplete', 'autocomplete', '@lostgradient/cinder/autocomplete'],
     ['Spectrogram', 'spectrogram', '@lostgradient/cinder/spectrogram'],
+    ['Backdrop', 'backdrop', '@lostgradient/cinder/backdrop'],
+    ['Alert dialog', 'alert-dialog', '@lostgradient/cinder/alert-dialog'],
+    ['Confirm dialog', 'confirm-dialog', '@lostgradient/cinder/confirm-dialog'],
+    ['Command menu', 'command-menu', '@lostgradient/cinder/command-menu'],
   ])(
     'marks %s as example-only when behavior needs authored examples',
     (name, kebabName, importPath) => {

--- a/packages/playground/src/component-page-playground.ts
+++ b/packages/playground/src/component-page-playground.ts
@@ -199,6 +199,13 @@ export type PlaygroundModel = {
 const EXAMPLE_ONLY_PLAYGROUND_COMPONENTS = new Set([
   'autocomplete',
   'spectrogram',
+  // These closed-by-default overlays need state, anchors, or callbacks that a
+  // bare mount cannot supply. Their authored examples provide the real working
+  // interaction instead of an empty stage.
+  'alert-dialog',
+  'backdrop',
+  'command-menu',
+  'confirm-dialog',
   'modal',
   'drawer',
   'popover',
@@ -253,6 +260,10 @@ function stringDefault(value: unknown): string {
  * diff because `patch` was the literal string "patch".
  */
 const COMPONENT_TEXT_SEEDS: Readonly<Record<string, Readonly<Record<string, string>>>> = {
+  'bar-chart': {
+    // The category key must name a property that actually exists on each datum.
+    categoryKey: 'month',
+  },
   image: {
     // An inline SVG data URI rather than a remote placeholder service: the docs
     // site ships no image assets, and the examples already use this pattern
@@ -288,6 +299,32 @@ const COMPONENT_TEXT_SEEDS: Readonly<Record<string, Readonly<Record<string, stri
  * exactly the sort of thing a reader would screenshot as a bug.
  */
 const COMPONENT_VALUE_SEEDS: Readonly<Record<string, Readonly<Record<string, unknown>>>> = {
+  'bar-chart': {
+    data: [
+      { month: 'January', revenue: 42 },
+      { month: 'February', revenue: 58 },
+      { month: 'March', revenue: 73 },
+    ],
+    series: [{ id: 'revenue', label: 'Revenue', valueKey: 'revenue' }],
+  },
+  'data-table': {
+    columns: [
+      { key: 'name', label: 'Name', rowHeader: true },
+      { key: 'role', label: 'Role' },
+    ],
+    rows: [
+      { id: 'ada', name: 'Ada Lovelace', role: 'Engineer' },
+      { id: 'grace', name: 'Grace Hopper', role: 'Admiral' },
+    ],
+  },
+  'keyboard-shortcuts': {
+    groups: [
+      {
+        label: 'General',
+        shortcuts: [{ action: 'Open command palette', keys: ['Meta', 'K'] }],
+      },
+    ],
+  },
   'shortcut-hint': { keys: ['Meta', 'Shift', 'P'] },
 };
 

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -200,6 +200,58 @@ test.describe('generated Playground accessibility', () => {
   }
 });
 
+test.describe('contract-specific Playground preview seeds', () => {
+  for (const [name, mountedSelector] of [
+    ['bar-chart', '.cinder-bar-chart'],
+    ['data-table', '.cinder-data-table'],
+    ['keyboard-shortcuts', '.cinder-keyboard-shortcuts'],
+  ] as const) {
+    test(`${name} mounts its contract-valid default preview without a console error`, async ({
+      page,
+    }) => {
+      const errors: string[] = [];
+      page.on('console', (message) => {
+        if (message.type() === 'error') errors.push(message.text());
+      });
+      page.on('pageerror', (error) => errors.push(error.message));
+
+      await page.goto(`/page/${name}?view=playground`, { waitUntil: 'load' });
+      const liveMount = page.locator('#playground-live-mount');
+      await expect(liveMount).toBeVisible();
+      await expect(liveMount.locator(mountedSelector)).toBeVisible();
+      expect(errors, `${name} preview errors`).toEqual([]);
+    });
+  }
+});
+
+test.describe('authored Playground preview fallbacks', () => {
+  for (const [name, visibleControl] of [
+    ['alert-dialog', 'Open alert dialog'],
+    ['backdrop', 'Show dimmed backdrop'],
+    ['confirm-dialog', 'Delete item'],
+  ] as const) {
+    test(`${name} shows its interactive example instead of an inert bare mount`, async ({
+      page,
+    }) => {
+      await page.goto(`/page/${name}?view=playground`, { waitUntil: 'load' });
+
+      await expect(page.getByText('Featured example', { exact: true })).toBeVisible();
+      await expect(page.getByRole('button', { name: visibleControl })).toBeVisible();
+      await expect(page.locator('#playground-live-mount')).toHaveCount(0);
+    });
+  }
+
+  test('command-menu shows its anchored interactive example instead of a bare mount', async ({
+    page,
+  }) => {
+    await page.goto('/page/command-menu?view=playground', { waitUntil: 'load' });
+
+    await expect(page.getByText('Featured example', { exact: true })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: 'Notes' })).toBeVisible();
+    await expect(page.locator('#playground-live-mount')).toHaveCount(0);
+  });
+});
+
 test.describe('narrow documentation layout', () => {
   for (const name of [
     'autocomplete',


### PR DESCRIPTION
## Summary

This repairs the Playground’s generic preview path where it cannot truthfully synthesize a component contract.

- supplies valid BarChart, DataTable, and KeyboardShortcuts preview data
- routes closed overlays to their existing interactive authored examples instead of mounting inert defaults
- adds unit and browser regression coverage for the model and rendered routes

## Root cause

The generic value synthesizer created structurally plausible but semantically disconnected props: chart category keys did not exist in the data, table rows had duplicate generated identity values, and shortcut groups omitted the nested shortcut list. Closed overlays also need state, anchors, or callbacks that a bare mount cannot provide.

## Validation

- `bun run --filter='@cinder/playground' test`
- `bun run --filter='@cinder/playground' typecheck`
- `bun run --filter='@cinder/testing' typecheck`
- `bun run test:browser -- tests/playground-documentation.playwright.ts`
- `bunx prettier --check packages/playground/src/component-page-playground.ts packages/playground/src/component-page-playground.test.ts packages/testing/tests/playground-documentation.playwright.ts`

Linear: CIN-54, CIN-55, CIN-56, CIN-57, CIN-58, CIN-59, CIN-60, CIN-61, CIN-63, CIN-64, CIN-319.