### PR TITLE
fix(release): use configured Node for provenance publish

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -127,6 +127,13 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@11.5.1
 
+      - name: Record configured Node runtime for publish
+        shell: bash
+        run: |
+          node_path="$(command -v node)"
+          "$node_path" --version
+          echo "CINDER_PUBLISH_NODE=$node_path" >> "$GITHUB_ENV"
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,6 +87,13 @@ jobs:
       - name: Upgrade npm
         run: npm install -g npm@11.5.1
 
+      - name: Record configured Node runtime for publish
+        shell: bash
+        run: |
+          node_path="$(command -v node)"
+          "$node_path" --version
+          echo "CINDER_PUBLISH_NODE=$node_path" >> "$GITHUB_ENV"
+
       - name: Install dependencies
         run: bun install --frozen-lockfile
 

--- a/packages/components/scripts/publish-release.test.ts
+++ b/packages/components/scripts/publish-release.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, mock, test } from 'bun:test';
 import {
   getPackFileName,
   nodePublishCommand,
+  resolveNodeExecutable,
   resolvePackageRootArgument,
   resolvePublishAction,
   runPublishRelease,
@@ -56,6 +57,19 @@ describe('publish-release package selection', () => {
       'publish',
       'package.tgz',
     ]);
+  });
+
+  test('prefers the workflow-provisioned Node executable over Bun PATH resolution', () => {
+    expect(
+      resolveNodeExecutable(
+        { CINDER_PUBLISH_NODE: '/opt/node-22/bin/node' },
+        () => '/opt/node-24/bin/node',
+      ),
+    ).toBe('/opt/node-22/bin/node');
+  });
+
+  test('falls back to the Node executable resolved from PATH outside release workflows', () => {
+    expect(resolveNodeExecutable({}, () => '/opt/node/bin/node')).toBe('/opt/node/bin/node');
   });
 });
 

--- a/packages/components/scripts/publish-release.ts
+++ b/packages/components/scripts/publish-release.ts
@@ -56,6 +56,14 @@ export function nodePublishCommand(nodeExecutable: string, publishArguments: str
   return [nodeExecutable, join(scriptDirectory, 'npm-publish.mjs'), ...publishArguments];
 }
 
+/** Prefer the Node runtime explicitly provisioned by the release workflow. */
+export function resolveNodeExecutable(
+  environment: NodeJS.ProcessEnv,
+  findNode: (command: string) => string | undefined,
+): string | undefined {
+  return environment['CINDER_PUBLISH_NODE'] ?? findNode('node');
+}
+
 async function validateConsumerArtifact(packageRootPath: string): Promise<void> {
   const validationResult = await $`bun run validate:consumer`.cwd(packageRootPath).nothrow();
   if (validationResult.exitCode !== 0) {
@@ -162,7 +170,7 @@ async function main(): Promise<void> {
       artifactExists: existsSync,
       validateConsumerArtifact: () => validateConsumerArtifact(packageRoot),
       spawnPublish: (publishArguments) => {
-        const nodeExecutable = Bun.which('node');
+        const nodeExecutable = resolveNodeExecutable(Bun.env, Bun.which);
         if (!nodeExecutable) {
           throw new Error('publish-release requires Node to execute npm publish.');
         }

--- a/packages/components/scripts/publish-release.ts
+++ b/packages/components/scripts/publish-release.ts
@@ -59,8 +59,8 @@ export function nodePublishCommand(nodeExecutable: string, publishArguments: str
 /** Prefer the Node runtime explicitly provisioned by the release workflow. */
 export function resolveNodeExecutable(
   environment: NodeJS.ProcessEnv,
-  findNode: (command: string) => string | undefined,
-): string | undefined {
+  findNode: (command: string) => string | null,
+): string | null {
   return environment['CINDER_PUBLISH_NODE'] ?? findNode('node');
 }
 

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -411,6 +411,20 @@ describe('validate-release-workflow changeset guards', () => {
     }
   });
 
+  test('pins the setup-node runtime for both provenance publish paths', () => {
+    const workspaceRoot = resolve(import.meta.dirname, '../../..');
+    for (const workflowName of ['release.yaml', 'release-manual.yaml']) {
+      const workflow = readFileSync(
+        join(workspaceRoot, '.github', 'workflows', workflowName),
+        'utf8',
+      );
+      expect(workflow).toContain('uses: actions/setup-node@v7');
+      expect(workflow).toContain("node-version: '22'");
+      expect(workflow).toContain('name: Record configured Node runtime for publish');
+      expect(workflow).toContain('CINDER_PUBLISH_NODE=$node_path');
+    }
+  });
+
   test('requires the root publish shortcut to use staged package artifacts in order', () => {
     const manifest = (script: string) => ({ scripts: { 'changeset:publish': script } });
     const markdown = 'bun run --filter=@lostgradient/markdown publish:release';


### PR DESCRIPTION
Fixes the trusted-publish OpenSSL failure by passing the Node 22 executable configured by `actions/setup-node` through to the publish helper. Applies the same pin to the manual provenance path and adds regression coverage.