### PR TITLE
fix(chat): preserve Edit message pointer activation

### DIFF
--- a/.changeset/calm-buttons-capture.md
+++ b/.changeset/calm-buttons-capture.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Keep Edit message pointer activation targeted while concurrent streaming updates move the transcript.

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -232,12 +232,26 @@ function createDragEvent(type: string, files: File[], types: string[] = ['Files'
 
 function createPointerEvent(
   type: string,
-  { button = 0, isPrimary = true, pointerId = 1 } = {},
+  {
+    button = 0,
+    clientX = 0,
+    clientY = 0,
+    isPrimary = true,
+    pointerId = 1,
+  }: {
+    button?: number;
+    clientX?: number;
+    clientY?: number;
+    isPrimary?: boolean;
+    pointerId?: number;
+  } = {},
 ): PointerEvent {
   return new PointerEvent(type, {
     bubbles: true,
     cancelable: true,
     button,
+    clientX,
+    clientY,
     isPrimary,
     pointerId,
   });
@@ -1079,7 +1093,7 @@ describe('ChatAdapter — command equivalence', () => {
     unmount(instance);
   });
 
-  test('captures the edit button pointer before streaming auto-scroll can move it', () => {
+  test('captures only the primary left-button pointer on the edit action', () => {
     const conversation = conversationFromMessages('adapter-edit-pointer-capture', [
       message('user-1', 'user', 'Original text', 0),
       message('assistant-1', 'assistant', 'Streaming reply', 1),
@@ -1102,6 +1116,67 @@ describe('ChatAdapter — command equivalence', () => {
     editButton.dispatchEvent(createPointerEvent('pointerdown', { pointerId: 7 }));
 
     expect(capturedPointers).toEqual([7]);
+    editButton.click();
+    flushSync();
+    expect(container.querySelectorAll('.chat-message-edit-textarea')).toHaveLength(1);
+
+    unmount(instance);
+  });
+
+  test('releases edit pointer capture after intentional drag movement', () => {
+    const conversation = conversationFromMessages('adapter-edit-pointer-release', [
+      message('user-1', 'user', 'Original text', 0),
+    ]);
+    const { container, instance } = mountChat({
+      id: 'chat-adapter-edit-pointer-release',
+      conversation,
+      adapter: { sendMessage: async () => {}, editMessage: async () => {} },
+    });
+
+    const editButton = container.querySelector<HTMLButtonElement>('.chat-message-edit-button')!;
+    const releasedPointers: number[] = [];
+    Object.defineProperties(editButton, {
+      setPointerCapture: { configurable: true, value: () => {} },
+      releasePointerCapture: {
+        configurable: true,
+        value: (pointerId: number) => releasedPointers.push(pointerId),
+      },
+    });
+
+    editButton.dispatchEvent(
+      createPointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 7 }),
+    );
+    editButton.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 14, clientY: 14, pointerId: 7 }),
+    );
+    expect(releasedPointers).toEqual([]);
+    editButton.dispatchEvent(
+      createPointerEvent('pointermove', { clientX: 20, clientY: 20, pointerId: 7 }),
+    );
+    expect(releasedPointers).toEqual([7]);
+
+    unmount(instance);
+  });
+
+  test('keeps edit activation available when pointer capture fails', () => {
+    const conversation = conversationFromMessages('adapter-edit-pointer-failure', [
+      message('user-1', 'user', 'Original text', 0),
+    ]);
+    const { container, instance } = mountChat({
+      id: 'chat-adapter-edit-pointer-failure',
+      conversation,
+      adapter: { sendMessage: async () => {}, editMessage: async () => {} },
+    });
+
+    const editButton = container.querySelector<HTMLButtonElement>('.chat-message-edit-button')!;
+    Object.defineProperty(editButton, 'setPointerCapture', {
+      configurable: true,
+      value: () => {
+        throw new DOMException('Pointer is no longer active', 'NotFoundError');
+      },
+    });
+
+    editButton.dispatchEvent(createPointerEvent('pointerdown'));
     editButton.click();
     flushSync();
     expect(container.querySelectorAll('.chat-message-edit-textarea')).toHaveLength(1);

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -1146,6 +1146,7 @@ describe('ChatAdapter — command equivalence', () => {
     editButton.dispatchEvent(
       createPointerEvent('pointerdown', { clientX: 10, clientY: 10, pointerId: 7 }),
     );
+    editButton.dispatchEvent(createPointerEvent('pointerup', { isPrimary: false, pointerId: 8 }));
     editButton.dispatchEvent(
       createPointerEvent('pointermove', { clientX: 14, clientY: 14, pointerId: 7 }),
     );

--- a/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
+++ b/packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts
@@ -230,6 +230,19 @@ function createDragEvent(type: string, files: File[], types: string[] = ['Files'
   return event;
 }
 
+function createPointerEvent(
+  type: string,
+  { button = 0, isPrimary = true, pointerId = 1 } = {},
+): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    button,
+    isPrimary,
+    pointerId,
+  });
+}
+
 describe('ChatAdapter — command equivalence', () => {
   test('retry routes to the callback when no adapter is supplied', () => {
     const retried: string[] = [];
@@ -1062,6 +1075,36 @@ describe('ChatAdapter — command equivalence', () => {
 
     expect(edited).toEqual([{ messageId: 'user-1', content: 'Updated text' }]);
     expect(conversation.messages['user-1']?.content).toBe('Original text');
+
+    unmount(instance);
+  });
+
+  test('captures the edit button pointer before streaming auto-scroll can move it', () => {
+    const conversation = conversationFromMessages('adapter-edit-pointer-capture', [
+      message('user-1', 'user', 'Original text', 0),
+      message('assistant-1', 'assistant', 'Streaming reply', 1),
+    ]);
+    const { container, instance } = mountChat({
+      id: 'chat-adapter-edit-pointer-capture',
+      conversation,
+      adapter: { sendMessage: async () => {}, editMessage: async () => {} },
+    });
+
+    const editButton = container.querySelector<HTMLButtonElement>('.chat-message-edit-button')!;
+    const capturedPointers: number[] = [];
+    Object.defineProperty(editButton, 'setPointerCapture', {
+      configurable: true,
+      value: (pointerId: number) => capturedPointers.push(pointerId),
+    });
+
+    editButton.dispatchEvent(createPointerEvent('pointerdown', { isPrimary: false, pointerId: 5 }));
+    editButton.dispatchEvent(createPointerEvent('pointerdown', { button: 2, pointerId: 6 }));
+    editButton.dispatchEvent(createPointerEvent('pointerdown', { pointerId: 7 }));
+
+    expect(capturedPointers).toEqual([7]);
+    editButton.click();
+    flushSync();
+    expect(container.querySelectorAll('.chat-message-edit-textarea')).toHaveLength(1);
 
     unmount(instance);
   });

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -139,6 +139,11 @@
     oneditingchange?.(true);
   }
 
+  function captureEditPointer(event: PointerEvent) {
+    if (!event.isPrimary || event.button !== 0) return;
+    (event.currentTarget as HTMLButtonElement).setPointerCapture(event.pointerId);
+  }
+
   function cancelEditing() {
     isEditing = false;
     editContent = '';
@@ -368,6 +373,7 @@
           <button
             type="button"
             class="chat-message-action-button chat-message-edit-button"
+            onpointerdown={captureEditPointer}
             onclick={startEditing}
             aria-label="Edit message"
           >

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -170,8 +170,8 @@
     }
   }
 
-  function clearEditPointerCapture() {
-    editPointerCapture = undefined;
+  function clearEditPointerCapture(event: PointerEvent) {
+    if (editPointerCapture?.pointerId === event.pointerId) editPointerCapture = undefined;
   }
 
   function cancelEditing() {

--- a/packages/chat/src/lib/components/chat/message/chat-message.svelte
+++ b/packages/chat/src/lib/components/chat/message/chat-message.svelte
@@ -131,6 +131,8 @@
   // Edit state
   let isEditing = $state(false);
   let editContent = $state('');
+  let editPointerCapture: { pointerId: number; clientX: number; clientY: number } | undefined;
+  const editPointerDragThreshold = 8;
   const canEdit = $derived(message.role === 'user' && onedit !== undefined && !streaming);
 
   function startEditing() {
@@ -141,7 +143,35 @@
 
   function captureEditPointer(event: PointerEvent) {
     if (!event.isPrimary || event.button !== 0) return;
-    (event.currentTarget as HTMLButtonElement).setPointerCapture(event.pointerId);
+    const button = event.currentTarget as HTMLButtonElement;
+    try {
+      button.setPointerCapture(event.pointerId);
+      editPointerCapture = {
+        pointerId: event.pointerId,
+        clientX: event.clientX,
+        clientY: event.clientY,
+      };
+    } catch {
+      editPointerCapture = undefined;
+    }
+  }
+
+  function releaseEditPointerAfterDrag(event: PointerEvent) {
+    if (!editPointerCapture || event.pointerId !== editPointerCapture.pointerId) return;
+    const horizontalMovement = event.clientX - editPointerCapture.clientX;
+    const verticalMovement = event.clientY - editPointerCapture.clientY;
+    if (Math.hypot(horizontalMovement, verticalMovement) < editPointerDragThreshold) return;
+
+    editPointerCapture = undefined;
+    try {
+      (event.currentTarget as HTMLButtonElement).releasePointerCapture(event.pointerId);
+    } catch {
+      // The browser may already have released capture after pointer cancellation.
+    }
+  }
+
+  function clearEditPointerCapture() {
+    editPointerCapture = undefined;
   }
 
   function cancelEditing() {
@@ -374,6 +404,10 @@
             type="button"
             class="chat-message-action-button chat-message-edit-button"
             onpointerdown={captureEditPointer}
+            onpointermove={releaseEditPointerAfterDrag}
+            onpointerup={clearEditPointerCapture}
+            onpointercancel={clearEditPointerCapture}
+            onlostpointercapture={clearEditPointerCapture}
             onclick={startEditing}
             aria-label="Edit message"
           >


### PR DESCRIPTION
## What changed

- capture primary left-button pointers on the Edit message control
- keep the subsequent pointer-up and click targeted while streaming auto-scroll moves the transcript
- add a load-bearing regression test for primary, secondary, and non-primary pointer behavior

## Root cause

Chatroom's real-browser interleaving test exposed a race before edit mode begins: while an assistant reply streams, transcript auto-scroll can move the Edit message button between pointer-down and pointer-up. The browser then loses the click target, so the editor never opens.

This uses the platform's pointer-capture primitive on the existing native button. Keyboard activation remains unchanged, and the browser releases capture after pointer-up or cancellation.

## Validation

- `bun run --filter=@lostgradient/chat test`
- `bun run --filter=@lostgradient/chat test:coverage`
- `bun run --filter=@lostgradient/chat lint`
- `bun run --filter=@lostgradient/chat typecheck`
- `bun run --filter=@lostgradient/chat build`
- `bun run --filter=@lostgradient/chat components:check`
- `bunx prettier --check packages/chat/src/lib/components/chat/message/chat-message.svelte packages/chat/src/lib/components/chat/adapter/chat-adapter.test.ts .changeset/calm-buttons-capture.md`
- `git diff --check`

Removing only the pointer-capture handler made the new regression fail (`expected [7], received []`); restoring it returned the suite to green. Correctness, test-integrity, accessibility/SSR, and security/simplicity committee reviews all passed.

Closes CIN-420.
