### PR TITLE
Fix provenance publishing with the provisioned Node runtime

### DIFF
--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -131,7 +131,8 @@ jobs:
         shell: bash
         run: |
           node_path="$(command -v node)"
-          npm_cli="$(npm root -g)/npm/bin/npm-cli.js"
+          node_prefix="$(dirname "$(dirname "$node_path")")"
+          npm_cli="$node_prefix/lib/node_modules/npm/bin/npm-cli.js"
           "$node_path" --version
           test -f "$npm_cli"
           echo "CINDER_PUBLISH_NODE=$node_path" >> "$GITHUB_ENV"

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -131,8 +131,11 @@ jobs:
         shell: bash
         run: |
           node_path="$(command -v node)"
+          npm_cli="$(npm root -g)/npm/bin/npm-cli.js"
           "$node_path" --version
+          test -f "$npm_cli"
           echo "CINDER_PUBLISH_NODE=$node_path" >> "$GITHUB_ENV"
+          echo "CINDER_PUBLISH_NPM_CLI=$npm_cli" >> "$GITHUB_ENV"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,7 +91,8 @@ jobs:
         shell: bash
         run: |
           node_path="$(command -v node)"
-          npm_cli="$(npm root -g)/npm/bin/npm-cli.js"
+          node_prefix="$(dirname "$(dirname "$node_path")")"
+          npm_cli="$node_prefix/lib/node_modules/npm/bin/npm-cli.js"
           "$node_path" --version
           test -f "$npm_cli"
           echo "CINDER_PUBLISH_NODE=$node_path" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,8 +91,11 @@ jobs:
         shell: bash
         run: |
           node_path="$(command -v node)"
+          npm_cli="$(npm root -g)/npm/bin/npm-cli.js"
           "$node_path" --version
+          test -f "$npm_cli"
           echo "CINDER_PUBLISH_NODE=$node_path" >> "$GITHUB_ENV"
+          echo "CINDER_PUBLISH_NPM_CLI=$npm_cli" >> "$GITHUB_ENV"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/packages/components/scripts/npm-publish.d.mts
+++ b/packages/components/scripts/npm-publish.d.mts
@@ -1,0 +1,8 @@
+export function resolveNpmPublishCommand(input: {
+  nodeExecutable: string;
+  npmCliPath: string | undefined;
+  publishArguments: string[];
+}): {
+  command: string;
+  arguments: string[];
+};

--- a/packages/components/scripts/npm-publish.mjs
+++ b/packages/components/scripts/npm-publish.mjs
@@ -1,14 +1,13 @@
 import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
 
 const publishArguments = process.argv.slice(2);
-const npmCliPath = process.env.CINDER_PUBLISH_NPM_CLI;
+const npmCliPath =
+  process.env.CINDER_PUBLISH_NPM_CLI ??
+  join(dirname(dirname(process.execPath)), 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
 
 if (publishArguments[0] !== 'publish') {
   throw new Error('npm-publish only accepts npm publish arguments.');
-}
-
-if (!npmCliPath) {
-  throw new Error('npm-publish requires CINDER_PUBLISH_NPM_CLI from the release workflow.');
 }
 
 process.stdout.write(

--- a/packages/components/scripts/npm-publish.mjs
+++ b/packages/components/scripts/npm-publish.mjs
@@ -1,10 +1,7 @@
 import { spawnSync } from 'node:child_process';
-import { dirname, join } from 'node:path';
 
 const publishArguments = process.argv.slice(2);
-const npmCliPath =
-  process.env.CINDER_PUBLISH_NPM_CLI ??
-  join(dirname(dirname(process.execPath)), 'lib', 'node_modules', 'npm', 'bin', 'npm-cli.js');
+const npmCliPath = process.env.CINDER_PUBLISH_NPM_CLI;
 
 if (publishArguments[0] !== 'publish') {
   throw new Error('npm-publish only accepts npm publish arguments.');
@@ -14,16 +11,27 @@ process.stdout.write(
   `publish-release — Node ${process.version} executing npm ${publishArguments.join(' ')}\n`,
 );
 
-// Do not spawn the `npm` executable by name: its `env node` shebang can select
-// Bun's PATH-preferred Node instead of the Node runtime that owns provenance.
-const result = spawnSync(process.execPath, [npmCliPath, ...publishArguments], {
-  cwd: process.cwd(),
-  env: {
-    ...process.env,
-    NPM_CONFIG_PROVENANCE: process.env.NPM_CONFIG_PROVENANCE ?? 'true',
-  },
-  stdio: 'inherit',
-});
+// Release workflows provide npm's CLI path so provenance uses the exact Node
+// runtime provisioned by setup-node. Outside those workflows, preserve npm's
+// platform-specific PATH resolution instead of guessing its installation
+// layout.
+const result = npmCliPath
+  ? spawnSync(process.execPath, [npmCliPath, ...publishArguments], {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NPM_CONFIG_PROVENANCE: process.env.NPM_CONFIG_PROVENANCE ?? 'true',
+      },
+      stdio: 'inherit',
+    })
+  : spawnSync('npm', publishArguments, {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        NPM_CONFIG_PROVENANCE: process.env.NPM_CONFIG_PROVENANCE ?? 'true',
+      },
+      stdio: 'inherit',
+    });
 
 if (result.error) throw result.error;
 process.exitCode = result.status ?? 1;

--- a/packages/components/scripts/npm-publish.mjs
+++ b/packages/components/scripts/npm-publish.mjs
@@ -1,37 +1,44 @@
 import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
-const publishArguments = process.argv.slice(2);
-const npmCliPath = process.env.CINDER_PUBLISH_NPM_CLI;
-
-if (publishArguments[0] !== 'publish') {
-  throw new Error('npm-publish only accepts npm publish arguments.');
+export function resolveNpmPublishCommand({ nodeExecutable, npmCliPath, publishArguments }) {
+  return npmCliPath
+    ? { command: nodeExecutable, arguments: [npmCliPath, ...publishArguments] }
+    : { command: 'npm', arguments: publishArguments };
 }
 
-process.stdout.write(
-  `publish-release — Node ${process.version} executing npm ${publishArguments.join(' ')}\n`,
-);
+function main() {
+  const publishArguments = process.argv.slice(2);
+  if (publishArguments[0] !== 'publish') {
+    throw new Error('npm-publish only accepts npm publish arguments.');
+  }
 
-// Release workflows provide npm's CLI path so provenance uses the exact Node
-// runtime provisioned by setup-node. Outside those workflows, preserve npm's
-// platform-specific PATH resolution instead of guessing its installation
-// layout.
-const result = npmCliPath
-  ? spawnSync(process.execPath, [npmCliPath, ...publishArguments], {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        NPM_CONFIG_PROVENANCE: process.env.NPM_CONFIG_PROVENANCE ?? 'true',
-      },
-      stdio: 'inherit',
-    })
-  : spawnSync('npm', publishArguments, {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        NPM_CONFIG_PROVENANCE: process.env.NPM_CONFIG_PROVENANCE ?? 'true',
-      },
-      stdio: 'inherit',
-    });
+  process.stdout.write(
+    `publish-release — Node ${process.version} executing npm ${publishArguments.join(' ')}\n`,
+  );
 
-if (result.error) throw result.error;
-process.exitCode = result.status ?? 1;
+  // Release workflows provide npm's CLI path so provenance uses the exact Node
+  // runtime provisioned by setup-node. Outside those workflows, preserve npm's
+  // platform-specific PATH resolution instead of guessing its installation
+  // layout.
+  const invocation = resolveNpmPublishCommand({
+    nodeExecutable: process.execPath,
+    npmCliPath: process.env.CINDER_PUBLISH_NPM_CLI,
+    publishArguments,
+  });
+  const result = spawnSync(invocation.command, invocation.arguments, {
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      NPM_CONFIG_PROVENANCE: process.env.NPM_CONFIG_PROVENANCE ?? 'true',
+    },
+    stdio: 'inherit',
+  });
+
+  if (result.error) throw result.error;
+  process.exitCode = result.status ?? 1;
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main();
+}

--- a/packages/components/scripts/npm-publish.mjs
+++ b/packages/components/scripts/npm-publish.mjs
@@ -1,16 +1,23 @@
 import { spawnSync } from 'node:child_process';
 
 const publishArguments = process.argv.slice(2);
+const npmCliPath = process.env.CINDER_PUBLISH_NPM_CLI;
 
 if (publishArguments[0] !== 'publish') {
   throw new Error('npm-publish only accepts npm publish arguments.');
+}
+
+if (!npmCliPath) {
+  throw new Error('npm-publish requires CINDER_PUBLISH_NPM_CLI from the release workflow.');
 }
 
 process.stdout.write(
   `publish-release — Node ${process.version} executing npm ${publishArguments.join(' ')}\n`,
 );
 
-const result = spawnSync('npm', publishArguments, {
+// Do not spawn the `npm` executable by name: its `env node` shebang can select
+// Bun's PATH-preferred Node instead of the Node runtime that owns provenance.
+const result = spawnSync(process.execPath, [npmCliPath, ...publishArguments], {
   cwd: process.cwd(),
   env: {
     ...process.env,

--- a/packages/components/scripts/npm-publish.test.ts
+++ b/packages/components/scripts/npm-publish.test.ts
@@ -2,7 +2,35 @@ import { describe, expect, test } from 'bun:test';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 
+import { resolveNpmPublishCommand } from './npm-publish.mjs';
+
 describe('npm-publish', () => {
+  test('runs the workflow-provisioned npm CLI with the same Node runtime', () => {
+    expect(
+      resolveNpmPublishCommand({
+        nodeExecutable: '/opt/node/bin/node',
+        npmCliPath: '/opt/node/lib/node_modules/npm/bin/npm-cli.js',
+        publishArguments: ['publish', 'package.tgz'],
+      }),
+    ).toEqual({
+      command: '/opt/node/bin/node',
+      arguments: ['/opt/node/lib/node_modules/npm/bin/npm-cli.js', 'publish', 'package.tgz'],
+    });
+  });
+
+  test('uses the platform npm executable outside release workflows', () => {
+    expect(
+      resolveNpmPublishCommand({
+        nodeExecutable: '/opt/node/bin/node',
+        npmCliPath: undefined,
+        publishArguments: ['publish', 'package.tgz', '--dry-run'],
+      }),
+    ).toEqual({
+      command: 'npm',
+      arguments: ['publish', 'package.tgz', '--dry-run'],
+    });
+  });
+
   test('runs under Node before it delegates to npm publish', () => {
     const nodeExecutable = Bun.which('node');
     expect(nodeExecutable).toBeDefined();

--- a/packages/components/scripts/publish-release.test.ts
+++ b/packages/components/scripts/publish-release.test.ts
@@ -64,11 +64,12 @@ describe('publish-release package selection', () => {
   test('runs the provisioned npm CLI with the same Node runtime', () => {
     const wrapper = readFileSync(join(import.meta.dir, 'npm-publish.mjs'), 'utf8');
     expect(wrapper).toContain('CINDER_PUBLISH_NPM_CLI');
-    expect(wrapper).toContain(
-      "join(dirname(dirname(process.execPath)), 'lib', 'node_modules', 'npm'",
-    );
     expect(wrapper).toContain('spawnSync(process.execPath, [npmCliPath, ...publishArguments]');
-    expect(wrapper).not.toContain("spawnSync('npm', publishArguments");
+  });
+
+  test('uses the platform npm executable outside release workflows', () => {
+    const wrapper = readFileSync(join(import.meta.dir, 'npm-publish.mjs'), 'utf8');
+    expect(wrapper).toContain("spawnSync('npm', publishArguments");
   });
 
   test('prefers the workflow-provisioned Node executable over Bun PATH resolution', () => {

--- a/packages/components/scripts/publish-release.test.ts
+++ b/packages/components/scripts/publish-release.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 import {
   getPackFileName,
@@ -57,6 +59,13 @@ describe('publish-release package selection', () => {
       'publish',
       'package.tgz',
     ]);
+  });
+
+  test('runs the provisioned npm CLI with the same Node runtime', () => {
+    const wrapper = readFileSync(join(import.meta.dir, 'npm-publish.mjs'), 'utf8');
+    expect(wrapper).toContain('CINDER_PUBLISH_NPM_CLI');
+    expect(wrapper).toContain('spawnSync(process.execPath, [npmCliPath, ...publishArguments]');
+    expect(wrapper).not.toContain("spawnSync('npm', publishArguments");
   });
 
   test('prefers the workflow-provisioned Node executable over Bun PATH resolution', () => {

--- a/packages/components/scripts/publish-release.test.ts
+++ b/packages/components/scripts/publish-release.test.ts
@@ -64,6 +64,9 @@ describe('publish-release package selection', () => {
   test('runs the provisioned npm CLI with the same Node runtime', () => {
     const wrapper = readFileSync(join(import.meta.dir, 'npm-publish.mjs'), 'utf8');
     expect(wrapper).toContain('CINDER_PUBLISH_NPM_CLI');
+    expect(wrapper).toContain(
+      "join(dirname(dirname(process.execPath)), 'lib', 'node_modules', 'npm'",
+    );
     expect(wrapper).toContain('spawnSync(process.execPath, [npmCliPath, ...publishArguments]');
     expect(wrapper).not.toContain("spawnSync('npm', publishArguments");
   });

--- a/packages/components/scripts/publish-release.test.ts
+++ b/packages/components/scripts/publish-release.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, mock, test } from 'bun:test';
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
 
 import {
   getPackFileName,
@@ -59,17 +57,6 @@ describe('publish-release package selection', () => {
       'publish',
       'package.tgz',
     ]);
-  });
-
-  test('runs the provisioned npm CLI with the same Node runtime', () => {
-    const wrapper = readFileSync(join(import.meta.dir, 'npm-publish.mjs'), 'utf8');
-    expect(wrapper).toContain('CINDER_PUBLISH_NPM_CLI');
-    expect(wrapper).toContain('spawnSync(process.execPath, [npmCliPath, ...publishArguments]');
-  });
-
-  test('uses the platform npm executable outside release workflows', () => {
-    const wrapper = readFileSync(join(import.meta.dir, 'npm-publish.mjs'), 'utf8');
-    expect(wrapper).toContain("spawnSync('npm', publishArguments");
   });
 
   test('prefers the workflow-provisioned Node executable over Bun PATH resolution', () => {

--- a/packages/components/scripts/validate-release-workflow.test.ts
+++ b/packages/components/scripts/validate-release-workflow.test.ts
@@ -411,7 +411,7 @@ describe('validate-release-workflow changeset guards', () => {
     }
   });
 
-  test('pins the Node runtime and enables OpenSSL support for both provenance publish paths', () => {
+  test('pins Node, npm, and OpenSSL support for both provenance publish paths', () => {
     const workspaceRoot = resolve(import.meta.dirname, '../../..');
     for (const workflowName of ['release.yaml', 'release-manual.yaml']) {
       const workflow = readFileSync(
@@ -422,6 +422,7 @@ describe('validate-release-workflow changeset guards', () => {
       expect(workflow).toContain("node-version: '22'");
       expect(workflow).toContain('name: Record configured Node runtime for publish');
       expect(workflow).toContain('CINDER_PUBLISH_NODE=$node_path');
+      expect(workflow).toContain('CINDER_PUBLISH_NPM_CLI=$npm_cli');
       expect(workflow).toContain('NODE_OPTIONS: --openssl-legacy-provider');
     }
   });


### PR DESCRIPTION
## Summary

- execute npm's CLI directly through the configured Node 22 binary
- preserve the OpenSSL provider required by provenance signing
- cover both trusted and manual publish workflows

## Verification

- 
- @lostgradient/cinder test: bun test v1.3.14 (d1632b29) 1x PARALLEL
@lostgradient/cinder test: 
@lostgradient/cinder test: scripts/publish-release.test.ts:
@lostgradient/cinder test: (pass) publish-release package selection > derives scoped tarball names for either public package [0.10ms]
@lostgradient/cinder test: (pass) publish-release package selection > resolves explicit package roots relative to the invoking package [0.12ms]
@lostgradient/cinder test: (pass) publish-release package selection > uses the components root by default and rejects missing values [0.05ms]
@lostgradient/cinder test: (pass) publish-release package selection > routes npm publish through an explicit Node runtime helper [0.06ms]
@lostgradient/cinder test: (pass) publish-release package selection > runs the provisioned npm CLI with the same Node runtime [0.14ms]
@lostgradient/cinder test: (pass) publish-release package selection > prefers the workflow-provisioned Node executable over Bun PATH resolution [0.03ms]
@lostgradient/cinder test: (pass) publish-release package selection > falls back to the Node executable resolved from PATH outside release workflows [0.01ms]
@lostgradient/cinder test: (pass) publish-release existing-version handling > skips publish when the package version already exists [0.02ms]
@lostgradient/cinder test: (pass) publish-release existing-version handling > skips dry-run publish when the package version already exists
@lostgradient/cinder test: (pass) publish-release existing-version handling > publishes when the package version is not present on npm [0.01ms]
@lostgradient/cinder test: (pass) publish-release existing-version handling > skips the dry-run publish command when the package version already exists [0.27ms]
@lostgradient/cinder test: (pass) publish-release existing-version handling > rebuilds the consumer artifact before a dry-run publish when skip-validation has no tarball [0.24ms]
@lostgradient/cinder test: (pass) publish-release existing-version handling > publishes only the tarball matching the source manifest version [0.10ms]
@lostgradient/cinder test: 
@lostgradient/cinder test: scripts/validate-release-workflow.test.ts:
@lostgradient/cinder test: (pass) manual release provenance guard > requires each manual release job to bind dispatch provenance to its tag [0.12ms]
@lostgradient/cinder test: (pass) manual release provenance guard > rejects a manual publish job that only checks out the tag [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects runner, the context that caused the outage [0.31ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects runner via bracket access [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects env, which is not available to itself [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects jobs
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects needs [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects matrix [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects steps [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects strategy [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects hashFiles, which needs a workspace [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects hashFiles regardless of casing [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects the always status function
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects the success status function [0.03ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects a bare context with no property access [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects a bare context passed to an allowed function [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > rejects a bare context inside a comparison
@lostgradient/cinder test: (pass) workflow-level env context guard > allows secrets [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > allows vars
@lostgradient/cinder test: (pass) workflow-level env context guard > allows a deep github path
@lostgradient/cinder test: (pass) workflow-level env context guard > allows github with bracket access mid-chain
@lostgradient/cinder test: (pass) workflow-level env context guard > allows github inside an interpolated string
@lostgradient/cinder test: (pass) workflow-level env context guard > allows an always-available function [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > allows toJSON over an allowed context
@lostgradient/cinder test: (pass) workflow-level env context guard > allows a bare allowed context
@lostgradient/cinder test: (pass) workflow-level env context guard > allows a boolean literal
@lostgradient/cinder test: (pass) workflow-level env context guard > allows a comparison against an allowed context
@lostgradient/cinder test: (pass) workflow-level env context guard > allows a dotted string literal argument [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > allows a boolean expression over github [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > allows a plain value with no expression
@lostgradient/cinder test: (pass) workflow-level env context guard > reports only the root of a chain, not every segment [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env context guard > collects a root from each expression on one line [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env block scanning > collects entries in the top-level env block only [0.08ms]
@lostgradient/cinder test: (pass) workflow-level env block scanning > keeps scanning past a comment at column zero [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env block scanning > keeps scanning past a blank line inside the block [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env block scanning > stops at the next real top-level key [0.02ms]
@lostgradient/cinder test: (pass) workflow-level env block scanning > returns nothing when there is no workflow-level env block [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env block scanning > inspects an inline flow mapping [0.01ms]
@lostgradient/cinder test: (pass) workflow-level env block scanning > does not treat a flow mapping as an open block [0.02ms]
@lostgradient/cinder test: (pass) Playwright dependency setup > main-green.yaml normalizes the hosted-runner Ubuntu mirror before installing Playwright dependencies [0.15ms]
@lostgradient/cinder test: (pass) Playwright dependency setup > release.yaml normalizes the hosted-runner Ubuntu mirror before installing Playwright dependencies [0.04ms]
@lostgradient/cinder test: (pass) Playwright dependency setup > release-manual.yaml normalizes the hosted-runner Ubuntu mirror before installing Playwright dependencies [0.03ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires artifact and publish commands for every public package [0.34ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires Markdown to publish before Cinder before Editor before Chat before cinder-mcp [0.21ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > rejects dry-run publish steps that drift out of order behind a correct push path [0.11ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > builds Cinder before Chat in fresh-checkout coverage workflows [0.14ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > pins Node, npm, and OpenSSL support for both provenance publish paths [0.13ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires the root publish shortcut to use staged package artifacts in order [0.06ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > keeps root source validation separate from the packed-consumer release gate [0.07ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires the manual Chat bootstrap to preflight its Cinder and Markdown peers [0.08ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires the manual Cinder bootstrap to preflight its Markdown dependency [0.05ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires the manual cinder-mcp bootstrap to preflight its Cinder dependency [0.07ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > the stock Changesets plan keeps both public releases pre-1.0 minors [13.18ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > finds permissions only in workflow or job permission blocks [0.16ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > finds generated pull request workflows that are not explicitly dispatched [0.11ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > finds workflow actions that still target deprecated Node 20 majors [0.18ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires manual deploys to default to preview [0.06ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > requires the production dispatch expression on an active run line [0.02ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > parses package names from changeset front matter [1.15ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > reports malformed changeset front matter with a targeted error [0.43ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > reports pending changesets for ignored packages [1.18ms]
@lostgradient/cinder test: (pass) validate-release-workflow changeset guards > ignores normal public-package changesets [0.53ms]
@lostgradient/cinder test: 
@lostgradient/cinder test:  75 pass
@lostgradient/cinder test:  0 fail
@lostgradient/cinder test:  138 expect() calls
@lostgradient/cinder test: Ran 75 tests across 2 files. [454.00ms]
@lostgradient/cinder test: Exited with code 0