### PR TITLE
Fix the Chat hydration release preflight

### DIFF
--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -26,6 +26,7 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
       cwd: '/fixture',
       stdout: 'pipe',
       stderr: 'pipe',
+      environment: expect.objectContaining({ CINDER_CHAT_DEV_HYDRATION: '1' }),
     });
   });
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -10,6 +10,7 @@ import {
   EXAMPLES_CONSUMER_READINESS_PATH,
   parseHydrationBrowserProcessIds,
   preoptimizeSvelteKitChatHydration,
+  prepareSvelteKitChatHydrationDevServer,
   resolveChatFixtureCinderVersion,
   runBoundedHydrationTeardown,
   startSvelteKitChatHydrationDevServer,
@@ -103,6 +104,28 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
       }),
     );
     expect(startServer.mock.calls[0]?.[0]).not.toContain('--force');
+  });
+
+  test('does not reserve a port or start Vite when optimization fails', async () => {
+    const optimizerError = new Error('optimizer failed');
+    const preoptimize = mock(async () => {
+      throw optimizerError;
+    });
+    const pickPort = mock(async () => 4_321);
+    const startServer = mock(
+      (_command: string[], _options: SvelteKitChatHydrationDevServerOptions) =>
+        ({}) as Bun.ReadableSubprocess,
+    );
+
+    await expect(
+      prepareSvelteKitChatHydrationDevServer('/fixture', 'latest', {
+        pickPort,
+        preoptimize,
+        startServer,
+      }),
+    ).rejects.toBe(optimizerError);
+    expect(pickPort).not.toHaveBeenCalled();
+    expect(startServer).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 
 import { getPackFileName } from './publish-release.ts';
 import { packageTarballPath } from './report-package-weight.ts';
+import type { SvelteKitChatHydrationDevServerOptions } from './validate-consumers.ts';
 import {
   bumpPackageVersion,
   chatPeerValidationTarballPath,
@@ -11,13 +12,14 @@ import {
   preoptimizeSvelteKitChatHydration,
   resolveChatFixtureCinderVersion,
   runBoundedHydrationTeardown,
+  startSvelteKitChatHydrationDevServer,
   stopDevelopmentServer,
   SVELTEKIT_HYDRATION_ROUTES,
   unreclaimedTeardownFailures,
 } from './validate-consumers.ts';
 
 describe('SvelteKit Chat hydration optimizer preflight', () => {
-  test('finishes forced dependency optimization before starting route readiness', async () => {
+  test('forces dependency optimization under the Chat hydration environment', async () => {
     const runCommand = mock(async () => ({ exitCode: 0, stdout: 'optimized', stderr: '' }));
 
     await preoptimizeSvelteKitChatHydration('/fixture', runCommand);
@@ -26,7 +28,11 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
       cwd: '/fixture',
       stdout: 'pipe',
       stderr: 'pipe',
-      environment: expect.objectContaining({ CINDER_CHAT_DEV_HYDRATION: '1' }),
+      environment: {
+        CINDER_CHAT_DEV_HYDRATION: '1',
+        LANG: 'en_US.UTF-8',
+        TZ: 'UTC',
+      },
     });
   });
 
@@ -38,8 +44,56 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
     }));
 
     await expect(preoptimizeSvelteKitChatHydration('/fixture', runCommand)).rejects.toThrow(
-      'Vite dependency optimization failed before Chat hydration readiness',
+      'Vite dependency optimization failed before Chat hydration readiness:\noptimizer output\noptimizer failure',
     );
+  });
+
+  test('awaits optimization before starting Vite dev without forced reoptimization', async () => {
+    const events: string[] = [];
+    let finishOptimization!: () => void;
+    const optimizationGate = new Promise<void>((resolve) => {
+      finishOptimization = resolve;
+    });
+    const preoptimize = mock(async () => {
+      events.push('optimize:start');
+      await optimizationGate;
+      events.push('optimize:finish');
+    });
+    const fakeServer = {} as Bun.ReadableSubprocess;
+    const startServer = mock(
+      (_command: string[], _options: SvelteKitChatHydrationDevServerOptions) => {
+        events.push('server:start');
+        return fakeServer;
+      },
+    );
+
+    const serverPromise = startSvelteKitChatHydrationDevServer('/fixture', 4_321, {
+      preoptimize,
+      startServer,
+    });
+    await Promise.resolve();
+
+    expect(events).toEqual(['optimize:start']);
+    expect(startServer).not.toHaveBeenCalled();
+
+    finishOptimization();
+    await expect(serverPromise).resolves.toBe(fakeServer);
+    expect(events).toEqual(['optimize:start', 'optimize:finish', 'server:start']);
+    expect(startServer).toHaveBeenCalledWith(
+      ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', '4321', '--strictPort'],
+      expect.objectContaining({
+        cwd: '/fixture',
+        detached: true,
+        env: expect.objectContaining({
+          CINDER_CHAT_DEV_HYDRATION: '1',
+          LANG: 'en_US.UTF-8',
+          TZ: 'UTC',
+        }),
+        stderr: 'pipe',
+        stdout: 'pipe',
+      }),
+    );
+    expect(startServer.mock.calls[0]?.[0]).not.toContain('--force');
   });
 });
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -48,37 +48,46 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
     );
   });
 
-  test('awaits optimization before starting Vite dev without forced reoptimization', async () => {
-    const events: string[] = [];
-    let finishOptimization!: () => void;
-    const optimizationGate = new Promise<void>((resolve) => {
-      finishOptimization = resolve;
-    });
-    const preoptimize = mock(async () => {
-      events.push('optimize:start');
-      await optimizationGate;
-      events.push('optimize:finish');
-    });
+  test('reports a shared-readiness-budget abort without starting Vite', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const runCommand = mock(async () => ({ exitCode: 130, stdout: '', stderr: '' }));
+
+    await expect(
+      preoptimizeSvelteKitChatHydration('/fixture', runCommand, controller.signal),
+    ).rejects.toThrow(
+      'Vite dependency optimization exceeded the shared Chat hydration readiness budget',
+    );
+    expect(runCommand).toHaveBeenCalledWith(
+      'bun',
+      ['x', 'vite', 'optimize', '--force'],
+      expect.objectContaining({ signal: controller.signal }),
+    );
+  });
+
+  test('rejects published-package source-map warnings from successful optimization', async () => {
+    const runCommand = mock(async () => ({
+      exitCode: 0,
+      stdout: 'warning: @lostgradient/cinder/dist/index.js.map points to missing source',
+      stderr: '',
+    }));
+
+    await expect(preoptimizeSvelteKitChatHydration('/fixture', runCommand)).rejects.toThrow(
+      'Vite dependency optimization emitted source-map warnings for published package artifacts',
+    );
+  });
+
+  test('starts Vite dev without forced reoptimization', () => {
     const fakeServer = {} as Bun.ReadableSubprocess;
     const startServer = mock(
       (_command: string[], _options: SvelteKitChatHydrationDevServerOptions) => {
-        events.push('server:start');
         return fakeServer;
       },
     );
 
-    const serverPromise = startSvelteKitChatHydrationDevServer('/fixture', 4_321, {
-      preoptimize,
-      startServer,
-    });
-    await Promise.resolve();
+    const server = startSvelteKitChatHydrationDevServer('/fixture', 4_321, { startServer });
 
-    expect(events).toEqual(['optimize:start']);
-    expect(startServer).not.toHaveBeenCalled();
-
-    finishOptimization();
-    await expect(serverPromise).resolves.toBe(fakeServer);
-    expect(events).toEqual(['optimize:start', 'optimize:finish', 'server:start']);
+    expect(server).toBe(fakeServer);
     expect(startServer).toHaveBeenCalledWith(
       ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', '4321', '--strictPort'],
       expect.objectContaining({
@@ -94,25 +103,6 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
       }),
     );
     expect(startServer.mock.calls[0]?.[0]).not.toContain('--force');
-  });
-
-  test('does not start Vite dev when optimization fails', async () => {
-    const optimizerError = new Error('optimizer failed');
-    const preoptimize = mock(async () => {
-      throw optimizerError;
-    });
-    const startServer = mock(
-      (_command: string[], _options: SvelteKitChatHydrationDevServerOptions) =>
-        ({}) as Bun.ReadableSubprocess,
-    );
-
-    await expect(
-      startSvelteKitChatHydrationDevServer('/fixture', 4_321, {
-        preoptimize,
-        startServer,
-      }),
-    ).rejects.toBe(optimizerError);
-    expect(startServer).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { getPackFileName } from './publish-release.ts';
@@ -11,6 +13,7 @@ import {
   parseHydrationBrowserProcessIds,
   preoptimizeSvelteKitChatHydration,
   prepareSvelteKitChatHydrationDevServer,
+  removeFixtureEntries,
   resolveChatFixtureCinderVersion,
   runBoundedHydrationTeardown,
   startSvelteKitChatHydrationDevServer,
@@ -18,6 +21,26 @@ import {
   SVELTEKIT_HYDRATION_ROUTES,
   unreclaimedTeardownFailures,
 } from './validate-consumers.ts';
+
+describe('consumer fixture cleanup', () => {
+  test('removes nested requested entries and tolerates a missing entry', () => {
+    const fixtureDirectory = mkdtempSync(join(tmpdir(), 'cinder-consumer-cleanup-'));
+    const nestedDirectory = join(fixtureDirectory, '.svelte-kit', 'output', 'client');
+    mkdirSync(nestedDirectory, { recursive: true });
+    writeFileSync(join(nestedDirectory, 'entry.js'), 'generated');
+    mkdirSync(join(fixtureDirectory, 'build'), { recursive: true });
+
+    try {
+      removeFixtureEntries(fixtureDirectory, ['.svelte-kit', 'build', 'missing']);
+
+      expect(existsSync(join(fixtureDirectory, '.svelte-kit'))).toBe(false);
+      expect(existsSync(join(fixtureDirectory, 'build'))).toBe(false);
+      expect(existsSync(fixtureDirectory)).toBe(true);
+    } finally {
+      rmSync(fixtureDirectory, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('SvelteKit Chat hydration optimizer preflight', () => {
   test('forces dependency optimization under the Chat hydration environment', async () => {

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -95,6 +95,25 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
     );
     expect(startServer.mock.calls[0]?.[0]).not.toContain('--force');
   });
+
+  test('does not start Vite dev when optimization fails', async () => {
+    const optimizerError = new Error('optimizer failed');
+    const preoptimize = mock(async () => {
+      throw optimizerError;
+    });
+    const startServer = mock(
+      (_command: string[], _options: SvelteKitChatHydrationDevServerOptions) =>
+        ({}) as Bun.ReadableSubprocess,
+    );
+
+    await expect(
+      startSvelteKitChatHydrationDevServer('/fixture', 4_321, {
+        preoptimize,
+        startServer,
+      }),
+    ).rejects.toBe(optimizerError);
+    expect(startServer).not.toHaveBeenCalled();
+  });
 });
 
 describe('SvelteKit hydration route matrix', () => {

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { describe, expect, mock, test } from 'bun:test';
 import { join } from 'node:path';
 
 import { getPackFileName } from './publish-release.ts';
@@ -8,12 +8,39 @@ import {
   chatPeerValidationTarballPath,
   EXAMPLES_CONSUMER_READINESS_PATH,
   parseHydrationBrowserProcessIds,
+  preoptimizeSvelteKitChatHydration,
   resolveChatFixtureCinderVersion,
   runBoundedHydrationTeardown,
   stopDevelopmentServer,
   SVELTEKIT_HYDRATION_ROUTES,
   unreclaimedTeardownFailures,
 } from './validate-consumers.ts';
+
+describe('SvelteKit Chat hydration optimizer preflight', () => {
+  test('finishes forced dependency optimization before starting route readiness', async () => {
+    const runCommand = mock(async () => ({ exitCode: 0, stdout: 'optimized', stderr: '' }));
+
+    await preoptimizeSvelteKitChatHydration('/fixture', runCommand);
+
+    expect(runCommand).toHaveBeenCalledWith('bun', ['x', 'vite', 'optimize', '--force'], {
+      cwd: '/fixture',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+  });
+
+  test('stops before route readiness when dependency optimization fails', async () => {
+    const runCommand = mock(async () => ({
+      exitCode: 1,
+      stdout: 'optimizer output',
+      stderr: 'optimizer failure',
+    }));
+
+    await expect(preoptimizeSvelteKitChatHydration('/fixture', runCommand)).rejects.toThrow(
+      'Vite dependency optimization failed before Chat hydration readiness',
+    );
+  });
+});
 
 describe('SvelteKit hydration route matrix', () => {
   test('uses focused feature routes instead of the monolithic dev SSR fixture', () => {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1366,20 +1366,11 @@ async function assertSvelteKitDevChatHydrationRoute(
   fixtureDirectory: string,
   label: string,
 ): Promise<void> {
+  await preoptimizeSvelteKitChatHydration(fixtureDirectory);
   const httpPort = await pickEphemeralPort();
   let hydrationAssertionsPassed = false;
   const devServer = Bun.spawn(
-    [
-      'bunx',
-      'vite',
-      'dev',
-      '--force',
-      '--host',
-      '127.0.0.1',
-      '--port',
-      String(httpPort),
-      '--strictPort',
-    ],
+    ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(httpPort), '--strictPort'],
     {
       cwd: fixtureDirectory,
       detached: true,
@@ -1461,6 +1452,22 @@ async function assertSvelteKitDevChatHydrationRoute(
         }
       }
     }
+  }
+}
+
+export async function preoptimizeSvelteKitChatHydration(
+  fixtureDirectory: string,
+  runCommand: typeof runHookCommand = runHookCommand,
+): Promise<void> {
+  const result = await runCommand('bun', ['x', 'vite', 'optimize', '--force'], {
+    cwd: fixtureDirectory,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (result.exitCode !== 0) {
+    fail(
+      `Vite dependency optimization failed before Chat hydration readiness:\n${result.stdout}\n${result.stderr}`,
+    );
   }
 }
 

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -979,7 +979,7 @@ async function runStylesConsumerFixture(): Promise<void> {
   });
 
   try {
-    await removeFixtureEntries(fixtureDirectory, ['node_modules', 'dist']);
+    removeFixtureEntries(fixtureDirectory, ['node_modules', 'dist']);
     const installResult = await runHookCommand('bun', ['install', '--no-save'], {
       cwd: fixtureDirectory,
       stdout: 'pipe',
@@ -1106,7 +1106,7 @@ async function runSveltePeerCompatibilityFixture(
   const restoreManifest = injectTarballIntoFixture(fixtureDirectory, { svelteVersion });
 
   try {
-    await removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
+    removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
     const installResult = await runHookCommand('bun', ['install', '--no-save'], {
       cwd: fixtureDirectory,
       stdout: 'pipe',
@@ -1137,7 +1137,7 @@ async function runTypescriptCompatibilityFixture(
   const restoreManifest = injectTarballIntoFixture(fixtureDirectory, { typescriptVersion });
 
   try {
-    await removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
+    removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
     const installResult = await runHookCommand('bun', ['install', '--no-save'], {
       cwd: fixtureDirectory,
       stdout: 'pipe',
@@ -1761,7 +1761,7 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
 
   try {
     process.stdout.write(`[validate-consumers] sveltekit-consumer ${label}: cleaning fixture…\n`);
-    await removeFixtureEntries(fixtureDirectory, ['node_modules', '.svelte-kit', 'build']);
+    removeFixtureEntries(fixtureDirectory, ['node_modules', '.svelte-kit', 'build']);
     process.stdout.write(`[validate-consumers] sveltekit-consumer ${label}: cleaned fixture.\n`);
 
     process.stdout.write(`[validate-consumers] sveltekit-consumer ${label}: installing…\n`);
@@ -2868,7 +2868,7 @@ async function runNodeFixture(): Promise<void> {
   const restoreManifest = injectTarballIntoFixture(fixtureDirectory);
 
   try {
-    await removeFixtureEntries(fixtureDirectory, ['node_modules', 'dist']);
+    removeFixtureEntries(fixtureDirectory, ['node_modules', 'dist']);
     const installResult = await runHookCommand('bun', ['install', '--no-save'], {
       cwd: fixtureDirectory,
       stdout: 'pipe',
@@ -3006,7 +3006,7 @@ async function runTypescriptConsumerFixture(): Promise<void> {
   const restoreManifest = injectTarballIntoFixture(fixtureDirectory);
 
   try {
-    await removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
+    removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
     const installResult = await runHookCommand('bun', ['install', '--no-save'], {
       cwd: fixtureDirectory,
       stdout: 'pipe',
@@ -3048,7 +3048,7 @@ async function runExamplesConsumerFixture(): Promise<void> {
   const restoreManifest = injectTarballIntoFixture(fixtureDirectory);
 
   try {
-    await removeFixtureEntries(fixtureDirectory, [
+    removeFixtureEntries(fixtureDirectory, [
       'node_modules',
       '.svelte-kit',
       'build',

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1362,6 +1362,12 @@ function formatServerOutput(stdout: string, stderr: string): string {
   return `:\n${formatStreamTail('stdout', stdout)}\n${formatStreamTail('stderr', stderr)}`;
 }
 
+const svelteKitChatHydrationEnvironment = {
+  CINDER_CHAT_DEV_HYDRATION: '1',
+  TZ: 'UTC',
+  LANG: 'en_US.UTF-8',
+};
+
 async function assertSvelteKitDevChatHydrationRoute(
   fixtureDirectory: string,
   label: string,
@@ -1378,9 +1384,7 @@ async function assertSvelteKitDevChatHydrationRoute(
       stderr: 'pipe',
       env: {
         ...Bun.env,
-        CINDER_CHAT_DEV_HYDRATION: '1',
-        TZ: 'UTC',
-        LANG: 'en_US.UTF-8',
+        ...svelteKitChatHydrationEnvironment,
       },
     },
   );
@@ -1463,6 +1467,7 @@ export async function preoptimizeSvelteKitChatHydration(
     cwd: fixtureDirectory,
     stdout: 'pipe',
     stderr: 'pipe',
+    environment: svelteKitChatHydrationEnvironment,
   });
   if (result.exitCode !== 0) {
     fail(

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   readFileSync,
   realpathSync,
+  rmSync,
   statSync,
   symlinkSync,
   writeFileSync,
@@ -136,13 +137,12 @@ function fail(message: string): never {
   throw new ValidationError(message);
 }
 
-async function removeFixtureEntries(
-  fixtureDirectory: string,
-  entries: readonly string[],
-): Promise<void> {
-  // Bun 1.3 can throw EFAULT when multiple recursive fs removals run concurrently.
+export function removeFixtureEntries(fixtureDirectory: string, entries: readonly string[]): void {
+  // Bun 1.3 can throw EFAULT from its asynchronous recursive rm implementation,
+  // even when multiple removals are awaited sequentially. This validation CLI
+  // does not need concurrent filesystem work, so keep cleanup synchronous.
   for (const entry of entries) {
-    await rm(join(fixtureDirectory, entry), { recursive: true, force: true });
+    rmSync(join(fixtureDirectory, entry), { recursive: true, force: true });
   }
 }
 

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1383,6 +1383,12 @@ type SvelteKitChatHydrationDevServerDependencies = {
   ) => Bun.ReadableSubprocess;
 };
 
+type SvelteKitChatHydrationPreparationDependencies = SvelteKitChatHydrationDevServerDependencies & {
+  now?: () => number;
+  pickPort?: () => Promise<number>;
+  preoptimize?: (fixtureDirectory: string, signal: AbortSignal) => Promise<void>;
+};
+
 export function startSvelteKitChatHydrationDevServer(
   fixtureDirectory: string,
   httpPort: number,
@@ -1407,15 +1413,25 @@ export function startSvelteKitChatHydrationDevServer(
   );
 }
 
-async function assertSvelteKitDevChatHydrationRoute(
+export async function prepareSvelteKitChatHydrationDevServer(
   fixtureDirectory: string,
   label: string,
-): Promise<void> {
-  const readinessDeadline = Date.now() + SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS;
+  dependencies: SvelteKitChatHydrationPreparationDependencies = {},
+): Promise<{
+  devServer: Bun.ReadableSubprocess;
+  httpPort: number;
+  remainingReadinessBudget: number;
+}> {
+  const now = dependencies.now ?? Date.now;
+  const readinessDeadline = now() + SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS;
   const optimizationSignal = AbortSignal.timeout(SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS);
-  await preoptimizeSvelteKitChatHydration(fixtureDirectory, undefined, optimizationSignal);
+  const preoptimize =
+    dependencies.preoptimize ??
+    ((directory: string, signal: AbortSignal) =>
+      preoptimizeSvelteKitChatHydration(directory, undefined, signal));
+  await preoptimize(fixtureDirectory, optimizationSignal);
 
-  const remainingReadinessBudget = readinessDeadline - Date.now();
+  const remainingReadinessBudget = readinessDeadline - now();
   if (remainingReadinessBudget <= 0) {
     fail(
       `sveltekit-consumer ${label} /chat-layout dependency optimization exhausted its shared ${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms readiness budget`,
@@ -1424,9 +1440,22 @@ async function assertSvelteKitDevChatHydrationRoute(
 
   // Reserve a port only after pre-optimization, so another process cannot
   // claim this short-lived probe reservation while Vite is still working.
-  const httpPort = await pickEphemeralPort();
+  const httpPort = await (dependencies.pickPort ?? pickEphemeralPort)();
+  const devServer = startSvelteKitChatHydrationDevServer(
+    fixtureDirectory,
+    httpPort,
+    dependencies.startServer === undefined ? {} : { startServer: dependencies.startServer },
+  );
+  return { devServer, httpPort, remainingReadinessBudget };
+}
+
+async function assertSvelteKitDevChatHydrationRoute(
+  fixtureDirectory: string,
+  label: string,
+): Promise<void> {
   let hydrationAssertionsPassed = false;
-  const devServer = startSvelteKitChatHydrationDevServer(fixtureDirectory, httpPort);
+  const { devServer, httpPort, remainingReadinessBudget } =
+    await prepareSvelteKitChatHydrationDevServer(fixtureDirectory, label);
   const unregisterDevServerProcessGroup = registerHookProcessGroup(devServer.pid);
   const devServerStdout = devServer.stdout
     ? new Response(devServer.stdout).text()

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1368,14 +1368,33 @@ const svelteKitChatHydrationEnvironment = {
   LANG: 'en_US.UTF-8',
 };
 
-async function assertSvelteKitDevChatHydrationRoute(
+export type SvelteKitChatHydrationDevServerOptions = {
+  cwd: string;
+  detached: true;
+  stdout: 'pipe';
+  stderr: 'pipe';
+  env: Record<string, string | undefined>;
+};
+
+type SvelteKitChatHydrationDevServerDependencies = {
+  preoptimize?: (fixtureDirectory: string) => Promise<void>;
+  startServer?: (
+    command: string[],
+    options: SvelteKitChatHydrationDevServerOptions,
+  ) => Bun.ReadableSubprocess;
+};
+
+export async function startSvelteKitChatHydrationDevServer(
   fixtureDirectory: string,
-  label: string,
-): Promise<void> {
-  await preoptimizeSvelteKitChatHydration(fixtureDirectory);
-  const httpPort = await pickEphemeralPort();
-  let hydrationAssertionsPassed = false;
-  const devServer = Bun.spawn(
+  httpPort: number,
+  dependencies: SvelteKitChatHydrationDevServerDependencies = {},
+): Promise<Bun.ReadableSubprocess> {
+  await (dependencies.preoptimize ?? preoptimizeSvelteKitChatHydration)(fixtureDirectory);
+  const startServer =
+    dependencies.startServer ??
+    ((command: string[], options: SvelteKitChatHydrationDevServerOptions) =>
+      Bun.spawn(command, options));
+  return startServer(
     ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(httpPort), '--strictPort'],
     {
       cwd: fixtureDirectory,
@@ -1388,6 +1407,15 @@ async function assertSvelteKitDevChatHydrationRoute(
       },
     },
   );
+}
+
+async function assertSvelteKitDevChatHydrationRoute(
+  fixtureDirectory: string,
+  label: string,
+): Promise<void> {
+  const httpPort = await pickEphemeralPort();
+  let hydrationAssertionsPassed = false;
+  const devServer = await startSvelteKitChatHydrationDevServer(fixtureDirectory, httpPort);
   const unregisterDevServerProcessGroup = registerHookProcessGroup(devServer.pid);
   const devServerStdout = devServer.stdout
     ? new Response(devServer.stdout).text()

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -1377,19 +1377,17 @@ export type SvelteKitChatHydrationDevServerOptions = {
 };
 
 type SvelteKitChatHydrationDevServerDependencies = {
-  preoptimize?: (fixtureDirectory: string) => Promise<void>;
   startServer?: (
     command: string[],
     options: SvelteKitChatHydrationDevServerOptions,
   ) => Bun.ReadableSubprocess;
 };
 
-export async function startSvelteKitChatHydrationDevServer(
+export function startSvelteKitChatHydrationDevServer(
   fixtureDirectory: string,
   httpPort: number,
   dependencies: SvelteKitChatHydrationDevServerDependencies = {},
-): Promise<Bun.ReadableSubprocess> {
-  await (dependencies.preoptimize ?? preoptimizeSvelteKitChatHydration)(fixtureDirectory);
+): Bun.ReadableSubprocess {
   const startServer =
     dependencies.startServer ??
     ((command: string[], options: SvelteKitChatHydrationDevServerOptions) =>
@@ -1413,9 +1411,22 @@ async function assertSvelteKitDevChatHydrationRoute(
   fixtureDirectory: string,
   label: string,
 ): Promise<void> {
+  const readinessDeadline = Date.now() + SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS;
+  const optimizationSignal = AbortSignal.timeout(SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS);
+  await preoptimizeSvelteKitChatHydration(fixtureDirectory, undefined, optimizationSignal);
+
+  const remainingReadinessBudget = readinessDeadline - Date.now();
+  if (remainingReadinessBudget <= 0) {
+    fail(
+      `sveltekit-consumer ${label} /chat-layout dependency optimization exhausted its shared ${SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS}ms readiness budget`,
+    );
+  }
+
+  // Reserve a port only after pre-optimization, so another process cannot
+  // claim this short-lived probe reservation while Vite is still working.
   const httpPort = await pickEphemeralPort();
   let hydrationAssertionsPassed = false;
-  const devServer = await startSvelteKitChatHydrationDevServer(fixtureDirectory, httpPort);
+  const devServer = startSvelteKitChatHydrationDevServer(fixtureDirectory, httpPort);
   const unregisterDevServerProcessGroup = registerHookProcessGroup(devServer.pid);
   const devServerStdout = devServer.stdout
     ? new Response(devServer.stdout).text()
@@ -1430,7 +1441,7 @@ async function assertSvelteKitDevChatHydrationRoute(
     const chatLayoutStartedAt = Date.now();
     await waitForReadyHtml({
       url: routeUrl,
-      timeoutMs: SVELTEKIT_DEV_SSR_READINESS_TIMEOUT_MS,
+      timeoutMs: remainingReadinessBudget,
       pollIntervalMs: SVELTEKIT_DEV_SSR_POLL_INTERVAL_MS,
       runningServer: devServer,
       isReady: (html) => html.includes('Empty Chat hydration') && html.includes('No messages yet'),
@@ -1490,17 +1501,29 @@ async function assertSvelteKitDevChatHydrationRoute(
 export async function preoptimizeSvelteKitChatHydration(
   fixtureDirectory: string,
   runCommand: typeof runHookCommand = runHookCommand,
+  signal?: AbortSignal,
 ): Promise<void> {
   const result = await runCommand('bun', ['x', 'vite', 'optimize', '--force'], {
     cwd: fixtureDirectory,
     stdout: 'pipe',
     stderr: 'pipe',
     environment: svelteKitChatHydrationEnvironment,
+    ...(signal === undefined ? {} : { signal }),
   });
-  if (result.exitCode !== 0) {
+  const sourceMapWarnings = extractPublishedPackageSourceMapWarnings(
+    `${result.stdout}\n${result.stderr}`,
+  );
+  if (sourceMapWarnings.length > 0) {
     fail(
-      `Vite dependency optimization failed before Chat hydration readiness:\n${result.stdout}\n${result.stderr}`,
+      `Vite dependency optimization emitted source-map warnings for published package artifacts:\n` +
+        sourceMapWarnings.map((warning) => `  ${warning}`).join('\n'),
     );
+  }
+  if (result.exitCode !== 0) {
+    const failurePrefix = signal?.aborted
+      ? 'Vite dependency optimization exceeded the shared Chat hydration readiness budget'
+      : 'Vite dependency optimization failed before Chat hydration readiness';
+    fail(`${failurePrefix}:\n${result.stdout}\n${result.stderr}`);
   }
 }
 

--- a/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
+++ b/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
@@ -104,10 +104,11 @@ async function installPausedClock(page: Page): Promise<void> {
   await page.clock.install();
   // Read the installed browser clock rather than Node's wall clock. The latter
   // can already be behind by the time `pauseAt` reaches the page, which makes
-  // Playwright reject the request as a fast-forward into the past. The small
-  // advance stays below the 350ms timer whose ordering these tests exercise.
+  // Playwright reject the request as a fast-forward into the past. Give the
+  // protocol a full minute of headroom; the interactions below have not run
+  // yet, so none of the 350ms timers under test have been scheduled.
   const currentTime = await page.evaluate(() => Date.now());
-  await page.clock.pauseAt(new Date(currentTime + 100));
+  await page.clock.pauseAt(new Date(currentTime + 60_000));
 }
 
 test.describe('ReviewEditor.scrollToThread (cinder#1316, cinder#1317)', () => {

--- a/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
+++ b/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
@@ -101,11 +101,12 @@ function anchor(mount: Locator, threadId: string): Locator {
  * instead of the bug.
  */
 async function installPausedClock(page: Page): Promise<void> {
-  // Pause at the current real instant rather than an artificial fixed offset.
-  // The protocol round trip after install can advance an unfrozen fake clock,
-  // so a target derived from a static timestamp could be in the past.
+  // `pauseAt` advances to its target, so account for the protocol round trip
+  // after installation. A current-time target can already be in the past by
+  // the time Chromium receives it; no interaction timer has been scheduled
+  // yet, so this one-second lead cannot affect the assertions below.
   await page.clock.install();
-  await page.clock.pauseAt(new Date());
+  await page.clock.pauseAt(new Date(Date.now() + 1_000));
 }
 
 test.describe('ReviewEditor.scrollToThread (cinder#1316, cinder#1317)', () => {

--- a/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
+++ b/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
@@ -101,11 +101,13 @@ function anchor(mount: Locator, threadId: string): Locator {
  * instead of the bug.
  */
 async function installPausedClock(page: Page): Promise<void> {
-  // Pause at the current real instant rather than an artificial fixed offset.
-  // The protocol round trip after install can advance an unfrozen fake clock,
-  // so a target derived from a static timestamp could be in the past.
   await page.clock.install();
-  await page.clock.pauseAt(new Date());
+  // Read the installed browser clock rather than Node's wall clock. The latter
+  // can already be behind by the time `pauseAt` reaches the page, which makes
+  // Playwright reject the request as a fast-forward into the past. The small
+  // advance stays below the 350ms timer whose ordering these tests exercise.
+  const currentTime = await page.evaluate(() => Date.now());
+  await page.clock.pauseAt(new Date(currentTime + 100));
 }
 
 test.describe('ReviewEditor.scrollToThread (cinder#1316, cinder#1317)', () => {

--- a/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
+++ b/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
@@ -101,12 +101,11 @@ function anchor(mount: Locator, threadId: string): Locator {
  * instead of the bug.
  */
 async function installPausedClock(page: Page): Promise<void> {
-  // `pauseAt` advances to its target, so account for the protocol round trip
-  // after installation. A current-time target can already be in the past by
-  // the time Chromium receives it; no interaction timer has been scheduled
-  // yet, so this one-second lead cannot affect the assertions below.
+  // Pause at the current real instant rather than an artificial fixed offset.
+  // The protocol round trip after install can advance an unfrozen fake clock,
+  // so a target derived from a static timestamp could be in the past.
   await page.clock.install();
-  await page.clock.pauseAt(new Date(Date.now() + 1_000));
+  await page.clock.pauseAt(new Date());
 }
 
 test.describe('ReviewEditor.scrollToThread (cinder#1316, cinder#1317)', () => {


### PR DESCRIPTION
## Summary

- force Vite dependency optimization as an explicit checked preflight
- start Chat hydration readiness only after optimization completes
- keep the existing 25-second readiness deadline and add behavioral command/failure coverage

## Failure evidence

Release run 32426561941 timed out on `/chat-layout` while Vite was still bundling forced dependencies. The server announced readiness before optimization completed, so the route deadline measured optimizer startup instead of route readiness.

## Verification

- `bun test packages/components/scripts/validate-consumers.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder validate:consumer`
- `git diff --check`

The full packed-consumer matrix passed locally, including both Chat hydration fixtures, minimum/latest Svelte compatibility, and all 422 generated examples.

Linear: CIN-385
