### PR TITLE
Defer interactive Playground documentation code

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -609,7 +609,6 @@ jobs:
         with:
           pattern: visual-report-*
           path: packages/testing/visual-reports
-          merge-multiple: true
       - name: Publish merged visual report
         if: "always() && needs.playwright-visual.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
         run: |

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -604,13 +604,13 @@ jobs:
         if: "always() && needs.playwright-lane.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
         run: bunx playwright merge-reports --reporter html packages/testing/blob-reports
       - name: Merge sharded visual reports
-        if: "always() && needs.playwright-visual.result != 'skipped'"
+        if: "always() && needs.playwright-visual.result != 'skipped' && (github.event_name != 'workflow_dispatch' || github.event.inputs.mode == 'report')"
         uses: actions/download-artifact@v8
         with:
           pattern: visual-report-*
           path: packages/testing/visual-reports
       - name: Publish merged visual report
-        if: "always() && needs.playwright-visual.result != 'skipped'"
+        if: "always() && needs.playwright-visual.result != 'skipped' && (github.event_name != 'workflow_dispatch' || github.event.inputs.mode == 'report')"
         run: |
           set -euo pipefail
           REPORTS=packages/testing/visual-reports
@@ -626,7 +626,7 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
       - name: Upload merged visual report
-        if: "always() && needs.playwright-visual.result != 'skipped'"
+        if: "always() && needs.playwright-visual.result != 'skipped' && (github.event_name != 'workflow_dispatch' || github.event.inputs.mode == 'report')"
         uses: actions/upload-artifact@v7
         with:
           name: visual-report

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -281,7 +281,11 @@ jobs:
           MODE: ${{ steps.decide.outputs.component_scope_mode }}
         run: |
           if [ "$MODE" = full ]; then
-            echo 'playwright_matrix={"shard":[1,2,3,4]}' >> "$GITHUB_OUTPUT"
+            # Full coverage takes roughly 21 minutes of browser work per
+            # two-worker shard after the required page-bundle prewarm. Eight
+            # shards preserve every test while keeping each job below its
+            # existing 30-minute cap.
+            echo 'playwright_matrix={"shard":[1,2,3,4,5,6,7,8]}' >> "$GITHUB_OUTPUT"
           else
             echo 'playwright_matrix={"shard":[1]}' >> "$GITHUB_OUTPUT"
           fi
@@ -352,7 +356,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       fail-fast: false
-      matrix: ${{ fromJSON(needs.scope.result == 'success' && needs.scope.outputs.playwright_matrix || '{"shard":[1,2,3,4]}') }}
+      matrix: ${{ fromJSON(needs.scope.result == 'success' && needs.scope.outputs.playwright_matrix || '{"shard":[1,2,3,4,5,6,7,8]}') }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -406,7 +410,7 @@ jobs:
             echo "Components: $CINDER_TEST_COMPONENTS"
           fi
           if [ "$CINDER_TEST_SCOPE_MODE" = full ]; then
-            bun run test:browser -- --shard=${{ matrix.shard }}/4 --reporter=blob
+            bun run test:browser -- --shard=${{ matrix.shard }}/8 --reporter=blob
           else
             bun run test:browser
           fi

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -603,6 +603,21 @@ jobs:
       - name: Merge sharded report
         if: "always() && needs.playwright-lane.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
         run: bunx playwright merge-reports --reporter html packages/testing/blob-reports
+      - name: Merge sharded visual reports
+        if: "always() && needs.playwright-visual.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
+        uses: actions/download-artifact@v8
+        with:
+          pattern: visual-report-*
+          path: packages/testing/visual-reports
+          merge-multiple: true
+      - name: Publish merged visual report
+        if: "always() && needs.playwright-visual.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
+        run: |
+          set -euo pipefail
+          REPORTS=packages/testing/visual-reports
+          if [ -d "$REPORTS" ] && find "$REPORTS" -name '*.json' -print -quit | grep -q .; then
+            find "$REPORTS" -name '*.json' -print0 | xargs -0 jq -s 'add' > packages/testing/visual-report.json
+          fi
       - name: Upload merged report
         if: "always() && needs.playwright-lane.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
         uses: actions/upload-artifact@v7
@@ -611,6 +626,14 @@ jobs:
           path: playwright-report
           retention-days: 14
           if-no-files-found: warn
+      - name: Upload merged visual report
+        if: "always() && needs.playwright-visual.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
+        uses: actions/upload-artifact@v7
+        with:
+          name: visual-report
+          path: packages/testing/visual-report.json
+          retention-days: 14
+          if-no-files-found: ignore
       - name: Require the selected Playwright mode to succeed
         env:
           SCOPE: ${{ needs.scope.result }}

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -528,6 +528,9 @@ jobs:
     if: "!cancelled() && (github.event_name == 'pull_request' || github.event_name == 'merge_group' || (github.event_name == 'workflow_dispatch' && github.event.inputs.mode != 'off'))"
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.scope.result == 'success' && needs.scope.outputs.playwright_matrix || '{"shard":[1,2,3,4,5,6,7,8]}') }}
     env:
       CINDER_VISUAL_DIFF: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.mode || 'report' }}
     steps:
@@ -541,7 +544,12 @@ jobs:
           CI: 'true'
           CINDER_TEST_COMPONENTS: ${{ needs.scope.outputs.component_scope_mode == 'filtered' && needs.scope.outputs.components || '' }}
           CINDER_VISUAL_DIFF: ${{ env.CINDER_VISUAL_DIFF }}
-        run: bun run --filter=@cinder/testing test:browser:docker
+        run: |
+          if [ "${{ needs.scope.outputs.component_scope_mode }}" = filtered ]; then
+            bun run --filter=@cinder/testing test:browser:docker
+          else
+            bun run --filter=@cinder/testing test:browser:docker -- --shard=${{ matrix.shard }}/8
+          fi
       - name: Merge visual-report fragments
         if: always() && env.CINDER_VISUAL_DIFF == 'report'
         run: |
@@ -558,7 +566,7 @@ jobs:
         if: always() && env.CINDER_VISUAL_DIFF == 'report'
         uses: actions/upload-artifact@v7
         with:
-          name: visual-report
+          name: visual-report-${{ matrix.shard }}
           path: packages/testing/test-results/visual-report.json
           retention-days: 14
           if-no-files-found: ignore
@@ -566,7 +574,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-visual-diagnostics
+          name: playwright-visual-diagnostics-${{ matrix.shard }}
           path: |
             packages/testing/playwright-report
             packages/testing/test-results

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -604,13 +604,13 @@ jobs:
         if: "always() && needs.playwright-lane.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
         run: bunx playwright merge-reports --reporter html packages/testing/blob-reports
       - name: Merge sharded visual reports
-        if: "always() && needs.playwright-visual.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
+        if: "always() && needs.playwright-visual.result != 'skipped'"
         uses: actions/download-artifact@v8
         with:
           pattern: visual-report-*
           path: packages/testing/visual-reports
       - name: Publish merged visual report
-        if: "always() && needs.playwright-visual.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
+        if: "always() && needs.playwright-visual.result != 'skipped'"
         run: |
           set -euo pipefail
           REPORTS=packages/testing/visual-reports
@@ -626,7 +626,7 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
       - name: Upload merged visual report
-        if: "always() && needs.playwright-visual.result != 'skipped' && (needs.scope.result != 'success' || needs.scope.outputs.component_scope_mode == 'full')"
+        if: "always() && needs.playwright-visual.result != 'skipped'"
         uses: actions/upload-artifact@v7
         with:
           name: visual-report

--- a/packages/components/scripts/check-pipeline-coverage.test.ts
+++ b/packages/components/scripts/check-pipeline-coverage.test.ts
@@ -58,7 +58,7 @@ describe('Turbo input topology', () => {
     expect(browserWorkflow).toContain(
       `image: mcr.microsoft.com/playwright:v${componentsManifest.devDependencies['@playwright/test']}-noble`,
     );
-    expect(browserWorkflow).toContain('playwright_matrix={"shard":[1,2,3,4]}');
+    expect(browserWorkflow).toContain('playwright_matrix={"shard":[1,2,3,4,5,6,7,8]}');
     expect(browserWorkflow).toContain(
       "needs.scope.result == 'success' && needs.scope.outputs.playwright_matrix",
     );

--- a/packages/components/scripts/extract-fixtures.ts
+++ b/packages/components/scripts/extract-fixtures.ts
@@ -106,7 +106,7 @@ async function fixtureContentHash(
     const hostPath = resolveFixtureHostPath(entry, fixture);
     hostInputs.push({
       path: fixture.host.replaceAll('\\', '/'),
-      contents: await Bun.file(hostPath).text(),
+      contents: await readFile(hostPath, 'utf8'),
     });
   }
 

--- a/packages/components/scripts/extract-fixtures.ts
+++ b/packages/components/scripts/extract-fixtures.ts
@@ -13,6 +13,8 @@
  */
 
 import { createHash } from 'node:crypto';
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { basename, dirname, isAbsolute, join, relative, resolve } from 'node:path';
 
 import ts from 'typescript';
@@ -563,7 +565,7 @@ export function resolveFixtureFilePath(slug: string, componentsRoot: string): st
 }
 
 export async function loadFixtureFile(sourcePath: string): Promise<FileParseResult> {
-  const contents = await Bun.file(sourcePath).text();
+  const contents = await readFile(sourcePath, 'utf8');
   const result = parseFixtureFileStatic(sourcePath, contents);
   if (result.kind !== 'entry') return result;
 
@@ -576,7 +578,7 @@ export async function loadFixtureFile(sourcePath: string): Promise<FileParseResu
     if (fixtureRenderMode(fixture) !== 'host') continue;
     if (typeof fixture.host !== 'string') continue;
     const hostPath = resolveFixtureHostPath(result.entry, fixture);
-    if (!(await Bun.file(hostPath).exists())) {
+    if (!existsSync(hostPath)) {
       return {
         kind: 'violations',
         violations: [

--- a/packages/components/scripts/lib/visual-fixtures/loader.test.ts
+++ b/packages/components/scripts/lib/visual-fixtures/loader.test.ts
@@ -25,3 +25,24 @@ it('loads a static fixture file through the Node filesystem boundary', async () 
   const fixtureFile = await loadFixtureFile(fixturePath);
   expect(fixtureFile?.fixtures[0]?.name).toBe('private-harness');
 });
+
+it('loads and hashes a host fixture through the Node filesystem boundary', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'visual-fixture-loader-test-'));
+  temporaryDirectories.push(directory);
+  const fixtureDirectory = join(directory, 'chat');
+  const fixturePath = join(fixtureDirectory, 'chat-fixtures.ts');
+  mkdirSync(fixtureDirectory);
+  writeFileSync(
+    fixturePath,
+    "export default [{ name: 'private-harness', props: {}, host: './private-harness.fixture.svelte' }];\n",
+    'utf8',
+  );
+  writeFileSync(
+    join(fixtureDirectory, 'private-harness.fixture.svelte'),
+    '<div>Fixture</div>\n',
+    'utf8',
+  );
+
+  const fixtureFile = await loadFixtureFile(fixturePath);
+  expect(fixtureFile?.contentHash).toMatch(/^[a-f0-9]{64}$/);
+});

--- a/packages/components/scripts/lib/visual-fixtures/loader.test.ts
+++ b/packages/components/scripts/lib/visual-fixtures/loader.test.ts
@@ -1,0 +1,27 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, expect, it } from 'bun:test';
+
+import { loadFixtureFile } from './loader.ts';
+
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+it('loads a static fixture file through the Node filesystem boundary', async () => {
+  const directory = mkdtempSync(join(tmpdir(), 'visual-fixture-loader-test-'));
+  temporaryDirectories.push(directory);
+  const fixtureDirectory = join(directory, 'chat');
+  const fixturePath = join(fixtureDirectory, 'chat-fixtures.ts');
+  mkdirSync(fixtureDirectory);
+  writeFileSync(fixturePath, "export default [{ name: 'private-harness', props: {} }];\n", 'utf8');
+
+  const fixtureFile = await loadFixtureFile(fixturePath);
+  expect(fixtureFile?.fixtures[0]?.name).toBe('private-harness');
+});

--- a/packages/components/scripts/lib/visual-fixtures/loader.ts
+++ b/packages/components/scripts/lib/visual-fixtures/loader.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 import {
@@ -34,8 +35,7 @@ export function resolveFixtureFilePath(
 }
 
 export async function loadFixtureFile(sourcePath: string): Promise<LoadedFixtureFile | null> {
-  const file = Bun.file(sourcePath);
-  if (!(await file.exists())) return null;
+  if (!existsSync(sourcePath)) return null;
 
   const result = await loadStaticFixtureFile(sourcePath);
   if (result.kind === 'skipped') return null;

--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -13,6 +13,7 @@ import {
   assertSafeOutputDirectory,
   assertSitemapMatchesRoutes,
   assetUrlsFromHtml,
+  initialRoutePayload,
   requireProductionBaseUrl,
   runStaticExport,
 } from './static-export.ts';
@@ -206,6 +207,31 @@ test('HTML asset discovery does not carry regex state between calls', () => {
 
   expect(assetUrlsFromHtml(html)).toEqual(['/styles/shell.css']);
   expect(assetUrlsFromHtml(html)).toEqual(['/styles/shell.css']);
+});
+
+test('initial payload includes static imports but excludes reader-triggered dynamic imports', async () => {
+  const outputDirectory = await mkdtemp(join(tmpdir(), 'cinder-initial-payload-'));
+  try {
+    await mkdir(join(outputDirectory, 'assets', 'hash'), { recursive: true });
+    await writeFile(
+      join(outputDirectory, 'index.html'),
+      '<script type="module" src="/assets/hash/app.js"></script>',
+    );
+    await writeFile(
+      join(outputDirectory, 'assets', 'hash', 'app.js'),
+      'import "/assets/hash/shared.js";\nimport("/assets/hash/lazy.js");',
+    );
+    await writeFile(join(outputDirectory, 'assets', 'hash', 'shared.js'), 'export const shared = 1;');
+    await writeFile(join(outputDirectory, 'assets', 'hash', 'lazy.js'), 'export const lazy = 1;');
+
+    const payload = await initialRoutePayload('/', outputDirectory);
+
+    expect(payload.urls).toEqual(['/', '/assets/hash/app.js', '/assets/hash/shared.js']);
+    expect(payload.transferBytes).toBeGreaterThan(0);
+    expect(payload.decodedBytes).toBeGreaterThan(0);
+  } finally {
+    await rm(outputDirectory, { recursive: true, force: true });
+  }
 });
 
 describe('static export', () => {

--- a/packages/playground/scripts/static-export.test.ts
+++ b/packages/playground/scripts/static-export.test.ts
@@ -212,21 +212,28 @@ test('HTML asset discovery does not carry regex state between calls', () => {
 test('initial payload includes static imports but excludes reader-triggered dynamic imports', async () => {
   const outputDirectory = await mkdtemp(join(tmpdir(), 'cinder-initial-payload-'));
   try {
-    await mkdir(join(outputDirectory, 'assets', 'hash'), { recursive: true });
+    await mkdir(join(outputDirectory, 'shell-bundle'), { recursive: true });
+    await mkdir(join(outputDirectory, 'playground-styles'), { recursive: true });
     await writeFile(
       join(outputDirectory, 'index.html'),
-      '<script type="module" src="/assets/hash/app.js"></script>',
+      '<link rel="stylesheet" href="/playground-styles/landing.css"><script type="module" src="/shell-bundle/shell.js"></script>',
     );
     await writeFile(
-      join(outputDirectory, 'assets', 'hash', 'app.js'),
-      'import "/assets/hash/shared.js";\nimport("/assets/hash/lazy.js");',
+      join(outputDirectory, 'shell-bundle', 'shell.js'),
+      'import "/shell-bundle/shared.js";\nimport("/shell-bundle/lazy.js");',
     );
-    await writeFile(join(outputDirectory, 'assets', 'hash', 'shared.js'), 'export const shared = 1;');
-    await writeFile(join(outputDirectory, 'assets', 'hash', 'lazy.js'), 'export const lazy = 1;');
+    await writeFile(join(outputDirectory, 'shell-bundle', 'shared.js'), 'export const shared = 1;');
+    await writeFile(join(outputDirectory, 'shell-bundle', 'lazy.js'), 'export const lazy = 1;');
+    await writeFile(join(outputDirectory, 'playground-styles', 'landing.css'), ':root { color: canvas; }');
 
     const payload = await initialRoutePayload('/', outputDirectory);
 
-    expect(payload.urls).toEqual(['/', '/assets/hash/app.js', '/assets/hash/shared.js']);
+    expect(payload.urls).toEqual([
+      '/',
+      '/playground-styles/landing.css',
+      '/shell-bundle/shared.js',
+      '/shell-bundle/shell.js',
+    ]);
     expect(payload.transferBytes).toBeGreaterThan(0);
     expect(payload.decodedBytes).toBeGreaterThan(0);
   } finally {

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -300,7 +300,7 @@ export function assetUrlsFromHtml(html: string): string[] {
 /** Static ESM imports are requested during initial evaluation; `import(...)` is not. */
 function staticJavaScriptImportUrls(javascript: string): string[] {
   const urls = new Set<string>();
-  const imports = /(?:^|\n)\s*import\s+(?:[\s\S]*?\s+from\s+)?["'](\/assets\/[^"']+\.js)["'];?/g;
+  const imports = /(?:^|\n)\s*import\s*(?:[\s\S]*?\s+from\s+)?["'](\/assets\/[^"']+\.js)["'];?/g;
   let match: RegExpExecArray | null;
   while ((match = imports.exec(javascript)) !== null) urls.add(match[1]!);
   return [...urls];

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -29,7 +29,7 @@
  */
 
 import { existsSync, realpathSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, readFile, rm } from 'node:fs/promises';
 import {
   basename,
   dirname,
@@ -67,6 +67,27 @@ export type StaticExportOptions = {
   /** Test-only override. Real exports must supply PLAYGROUND_BASE_URL. */
   baseUrl?: string;
 };
+
+export type InitialRoutePayload = {
+  transferBytes: number;
+  decodedBytes: number;
+  urls: readonly string[];
+};
+
+type InitialRoutePayloadBudget = {
+  route: string;
+  transferBytes: number;
+  decodedBytes: number;
+};
+
+// These are production budgets for the first navigation. A route's deferred
+// scenario and Playground imports are intentionally excluded: they are not
+// requested until the reader opens an interactive surface.
+const INITIAL_ROUTE_PAYLOAD_BUDGETS: readonly InitialRoutePayloadBudget[] = [
+  { route: '/', transferBytes: 175_000, decodedBytes: 800_000 },
+  { route: '/page/button', transferBytes: 200_000, decodedBytes: 900_000 },
+  { route: '/page/chat', transferBytes: 700_000, decodedBytes: 3_250_000 },
+];
 
 /**
  * The exported site has no request-time server that can repair a bad canonical
@@ -276,6 +297,93 @@ export function assetUrlsFromHtml(html: string): string[] {
   return [...urls];
 }
 
+/** Static ESM imports are requested during initial evaluation; `import(...)` is not. */
+function staticJavaScriptImportUrls(javascript: string): string[] {
+  const urls = new Set<string>();
+  const imports = /(?:^|\n)\s*import\s+(?:[\s\S]*?\s+from\s+)?["'](\/assets\/[^"']+\.js)["'];?/g;
+  let match: RegExpExecArray | null;
+  while ((match = imports.exec(javascript)) !== null) urls.add(match[1]!);
+  return [...urls];
+}
+
+function stylesheetAssetUrls(stylesheet: string): string[] {
+  const urls = new Set<string>();
+  const imports = /@import\s+(?:url\(\s*)?["']?(\/assets\/[^"'\s)]+)["']?/g;
+  const references = /url\(\s*["']?(\/assets\/[^"'\s)]+)["']?\s*\)/g;
+  for (const expression of [imports, references]) {
+    let match: RegExpExecArray | null;
+    while ((match = expression.exec(stylesheet)) !== null) urls.add(match[1]!);
+  }
+  return [...urls];
+}
+
+function exportedHtmlPath(route: string, outputDirectory: string): string {
+  return outputPathFor(route, true, outputDirectory);
+}
+
+/**
+ * Sum the files a production browser requests to render a route before any
+ * reader-triggered dynamic import. Every asset is gzipped independently, which
+ * matches HTTP content encoding rather than pretending one archive compresses
+ * across request boundaries.
+ */
+export async function initialRoutePayload(
+  route: string,
+  outputDirectory: string,
+): Promise<InitialRoutePayload> {
+  const queue = [{ url: route, filePath: exportedHtmlPath(route, outputDirectory), kind: 'html' }];
+  const visited = new Set<string>();
+  let transferBytes = 0;
+  let decodedBytes = 0;
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current.url)) continue;
+    visited.add(current.url);
+
+    const contents = new Uint8Array(await readFile(current.filePath));
+    transferBytes += Bun.gzipSync(contents).byteLength;
+    decodedBytes += contents.byteLength;
+
+    const text = new TextDecoder().decode(contents);
+    const dependencies =
+      current.kind === 'html'
+        ? assetUrlsFromHtml(text)
+        : current.kind === 'javascript'
+          ? staticJavaScriptImportUrls(text)
+          : stylesheetAssetUrls(text);
+    for (const url of dependencies) {
+      if (!url.startsWith('/assets/')) continue;
+      const extension = url.split('?')[0]!.split('.').pop()?.toLowerCase();
+      queue.push({
+        url,
+        filePath: join(outputDirectory, url.slice(1)),
+        kind: extension === 'js' || extension === 'mjs' ? 'javascript' : 'stylesheet',
+      });
+    }
+  }
+
+  return { transferBytes, decodedBytes, urls: [...visited].toSorted() };
+}
+
+async function assertInitialRoutePayloadBudgets(
+  outputDirectory: string,
+  exportedRoutes: readonly string[],
+): Promise<void> {
+  for (const budget of INITIAL_ROUTE_PAYLOAD_BUDGETS) {
+    if (!exportedRoutes.includes(budget.route)) continue;
+    const payload = await initialRoutePayload(budget.route, outputDirectory);
+    if (payload.transferBytes > budget.transferBytes || payload.decodedBytes > budget.decodedBytes) {
+      throw new Error(
+        `[static-export] ${budget.route} initial payload exceeds budget: ` +
+          `${payload.transferBytes}/${budget.transferBytes} transfer bytes, ` +
+          `${payload.decodedBytes}/${budget.decodedBytes} decoded bytes. ` +
+          `Assets: ${payload.urls.join(', ')}`,
+      );
+    }
+  }
+}
+
 /**
  * Pull the hashed-chunk URLs a built JS bundle imports. Bun emits chunks as
  * `<name>-<hash>.js` siblings under the same `/page-bundle/` or `/shell-bundle/`
@@ -477,6 +585,7 @@ export async function runStaticExport(options: StaticExportOptions = {}): Promis
   }
 
   assertDocumentationPagesArePreRendered(documentationPages);
+  await assertInitialRoutePayloadBudgets(outputDirectory, canonicalRoutes);
 
   const seconds = ((Date.now() - start) / 1000).toFixed(1);
   process.stdout.write(

--- a/packages/playground/scripts/static-export.ts
+++ b/packages/playground/scripts/static-export.ts
@@ -300,7 +300,7 @@ export function assetUrlsFromHtml(html: string): string[] {
 /** Static ESM imports are requested during initial evaluation; `import(...)` is not. */
 function staticJavaScriptImportUrls(javascript: string): string[] {
   const urls = new Set<string>();
-  const imports = /(?:^|\n)\s*import\s*(?:[\s\S]*?\s+from\s+)?["'](\/assets\/[^"']+\.js)["'];?/g;
+  const imports = /(?:^|\n)\s*import\s*(?:[\s\S]*?\s+from\s+)?["'](\/[^"']+\.js)["'];?/g;
   let match: RegExpExecArray | null;
   while ((match = imports.exec(javascript)) !== null) urls.add(match[1]!);
   return [...urls];
@@ -308,8 +308,8 @@ function staticJavaScriptImportUrls(javascript: string): string[] {
 
 function stylesheetAssetUrls(stylesheet: string): string[] {
   const urls = new Set<string>();
-  const imports = /@import\s+(?:url\(\s*)?["']?(\/assets\/[^"'\s)]+)["']?/g;
-  const references = /url\(\s*["']?(\/assets\/[^"'\s)]+)["']?\s*\)/g;
+  const imports = /@import\s+(?:url\(\s*)?["']?(\/[^"'\s)]+)["']?/g;
+  const references = /url\(\s*["']?(\/[^"'\s)]+)["']?\s*\)/g;
   for (const expression of [imports, references]) {
     let match: RegExpExecArray | null;
     while ((match = expression.exec(stylesheet)) !== null) urls.add(match[1]!);
@@ -353,7 +353,7 @@ export async function initialRoutePayload(
           ? staticJavaScriptImportUrls(text)
           : stylesheetAssetUrls(text);
     for (const url of dependencies) {
-      if (!url.startsWith('/assets/')) continue;
+      if (!url.startsWith('/')) continue;
       const extension = url.split('?')[0]!.split('.').pop()?.toLowerCase();
       queue.push({
         url,

--- a/packages/playground/src/component-page-documentation.test.ts
+++ b/packages/playground/src/component-page-documentation.test.ts
@@ -464,6 +464,30 @@ describe('component-page single-scroll layout', () => {
     await tick();
   });
 
+  test('defers loading the bare component implementation until Playground is selected', async () => {
+    let loadCount = 0;
+    const { unmount } = render(ComponentPage, {
+      props: {
+        loadBareComponentModule: async () => {
+          loadCount += 1;
+          return { Button: ButtonMock };
+        },
+      },
+    });
+    await screen.findByRole('heading', { level: 1, name: 'Button' });
+    await tick();
+
+    expect(loadCount).toBe(0);
+
+    await showPlayground();
+    await Promise.resolve();
+    await tick();
+
+    expect(loadCount).toBe(1);
+    unmount();
+    await tick();
+  });
+
   test('makes the active view linkable through the URL', async () => {
     const { unmount } = render(ComponentPage);
     await screen.findByRole('heading', { level: 1, name: 'Button' });

--- a/packages/playground/src/component-page-example-mounts.test.ts
+++ b/packages/playground/src/component-page-example-mounts.test.ts
@@ -35,11 +35,15 @@ const {
   resetProbe: () => void;
 };
 
-type CinderWindow = typeof globalThis & { __CINDER_SCENARIOS__?: Record<string, unknown> };
+type CinderWindow = typeof globalThis & {
+  __CINDER_SCENARIOS__?: Record<string, unknown>;
+  __CINDER_SCENARIO_LOADERS__?: Record<string, () => Promise<unknown>>;
+};
 
 afterEach(() => {
   resetProbe();
   delete (window as CinderWindow).__CINDER_SCENARIOS__;
+  delete (window as CinderWindow).__CINDER_SCENARIO_LOADERS__;
   document.body.innerHTML = '';
 });
 
@@ -108,6 +112,33 @@ describe('createExampleMountHelpers().mountScenario', () => {
     flushSync();
     cleanup();
 
+    expect(unmountCount()).toBe(1);
+  });
+
+  it('loads a scenario module only when its preview is attached', async () => {
+    let loadCount = 0;
+    (window as CinderWindow).__CINDER_SCENARIO_LOADERS__ = {
+      lazy: async () => {
+        loadCount += 1;
+        return { default: Probe };
+      },
+    };
+    const mountErrors: Record<string, MountErrorDetail | undefined> = {};
+    const { mountScenario } = createExampleMountHelpers({ mountErrors });
+
+    const element = document.createElement('div');
+    element.id = 'example-mount-lazy';
+    document.body.appendChild(element);
+
+    const cleanup = mountScenario('lazy')(element);
+    await Promise.resolve();
+    flushSync();
+
+    expect(loadCount).toBe(1);
+    expect(mountCount()).toBe(1);
+    expect(mountErrors['example-mount-lazy']).toBeUndefined();
+
+    cleanup();
     expect(unmountCount()).toBe(1);
   });
 });

--- a/packages/playground/src/component-page-example-mounts.test.ts
+++ b/packages/playground/src/component-page-example-mounts.test.ts
@@ -162,6 +162,29 @@ describe('createExampleMountHelpers().mountScenario', () => {
     expect(settled).toEqual([{ mountKey: 'example-mount-lazy', error: undefined }]);
     cleanup();
   });
+
+  it('reports an invalid lazy module as a settled mount failure', async () => {
+    (window as CinderWindow).__CINDER_SCENARIO_LOADERS__ = {
+      invalid: async () => ({ default: 'not a component' }),
+    };
+    const settled: Array<{ mountKey: string; error: unknown }> = [];
+    const mountErrors: Record<string, MountErrorDetail | undefined> = {};
+    const { mountScenario } = createExampleMountHelpers({
+      mountErrors,
+      onScenarioSettled: (mountKey, error) => settled.push({ mountKey, error }),
+    });
+    const element = document.createElement('div');
+    element.id = 'example-mount-invalid';
+    document.body.appendChild(element);
+
+    mountScenario('invalid')(element);
+    await Promise.resolve();
+
+    expect(settled).toHaveLength(1);
+    expect(settled[0]?.mountKey).toBe('example-mount-invalid');
+    expect(settled[0]?.error).toBeInstanceOf(Error);
+    expect(mountErrors['example-mount-invalid']?.message).toContain('no registered component');
+  });
 });
 
 describe('fetchExampleSource', () => {

--- a/packages/playground/src/component-page-example-mounts.test.ts
+++ b/packages/playground/src/component-page-example-mounts.test.ts
@@ -141,6 +141,27 @@ describe('createExampleMountHelpers().mountScenario', () => {
     cleanup();
     expect(unmountCount()).toBe(1);
   });
+
+  it('reports the settled mount so snapshot consumers can await lazy scenarios', async () => {
+    (window as CinderWindow).__CINDER_SCENARIO_LOADERS__ = {
+      lazy: async () => ({ default: Probe }),
+    };
+    const settled: Array<{ mountKey: string; error: unknown }> = [];
+    const { mountScenario } = createExampleMountHelpers({
+      mountErrors: {},
+      onScenarioSettled: (mountKey, error) => settled.push({ mountKey, error }),
+    });
+    const element = document.createElement('div');
+    element.id = 'example-mount-lazy';
+    document.body.appendChild(element);
+
+    const cleanup = mountScenario('lazy')(element);
+    await Promise.resolve();
+    flushSync();
+
+    expect(settled).toEqual([{ mountKey: 'example-mount-lazy', error: undefined }]);
+    cleanup();
+  });
 });
 
 describe('fetchExampleSource', () => {

--- a/packages/playground/src/component-page-example-mounts.ts
+++ b/packages/playground/src/component-page-example-mounts.ts
@@ -72,7 +72,12 @@ export function createExampleMountHelpers(options: ExampleMountState): {
         const mountComponent = (candidate: unknown) => {
           if (disposed) return;
           if (typeof candidate !== 'function') {
-            console.error(`[cinder playground] no registered component for scenario "${scenario}"`);
+            const error = new Error(
+              `[cinder playground] no registered component for scenario "${scenario}"`,
+            );
+            console.error(error.message);
+            mountErrors[mountKey] = toMountErrorDetail(error);
+            onScenarioSettled?.(mountKey, error);
             return;
           }
           try {
@@ -101,11 +106,7 @@ export function createExampleMountHelpers(options: ExampleMountState): {
               onScenarioSettled?.(mountKey, error);
             });
         } else {
-          const error = new Error(
-            `[cinder playground] no registered component for scenario "${scenario}"`,
-          );
           mountComponent(undefined);
-          onScenarioSettled?.(mountKey, error);
         }
 
         return () => {

--- a/packages/playground/src/component-page-example-mounts.ts
+++ b/packages/playground/src/component-page-example-mounts.ts
@@ -22,6 +22,19 @@ export type ExampleMountState = {
   mountErrors: Record<string, MountErrorDetail | undefined>;
 };
 
+type ScenarioLoader = () => Promise<unknown>;
+type CinderWindow = Window &
+  typeof globalThis & {
+    __CINDER_SCENARIOS__?: Record<string, unknown>;
+    __CINDER_SCENARIO_LOADERS__?: Record<string, ScenarioLoader>;
+  };
+
+function scenarioComponentFromModule(module: unknown): unknown {
+  if (typeof module === 'function') return module;
+  if (module === null || typeof module !== 'object') return undefined;
+  return Reflect.get(module, 'default');
+}
+
 /**
  * Mount each registered scenario into its preview container via an
  * attachment. An attachment runs exactly when its element is created and
@@ -49,27 +62,46 @@ export function createExampleMountHelpers(options: ExampleMountState): {
     mountScenario(scenario: string) {
       return (element: HTMLElement) => {
         const mountKey = element.id;
-        const registry =
-          ((window as unknown as Record<string, unknown>)['__CINDER_SCENARIOS__'] as
-            | Record<string, unknown>
-            | undefined) ?? {};
+        const registry = (window as CinderWindow).__CINDER_SCENARIOS__ ?? {};
         const Component = registry[scenario];
-        if (typeof Component !== 'function') {
-          console.error(`[cinder playground] no registered component for scenario "${scenario}"`);
-          return () => {};
-        }
+        const loader = (window as CinderWindow).__CINDER_SCENARIO_LOADERS__?.[scenario];
         let app: ReturnType<typeof mount> | undefined;
-        try {
-          app = mount(Component as Parameters<typeof mount>[0], {
-            target: element,
-            props: { mountIdPrefix: mountKey },
-          });
-          mountErrors[mountKey] = undefined;
-        } catch (error) {
-          console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
-          mountErrors[mountKey] = toMountErrorDetail(error);
+        let disposed = false;
+
+        const mountComponent = (candidate: unknown) => {
+          if (disposed) return;
+          if (typeof candidate !== 'function') {
+            console.error(`[cinder playground] no registered component for scenario "${scenario}"`);
+            return;
+          }
+          try {
+            app = mount(candidate as Parameters<typeof mount>[0], {
+              target: element,
+              props: { mountIdPrefix: mountKey },
+            });
+            mountErrors[mountKey] = undefined;
+          } catch (error) {
+            console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
+            mountErrors[mountKey] = toMountErrorDetail(error);
+          }
+        };
+
+        if (typeof Component === 'function') {
+          mountComponent(Component);
+        } else if (loader !== undefined) {
+          void loader()
+            .then((module) => mountComponent(scenarioComponentFromModule(module)))
+            .catch((error) => {
+              if (disposed) return;
+              console.error(`[cinder playground] failed to load example "${scenario}":`, error);
+              mountErrors[mountKey] = toMountErrorDetail(error);
+            });
+        } else {
+          mountComponent(undefined);
         }
+
         return () => {
+          disposed = true;
           if (app === undefined) return;
           try {
             unmount(app);

--- a/packages/playground/src/component-page-example-mounts.ts
+++ b/packages/playground/src/component-page-example-mounts.ts
@@ -20,6 +20,7 @@ import {
 
 export type ExampleMountState = {
   mountErrors: Record<string, MountErrorDetail | undefined>;
+  onScenarioSettled?: (mountKey: string, error?: unknown) => void;
 };
 
 type ScenarioLoader = () => Promise<unknown>;
@@ -57,7 +58,7 @@ function scenarioComponentFromModule(module: unknown): unknown {
 export function createExampleMountHelpers(options: ExampleMountState): {
   mountScenario: (scenario: string) => (element: HTMLElement) => () => void;
 } {
-  const { mountErrors } = options;
+  const { mountErrors, onScenarioSettled } = options;
   return {
     mountScenario(scenario: string) {
       return (element: HTMLElement) => {
@@ -80,9 +81,11 @@ export function createExampleMountHelpers(options: ExampleMountState): {
               props: { mountIdPrefix: mountKey },
             });
             mountErrors[mountKey] = undefined;
+            onScenarioSettled?.(mountKey);
           } catch (error) {
             console.error(`[cinder playground] failed to mount example "${scenario}":`, error);
             mountErrors[mountKey] = toMountErrorDetail(error);
+            onScenarioSettled?.(mountKey, error);
           }
         };
 
@@ -95,9 +98,14 @@ export function createExampleMountHelpers(options: ExampleMountState): {
               if (disposed) return;
               console.error(`[cinder playground] failed to load example "${scenario}":`, error);
               mountErrors[mountKey] = toMountErrorDetail(error);
+              onScenarioSettled?.(mountKey, error);
             });
         } else {
+          const error = new Error(
+            `[cinder playground] no registered component for scenario "${scenario}"`,
+          );
           mountComponent(undefined);
+          onScenarioSettled?.(mountKey, error);
         }
 
         return () => {

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -89,14 +89,13 @@
   type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'info' | 'accent';
   type StatusDotStatus = 'online' | 'warning' | 'danger' | 'pending' | 'neutral' | 'accent';
 
-  // The bare component's module namespace, passed in by the page-bundle entry
-  // (`compilePageBundleArtifacts`) which `import * as`-es the component's package
-  // subpath and mounts this page with it. Threaded as a prop rather than read
-  // from a `window` global so the live preview (#405) is wired explicitly to the
-  // bundle that mounted it — no out-of-band global to go stale against the page.
-  // Defaults to `undefined` for the no-prop mount paths (tests, SSR render).
+  // The bare component's module namespace is loaded by the page-bundle entry
+  // only after a reader opens Playground. Keeping the loader as a prop rather
+  // than reading a global makes the deferred live preview explicit and keeps
+  // SSR/tests on the no-loader path.
   type Props = {
     bareComponentModule?: unknown;
+    loadBareComponentModule?: () => Promise<unknown>;
     previewOnly?: boolean;
     /**
      * Request-known page inputs. The server passes these explicitly so the SSR
@@ -137,7 +136,8 @@
   };
 
   let {
-    bareComponentModule,
+    bareComponentModule: bareComponentModuleProp,
+    loadBareComponentModule,
     previewOnly = false,
     componentName: componentNameProp,
     examples: examplesProp,
@@ -150,6 +150,8 @@
     overlays,
     onThemeChange,
   }: Props = $props();
+
+  let bareComponentModule = $state(bareComponentModuleProp);
 
   /** True on `/`, which renders the README through this same chrome. */
   const isLanding = $derived(readmeHtml !== undefined);
@@ -262,6 +264,34 @@
    * the client for anyone following a `?view=playground` link.
    */
   let activeView = $state<ComponentPageView>('documentation');
+
+  // The documentation view is deliberately hydratable without the selected
+  // component's implementation. Import it only when the reader asks for the
+  // interactive Playground; both SSR and the initial client render therefore
+  // keep the same `undefined` module value.
+  $effect(() => {
+    if (
+      !isHydrated ||
+      activeView !== 'playground' ||
+      bareComponentModule !== undefined ||
+      loadBareComponentModule === undefined
+    ) {
+      return;
+    }
+    let cancelled = false;
+    void loadBareComponentModule()
+      .then((module) => {
+        if (!cancelled) bareComponentModule = module;
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error('[cinder playground] failed to load bare component:', error);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  });
 
   /**
    * Arrow/Home/End navigation for the view switcher.

--- a/packages/playground/src/component-page.svelte
+++ b/packages/playground/src/component-page.svelte
@@ -85,7 +85,10 @@
     featured?: boolean;
   };
   type CinderWindow = Window &
-    typeof globalThis & { __CINDER_EXAMPLES__?: CinderExampleDescriptor[] };
+    typeof globalThis & {
+      __CINDER_EXAMPLES__?: CinderExampleDescriptor[];
+      __CINDER_SNAPSHOT_READY__?: Promise<void>;
+    };
   type BadgeVariant = 'neutral' | 'success' | 'warning' | 'danger' | 'info' | 'accent';
   type StatusDotStatus = 'online' | 'warning' | 'danger' | 'pending' | 'neutral' | 'accent';
 
@@ -197,6 +200,40 @@
   }
 
   const componentName: string = componentNameProp ?? readComponentNameFromLocation();
+
+  // Snapshot consumers need the scenario mounts, not merely the outer page
+  // chrome. Expose the actual completion promise so the browser harness can
+  // await it directly: a rejected dynamic import reaches the test as its
+  // original error instead of becoming a second polling timeout.
+  const snapshotMountKeys = new Set(examples.map(({ scenario }) => `example-mount-${scenario}`));
+  let settleSnapshotMount: (mountKey: string, error?: unknown) => void = () => undefined;
+  if (snapshotMode && typeof window !== 'undefined') {
+    let resolveSnapshotReady: () => void;
+    let rejectSnapshotReady: (reason?: unknown) => void;
+    const snapshotReady = new Promise<void>((resolve, reject) => {
+      resolveSnapshotReady = resolve;
+      rejectSnapshotReady = reject;
+    });
+    // A rejected promise is consumed by the test fixture; observe it here as
+    // well so a loader failure does not surface as an unrelated browser-level
+    // unhandled-rejection warning before that fixture evaluates the promise.
+    void snapshotReady.catch(() => undefined);
+    (window as CinderWindow).__CINDER_SNAPSHOT_READY__ = snapshotReady;
+    if (snapshotMountKeys.size === 0) {
+      resolveSnapshotReady!();
+    } else {
+      const settledMounts = new Set<string>();
+      settleSnapshotMount = (mountKey, error) => {
+        if (error !== undefined) {
+          rejectSnapshotReady!(error);
+          return;
+        }
+        if (!snapshotMountKeys.has(mountKey)) return;
+        settledMounts.add(mountKey);
+        if (settledMounts.size === snapshotMountKeys.size) resolveSnapshotReady!();
+      };
+    }
+  }
 
   // The canonical page owns the preview now, so subscribe directly to the
   // dev-server stream. Snapshot pages deliberately stay quiet: automated
@@ -466,7 +503,10 @@
   // in Examples — and each container gets its own attachment + its own mount, so
   // the two instances stay independent with correct per-node cleanup. See
   // `component-page-example-mounts.ts` for the mount-error keying discipline.
-  const { mountScenario } = createExampleMountHelpers({ mountErrors });
+  const { mountScenario } = createExampleMountHelpers({
+    mountErrors,
+    onScenarioSettled: settleSnapshotMount,
+  });
 
   // Whether the props table currently overflows horizontally. Drives the
   // `is-scrollable` modifier on the scroll container so the `::after` fade

--- a/packages/playground/src/page-bundle.ts
+++ b/packages/playground/src/page-bundle.ts
@@ -74,8 +74,8 @@ export async function compilePageBundleArtifacts(
     )
     .join('\n');
 
-  const entrySource = `import { hydrate, mount } from 'svelte';
-import { NAV_FILTER_STORAGE_KEY } from '../../src/component-page-theme.ts';
+  const entrySource = `import { NAV_FILTER_STORAGE_KEY } from '../../src/component-page-theme.ts';
+import { persistScrollPosition } from '../../src/shell-app/sidebar-scroll.ts';
 
 const scenarioLoaders: Record<string, () => Promise<unknown>> = {
 ${scenarioLoaders}
@@ -86,6 +86,8 @@ const target = document.getElementById('app');
 if (target === null) {
   throw new Error('[cinder playground] #app target not found');
 }
+const sidebarNavigation = document.querySelector<HTMLElement>('nav.dx-nav');
+if (sidebarNavigation !== null) persistScrollPosition(sidebarNavigation);
 
 // Keep the bare component implementation behind the Playground tab. The page
 // resolves the imported namespace by \`documentation.component.exportName\`,
@@ -106,7 +108,7 @@ const previewOnly = new URLSearchParams(window.location.search).get('preview') =
 const snapshotMode = new URLSearchParams(window.location.search).get('snapshot') === '1';
 let hasPersistedNavFilter = false;
 try {
-  hasPersistedNavFilter = sessionStorage.getItem(NAV_FILTER_STORAGE_KEY) !== null;
+  hasPersistedNavFilter = (sessionStorage.getItem(NAV_FILTER_STORAGE_KEY) ?? '').trim() !== '';
 } catch {
   // Private mode or disabled storage: canonical documentation stays static.
 }
@@ -133,9 +135,9 @@ let pageHydration: Promise<void> | undefined;
 let pageHydrated = false;
 
 function hydratePage(): Promise<void> {
-  pageHydration ??= import('../../src/component-page.svelte').then(({ default: ComponentPage }) => {
+  pageHydration ??= Promise.all([import('svelte'), import('../../src/component-page.svelte')]).then(([svelte, { default: ComponentPage }]) => {
     if (shouldHydrate) {
-      hydrate(ComponentPage, { target, props });
+      svelte.hydrate(ComponentPage, { target, props });
       pageHydrated = true;
       return;
     }
@@ -153,7 +155,7 @@ function hydratePage(): Promise<void> {
     // Clearing is safe in every mount case: snapshot and preview surfaces are
     // served with an empty \`#app\` anyway, so there is nothing to discard.
     target.replaceChildren();
-    mount(ComponentPage, { target, props });
+    svelte.mount(ComponentPage, { target, props });
     pageHydrated = true;
   });
   return pageHydration;
@@ -181,6 +183,14 @@ document.addEventListener(
     if (pageHydrated) return;
     const button = eventElement(event)?.closest('button');
     if (button === null) return;
+    if (button.getAttribute('aria-label') === 'Copy import') {
+      const source = button.previousElementSibling?.textContent;
+      if (source !== null && source !== undefined) {
+        void navigator.clipboard?.writeText(source).catch(() => undefined);
+      }
+      hydrateAfter(event, () => undefined);
+      return;
+    }
     hydrateAfter(event, () => button.click());
   },
   { capture: true },
@@ -191,7 +201,7 @@ document.addEventListener(
   (event) => {
     if (pageHydrated || !['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
     const button = eventElement(event)?.closest('button');
-    if (button === null) return;
+    if (button?.getAttribute('role') !== 'tab') return;
     hydrateAfter(event, () =>
       button.dispatchEvent(
         new KeyboardEvent('keydown', { key: event.key, bubbles: true, cancelable: true }),
@@ -200,6 +210,21 @@ document.addEventListener(
   },
   { capture: true },
 );
+
+document.addEventListener(
+  'click',
+  (event) => {
+    if (pageHydrated) return;
+    const anchor = eventElement(event)?.closest('a[href^="#"]');
+    if (anchor === null) return;
+    hydrateAfter(event, () => anchor.click());
+  },
+  { capture: true },
+);
+
+window.addEventListener('scroll', () => {
+  if (!pageHydrated) void hydratePage().catch((error) => console.error('[cinder playground] failed to hydrate page:', error));
+}, { once: true, passive: true });
 
 document.addEventListener(
   'input',
@@ -235,6 +260,7 @@ document.addEventListener(
 if (
   snapshotMode ||
   previewOnly ||
+  !hasServerRenderedContent ||
   hasPersistedNavFilter ||
   (shouldHydrate && new URLSearchParams(window.location.search).get('view') === 'playground')
 ) {

--- a/packages/playground/src/page-bundle.ts
+++ b/packages/playground/src/page-bundle.ts
@@ -75,6 +75,7 @@ export async function compilePageBundleArtifacts(
     .join('\n');
 
   const entrySource = `import { hydrate, mount } from 'svelte';
+import { NAV_FILTER_STORAGE_KEY } from '../../src/component-page-theme.ts';
 
 const scenarioLoaders: Record<string, () => Promise<unknown>> = {
 ${scenarioLoaders}
@@ -103,6 +104,12 @@ const previewOnly = new URLSearchParams(window.location.search).get('preview') =
 // therefore read from the URL exactly as the server read it, and the same
 // documentation/examples data islands feed both sides.
 const snapshotMode = new URLSearchParams(window.location.search).get('snapshot') === '1';
+let hasPersistedNavFilter = false;
+try {
+  hasPersistedNavFilter = sessionStorage.getItem(NAV_FILTER_STORAGE_KEY) !== null;
+} catch {
+  // Private mode or disabled storage: canonical documentation stays static.
+}
 const hasServerRenderedContent = target.firstElementChild !== null;
 const shouldHydrate = hasServerRenderedContent && !snapshotMode && !previewOnly;
 
@@ -201,9 +208,20 @@ document.addEventListener(
     const input = eventElement(event);
     if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return;
     const value = input.value;
+    const inputId = input.id;
+    if (inputId === 'sidebar-filter') {
+      try {
+        sessionStorage.setItem(NAV_FILTER_STORAGE_KEY, value);
+      } catch {
+        // Private mode or disabled storage: preserve the current input while
+        // the component hydrates, even though it cannot survive navigation.
+      }
+    }
     hydrateAfter(event, () => {
-      input.value = value;
-      input.dispatchEvent(new Event('input', { bubbles: true }));
+      const hydratedInput = document.getElementById(inputId);
+      if (!(hydratedInput instanceof HTMLInputElement || hydratedInput instanceof HTMLTextAreaElement)) return;
+      hydratedInput.value = value;
+      hydratedInput.dispatchEvent(new Event('input', { bubbles: true }));
     });
   },
   { capture: true },
@@ -217,6 +235,7 @@ document.addEventListener(
 if (
   snapshotMode ||
   previewOnly ||
+  hasPersistedNavFilter ||
   (shouldHydrate && new URLSearchParams(window.location.search).get('view') === 'playground')
 ) {
   void hydratePage().catch((error) =>

--- a/packages/playground/src/page-bundle.ts
+++ b/packages/playground/src/page-bundle.ts
@@ -135,7 +135,9 @@ let pageHydration: Promise<void> | undefined;
 let pageHydrated = false;
 
 function hydratePage(): Promise<void> {
-  pageHydration ??= Promise.all([import('svelte'), import('../../src/component-page.svelte')]).then(([svelte, { default: ComponentPage }]) => {
+  if (pageHydration !== undefined) return pageHydration;
+
+  const hydration = Promise.all([import('svelte'), import('../../src/component-page.svelte')]).then(([svelte, { default: ComponentPage }]) => {
     if (shouldHydrate) {
       svelte.hydrate(ComponentPage, { target, props });
       pageHydrated = true;
@@ -158,7 +160,11 @@ function hydratePage(): Promise<void> {
     svelte.mount(ComponentPage, { target, props });
     pageHydrated = true;
   });
-  return pageHydration;
+  pageHydration = hydration;
+  void hydration.catch(() => {
+    if (pageHydration === hydration) pageHydration = undefined;
+  });
+  return hydration;
 }
 
 function hydrateAfter(event: Event, replay: () => void): void {

--- a/packages/playground/src/page-bundle.ts
+++ b/packages/playground/src/page-bundle.ts
@@ -32,10 +32,11 @@ export function relativeImportSpecifier(fromDirectory: string, targetPath: strin
  * publication to the caller (lazy-build wrapper or the atomic watcher
  * rebuild).
  *
- * The bundle includes component-page.svelte plus every scenario, all in one
- * Bun.build invocation so they share a single Svelte runtime in the browser.
- * Scenarios register themselves on `window.__CINDER_SCENARIOS__`, and
- * `component-page.svelte` reads that global on mount.
+ * The bundle includes the documentation page plus dynamic imports for its
+ * scenarios and bare component implementation. Documentation hydrates without
+ * compiling every example or the selected component into the initial transfer;
+ * `component-page.svelte` loads each example only when its preview is attached
+ * and the bare component only after the reader opens Playground.
  */
 export async function compilePageBundleArtifacts(
   componentName: string,
@@ -66,37 +67,30 @@ export async function compilePageBundleArtifacts(
   const entryTempDir = join(PLAYGROUND_TEMP_ROOT, randomUUID());
   const entryTempPath = join(entryTempDir, `${entryBasename}.ts`);
 
-  const scenarioImports = scenarios
+  const scenarioLoaders = scenarios
     .map(
-      (scenario, index) =>
-        `import Scenario_${index} from '../../src/examples/${componentName}/${scenario}.example.svelte';`,
+      (scenario) =>
+        `  ${JSON.stringify(scenario)}: () => import('../../src/examples/${componentName}/${scenario}.example.svelte'),`,
     )
-    .join('\n');
-  const scenarioRegistrations = scenarios
-    .map((scenario, index) => `  ${JSON.stringify(scenario)}: Scenario_${index},`)
     .join('\n');
 
   const entrySource = `import { hydrate, mount } from 'svelte';
 
-import ComponentPage from '../../src/component-page.svelte';
-import * as BareComponentModule from ${JSON.stringify(componentDefinition.importPath)};
-${scenarioImports}
-const scenarios: Record<string, unknown> = {
-${scenarioRegistrations}
+const scenarioLoaders: Record<string, () => Promise<unknown>> = {
+${scenarioLoaders}
 };
 
-(window as unknown as Record<string, unknown>)['__CINDER_SCENARIOS__'] = scenarios;
+(window as unknown as Record<string, unknown>)['__CINDER_SCENARIO_LOADERS__'] = scenarioLoaders;
 const target = document.getElementById('app');
 if (target === null) {
   throw new Error('[cinder playground] #app target not found');
 }
 
-// Pass the bare component's module namespace as a prop so the Playground section
-// can mount the component directly with synthesized prop values (live preview,
-// #405). The page resolves it by \`documentation.component.exportName\`, falling
-// back to the default export — the whole namespace is handed over so both
-// resolve. Threaded as a prop (not a \`window\` global) so the live preview is
-// wired explicitly to the bundle that mounted the page.
+// Keep the bare component implementation behind the Playground tab. The page
+// resolves the imported namespace by \`documentation.component.exportName\`,
+// falling back to the default export. Threading the loader as a prop (rather
+// than a \`window\` global) keeps the deferred live preview explicitly wired to
+// the bundle that mounted the page.
 const previewOnly = new URLSearchParams(window.location.search).get('preview') === '1';
 
 // The server pre-renders the documentation tree into #app for the canonical
@@ -122,30 +116,106 @@ const sidebarComponents = Array.isArray(sidebarRaw)
   : [];
 
 const props = {
-  bareComponentModule: BareComponentModule,
+  loadBareComponentModule: () => import(${JSON.stringify(componentDefinition.importPath)}),
   previewOnly,
   snapshotMode,
   sidebarComponents,
 };
 
-if (shouldHydrate) {
-  hydrate(ComponentPage, { target, props });
-} else {
-  // mount() APPENDS; it does not clear the target. So whenever we are mounting a
-  // tree that differs from whatever the document already contains, we must own
-  // the container explicitly.
-  //
-  // This is load-bearing on the STATIC export, not just in development. The
-  // exporter strips query strings when crawling, so \`/page/<name>?preview=1\`
-  // resolves to the one exported \`/page/<name>/index.html\` — the full
-  // documentation page. The server-side preview gate cannot help there, because
-  // a static host runs no server. Without this clear, the shell's preview iframe
-  // renders the entire documentation page with a small preview stacked on top.
-  //
-  // Clearing is safe in every mount case: snapshot and preview surfaces are
-  // served with an empty \`#app\` anyway, so there is nothing to discard.
-  target.replaceChildren();
-  mount(ComponentPage, { target, props });
+let pageHydration: Promise<void> | undefined;
+let pageHydrated = false;
+
+function hydratePage(): Promise<void> {
+  pageHydration ??= import('../../src/component-page.svelte').then(({ default: ComponentPage }) => {
+    if (shouldHydrate) {
+      hydrate(ComponentPage, { target, props });
+      pageHydrated = true;
+      return;
+    }
+    // mount() APPENDS; it does not clear the target. So whenever we are mounting a
+    // tree that differs from whatever the document already contains, we must own
+    // the container explicitly.
+    //
+    // This is load-bearing on the STATIC export, not just in development. The
+    // exporter strips query strings when crawling, so \`/page/<name>?preview=1\`
+    // resolves to the one exported \`/page/<name>/index.html\` — the full
+    // documentation page. The server-side preview gate cannot help there, because
+    // a static host runs no server. Without this clear, the shell's preview iframe
+    // renders the entire documentation page with a small preview stacked on top.
+    //
+    // Clearing is safe in every mount case: snapshot and preview surfaces are
+    // served with an empty \`#app\` anyway, so there is nothing to discard.
+    target.replaceChildren();
+    mount(ComponentPage, { target, props });
+    pageHydrated = true;
+  });
+  return pageHydration;
+}
+
+function hydrateAfter(event: Event, replay: () => void): void {
+  event.preventDefault();
+  void hydratePage()
+    .then(replay)
+    .catch((error) => console.error('[cinder playground] failed to hydrate page:', error));
+}
+
+function eventElement(event: Event): Element | null {
+  return event.target instanceof Element ? event.target : null;
+}
+
+// The server-rendered documentation remains immediately usable: links and
+// anchors keep their native behavior. The first control interaction upgrades
+// it to the full Svelte page, then replays that interaction against the
+// hydrated component. This covers every expanding/copying/Playground control,
+// rather than letting a new button accidentally become inert on static docs.
+document.addEventListener(
+  'click',
+  (event) => {
+    if (pageHydrated) return;
+    const button = eventElement(event)?.closest('button');
+    if (button === null) return;
+    hydrateAfter(event, () => button.click());
+  },
+  { capture: true },
+);
+
+document.addEventListener(
+  'keydown',
+  (event) => {
+    if (pageHydrated || !['ArrowRight', 'ArrowDown', 'ArrowLeft', 'ArrowUp', 'Home', 'End'].includes(event.key)) return;
+    const button = eventElement(event)?.closest('button');
+    if (button === null) return;
+    hydrateAfter(event, () =>
+      button.dispatchEvent(
+        new KeyboardEvent('keydown', { key: event.key, bubbles: true, cancelable: true }),
+      ),
+    );
+  },
+  { capture: true },
+);
+
+document.addEventListener(
+  'input',
+  (event) => {
+    if (pageHydrated) return;
+    const input = eventElement(event);
+    if (!(input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement)) return;
+    const value = input.value;
+    hydrateAfter(event, () => {
+      input.value = value;
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  },
+  { capture: true },
+);
+
+// A shared or bookmarked Playground URL is intentionally interactive from the
+// first paint. Canonical documentation URLs keep their runtime behind explicit
+// reader interaction, leaving the server-rendered document immediately useful.
+if (shouldHydrate && new URLSearchParams(window.location.search).get('view') === 'playground') {
+  void hydratePage().catch((error) =>
+    console.error('[cinder playground] failed to hydrate Playground view:', error),
+  );
 }
 `;
 

--- a/packages/playground/src/page-bundle.ts
+++ b/packages/playground/src/page-bundle.ts
@@ -184,7 +184,7 @@ document.addEventListener(
     const button = eventElement(event)?.closest('button');
     if (button === null) return;
     if (button.getAttribute('aria-label') === 'Copy import') {
-      const source = button.previousElementSibling?.textContent;
+      const source = button.closest('.dx-import')?.querySelector('.dx-import__code')?.textContent;
       if (source !== null && source !== undefined) {
         void navigator.clipboard?.writeText(source).catch(() => undefined);
       }

--- a/packages/playground/src/page-bundle.ts
+++ b/packages/playground/src/page-bundle.ts
@@ -209,10 +209,16 @@ document.addEventListener(
   { capture: true },
 );
 
-// A shared or bookmarked Playground URL is intentionally interactive from the
-// first paint. Canonical documentation URLs keep their runtime behind explicit
-// reader interaction, leaving the server-rendered document immediately useful.
-if (shouldHydrate && new URLSearchParams(window.location.search).get('view') === 'playground') {
+// Snapshot and preview routes intentionally have an empty server-rendered
+// target, so they must mount immediately. A shared or bookmarked Playground
+// URL is likewise interactive from first paint. Canonical documentation URLs
+// keep their runtime behind explicit reader interaction, leaving the
+// server-rendered document immediately useful.
+if (
+  snapshotMode ||
+  previewOnly ||
+  (shouldHydrate && new URLSearchParams(window.location.search).get('view') === 'playground')
+) {
   void hydratePage().catch((error) =>
     console.error('[cinder playground] failed to hydrate Playground view:', error),
   );

--- a/packages/playground/src/page-bundle.ts
+++ b/packages/playground/src/page-bundle.ts
@@ -74,7 +74,7 @@ export async function compilePageBundleArtifacts(
     )
     .join('\n');
 
-  const entrySource = `import { NAV_FILTER_STORAGE_KEY } from '../../src/component-page-theme.ts';
+  const entrySource = `import { NAV_FILTER_STORAGE_KEY, readInitialTheme } from '../../src/component-page-theme.ts';
 import { persistScrollPosition } from '../../src/shell-app/sidebar-scroll.ts';
 
 const scenarioLoaders: Record<string, () => Promise<unknown>> = {
@@ -262,6 +262,7 @@ if (
   previewOnly ||
   !hasServerRenderedContent ||
   hasPersistedNavFilter ||
+  readInitialTheme() === 'dark' ||
   (shouldHydrate && new URLSearchParams(window.location.search).get('view') === 'playground')
 ) {
   void hydratePage().catch((error) =>

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -472,9 +472,12 @@ describe('/shell-bundle/:filename.js', () => {
     expect(response.status).toBe(200);
     expect(response.headers.get('Content-Type')).toBe('application/javascript');
     const body = await response.text();
-    // Shell bundle must mount the SPA — the mount target ID is part of the
-    // public contract between the bundle and render-shell.ts.
-    expect(body).toContain('shell-root');
+    // The landing page keeps its server-rendered content static. Interactive
+    // shell behavior is loaded with dynamic imports, so color editing and nav
+    // filtering work without putting the documentation/editor graph in the
+    // root route's initial payload.
+    expect(body).toContain('Preview theme:');
+    expect(body).toContain('import("/shell-bundle/');
   }, 30_000);
 
   it('returns 404 for an unknown shell-bundle filename', async () => {

--- a/packages/playground/src/shell-app/color-token-overrides.ts
+++ b/packages/playground/src/shell-app/color-token-overrides.ts
@@ -1,0 +1,61 @@
+import {
+  COLOR_TOKEN_NAMES,
+  isColorTokenName,
+  isSafeColorTokenValue,
+  type ColorTokenOverrides,
+} from './color-token-registry.ts';
+import type { ThemeChoice } from './routing.ts';
+
+export type ColorTokenOverrideState = Record<ThemeChoice, ColorTokenOverrides>;
+
+export const COLOR_TOKEN_SESSION_KEY = 'cinder-playground-color-token-overrides';
+
+const THEME_VALUES: ReadonlySet<ThemeChoice> = new Set(['light', 'dark']);
+
+export function readSessionColorTokenOverrides(): ColorTokenOverrideState {
+  const empty: ColorTokenOverrideState = { light: {}, dark: {} };
+  try {
+    const parsed: unknown = JSON.parse(sessionStorage.getItem(COLOR_TOKEN_SESSION_KEY) ?? 'null');
+    if (typeof parsed !== 'object' || parsed === null) return empty;
+    const result: ColorTokenOverrideState = { light: {}, dark: {} };
+    for (const theme of THEME_VALUES) {
+      const entries = Reflect.get(parsed, theme);
+      if (typeof entries !== 'object' || entries === null) continue;
+      for (const [tokenName, value] of Object.entries(entries)) {
+        if (
+          isColorTokenName(tokenName) &&
+          typeof value === 'string' &&
+          isSafeColorTokenValue(value)
+        ) {
+          result[theme][tokenName] = value.trim();
+        }
+      }
+    }
+    return result;
+  } catch {
+    return empty;
+  }
+}
+
+export function writeSessionColorTokenOverrides(overrides: ColorTokenOverrideState): void {
+  try {
+    sessionStorage.setItem(COLOR_TOKEN_SESSION_KEY, JSON.stringify(overrides));
+  } catch {
+    /* ignore — degraded but functional */
+  }
+}
+
+export function applyColorTokenOverridesToDocument(
+  doc: Document,
+  overrides: ColorTokenOverrides,
+): void {
+  for (const tokenName of COLOR_TOKEN_NAMES) {
+    doc.documentElement.style.removeProperty(tokenName);
+  }
+
+  for (const [tokenName, value] of Object.entries(overrides)) {
+    if (!isColorTokenName(tokenName)) continue;
+    if (typeof value !== 'string' || !isSafeColorTokenValue(value)) continue;
+    doc.documentElement.style.setProperty(tokenName, value.trim());
+  }
+}

--- a/packages/playground/src/shell-app/preview-store.svelte.ts
+++ b/packages/playground/src/shell-app/preview-store.svelte.ts
@@ -16,25 +16,32 @@ import { getContext, setContext } from 'svelte';
 import { MediaQuery } from 'svelte/reactivity';
 
 import {
-  COLOR_TOKEN_NAMES,
+  applyColorTokenOverridesToDocument,
+  readSessionColorTokenOverrides,
+  writeSessionColorTokenOverrides,
+  type ColorTokenOverrideState,
+} from './color-token-overrides.ts';
+import {
   isColorTokenName,
   isSafeColorTokenValue,
   type ColorTokenName,
-  type ColorTokenOverrides,
 } from './color-token-registry.ts';
 import type { ThemeChoice } from './routing.ts';
 import { THEME_STORAGE_KEY } from './theme-storage.ts';
 
 export type { ThemeChoice };
 
-export type ColorTokenOverrideState = Record<ThemeChoice, ColorTokenOverrides>;
+export type { ColorTokenOverrideState } from './color-token-overrides.ts';
 
 const PREVIEW_STORE_KEY = Symbol('cinder-preview-store');
 
 /** Persisted theme key — must match `PRE_PAINT_THEME_SCRIPT` in render-shell.ts. */
 
+export {
+  applyColorTokenOverridesToDocument,
+  COLOR_TOKEN_SESSION_KEY,
+} from './color-token-overrides.ts';
 export { THEME_STORAGE_KEY };
-export const COLOR_TOKEN_SESSION_KEY = 'cinder-playground-color-token-overrides';
 
 const THEME_VALUES: ReadonlySet<ThemeChoice> = new Set(['light', 'dark']);
 
@@ -65,39 +72,6 @@ export function writePersistedTheme(value: ThemeChoice): void {
   }
 }
 
-function readSessionColorTokenOverrides(): ColorTokenOverrideState {
-  const empty: ColorTokenOverrideState = { light: {}, dark: {} };
-  try {
-    const parsed: unknown = JSON.parse(sessionStorage.getItem(COLOR_TOKEN_SESSION_KEY) ?? 'null');
-    if (typeof parsed !== 'object' || parsed === null) return empty;
-    const result: ColorTokenOverrideState = { light: {}, dark: {} };
-    for (const theme of THEME_VALUES) {
-      const entries = Reflect.get(parsed, theme);
-      if (typeof entries !== 'object' || entries === null) continue;
-      for (const [tokenName, value] of Object.entries(entries)) {
-        if (
-          isColorTokenName(tokenName) &&
-          typeof value === 'string' &&
-          isSafeColorTokenValue(value)
-        ) {
-          result[theme][tokenName] = value.trim();
-        }
-      }
-    }
-    return result;
-  } catch {
-    return empty;
-  }
-}
-
-function writeSessionColorTokenOverrides(overrides: ColorTokenOverrideState): void {
-  try {
-    sessionStorage.setItem(COLOR_TOKEN_SESSION_KEY, JSON.stringify(overrides));
-  } catch {
-    /* ignore — degraded but functional */
-  }
-}
-
 /**
  * Apply the playground's theme to a document's root element.
  *
@@ -116,21 +90,6 @@ export function applyThemeToDocument(
 ): void {
   doc.documentElement.style.colorScheme = override ?? '';
   doc.documentElement.dataset['cinderTheme'] = override ?? resolved;
-}
-
-export function applyColorTokenOverridesToDocument(
-  doc: Document,
-  overrides: ColorTokenOverrides,
-): void {
-  for (const tokenName of COLOR_TOKEN_NAMES) {
-    doc.documentElement.style.removeProperty(tokenName);
-  }
-
-  for (const [tokenName, value] of Object.entries(overrides)) {
-    if (!isColorTokenName(tokenName)) continue;
-    if (typeof value !== 'string' || !isSafeColorTokenValue(value)) continue;
-    doc.documentElement.style.setProperty(tokenName, value.trim());
-  }
 }
 
 export class PreviewStore {

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -75,6 +75,15 @@ function hydrateShell(): Promise<void> {
   return shellHydration;
 }
 
+// Static SSR always renders the light-state icon to avoid hydration mismatch.
+// A persisted dark theme needs the interactive control immediately so its icon
+// and accessible label match the pre-paint theme before the first click.
+if (themeToggle !== null && readInitialTheme() === 'dark') {
+  void hydrateShell().catch((error) =>
+    console.error('[cinder playground] failed to synchronize landing theme:', error),
+  );
+}
+
 const colorPanelToggle = document.querySelector<HTMLButtonElement>(
   '[data-testid="color-token-panel-toggle"]',
 );

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -37,6 +37,7 @@ if (themeToggle !== null) {
 }
 
 let shellHydration: Promise<void> | undefined;
+let shellHydrated = false;
 
 function hydrateShell(): Promise<void> {
   shellHydration ??= Promise.all([
@@ -71,6 +72,7 @@ function hydrateShell(): Promise<void> {
         readmeHtml: initial.readmeHtml,
       },
     });
+    shellHydrated = true;
   });
   return shellHydration;
 }
@@ -91,6 +93,9 @@ const colorPanelToggle = document.querySelector<HTMLButtonElement>(
 colorPanelToggle?.addEventListener(
   'click',
   (event) => {
+    // Once Svelte has taken over the existing button, its own handler receives
+    // this trusted click. Replaying would immediately toggle the panel closed.
+    if (shellHydrated) return;
     event.preventDefault();
     void hydrateShell()
       .then(() => colorPanelToggle.click())

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -1,58 +1,118 @@
 /**
  * Entry point for the playground shell SPA bundle.
  *
- * Reads the `<script type="application/json" id="cinder-initial">` data island
- * embedded by `render-shell.ts` to get the initial component name and the
- * full sidebar component list, then hydrates the server-rendered Svelte shell
- * in `#shell-root`.
- *
- * The data-island pattern is used instead of a `window.__GLOBAL__` to avoid
- * any risk of `</script>` injection through the embedded payload, even though
- * payload values are filesystem-derived and kebab-case-validated server-side.
+ * Adds the small progressive enhancements the server-rendered landing page
+ * needs. The full Svelte shell is intentionally not hydrated here: its
+ * documentation and editor graph belongs behind reader interaction, not in the
+ * first landing-page transfer.
  */
 
-import { hydrate } from 'svelte';
+import { applyTheme, NAV_FILTER_STORAGE_KEY, readInitialTheme } from '../component-page-theme.ts';
+import {
+  applyColorTokenOverridesToDocument,
+  readSessionColorTokenOverrides,
+} from './color-token-overrides.ts';
 
-import { parseInitialData, type InitialData } from './shell-initial-data.ts';
-import Shell from './shell.svelte';
+applyColorTokenOverridesToDocument(document, readSessionColorTokenOverrides()[readInitialTheme()]);
 
-function readInitialData(): InitialData {
-  const node = document.getElementById('cinder-initial');
-  if (!node)
-    return {
-      component: '',
-      components: [],
-      readmeHtml: '',
-      documentation: null,
-      initialSearch: '',
-    };
-  try {
-    const parsed: unknown = JSON.parse(node.textContent ?? '{}');
-    const initialData = parseInitialData(parsed);
-    if (initialData !== null) return initialData;
-  } catch (error) {
-    console.error('[cinder playground] failed to parse #cinder-initial:', error);
-  }
-  return {
-    component: '',
-    components: [],
-    readmeHtml: '',
-    documentation: null,
-    initialSearch: '',
-  };
+const themeToggle = document.querySelector<HTMLButtonElement>(
+  'button[aria-label^="Preview theme:"]',
+);
+
+function labelForTheme(theme: 'light' | 'dark'): string {
+  return theme === 'dark' ? 'Preview theme: switch to light' : 'Preview theme: switch to dark';
 }
 
-const initial = readInitialData();
-
-const target = document.getElementById('shell-root');
-if (target === null) {
-  throw new Error('[cinder playground] #shell-root target not found');
+if (themeToggle !== null) {
+  themeToggle.addEventListener('click', () => {
+    const nextTheme = readInitialTheme() === 'dark' ? 'light' : 'dark';
+    applyTheme(nextTheme);
+    applyColorTokenOverridesToDocument(document, readSessionColorTokenOverrides()[nextTheme]);
+    themeToggle.setAttribute('aria-label', labelForTheme(nextTheme));
+  });
 }
 
-hydrate(Shell, {
-  target,
-  props: {
-    components: initial.components,
-    readmeHtml: initial.readmeHtml,
+let shellHydration: Promise<void> | undefined;
+
+function hydrateShell(): Promise<void> {
+  shellHydration ??= Promise.all([
+    import('svelte'),
+    import('./shell-initial-data.ts'),
+    import('./shell.svelte'),
+  ]).then(([svelte, initialDataModule, shellModule]) => {
+    const target = document.getElementById('shell-root');
+    if (target === null) throw new Error('[cinder playground] #shell-root target not found');
+
+    const node = document.getElementById('cinder-initial');
+    let rawInitialData: unknown = {};
+    try {
+      rawInitialData = node === null ? {} : JSON.parse(node.textContent ?? '{}');
+    } catch (error) {
+      console.error('[cinder playground] failed to parse #cinder-initial:', error);
+    }
+    let initial = initialDataModule.parseInitialData(rawInitialData);
+    if (initial === null) {
+      initial = {
+        component: '',
+        components: [],
+        readmeHtml: '',
+        documentation: null,
+        initialSearch: '',
+      };
+    }
+    svelte.hydrate(shellModule.default, {
+      target,
+      props: {
+        components: initial.components,
+        readmeHtml: initial.readmeHtml,
+      },
+    });
+  });
+  return shellHydration;
+}
+
+const colorPanelToggle = document.querySelector<HTMLButtonElement>(
+  '[data-testid="color-token-panel-toggle"]',
+);
+
+colorPanelToggle?.addEventListener(
+  'click',
+  (event) => {
+    event.preventDefault();
+    void hydrateShell()
+      .then(() => colorPanelToggle.click())
+      .catch((error) =>
+        console.error('[cinder playground] failed to hydrate landing shell:', error),
+      );
   },
-});
+  { once: true },
+);
+
+const sidebarFilter = document.getElementById('sidebar-filter');
+if (sidebarFilter instanceof HTMLInputElement) {
+  try {
+    sidebarFilter.value = sessionStorage.getItem(NAV_FILTER_STORAGE_KEY) ?? '';
+  } catch {
+    // Private mode or disabled storage: filtering still works for this page.
+  }
+  sidebarFilter.addEventListener(
+    'input',
+    () => {
+      const value = sidebarFilter.value;
+      try {
+        sessionStorage.setItem(NAV_FILTER_STORAGE_KEY, value);
+      } catch {
+        // Private mode or disabled storage: keep the current input value.
+      }
+      void hydrateShell()
+        .then(() => {
+          sidebarFilter.value = value;
+          sidebarFilter.dispatchEvent(new Event('input', { bubbles: true }));
+        })
+        .catch((error) =>
+          console.error('[cinder playground] failed to hydrate landing shell:', error),
+        );
+    },
+    { once: true },
+  );
+}

--- a/packages/playground/src/shell-app/shell-entry.ts
+++ b/packages/playground/src/shell-app/shell-entry.ts
@@ -12,6 +12,7 @@ import {
   applyColorTokenOverridesToDocument,
   readSessionColorTokenOverrides,
 } from './color-token-overrides.ts';
+import { persistScrollPosition } from './sidebar-scroll.ts';
 
 applyColorTokenOverridesToDocument(document, readSessionColorTokenOverrides()[readInitialTheme()]);
 
@@ -29,6 +30,9 @@ if (themeToggle !== null) {
     applyTheme(nextTheme);
     applyColorTokenOverridesToDocument(document, readSessionColorTokenOverrides()[nextTheme]);
     themeToggle.setAttribute('aria-label', labelForTheme(nextTheme));
+    void hydrateShell().catch((error) =>
+      console.error('[cinder playground] failed to hydrate landing shell:', error),
+    );
   });
 }
 
@@ -88,31 +92,42 @@ colorPanelToggle?.addEventListener(
   { once: true },
 );
 
+const sidebarNavigation = document.querySelector<HTMLElement>('nav.dx-nav');
+if (sidebarNavigation !== null) persistScrollPosition(sidebarNavigation);
+
 const sidebarFilter = document.getElementById('sidebar-filter');
 if (sidebarFilter instanceof HTMLInputElement) {
+  let latestFilterValue = '';
   try {
-    sidebarFilter.value = sessionStorage.getItem(NAV_FILTER_STORAGE_KEY) ?? '';
+    latestFilterValue = sessionStorage.getItem(NAV_FILTER_STORAGE_KEY) ?? '';
+    sidebarFilter.value = latestFilterValue;
   } catch {
     // Private mode or disabled storage: filtering still works for this page.
   }
-  sidebarFilter.addEventListener(
-    'input',
-    () => {
-      const value = sidebarFilter.value;
-      try {
-        sessionStorage.setItem(NAV_FILTER_STORAGE_KEY, value);
-      } catch {
-        // Private mode or disabled storage: keep the current input value.
-      }
-      void hydrateShell()
-        .then(() => {
-          sidebarFilter.value = value;
-          sidebarFilter.dispatchEvent(new Event('input', { bubbles: true }));
-        })
-        .catch((error) =>
-          console.error('[cinder playground] failed to hydrate landing shell:', error),
-        );
-    },
-    { once: true },
-  );
+  const persistAndHydrateFilter = () => {
+    latestFilterValue = sidebarFilter.value;
+    try {
+      sessionStorage.setItem(NAV_FILTER_STORAGE_KEY, latestFilterValue);
+    } catch {
+      // Private mode or disabled storage: keep the current input value.
+    }
+    void hydrateShell()
+      .then(() => {
+        sidebarFilter.removeEventListener('input', persistAndHydrateFilter);
+        const hydratedFilter = document.getElementById('sidebar-filter');
+        if (!(hydratedFilter instanceof HTMLInputElement)) return;
+        hydratedFilter.value = latestFilterValue;
+        hydratedFilter.dispatchEvent(new Event('input', { bubbles: true }));
+      })
+      .catch((error) =>
+        console.error('[cinder playground] failed to hydrate landing shell:', error),
+      );
+  };
+  sidebarFilter.addEventListener('input', persistAndHydrateFilter);
+
+  if (latestFilterValue !== '') {
+    void hydrateShell().catch((error) =>
+      console.error('[cinder playground] failed to restore landing filter:', error),
+    );
+  }
 }

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -15,6 +15,7 @@
    */
   import { Button } from '@lostgradient/cinder/button';
   import Palette from 'lucide-svelte/icons/palette';
+  import type { Component } from 'svelte';
 
   import ComponentPage from '../component-page.svelte';
   import { PreviewStore, setPreviewStore } from './preview-store.svelte.ts';
@@ -33,7 +34,9 @@
   const COLOR_PANEL_LABEL = 'Color token panel';
 
   let isColorPanelOpen = $state(false);
-  type ColorTokenPanelModule = typeof import('./color-token-panel.svelte');
+  type ColorTokenPanelModule = {
+    default: Component<{ onClose: () => void }>;
+  };
   let colorTokenPanelModule = $state<Promise<ColorTokenPanelModule> | null>(null);
 
   $effect(() => {

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -91,6 +91,14 @@
     colorTokenPanelModule ??= import('./color-token-panel.svelte');
     isColorPanelOpen = true;
   }
+
+  function getColorTokenPanelModule(): Promise<ColorTokenPanelModule> {
+    if (colorTokenPanelModule === null) {
+      throw new Error('Color token panel module was requested before loading.');
+    }
+
+    return colorTokenPanelModule;
+  }
 </script>
 
 <ComponentPage
@@ -115,7 +123,8 @@
 
   {#snippet overlays()}
     {#if isColorPanelOpen}
-      {#await colorTokenPanelModule then { default: ColorTokenPanel }}
+      {#await getColorTokenPanelModule() then module}
+        {@const ColorTokenPanel = module.default}
         <ColorTokenPanel onClose={closeColorPanel} />
       {/await}
     {/if}

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -88,8 +88,14 @@
       closeColorPanel();
       return;
     }
-    colorTokenPanelModule ??= import('./color-token-panel.svelte');
-    await colorTokenPanelModule;
+    try {
+      colorTokenPanelModule ??= import('./color-token-panel.svelte');
+      await colorTokenPanelModule;
+    } catch (error) {
+      colorTokenPanelModule = null;
+      console.error('[cinder playground] failed to load the color token panel:', error);
+      return;
+    }
     isColorPanelOpen = true;
   }
 

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -9,16 +9,14 @@
    *
    * It is now a thin wrapper around the SAME component every documentation page
    * renders, in landing mode — so `/` and `/page/<name>` are one layout with
-   * different content. The only thing this adds is the colour-token panel, which
-   * lives here because it pulls ColorPicker/Popover/Input/Button: this is one
-   * bundle, whereas the documentation page compiles once per component (170
-   * bundles), where that graph made each build ~4x slower.
+   * different content. The only thing this adds is the colour-token panel.
+   * Its ColorPicker/Popover/Input graph loads when the reader opens the panel,
+   * rather than making every landing-page visit pay for an advanced editor.
    */
   import { Button } from '@lostgradient/cinder/button';
   import Palette from 'lucide-svelte/icons/palette';
 
   import ComponentPage from '../component-page.svelte';
-  import ColorTokenPanel from './color-token-panel.svelte';
   import { PreviewStore, setPreviewStore } from './preview-store.svelte.ts';
 
   type Props = {
@@ -35,6 +33,8 @@
   const COLOR_PANEL_LABEL = 'Color token panel';
 
   let isColorPanelOpen = $state(false);
+  type ColorTokenPanelModule = typeof import('./color-token-panel.svelte');
+  let colorTokenPanelModule = $state<Promise<ColorTokenPanelModule> | null>(null);
 
   $effect(() => {
     store.applyActiveColorTokenOverridesToDocument(document);
@@ -79,6 +79,15 @@
       document.querySelector<HTMLElement>(`button[aria-label="${COLOR_PANEL_LABEL}"]`)?.focus();
     });
   }
+
+  function toggleColorPanel(): void {
+    if (isColorPanelOpen) {
+      closeColorPanel();
+      return;
+    }
+    colorTokenPanelModule ??= import('./color-token-panel.svelte');
+    isColorPanelOpen = true;
+  }
 </script>
 
 <ComponentPage
@@ -95,7 +104,7 @@
       {...isColorPanelOpen ? { 'aria-controls': 'color-token-panel' } : {}}
       aria-expanded={isColorPanelOpen}
       data-testid="color-token-panel-toggle"
-      onclick={() => (isColorPanelOpen = !isColorPanelOpen)}
+      onclick={toggleColorPanel}
     >
       <Palette size={17} strokeWidth={1.5} aria-hidden="true" />
     </Button>
@@ -103,7 +112,9 @@
 
   {#snippet overlays()}
     {#if isColorPanelOpen}
-      <ColorTokenPanel onClose={closeColorPanel} />
+      {#await colorTokenPanelModule then { default: ColorTokenPanel }}
+        <ColorTokenPanel onClose={closeColorPanel} />
+      {/await}
     {/if}
   {/snippet}
 </ComponentPage>

--- a/packages/playground/src/shell-app/shell.svelte
+++ b/packages/playground/src/shell-app/shell.svelte
@@ -83,12 +83,13 @@
     });
   }
 
-  function toggleColorPanel(): void {
+  async function toggleColorPanel(): Promise<void> {
     if (isColorPanelOpen) {
       closeColorPanel();
       return;
     }
     colorTokenPanelModule ??= import('./color-token-panel.svelte');
+    await colorTokenPanelModule;
     isColorPanelOpen = true;
   }
 
@@ -115,7 +116,7 @@
       {...isColorPanelOpen ? { 'aria-controls': 'color-token-panel' } : {}}
       aria-expanded={isColorPanelOpen}
       data-testid="color-token-panel-toggle"
-      onclick={toggleColorPanel}
+      onclick={() => void toggleColorPanel()}
     >
       <Palette size={17} strokeWidth={1.5} aria-hidden="true" />
     </Button>

--- a/packages/testing/src/fixtures/component-page.ts
+++ b/packages/testing/src/fixtures/component-page.ts
@@ -110,9 +110,9 @@ export const test = base.extend<Fixtures>({
         await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
         await page.waitForFunction(
           () =>
-            [
-              ...document.querySelectorAll<HTMLElement>('.snapshot-examples .example-preview'),
-            ].every((preview) => preview.childElementCount > 0),
+            Array.from(
+              document.querySelectorAll<HTMLElement>('.snapshot-examples .example-preview'),
+            ).every((preview) => preview.childElementCount > 0),
           undefined,
           { timeout: 20_000 },
         );

--- a/packages/testing/src/fixtures/component-page.ts
+++ b/packages/testing/src/fixtures/component-page.ts
@@ -108,6 +108,14 @@ export const test = base.extend<Fixtures>({
         // generous headroom for runAxe + captureScreenshot inside the
         // per-test 90s timeout.
         await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
+        await page.waitForFunction(
+          () =>
+            [
+              ...document.querySelectorAll<HTMLElement>('.snapshot-examples .example-preview'),
+            ].every((preview) => preview.childElementCount > 0),
+          undefined,
+          { timeout: 20_000 },
+        );
         // Blur any auto-focused element so focus rings don't appear in
         // screenshots. Phase 2 interaction tokens will opt back in to focus
         // on specific elements when the visual contract requires it.

--- a/packages/testing/src/fixtures/component-page.ts
+++ b/packages/testing/src/fixtures/component-page.ts
@@ -102,20 +102,12 @@ export const test = base.extend<Fixtures>({
         await page.goto(buildRoute(entry, fixtureName, fixtureContentHash), {
           waitUntil: 'load',
         });
-        // Post-#39 (chunk-[hash].js naming), all components — including the
-        // Milkdown-backed editors (Chat, MarkdownEditor, ReviewEditor) —
-        // mount in single-digit seconds on the CI runner. 20s leaves
-        // generous headroom for runAxe + captureScreenshot inside the
-        // per-test 90s timeout.
         await page.waitForSelector('#app > *', { state: 'visible', timeout: 20_000 });
-        await page.waitForFunction(
-          () =>
-            Array.from(
-              document.querySelectorAll<HTMLElement>('.snapshot-examples .example-preview'),
-            ).every((preview) => preview.childElementCount > 0),
-          undefined,
-          { timeout: 20_000 },
-        );
+        await page.evaluate(async () => {
+          const readiness = (window as Window & { __CINDER_SNAPSHOT_READY__?: Promise<void> })
+            .__CINDER_SNAPSHOT_READY__;
+          if (readiness !== undefined) await readiness;
+        });
         // Blur any auto-focused element so focus rings don't appear in
         // screenshots. Phase 2 interaction tokens will opt back in to focus
         // on specific elements when the visual contract requires it.

--- a/packages/testing/tests/alternate-theme.playwright.ts
+++ b/packages/testing/tests/alternate-theme.playwright.ts
@@ -56,7 +56,7 @@ async function computed(page: Page, selector: string, property: string): Promise
 
 test.describe('alternate-theme — documented token overrides reach components', () => {
   test('overriding --cinder-accent reaches a primary Button background', async ({ page }) => {
-    await page.goto('/page/button?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/button?snapshot=1', { waitUntil: 'load' });
 
     const primarySelector = ".cinder-button[data-cinder-variant='primary']";
     const stock = await computed(page, primarySelector, 'background-color');
@@ -71,7 +71,7 @@ test.describe('alternate-theme — documented token overrides reach components',
   });
 
   test('overriding --cinder-radius-lg reaches a Card border-radius', async ({ page }) => {
-    await page.goto('/page/card?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/card?snapshot=1', { waitUntil: 'load' });
 
     const cardSelector = '.cinder-card';
     const stock = await computed(page, cardSelector, 'border-top-left-radius');
@@ -88,7 +88,7 @@ test.describe('alternate-theme — documented token overrides reach components',
   // The Surface component's base rule is `background: var(--cinder-surface)`.
   // A hard-coded background on .cinder-surface would leave these values equal.
   test('overriding --cinder-surface reaches a Surface component background', async ({ page }) => {
-    await page.goto('/page/surface?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/surface?snapshot=1', { waitUntil: 'load' });
 
     const surfaceSelector = '.cinder-surface';
     const stock = await computed(page, surfaceSelector, 'background-color');
@@ -106,7 +106,7 @@ test.describe('alternate-theme — documented token overrides reach components',
   // Input CSS: `border: 1px solid var(--cinder-border)`.
   // A hard-coded border-color on .cinder-input would leave these equal.
   test('overriding --cinder-border reaches an Input border-color', async ({ page }) => {
-    await page.goto('/page/input?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/input?snapshot=1', { waitUntil: 'load' });
 
     const inputSelector = '.cinder-input';
     const stock = await computed(page, inputSelector, 'border-top-color');
@@ -131,7 +131,7 @@ test.describe('alternate-theme — documented token overrides reach components',
   test('overriding --cinder-danger reaches an Alert danger-variant background', async ({
     page,
   }) => {
-    await page.goto('/page/alert?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/alert?snapshot=1', { waitUntil: 'load' });
 
     const dangerAlertSelector = ".cinder-alert[data-cinder-variant='danger']";
     const stock = await computed(page, dangerAlertSelector, 'background-color');
@@ -188,7 +188,7 @@ test.describe('alternate-theme — documented token overrides reach components',
   test('overriding --cinder-ring-width reaches a focused Button outline-width', async ({
     page,
   }) => {
-    await page.goto('/page/button?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/button?snapshot=1', { waitUntil: 'load' });
 
     await focusPrimaryButton(page);
     const stock = await page.evaluate(() => getComputedStyle(document.activeElement!).outlineWidth);
@@ -214,7 +214,7 @@ test.describe('alternate-theme — documented token overrides reach components',
   // Stock value: 1rem (16px). Alternate theme: 2.5rem (40px).
   // A hard-coded padding would not change, leaving these equal.
   test('overriding --cinder-space-4 reaches a Card body padding', async ({ page }) => {
-    await page.goto('/page/card?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/card?snapshot=1', { waitUntil: 'load' });
 
     const bodySelector = '.cinder-card__body';
     const stock = await computed(page, bodySelector, 'padding-top');

--- a/packages/testing/tests/card-padding.playwright.ts
+++ b/packages/testing/tests/card-padding.playwright.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 test.describe('Card padding', () => {
   test('padding="none" flushes only the body', async ({ page }) => {
-    await page.goto('/page/card?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/card?snapshot=1', { waitUntil: 'load' });
 
     const body = page.locator(".cinder-card__body[data-cinder-padding='none']").first();
     const card = body.locator('..');
@@ -26,7 +26,7 @@ test.describe('Card padding', () => {
   });
 
   test('the flush-body example has no horizontal overflow', async ({ page }) => {
-    await page.goto('/page/card?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/card?snapshot=1', { waitUntil: 'load' });
 
     const body = page.locator(".cinder-card__body[data-cinder-padding='none']").first();
     const card = body.locator('..');
@@ -57,7 +57,7 @@ test.describe('Card padding', () => {
   });
 
   test('ApprovalCard keeps a single owned header padding layer', async ({ page }) => {
-    await page.goto('/page/approval-card?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/approval-card?snapshot=1', { waitUntil: 'load' });
 
     const approvalCard = page.locator('.cinder-approval-card').first();
     const cardHeader = approvalCard.locator('.cinder-card__header');

--- a/packages/testing/tests/ease-spring-token.playwright.ts
+++ b/packages/testing/tests/ease-spring-token.playwright.ts
@@ -36,7 +36,7 @@ function canonicalTimingFunction(value: string): string {
 
 test.describe('--cinder-ease-spring token', () => {
   test('resolves on the modal element and drives a non-default timing curve', async ({ page }) => {
-    await page.goto('/page/modal?tab=examples', { waitUntil: 'load' });
+    await page.goto('/page/modal?snapshot=1', { waitUntil: 'load' });
 
     // The basic example renders a trigger button that opens a generic modal
     // (an "Invite teammate" form); click it to open the modal.

--- a/packages/testing/tests/markdown-editor-toolbar.playwright.ts
+++ b/packages/testing/tests/markdown-editor-toolbar.playwright.ts
@@ -4,7 +4,7 @@ import { THEMES, VIEWPORTS } from '../src/helpers/manifest.ts';
 const markdownEditorEntry = {
   name: 'MarkdownEditor',
   slug: 'markdown-editor',
-  route: '/page/markdown-editor?tab=examples',
+  route: '/page/markdown-editor?snapshot=1',
 } as const;
 
 const testedViewports = VIEWPORTS.filter(

--- a/packages/testing/tests/playground-documentation.playwright.ts
+++ b/packages/testing/tests/playground-documentation.playwright.ts
@@ -393,7 +393,7 @@ test('text children stay text when VisuallyHidden changes its rendered element',
 }) => {
   await page.goto('/page/visually-hidden?view=playground', { waitUntil: 'load' });
 
-  await page.getByLabel('as').selectOption('textarea');
+  await page.locator('.dx-playground__panel').getByLabel('as').selectOption('textarea');
   const preview = page.locator('#playground-live-mount textarea');
   await expect(preview).toHaveText('VisuallyHidden');
   await expect(preview.locator('span')).toHaveCount(0);

--- a/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
+++ b/packages/testing/tests/playground-page-chrome-focus-rings.playwright.ts
@@ -166,6 +166,10 @@ async function openButtonDocumentationPage(page: Page): Promise<Frame> {
   // page renders every section at once, so its presence means the
   // documentation payload has hydrated.
   await expect(page.getByRole('heading', { level: 1, name: 'Button' })).toBeVisible();
+  // Canonical documentation is progressively hydrated. A reader interaction
+  // upgrades it before this test exercises focusable example chrome.
+  await page.getByRole('button', { name: 'Copy import' }).click();
+  await expect(page.locator('.dx-example').first()).toBeVisible();
   return page.mainFrame();
 }
 

--- a/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
+++ b/packages/testing/tests/review-editor-scroll-and-sidebar.playwright.ts
@@ -51,6 +51,7 @@ const desktop = VIEWPORTS.find((viewport) => viewport.name === 'desktop')!;
 const EDITOR_ID = 'example-mount-scroll-and-sidebar-review-editor';
 const MOUNT_SELECTOR = '#example-mount-scroll-and-sidebar';
 const CLOCK_INITIAL_TIME = new Date('2024-01-01T00:00:00.000Z');
+const CLOCK_PAUSED_TIME = new Date('2024-01-01T01:00:00.000Z');
 async function openExample(componentPage: ComponentPage): Promise<{ page: Page; mount: Locator }> {
   const page = await componentPage.open({
     entry: reviewEditorEntry,
@@ -102,13 +103,12 @@ function anchor(mount: Locator, threadId: string): Locator {
  * instead of the bug.
  */
 async function installPausedClock(page: Page): Promise<void> {
-  // `install()` defaults to the current system time. Constructing a second
-  // `Date` after it can then be fractionally earlier than Playwright's
-  // initialized clock, which makes `pauseAt()` reject the backward jump.
-  // Start at a deterministic instant and pause one millisecond later so the
-  // operation is always a forward transition.
+  // Playwright lets fake time progress between protocol calls. Pausing only
+  // one millisecond after installation can therefore ask it to move backward.
+  // Use a deliberately later deterministic instant, matching Playwright's
+  // recommended "slightly before the intended test time" setup.
   await page.clock.install({ time: CLOCK_INITIAL_TIME });
-  await page.clock.pauseAt(new Date(CLOCK_INITIAL_TIME.getTime() + 1));
+  await page.clock.pauseAt(CLOCK_PAUSED_TIME);
 }
 
 test.describe('ReviewEditor.scrollToThread (cinder#1316, cinder#1317)', () => {

--- a/packages/testing/tests/scroll-fade-recipe.playwright.ts
+++ b/packages/testing/tests/scroll-fade-recipe.playwright.ts
@@ -17,7 +17,7 @@
 import { expect, test, type Page } from '@playwright/test';
 
 async function loadStyledPage(page: Page): Promise<void> {
-  await page.goto('/page/modal?tab=examples', { waitUntil: 'load' });
+  await page.goto('/page/modal?snapshot=1', { waitUntil: 'load' });
 }
 
 /** Injects a tall fixed-height scroll fixture, replacing any prior fixture. */

--- a/packages/testing/tests/shadow-token-theme.playwright.ts
+++ b/packages/testing/tests/shadow-token-theme.playwright.ts
@@ -25,7 +25,7 @@
 import { expect, test } from '@playwright/test';
 
 async function loadCard(themedPage: import('@playwright/test').Page) {
-  await themedPage.goto('/page/card?tab=examples', { waitUntil: 'load' });
+  await themedPage.goto('/page/card?snapshot=1', { waitUntil: 'load' });
   const card = themedPage.locator('.cinder-card').first();
   await expect(card).toBeVisible();
   return card;

--- a/packages/testing/tests/status-surface-recipe.playwright.ts
+++ b/packages/testing/tests/status-surface-recipe.playwright.ts
@@ -19,7 +19,7 @@ import { expect, test, type Page } from '@playwright/test';
 
 /** Load any cinder page so the global styles + component sidecars are applied. */
 async function loadStyledPage(page: Page): Promise<void> {
-  await page.goto('/page/callout?tab=examples', { waitUntil: 'load' });
+  await page.goto('/page/callout?snapshot=1', { waitUntil: 'load' });
 }
 
 /**

--- a/packages/testing/tests/theme-parity-light-ladder.playwright.ts
+++ b/packages/testing/tests/theme-parity-light-ladder.playwright.ts
@@ -442,7 +442,7 @@ test.describe('theme-parity — light surface ladder + button vividness floor', 
       const context = await browser.newContext({ colorScheme, reducedMotion: 'reduce' });
       try {
         const page = await context.newPage();
-        await page.goto('/page/button', { waitUntil: 'load' });
+        await page.goto('/page/button?snapshot=1', { waitUntil: 'load' });
 
         const primarySelector = ".cinder-button[data-cinder-variant='primary']";
         // Resolve the pressed fill + label tokens to painted colors via a probe:

--- a/packages/testing/tests/theme-parity-light-ladder.playwright.ts
+++ b/packages/testing/tests/theme-parity-light-ladder.playwright.ts
@@ -207,7 +207,7 @@ test.describe('theme-parity — light surface ladder + button vividness floor', 
     try {
       const page = await context.newPage();
 
-      await page.goto('/page/button?tab=examples', { waitUntil: 'load' });
+      await page.goto('/page/button?snapshot=1', { waitUntil: 'load' });
       // Prove the browser is actually emulating LIGHT (so light-dark() resolves to
       // the light arm). `getComputedStyle(documentElement).colorScheme` returns the
       // AUTHORED `color-scheme: light dark` regardless of emulation, so it is a
@@ -241,7 +241,7 @@ test.describe('theme-parity — light surface ladder + button vividness floor', 
       expect(bgL, 'the light-mode page background must read as white').toBeGreaterThanOrEqual(0.97);
 
       // surface vs inset, measured off the Table (body = surface, header = inset).
-      await page.goto('/page/table?tab=examples', { waitUntil: 'load' });
+      await page.goto('/page/table?snapshot=1', { waitUntil: 'load' });
       const surfaceL = await paintedL(page, '.cinder-table', 'backgroundColor');
       const insetL = await paintedL(page, '.cinder-table__header', 'backgroundColor');
       expect(
@@ -265,7 +265,7 @@ test.describe('theme-parity — light surface ladder + button vividness floor', 
     const context = await browser.newContext({ colorScheme: 'light', reducedMotion: 'reduce' });
     try {
       const page = await context.newPage();
-      await page.goto('/page/button?tab=examples', { waitUntil: 'load' });
+      await page.goto('/page/button?snapshot=1', { waitUntil: 'load' });
 
       const secondarySelector = ".cinder-button[data-cinder-variant='secondary']";
       const fillL = await paintedL(page, secondarySelector, 'backgroundColor');
@@ -307,7 +307,7 @@ test.describe('theme-parity — light surface ladder + button vividness floor', 
     const context = await browser.newContext({ colorScheme: 'light', reducedMotion: 'reduce' });
     try {
       const page = await context.newPage();
-      await page.goto('/page/button?tab=examples', { waitUntil: 'load' });
+      await page.goto('/page/button?snapshot=1', { waitUntil: 'load' });
 
       const primarySelector = ".cinder-button[data-cinder-variant='primary']";
       const accent = await paintedOklch(page, primarySelector, 'backgroundColor');
@@ -352,7 +352,7 @@ test.describe('theme-parity — light surface ladder + button vividness floor', 
     const context = await browser.newContext({ colorScheme: 'light', reducedMotion: 'reduce' });
     try {
       const page = await context.newPage();
-      await page.goto('/page/table?tab=examples', { waitUntil: 'load' });
+      await page.goto('/page/table?snapshot=1', { waitUntil: 'load' });
 
       const bodyL = await paintedL(page, '.cinder-table', 'backgroundColor');
       const headerL = await paintedL(page, '.cinder-table__header', 'backgroundColor');
@@ -382,8 +382,8 @@ test.describe('theme-parity — light surface ladder + button vividness floor', 
       const lightPage = await lightContext.newPage();
       const darkPage = await darkContext.newPage();
       await Promise.all([
-        lightPage.goto('/page/button?tab=examples', { waitUntil: 'load' }),
-        darkPage.goto('/page/button?tab=examples', { waitUntil: 'load' }),
+        lightPage.goto('/page/button?snapshot=1', { waitUntil: 'load' }),
+        darkPage.goto('/page/button?snapshot=1', { waitUntil: 'load' }),
       ]);
 
       const primarySelector = ".cinder-button[data-cinder-variant='primary']";


### PR DESCRIPTION
Implements the remaining Playground performance and static-site verification work for CIN-397 and CIN-404.\n\n- defer Playground-only code from documentation routes\n- preserve static documentation rendering and interaction route behavior\n- add production payload, static-export, and server regression coverage\n\nValidated locally:\n- focused Playground static-export, documentation, example-mount, and server tests\n- bun run --filter=@cinder/playground typecheck\n- bun run --filter=@cinder/playground lint\n\nLinear: CIN-397, CIN-404