### PR TITLE
feat(chat): re-export Conversationalist transcript mutation and query helpers

### DIFF
--- a/.changeset/cin-388-transcript-mutation-helpers.md
+++ b/.changeset/cin-388-transcript-mutation-helpers.md
@@ -1,0 +1,9 @@
+---
+'@lostgradient/chat': minor
+---
+
+Re-export Conversationalist's canonical transcript mutation helpers—`updateMessage`, `removeMessage`, `setMessageHidden`, and `replaceToolResult`—along with the `MessageUpdate` type, so consumers no longer need to import `conversationalist` directly or hand-walk transcript internals for these common mutations. Unknown message or tool-call identifiers are no-ops.
+
+Root-export the existing `getMessages` query helper, and add two new typed query helpers: `getUnresolvedToolApprovals` (finds every `tool-result` message still parked on `action_required` with a pending action) and `findToolResultMessage` (locates a `tool-result` message by tool-call identifier).
+
+Bumps the `conversationalist` dependency to `^0.7.0`.

--- a/bun.lock
+++ b/bun.lock
@@ -24,7 +24,7 @@
       "name": "@lostgradient/chat",
       "version": "0.12.0",
       "dependencies": {
-        "conversationalist": "^0.6.1",
+        "conversationalist": "^0.7.0",
         "decode-named-character-reference": "^1.3.0",
         "micromark-util-decode-numeric-character-reference": "^2.0.0",
         "zod": "4.4.3",
@@ -837,7 +837,7 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "conversationalist": ["conversationalist@0.6.1", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.116.0", "zod": "^4.4.3" }, "optionalPeers": ["@anthropic-ai/sdk"] }, "sha512-S+QhPrVO7YCFndUEt/oYYJXUdLzbNM93w0+AlxyDwGZ42lG2CCblOI987xyCZtf1MMOsz4pdOrCY3VKS8LA7hw=="],
+    "conversationalist": ["conversationalist@0.7.0", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.116.0", "zod": "^4.4.3" }, "optionalPeers": ["@anthropic-ai/sdk"] }, "sha512-9txrLkbNh3FvwZ21JqtNOrO4a00XEPyGD8uV8alq8qAdEky2+k8sMDHnPfA4IiIU8wodzrH12gCTHM+0zrqr2w=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 

--- a/packages/chat/package.json
+++ b/packages/chat/package.json
@@ -169,7 +169,7 @@
     "validate:consumer": "bun run scripts/validate-consumer.ts"
   },
   "dependencies": {
-    "conversationalist": "^0.6.1",
+    "conversationalist": "^0.7.0",
     "decode-named-character-reference": "^1.3.0",
     "micromark-util-decode-numeric-character-reference": "^2.0.0",
     "zod": "4.4.3"

--- a/packages/chat/scripts/pack-for-publish.ts
+++ b/packages/chat/scripts/pack-for-publish.ts
@@ -37,7 +37,7 @@ const STAGING_ROOT = join(PACKAGE_ROOT, 'node_modules', '.cache', 'publish-stagi
 // host apps never install or version-pick them directly.
 const REQUIRED_PEERS = new Set(['@lostgradient/cinder', '@lostgradient/markdown', 'svelte']);
 const REQUIRED_DEPENDENCIES: Record<string, string> = {
-  conversationalist: '^0.6.1',
+  conversationalist: '^0.7.0',
   'decode-named-character-reference': '^1.3.0',
   'micromark-util-decode-numeric-character-reference': '^2.0.0',
   zod: '4.4.3',

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -40,7 +40,7 @@ describe('Chat package ownership boundary', () => {
   test('keeps host-supplied runtime singletons peer-only and owns its conversation-model dependencies', () => {
     expect(() => assertSourceManifest(chatManifest)).not.toThrow();
     expect(chatManifest.dependencies).toEqual({
-      conversationalist: '^0.6.1',
+      conversationalist: '^0.7.0',
       'decode-named-character-reference': '^1.3.0',
       'micromark-util-decode-numeric-character-reference': '^2.0.0',
       zod: '4.4.3',

--- a/packages/chat/src/lib/components/chat/README.md
+++ b/packages/chat/src/lib/components/chat/README.md
@@ -159,6 +159,58 @@ async editMessage({ messageId, content }) {
 `RewindOptions` bag (`preserveToolPairs: false` cuts strictly at the boundary,
 leaving a straddled tool call pending).
 
+### Transcript mutation and query helpers
+
+`@lostgradient/chat` re-exports Conversationalist's canonical transcript
+mutation and query helpers so consumers never hand-walk `conversation.ids` /
+`conversation.messages` or import `conversationalist` directly:
+
+```ts
+import {
+  findToolResultMessage,
+  getMessages,
+  getUnresolvedToolApprovals,
+  removeMessage,
+  replaceToolResult,
+  setMessageHidden,
+  updateMessage,
+} from '@lostgradient/chat';
+
+// Edit a message's content in place, keeping identity, role, order, and
+// creation time intact.
+conversation = updateMessage(conversation, messageId, { content: 'Edited' });
+
+// Hide or reveal a message without removing it.
+conversation = setMessageHidden(conversation, messageId, true);
+
+// Remove a message and renumber the surviving positions.
+conversation = removeMessage(conversation, messageId);
+
+// Swap in the final outcome for a tool call that was parked on
+// `action_required` once the consumer approves or denies it.
+conversation = replaceToolResult(conversation, toolCallId, {
+  callId: toolCallId,
+  outcome: 'success',
+  content: { approved: true },
+});
+```
+
+`updateMessage`, `removeMessage`, `setMessageHidden`, and `replaceToolResult`
+are no-ops—they return the original history unchanged—when given an unknown
+message or tool-call identifier, so callers do not need to guard against a
+stale ID.
+
+`getMessages(conversation, { includeHidden? })` returns the ordered,
+non-hidden messages Chat renders (pass `includeHidden: true` to include hidden
+ones too). `getUnresolvedToolApprovals(conversation)` finds every
+`tool-result` message still parked on `outcome: 'action_required'` with a
+pending `action`—the transcript-level source of truth for "does this
+conversation have an approval waiting," independent of any UI-only
+approved/denied state. `findToolResultMessage(conversation, toolCallId)` locates
+the `tool-result` message for a given tool-call ID, which `replaceToolResult`
+needs. Both query helpers accept the same `{ includeHidden? }` option as
+`getMessages`.
+
 > [!WARNING] `ChatAdapter.subscribe` runs inside Chat's own effect
 > Chat opens `subscribe` from inside its internal mount `$effect`, so a
 > synchronous `$state` write inside `subscribe` can throw

--- a/packages/chat/src/lib/components/chat/builders.test.ts
+++ b/packages/chat/src/lib/components/chat/builders.test.ts
@@ -16,8 +16,12 @@ import {
   createConversationHistory,
   markMessageDeliveryFailed,
   prependMessages,
+  removeMessage,
+  replaceToolResult,
   rewindBeforeMessage,
   rewindBeforePosition,
+  setMessageHidden,
+  updateMessage,
 } from './builders.ts';
 
 describe('chat conversation builders', () => {
@@ -205,5 +209,52 @@ describe('chat conversation builders', () => {
     expect(messages.map((message) => message.position)).toEqual(
       Array.from({ length: 12 }, (_, index) => index),
     );
+  });
+
+  test('re-exports the 0.7 transcript mutation helpers', async () => {
+    let conversation = createConversationHistory({ id: 'conversation-mutations' });
+    conversation = appendUserMessage(conversation, 'Original');
+    const messageId = conversation.ids[0]!;
+
+    const updated = updateMessage(conversation, messageId, { content: 'Edited' });
+    expect(updated.messages[messageId]!.content).toBe('Edited');
+    expect(updated.messages[messageId]!.role).toBe('user');
+
+    const hidden = setMessageHidden(updated, messageId, true);
+    expect(hidden.messages[messageId]!.hidden).toBe(true);
+    const visible = setMessageHidden(hidden, messageId, false);
+    expect(visible.messages[messageId]!.hidden).toBe(false);
+
+    let withTool = appendToolCall(visible, { id: 'call-1', name: 'lookup', arguments: {} });
+    withTool = await appendToolResultAsync(withTool, {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval' },
+    });
+    const resolved = replaceToolResult(withTool, 'call-1', {
+      callId: 'call-1',
+      outcome: 'success',
+      content: { approved: true },
+    });
+    const resolvedResult = resolved.ids
+      .map((id) => resolved.messages[id]!)
+      .find((message) => message.role === 'tool-result')!;
+    expect(resolvedResult.toolResult?.outcome).toBe('success');
+
+    const withoutMessage = removeMessage(resolved, messageId);
+    expect(withoutMessage.ids).not.toContain(messageId);
+
+    // Unknown identifiers are no-ops, returning the original history unchanged.
+    expect(updateMessage(conversation, 'missing', { content: 'x' })).toBe(conversation);
+    expect(removeMessage(conversation, 'missing')).toBe(conversation);
+    expect(setMessageHidden(conversation, 'missing', true)).toBe(conversation);
+    expect(
+      replaceToolResult(conversation, 'missing', {
+        callId: 'missing',
+        outcome: 'success',
+        content: null,
+      }),
+    ).toBe(conversation);
   });
 });

--- a/packages/chat/src/lib/components/chat/builders.ts
+++ b/packages/chat/src/lib/components/chat/builders.ts
@@ -29,6 +29,18 @@ export {
 export { rewindBeforeMessage, rewindBeforePosition } from 'conversationalist/context';
 export type { RewindOptions } from 'conversationalist/context';
 
+// Transcript mutation helpers—canonical in-place edits (update, remove,
+// hide/show, replace a tool result) that keep message identity, role, order,
+// and creation time intact. Every helper is a no-op (returns the original
+// history unchanged) when given an unknown message or tool-call identifier.
+export {
+  removeMessage,
+  replaceToolResult,
+  setMessageHidden,
+  updateMessage,
+} from 'conversationalist';
+export type { MessageUpdate } from 'conversationalist';
+
 const DELIVERY_STATUS_METADATA_KEY = '_deliveryStatus';
 
 /** Mark a message as failed so Chat renders its retry affordance. */

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -52,10 +52,14 @@ export {
   createConversationHistory,
   markMessageDeliveryFailed,
   prependMessages,
+  removeMessage,
+  replaceToolResult,
   rewindBeforeMessage,
   rewindBeforePosition,
+  setMessageHidden,
+  updateMessage,
 } from './builders.ts';
-export type { RewindOptions } from './builders.ts';
+export type { MessageUpdate, RewindOptions } from './builders.ts';
 
 // Streaming conversation builders — keep the immutable snapshot and Chat's
 // imperative streaming surface in sync through the package's own
@@ -122,14 +126,18 @@ export type {
 // Utilities
 export {
   CINDER_ARTIFACT_METADATA_KEY,
+  findToolResultMessage,
   formatMessageAsMarkdown,
   getMessageRoleLabel,
+  getMessages,
   getMessageText,
+  getUnresolvedToolApprovals,
   messagesToMarkdown,
   pairToolCallsWithResults,
   resolveMessageArtifact,
   type ChatExportOptions,
   type DeliveryStatus,
+  type UnresolvedToolApproval,
 } from './utilities/index.ts';
 export type { StepInfo } from './utilities/types.ts';
 

--- a/packages/chat/src/lib/components/chat/index.ts
+++ b/packages/chat/src/lib/components/chat/index.ts
@@ -137,6 +137,7 @@ export {
   resolveMessageArtifact,
   type ChatExportOptions,
   type DeliveryStatus,
+  type ToolResultMessage,
   type UnresolvedToolApproval,
 } from './utilities/index.ts';
 export type { StepInfo } from './utilities/types.ts';

--- a/packages/chat/src/lib/components/chat/utilities/conversation.test.ts
+++ b/packages/chat/src/lib/components/chat/utilities/conversation.test.ts
@@ -132,6 +132,46 @@ describe('getUnresolvedToolApprovals', () => {
 
     expect(getUnresolvedToolApprovals(conversation)).toHaveLength(0);
   });
+
+  it('excludes a call whose later result resolved a superseded action_required result', () => {
+    const pending: ToolResult = {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval' },
+    };
+    const resolved: ToolResult = { callId: 'call-1', outcome: 'success', content: null };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: pending }),
+      message({ id: 'r2', role: 'tool-result', toolResult: resolved }),
+    ]);
+
+    expect(getUnresolvedToolApprovals(conversation)).toHaveLength(0);
+  });
+
+  it('uses the latest action_required result when a call has more than one', () => {
+    const first: ToolResult = {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval', message: 'first' },
+    };
+    const second: ToolResult = {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval', message: 'second' },
+    };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: first }),
+      message({ id: 'r2', role: 'tool-result', toolResult: second }),
+    ]);
+
+    const approvals = getUnresolvedToolApprovals(conversation);
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0]?.message.id).toBe('r2');
+    expect(approvals[0]?.result.action.message).toBe('second');
+  });
 });
 
 describe('findToolResultMessage', () => {
@@ -170,6 +210,17 @@ describe('findToolResultMessage', () => {
 
     expect(findToolResultMessage(conversation, 'call-1')).toBeUndefined();
     expect(findToolResultMessage(conversation, 'call-1', { includeHidden: true })?.id).toBe('m1');
+  });
+
+  it('returns the latest result when a call has more than one, matching pairToolCallsWithResults', () => {
+    const earlier: ToolResult = { callId: 'call-1', outcome: 'error', content: null };
+    const later: ToolResult = { callId: 'call-1', outcome: 'success', content: null };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: earlier }),
+      message({ id: 'r2', role: 'tool-result', toolResult: later }),
+    ]);
+
+    expect(findToolResultMessage(conversation, 'call-1')?.id).toBe('r2');
   });
 });
 

--- a/packages/chat/src/lib/components/chat/utilities/conversation.test.ts
+++ b/packages/chat/src/lib/components/chat/utilities/conversation.test.ts
@@ -172,6 +172,74 @@ describe('getUnresolvedToolApprovals', () => {
     expect(approvals[0]?.message.id).toBe('r2');
     expect(approvals[0]?.result.action.message).toBe('second');
   });
+
+  it('treats a hidden resolving result as superseding an earlier visible action_required result', () => {
+    const pending: ToolResult = {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval' },
+    };
+    const resolvedHidden: ToolResult = { callId: 'call-1', outcome: 'success', content: null };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: pending }),
+      message({ id: 'r2', role: 'tool-result', toolResult: resolvedHidden, hidden: true }),
+    ]);
+
+    // The call is resolved even though the resolving message is hidden — a
+    // visible-but-superseded action_required must not leak through, with or
+    // without includeHidden.
+    expect(getUnresolvedToolApprovals(conversation)).toHaveLength(0);
+    expect(getUnresolvedToolApprovals(conversation, { includeHidden: true })).toHaveLength(0);
+  });
+
+  it('excludes a hidden latest action_required result by default and includes it with includeHidden', () => {
+    const pendingHidden: ToolResult = {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval' },
+    };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: pendingHidden, hidden: true }),
+    ]);
+
+    expect(getUnresolvedToolApprovals(conversation)).toHaveLength(0);
+    const withHidden = getUnresolvedToolApprovals(conversation, { includeHidden: true });
+    expect(withHidden).toHaveLength(1);
+    expect(withHidden[0]?.message.id).toBe('r1');
+  });
+
+  it('orders results by each call id’s latest occurrence, not first-seen order', () => {
+    const pendingA: ToolResult = {
+      callId: 'call-a',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval' },
+    };
+    const pendingB: ToolResult = {
+      callId: 'call-b',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval' },
+    };
+    const pendingAAgain: ToolResult = {
+      callId: 'call-a',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval', message: 'second look' },
+    };
+    // call-a's latest occurrence (r3) comes after call-b's only occurrence
+    // (r2), so call-b must be reported first despite call-a appearing first.
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: pendingA }),
+      message({ id: 'r2', role: 'tool-result', toolResult: pendingB }),
+      message({ id: 'r3', role: 'tool-result', toolResult: pendingAAgain }),
+    ]);
+
+    const approvals = getUnresolvedToolApprovals(conversation);
+    expect(approvals.map((approval) => approval.message.id)).toEqual(['r2', 'r3']);
+  });
 });
 
 describe('findToolResultMessage', () => {
@@ -221,6 +289,19 @@ describe('findToolResultMessage', () => {
     ]);
 
     expect(findToolResultMessage(conversation, 'call-1')?.id).toBe('r2');
+  });
+
+  it('treats a hidden latest result as superseding an earlier visible one for dedup, then applies includeHidden', () => {
+    const earlierVisible: ToolResult = { callId: 'call-1', outcome: 'error', content: null };
+    const laterHidden: ToolResult = { callId: 'call-1', outcome: 'success', content: null };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: earlierVisible }),
+      message({ id: 'r2', role: 'tool-result', toolResult: laterHidden, hidden: true }),
+    ]);
+
+    // The hidden r2 is authoritative — r1 must never be returned as a stand-in.
+    expect(findToolResultMessage(conversation, 'call-1')).toBeUndefined();
+    expect(findToolResultMessage(conversation, 'call-1', { includeHidden: true })?.id).toBe('r2');
   });
 });
 

--- a/packages/chat/src/lib/components/chat/utilities/conversation.test.ts
+++ b/packages/chat/src/lib/components/chat/utilities/conversation.test.ts
@@ -1,7 +1,17 @@
 import { describe, expect, it } from 'bun:test';
 
-import type { ConversationHistory, Message, ToolResult } from '../conversation-model.ts';
-import { getMessages, pairToolCallsWithResults } from './conversation.ts';
+import type {
+  ConversationHistory,
+  Message,
+  ToolAction,
+  ToolResult,
+} from '../conversation-model.ts';
+import {
+  findToolResultMessage,
+  getMessages,
+  getUnresolvedToolApprovals,
+  pairToolCallsWithResults,
+} from './conversation.ts';
 
 function message(overrides: Partial<Message> & Pick<Message, 'id'>): Message {
   return {
@@ -58,6 +68,108 @@ describe('getMessages', () => {
       'visible',
       'secret',
     ]);
+  });
+});
+
+describe('getUnresolvedToolApprovals', () => {
+  it('finds a tool-result message parked on action_required with an action', () => {
+    const pending: ToolResult & { action: ToolAction } = {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval', message: 'Allow this?' },
+    };
+    const result = message({ id: 'r1', role: 'tool-result', toolResult: pending });
+    const conversation = history([result]);
+
+    const approvals = getUnresolvedToolApprovals(conversation);
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0]?.message.id).toBe('r1');
+    expect(approvals[0]?.result).toBe(pending);
+  });
+
+  it('excludes resolved (success/error) and action-less results', () => {
+    const success: ToolResult = { callId: 'call-1', outcome: 'success', content: null };
+    const errored: ToolResult = { callId: 'call-2', outcome: 'error', content: null };
+    const noAction: ToolResult = { callId: 'call-3', outcome: 'action_required', content: null };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: success }),
+      message({ id: 'r2', role: 'tool-result', toolResult: errored }),
+      message({ id: 'r3', role: 'tool-result', toolResult: noAction }),
+    ]);
+
+    expect(getUnresolvedToolApprovals(conversation)).toHaveLength(0);
+  });
+
+  it('excludes hidden approvals by default and includes them with includeHidden', () => {
+    const pending: ToolResult = {
+      callId: 'call-1',
+      outcome: 'action_required',
+      content: null,
+      action: { type: 'approval' },
+    };
+    const conversation = history([
+      message({ id: 'r1', role: 'tool-result', toolResult: pending, hidden: true }),
+    ]);
+
+    expect(getUnresolvedToolApprovals(conversation)).toHaveLength(0);
+    expect(getUnresolvedToolApprovals(conversation, { includeHidden: true })).toHaveLength(1);
+  });
+
+  it('ignores non-tool-result messages carrying an incidental toolResult field', () => {
+    const conversation = history([
+      message({
+        id: 'a',
+        role: 'assistant',
+        toolResult: {
+          callId: 'call-1',
+          outcome: 'action_required',
+          content: null,
+          action: { type: 'approval' },
+        },
+      }),
+    ]);
+
+    expect(getUnresolvedToolApprovals(conversation)).toHaveLength(0);
+  });
+});
+
+describe('findToolResultMessage', () => {
+  it('finds the tool-result message whose result carries the given call id', () => {
+    const result: ToolResult = { callId: 'call-1', outcome: 'success', content: null };
+    const conversation = history([
+      message({
+        id: 'm1',
+        role: 'tool-call',
+        toolCall: { id: 'call-1', name: 'fn', arguments: {} },
+      }),
+      message({ id: 'm2', role: 'tool-result', toolResult: result }),
+    ]);
+
+    const found = findToolResultMessage(conversation, 'call-1');
+    expect(found?.id).toBe('m2');
+  });
+
+  it('returns undefined for an unknown call id (no-op)', () => {
+    const conversation = history([
+      message({
+        id: 'm1',
+        role: 'tool-result',
+        toolResult: { callId: 'call-1', outcome: 'success', content: null },
+      }),
+    ]);
+
+    expect(findToolResultMessage(conversation, 'missing')).toBeUndefined();
+  });
+
+  it('respects includeHidden like getMessages', () => {
+    const result: ToolResult = { callId: 'call-1', outcome: 'success', content: null };
+    const conversation = history([
+      message({ id: 'm1', role: 'tool-result', toolResult: result, hidden: true }),
+    ]);
+
+    expect(findToolResultMessage(conversation, 'call-1')).toBeUndefined();
+    expect(findToolResultMessage(conversation, 'call-1', { includeHidden: true })?.id).toBe('m1');
   });
 });
 

--- a/packages/chat/src/lib/components/chat/utilities/conversation.ts
+++ b/packages/chat/src/lib/components/chat/utilities/conversation.ts
@@ -41,16 +41,22 @@ function hasPendingAction(result: ToolResult): result is ToolResult & { action: 
 }
 
 /**
- * Finds the latest `tool-result` message for each tool-call id—matching
+ * Finds the latest `tool-result` message for each tool-call id, over the
+ * COMPLETE ordered transcript (hidden messages included)—matching
  * {@link pairToolCallsWithResults}'s last-result-wins semantics, so a
- * superseded `action_required` result is never mistaken for the current one.
+ * superseded `action_required` result is never mistaken for the current one,
+ * and a hidden resolving result still supersedes an earlier visible one.
+ * Iteration order follows each call's latest occurrence: `Map#set` does not
+ * reorder an existing key, so an existing entry is deleted before being
+ * re-set.
  */
 function latestToolResultsByCallId(
-  messages: ReadonlyArray<Message>,
+  conversation: ConversationHistory,
 ): Map<string, ToolResultMessage> {
   const latest = new Map<string, ToolResultMessage>();
-  for (const message of messages) {
+  for (const message of getMessages(conversation, { includeHidden: true })) {
     if (isToolResultMessage(message)) {
+      latest.delete(message.toolResult.callId);
       latest.set(message.toolResult.callId, message);
     }
   }
@@ -62,14 +68,18 @@ function latestToolResultsByCallId(
  * `action_required` with an action present—i.e. not yet resolved via
  * `replaceToolResult`. A call whose latest result has since moved to
  * `success`/`error` is excluded, even if an earlier `action_required` result
- * for the same call id exists earlier in the transcript.
+ * for the same call id exists earlier in the transcript, or the resolving
+ * result is itself hidden. By default a hidden latest result is excluded
+ * from the returned list, matching `getMessages`; pass `includeHidden: true`
+ * to include it.
  */
 export function getUnresolvedToolApprovals(
   conversation: ConversationHistory,
   options: { includeHidden?: boolean } = {},
 ): UnresolvedToolApproval[] {
   const approvals: UnresolvedToolApproval[] = [];
-  for (const message of latestToolResultsByCallId(getMessages(conversation, options)).values()) {
+  for (const message of latestToolResultsByCallId(conversation).values()) {
+    if (!options.includeHidden && message.hidden) continue;
     const result = message.toolResult;
     if (hasPendingAction(result)) {
       approvals.push({ message, result });
@@ -81,14 +91,18 @@ export function getUnresolvedToolApprovals(
 /**
  * Finds the current `tool-result` message for a tool-call id—the latest one
  * if the transcript carries more than one, matching
- * {@link pairToolCallsWithResults}'s last-result-wins semantics.
+ * {@link pairToolCallsWithResults}'s last-result-wins semantics. By default a
+ * hidden latest result is treated as not found, matching `getMessages`; pass
+ * `includeHidden: true` to return it.
  */
 export function findToolResultMessage(
   conversation: ConversationHistory,
   toolCallId: string,
   options: { includeHidden?: boolean } = {},
 ): ToolResultMessage | undefined {
-  return latestToolResultsByCallId(getMessages(conversation, options)).get(toolCallId);
+  const message = latestToolResultsByCallId(conversation).get(toolCallId);
+  if (!message || (!options.includeHidden && message.hidden)) return undefined;
+  return message;
 }
 
 /** Pairs tool calls with role-valid tool results from an already-ordered message array. */

--- a/packages/chat/src/lib/components/chat/utilities/conversation.ts
+++ b/packages/chat/src/lib/components/chat/utilities/conversation.ts
@@ -8,6 +8,7 @@
 import type {
   ConversationHistory,
   Message,
+  ToolAction,
   ToolCallPair,
   ToolResult,
 } from '../conversation-model.ts';
@@ -20,6 +21,45 @@ export function getMessages(
     .map((id) => conversation.messages[id])
     .filter((message): message is Message => message !== undefined)
     .filter((message) => options.includeHidden === true || !message.hidden);
+}
+
+/** A `tool-result` message parked on `action_required` with a pending action. */
+export type UnresolvedToolApproval = {
+  message: Message;
+  result: ToolResult & { action: ToolAction };
+};
+
+function hasPendingAction(result: ToolResult): result is ToolResult & { action: ToolAction } {
+  return result.outcome === 'action_required' && result.action !== undefined;
+}
+
+/**
+ * Finds every `tool-result` message still parked on `action_required` with an
+ * action present—i.e. not yet resolved via `replaceToolResult`.
+ */
+export function getUnresolvedToolApprovals(
+  conversation: ConversationHistory,
+  options: { includeHidden?: boolean } = {},
+): UnresolvedToolApproval[] {
+  const approvals: UnresolvedToolApproval[] = [];
+  for (const message of getMessages(conversation, options)) {
+    const result = message.toolResult;
+    if (message.role === 'tool-result' && result && hasPendingAction(result)) {
+      approvals.push({ message, result });
+    }
+  }
+  return approvals;
+}
+
+/** Finds the `tool-result` message whose result carries the given tool-call id. */
+export function findToolResultMessage(
+  conversation: ConversationHistory,
+  toolCallId: string,
+  options: { includeHidden?: boolean } = {},
+): Message | undefined {
+  return getMessages(conversation, options).find(
+    (message) => message.role === 'tool-result' && message.toolResult?.callId === toolCallId,
+  );
 }
 
 /** Pairs tool calls with role-valid tool results from an already-ordered message array. */

--- a/packages/chat/src/lib/components/chat/utilities/conversation.ts
+++ b/packages/chat/src/lib/components/chat/utilities/conversation.ts
@@ -23,9 +23,16 @@ export function getMessages(
     .filter((message) => options.includeHidden === true || !message.hidden);
 }
 
+/** A `tool-result` message whose `toolResult` is guaranteed present. */
+export type ToolResultMessage = Message & { role: 'tool-result'; toolResult: ToolResult };
+
+function isToolResultMessage(message: Message): message is ToolResultMessage {
+  return message.role === 'tool-result' && message.toolResult !== undefined;
+}
+
 /** A `tool-result` message parked on `action_required` with a pending action. */
 export type UnresolvedToolApproval = {
-  message: Message;
+  message: ToolResultMessage;
   result: ToolResult & { action: ToolAction };
 };
 
@@ -34,32 +41,54 @@ function hasPendingAction(result: ToolResult): result is ToolResult & { action: 
 }
 
 /**
- * Finds every `tool-result` message still parked on `action_required` with an
- * action present—i.e. not yet resolved via `replaceToolResult`.
+ * Finds the latest `tool-result` message for each tool-call id—matching
+ * {@link pairToolCallsWithResults}'s last-result-wins semantics, so a
+ * superseded `action_required` result is never mistaken for the current one.
+ */
+function latestToolResultsByCallId(
+  messages: ReadonlyArray<Message>,
+): Map<string, ToolResultMessage> {
+  const latest = new Map<string, ToolResultMessage>();
+  for (const message of messages) {
+    if (isToolResultMessage(message)) {
+      latest.set(message.toolResult.callId, message);
+    }
+  }
+  return latest;
+}
+
+/**
+ * Finds every tool call whose latest `tool-result` is still parked on
+ * `action_required` with an action present—i.e. not yet resolved via
+ * `replaceToolResult`. A call whose latest result has since moved to
+ * `success`/`error` is excluded, even if an earlier `action_required` result
+ * for the same call id exists earlier in the transcript.
  */
 export function getUnresolvedToolApprovals(
   conversation: ConversationHistory,
   options: { includeHidden?: boolean } = {},
 ): UnresolvedToolApproval[] {
   const approvals: UnresolvedToolApproval[] = [];
-  for (const message of getMessages(conversation, options)) {
+  for (const message of latestToolResultsByCallId(getMessages(conversation, options)).values()) {
     const result = message.toolResult;
-    if (message.role === 'tool-result' && result && hasPendingAction(result)) {
+    if (hasPendingAction(result)) {
       approvals.push({ message, result });
     }
   }
   return approvals;
 }
 
-/** Finds the `tool-result` message whose result carries the given tool-call id. */
+/**
+ * Finds the current `tool-result` message for a tool-call id—the latest one
+ * if the transcript carries more than one, matching
+ * {@link pairToolCallsWithResults}'s last-result-wins semantics.
+ */
 export function findToolResultMessage(
   conversation: ConversationHistory,
   toolCallId: string,
   options: { includeHidden?: boolean } = {},
-): Message | undefined {
-  return getMessages(conversation, options).find(
-    (message) => message.role === 'tool-result' && message.toolResult?.callId === toolCallId,
-  );
+): ToolResultMessage | undefined {
+  return latestToolResultsByCallId(getMessages(conversation, options)).get(toolCallId);
 }
 
 /** Pairs tool calls with role-valid tool results from an already-ordered message array. */

--- a/packages/chat/src/lib/components/chat/utilities/index.ts
+++ b/packages/chat/src/lib/components/chat/utilities/index.ts
@@ -11,6 +11,7 @@ export {
   getMessages,
   getUnresolvedToolApprovals,
   pairToolCallsWithResults,
+  type ToolResultMessage,
   type UnresolvedToolApproval,
 } from './conversation.ts';
 export {

--- a/packages/chat/src/lib/components/chat/utilities/index.ts
+++ b/packages/chat/src/lib/components/chat/utilities/index.ts
@@ -1,11 +1,18 @@
 /**
  * Chat data model helpers.
  *
- * Conversation-reading helpers ({@link getMessages}, {@link pairToolCallsWithResults})
- * and content/markdown utilities, all built on the Conversationalist model.
+ * Conversation-reading helpers ({@link getMessages}, {@link pairToolCallsWithResults},
+ * {@link getUnresolvedToolApprovals}, {@link findToolResultMessage}) and
+ * content/markdown utilities, all built on the Conversationalist model.
  */
 
-export { getMessages, pairToolCallsWithResults } from './conversation.ts';
+export {
+  findToolResultMessage,
+  getMessages,
+  getUnresolvedToolApprovals,
+  pairToolCallsWithResults,
+  type UnresolvedToolApproval,
+} from './conversation.ts';
 export {
   type ChatExportOptions,
   type ChatMessagePart,


### PR DESCRIPTION
## Summary

- Bumps `conversationalist` to `^0.7.0` (published in AB-26) and re-exports its canonical transcript mutation helpers — `updateMessage`, `removeMessage`, `setMessageHidden`, `replaceToolResult` — plus the `MessageUpdate` type, from `builders.ts`/root, so consumers stop importing `conversationalist` directly or hand-walking transcript internals for common mutations. Unknown identifiers are no-ops (verified in tests, matching upstream's documented behavior).
- Root-exports the existing `getMessages` helper, which previously was only reachable from `./utilities/index.ts`.
- Adds two new typed query helpers in `utilities/conversation.ts`: `getUnresolvedToolApprovals` (finds every `tool-result` message still parked on `outcome: 'action_required'` with a pending `action`) and `findToolResultMessage` (locates a `tool-result` message by tool-call identifier).
- Updates the pinned `conversationalist` version expectations in `scripts/pack-for-publish.ts` and `scripts/package-boundary.test.ts`.
- Documents the new helpers in `packages/chat/src/lib/components/chat/README.md`.

Closes CIN-388

## Test plan

- [x] `bun run --filter=@lostgradient/chat test`
- [x] `bun run --filter=@lostgradient/chat typecheck`
- [x] `bun run --filter=@lostgradient/chat build`
- [x] `bun run --filter=@lostgradient/chat validate:consumer`
- [x] `bun run --filter=@lostgradient/chat lint`