### PR TITLE
docs(diff-statistics): link both diff viewers from Related components (CIN-341)

### DIFF
--- a/packages/components/src/components/diff-statistics/README.md
+++ b/packages/components/src/components/diff-statistics/README.md
@@ -18,7 +18,7 @@ Compact inline display of added, modified, and removed line counts for a file di
 - [`Statistic`](../statistic/README.md) — general-purpose metric tile for non-diff numeric values.
 - [`StatisticGroup`](../statistic-group/README.md) — grid container for multiple `Statistic` tiles.
 - [`SourceDiffViewer`](../source-diff-viewer/README.md) — dependency-light unified-diff rendering whose per-file counts these statistics summarize.
-- [`DiffViewer`](../../../../editor/src/lib/components/diff-viewer/README.md) — `@lostgradient/editor`'s Markdown-oriented diff review surface, the other producer of diff counts.
+- [`DiffViewer`](https://github.com/stevekinney/cinder/tree/main/packages/editor/src/lib/components/diff-viewer) — `@lostgradient/editor`'s Markdown-oriented diff review surface, the other producer of diff counts.
 
 ## Usage
 

--- a/packages/components/src/components/diff-statistics/README.md
+++ b/packages/components/src/components/diff-statistics/README.md
@@ -17,6 +17,8 @@ Compact inline display of added, modified, and removed line counts for a file di
 
 - [`Statistic`](../statistic/README.md) — general-purpose metric tile for non-diff numeric values.
 - [`StatisticGroup`](../statistic-group/README.md) — grid container for multiple `Statistic` tiles.
+- [`SourceDiffViewer`](../source-diff-viewer/README.md) — dependency-light unified-diff rendering whose per-file counts these statistics summarize.
+- [`DiffViewer`](../../../../editor/src/lib/components/diff-viewer/README.md) — `@lostgradient/editor`'s Markdown-oriented diff review surface, the other producer of diff counts.
 
 ## Usage
 


### PR DESCRIPTION
Closes the one real gap in [CIN-341](https://linear.app/lost-gradient/issue/CIN-341/diffviewer-and-sourcediffviewer-document-which-to-use-or-unify): `source-diff-viewer/README.md` and the editor package's `diff-viewer/README.md` already cross-reference each other and state which to use, but `diff-statistics/README.md`'s Related components section never named either diff viewer back. Adds both links in the section's existing entry format. Docs-only; no changeset (the guard validates bump levels of existing changesets only).