### PR TITLE
fix(checkbox): forward the raw native event to onchange before the veto path (CIN-314)

### DIFF
--- a/.changeset/cin-314-checkbox-onchange-ordering.md
+++ b/.changeset/cin-314-checkbox-onchange-ordering.md
@@ -1,0 +1,9 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Fix `Checkbox` forwarding a mutated event to `onchange` instead of the browser's raw native event.
+
+Previously, `handleChange` ran `commitValue` (which invokes `onValueChangeRequest`/`onValueChange` and can veto the toggle) and mutated the DOM's `checked` state _before_ calling the consumer's `onchange`. That meant a consumer reading `event.target.checked` (or `event.currentTarget.checked`) inside `onchange` would see Cinder's post-veto value, not what the user actually did in the browser.
+
+**Migration note:** `onchange` now fires immediately after the native change event arrives, forwarding the raw, pre-veto `checked` value—before `onValueChangeRequest`, `onValueChange`, or the DOM re-sync run. If your `onchange` handler relied on the DOM already reflecting a vetoed/committed value, switch to `onValueChange` (fires with the committed value) or `onValueChangeRequest` (can inspect/veto the proposed value) instead.

--- a/packages/components/src/components/checkbox/checkbox.svelte
+++ b/packages/components/src/components/checkbox/checkbox.svelte
@@ -116,10 +116,15 @@
     };
   });
 
-  function handleChange(event: Event): void {
-    const target = event.currentTarget as HTMLInputElement;
+  function handleChange(event: Event & { currentTarget: EventTarget & HTMLInputElement }): void {
+    const target = event.currentTarget;
+    const rawChecked = target.checked;
+    // Forward the raw native event before Cinder's veto/commit machinery runs, so
+    // consumers observe the browser's actual value rather than a post-veto value
+    // that may have already been reverted on the DOM.
+    consumerOnchange?.(event);
     const committed = commitValue(
-      target.checked,
+      rawChecked,
       onValueChangeRequest,
       (next) => {
         checked = next;
@@ -128,7 +133,6 @@
     );
     target.checked = committed;
     target.indeterminate = indeterminate && !committed;
-    consumerOnchange?.(event as Parameters<NonNullable<CheckboxProps['onchange']>>[0]);
   }
 </script>
 

--- a/packages/components/src/components/checkbox/checkbox.test.ts
+++ b/packages/components/src/components/checkbox/checkbox.test.ts
@@ -136,6 +136,26 @@ describe('Checkbox', () => {
     expect(input.checked).toBe(false);
   });
 
+  test('onchange is forwarded with the raw pre-veto checked value even when onValueChangeRequest vetoes it', async () => {
+    let forwardedChecked: boolean | undefined;
+    const onchange = mock((event: Event) => {
+      forwardedChecked = (event.currentTarget as HTMLInputElement).checked;
+    });
+    const { container } = render(Checkbox, {
+      id: 'c',
+      checked: false,
+      onValueChangeRequest: () => false,
+      onchange,
+    });
+    const input = container.querySelector('#c') as HTMLInputElement;
+
+    await fireEvent.click(input);
+
+    expect(onchange).toHaveBeenCalledTimes(1);
+    expect(forwardedChecked).toBe(true);
+    expect(input.checked).toBe(false);
+  });
+
   test('onValueChange is called once with the committed value on user toggle', async () => {
     const onValueChange = mock((_next: boolean) => {});
     const { container } = render(Checkbox, {


### PR DESCRIPTION
Implements [CIN-314](https://linear.app/lost-gradient/issue/CIN-314/checkbox-mutates-targetchecked-before-forwarding-the-native-event-to): `handleChange` now calls the consumer's `onchange` immediately after reading the raw `target.checked`, before `commitValue(...)` runs or the DOM is re-synced — so the forwarded event reflects the browser's raw value, not Cinder's post-veto value. Cinder's internal callbacks (`onValueChangeRequest`, `onValueChange`) now fire after the consumer's `onchange`; that ordering change is the intended effect.

- Both type-casts removed by typing `handleChange`'s parameter as the event type Svelte's binding infers.
- Regression test (TDD): the forwarded event keeps the pre-veto `checked` value even when `onValueChangeRequest` vetoes and `input.checked` re-syncs to the vetoed value.
- Patch changeset with a migration note for consumers reading the post-veto value off the event (the committed value belongs to `onValueChange`).

Verification: checkbox suite 35 pass/0 fail; package typecheck 0 errors (16 pre-existing unrelated warnings); pre-commit ran the package's full typecheck+test gate at commit time.