### PR TITLE
docs(sidebar, side-navigation): reciprocal @avoidWhen metadata and accepted decision (CIN-106)

### DIFF
--- a/.changeset/cin-106-sidebar-side-navigation-metadata.md
+++ b/.changeset/cin-106-sidebar-side-navigation-metadata.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Add reciprocal `@avoidWhen` metadata to `Sidebar` and `SideNavigation` pointing at each other, and link both READMEs to the `docs/decisions/side-navigation-vs-sidebar.md` decision now that it is Accepted. Both components remain public and unchanged in behavior; this only clarifies the boundary between the responsive shell (`Sidebar`) and the accessibility-focused nav landmark (`SideNavigation`) in generated component metadata.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ This directory holds long-form documentation that does not live inside a compone
 - [Segmented control tablist variant](./decisions/segmented-control-tablist-variant.md): decision record for the tablist-style segmented-control follow-up.
 - [Color value format](./decisions/color-value-format.md): **open** — ColorField/ColorPicker hex-only output vs format-tagged values.
 - [`*Group` vs plural naming](./decisions/group-vs-plural-naming.md): **open** — decide once across the Group-suffixed families.
-- [SideNavigation vs Sidebar](./decisions/side-navigation-vs-sidebar.md): **open** — reconcile or keep distinct.
+- [SideNavigation vs Sidebar](./decisions/side-navigation-vs-sidebar.md): **accepted** — keep both; Sidebar is the responsive shell, SideNavigation the nav semantics.
 
 ## Historical Plans
 

--- a/docs/decisions/side-navigation-vs-sidebar.md
+++ b/docs/decisions/side-navigation-vs-sidebar.md
@@ -1,6 +1,6 @@
 # SideNavigation versus Sidebar
 
-**Status:** Accepted (2026-08-24).
+**Status:** Accepted 2026-08-24.
 
 Question: do `SideNavigation` and `Sidebar` reconcile into one component, or
 stay distinct?
@@ -23,5 +23,6 @@ component would force every consumer that only needs the nav landmark to also
 take on responsive-shell behavior, and vice versa.
 
 Both components carry reciprocal `@related`/`@avoidWhen` metadata pointing at
-each other and at this document, so the boundary is discoverable from either
-component's JSDoc.
+each other, and each component's README cites this document, so the boundary is
+discoverable from either component's JSDoc (the alternative) and README (the
+rationale).

--- a/docs/decisions/side-navigation-vs-sidebar.md
+++ b/docs/decisions/side-navigation-vs-sidebar.md
@@ -1,6 +1,6 @@
 # SideNavigation versus Sidebar
 
-**Status:** Open (raised 2026-08-05).
+**Status:** Accepted (2026-08-24).
 
 Question: do `SideNavigation` and `Sidebar` reconcile into one component, or
 stay distinct?
@@ -12,10 +12,16 @@ while `side-navigation` is a "vertical navigation column that hosts grouped
 side-navigation-item entries". The overlap is real at the naming level even
 though the responsibilities differ.
 
-Open: whether two public entries survive the behavior-first admission bar
-(`docs/decisions/component-admission-bar.md`), and if they do, whether the
-names can stop implying they are the same thing.
+Ruling: keep both components. Neither is renamed or removed. `Sidebar` is
+behavior — a responsive shell that composes `Drawer` and swaps to a mobile
+drawer below a configurable breakpoint. `SideNavigation` is accessibility
+semantics — a `<nav>` landmark with a required accessible label that can be
+used inside any container, including inside a `Sidebar`, a page body, or a
+custom shell. They compose (`SideNavigation` is the typical child of
+`Sidebar`'s navigation slot) rather than compete, so collapsing them into one
+component would force every consumer that only needs the nav landmark to also
+take on responsive-shell behavior, and vice versa.
 
-Closing this requires a boundary decision recorded here (choose-one-or-keep-
-both plus naming), and `@related`/`@avoidWhen` metadata on both components
-pointing at it.
+Both components carry reciprocal `@related`/`@avoidWhen` metadata pointing at
+each other and at this document, so the boundary is discoverable from either
+component's JSDoc.

--- a/packages/components/components.json
+++ b/packages/components/components.json
@@ -4193,6 +4193,10 @@
         {
           "reason": "Rendering expandable hierarchical non-navigation data.",
           "alternative": "tree"
+        },
+        {
+          "reason": "Needing the shell.",
+          "alternative": "sidebar"
         }
       ],
       "related": [
@@ -4288,6 +4292,10 @@
         },
         {
           "reason": "Rendering navigation entries directly — place side-navigation inside the sidebar column."
+        },
+        {
+          "reason": "Needing only an accessible nav landmark, not a responsive collapsing shell.",
+          "alternative": "side-navigation"
         }
       ],
       "related": ["side-navigation", "drawer"],

--- a/packages/components/src/components/side-navigation/README.md
+++ b/packages/components/src/components/side-navigation/README.md
@@ -2,6 +2,8 @@
 
 Vertical navigation panel for secondary or hierarchical app destinations.
 
+See the [SideNavigation versus Sidebar decision](https://github.com/stevekinney/cinder/blob/main/docs/decisions/side-navigation-vs-sidebar.md) for the boundary between the accessibility-focused nav landmark here and the responsive shell in Sidebar.
+
 ## Usage
 
 `SideNavigation` is a compound component. Import the parent and compose

--- a/packages/components/src/components/side-navigation/side-navigation.svelte
+++ b/packages/components/src/components/side-navigation/side-navigation.svelte
@@ -12,6 +12,7 @@
    * @avoidWhen Rendering a single flat horizontal nav row. | navigation-bar
    * @avoidWhen Showing an in-page heading outline. | table-of-contents
    * @avoidWhen Rendering expandable hierarchical non-navigation data. | tree
+   * @avoidWhen Needing the shell. | sidebar
    * @related side-navigation-item, side-navigation-group, navigation-bar, table-of-contents, tree, sidebar
    */
   export type { SideNavigationProps } from './side-navigation.types.ts';

--- a/packages/components/src/components/sidebar/README.md
+++ b/packages/components/src/components/sidebar/README.md
@@ -2,6 +2,8 @@
 
 Persistent side panel that houses navigation, filters, or supplementary page content.
 
+See the [SideNavigation versus Sidebar decision](https://github.com/stevekinney/cinder/blob/main/docs/decisions/side-navigation-vs-sidebar.md) for the boundary between the responsive shell here and the accessibility-focused nav landmark in SideNavigation.
+
 ## Usage
 
 ```svelte

--- a/packages/components/src/components/sidebar/sidebar.svelte
+++ b/packages/components/src/components/sidebar/sidebar.svelte
@@ -10,6 +10,7 @@
    * @useWhen Sharing collapsed state between a side-navigation column and the rest of the app shell via context.
    * @avoidWhen Building the page body itself rather than the surrounding shell — use a hand-rolled page scaffold instead.
    * @avoidWhen Rendering navigation entries directly — place side-navigation inside the sidebar column.
+   * @avoidWhen Needing only an accessible nav landmark, not a responsive collapsing shell. | side-navigation
    * @related side-navigation, drawer
    */
   export type { SidebarProps } from './sidebar.types.ts';


### PR DESCRIPTION
Implements [CIN-106](https://linear.app/lost-gradient/issue/CIN-106/keep-both-sidenavigation-and-sidebar-add-reciprocal-related-and): keep-both ruling — Sidebar is behavior (responsive shell composing Drawer), SideNavigation is accessibility semantics (nav column for any container).

- Sidebar gains a third `@avoidWhen` entry (`| side-navigation`), SideNavigation gains one pointing back (`| sidebar`), both using the existing pipe syntax alongside the existing entries.
- SideNavigation's new entry is deliberately terse ("Needing the shell.") — the component sat ~10 bytes under `manifest.test.ts`'s 1024-byte per-component guidance budget with five pre-existing entries, so the fuller behavior-vs-semantics wording lives on the Sidebar side and in the decision doc.
- Both READMEs cite `docs/decisions/side-navigation-vs-sidebar.md` as a linked prose sentence (data-table/table/feed/timeline convention), and that doc moves from Open to Accepted with the ruling replacing the Open framing.
- `components.json` regenerated via `components:generate`; patch changeset for `@lostgradient/cinder`.

Verification: `components:check` pass, manifest suite 19/0, pre-commit package gate green.