### PR TITLE
refactor(file-upload, chat): one shared upload-status union with 'ready' (CIN-371)

### DIFF
--- a/.changeset/chat-file-upload-status-source.md
+++ b/.changeset/chat-file-upload-status-source.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+`ChatAttachment.status` now uses cinder's `FileUploadStatus` union (re-exported from `@lostgradient/cinder`) instead of declaring its own duplicate literal type. The allowed values are unchanged (`'pending' | 'uploading' | 'ready' | 'error'`), but the type now resolves to `FileUploadStatus`, so anything re-exporting or structurally depending on the old locally-declared type should reference `FileUploadStatus` from `@lostgradient/cinder` going forward.

--- a/.changeset/rename-file-upload-status-ready.md
+++ b/.changeset/rename-file-upload-status-ready.md
@@ -1,5 +1,5 @@
 ---
-'@lostgradient/cinder': patch
+'@lostgradient/cinder': minor
 ---
 
 Rename `FileUploadStatus`'s `'success'` member to `'ready'`. `'ready'` is the canonical name because consumers (such as chat attachments) can create entries directly in that state without an upload ever occurring, which `'success'` couldn't express. Migration: replace any `status === 'success'` checks or literal `'success'` values against `FileUploadStatus`/`FileUploadEntry` with `'ready'`. The `data-status` attribute rendered by `FileUploadList` for the ready state also changed from `success` to `ready`; update any selectors that target it.

--- a/.changeset/rename-file-upload-status-ready.md
+++ b/.changeset/rename-file-upload-status-ready.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Rename `FileUploadStatus`'s `'success'` member to `'ready'`. `'ready'` is the canonical name because consumers (such as chat attachments) can create entries directly in that state without an upload ever occurring, which `'success'` couldn't express. Migration: replace any `status === 'success'` checks or literal `'success'` values against `FileUploadStatus`/`FileUploadEntry` with `'ready'`. The `data-status` attribute rendered by `FileUploadList` for the ready state also changed from `success` to `ready`; update any selectors that target it.

--- a/packages/chat/src/lib/components/chat/input/chat-attachment.ts
+++ b/packages/chat/src/lib/components/chat/input/chat-attachment.ts
@@ -1,3 +1,5 @@
+import type { FileUploadStatus } from '@lostgradient/cinder';
+
 import type { AttachmentKind } from './attachment-kind.ts';
 
 /** Attachment metadata for files (images, code, documents). */
@@ -7,6 +9,6 @@ export interface ChatAttachment {
   previewUrl: string;
   kind: AttachmentKind;
   textContent?: string;
-  status: 'pending' | 'uploading' | 'ready' | 'error';
+  status: FileUploadStatus;
   error?: string;
 }

--- a/packages/components/src/components/file-upload/README.md
+++ b/packages/components/src/components/file-upload/README.md
@@ -56,7 +56,7 @@ Resetting an associated native form clears the uncontrolled queue and reports
 an empty list through `onFilesChange`.
 
 Pass the controlled `files` prop to show your uploader's current `pending`,
-`uploading`, `success`, or `error` state. Set `progress` from 0–100 while an
+`uploading`, `ready`, or `error` state. Set `progress` from 0–100 while an
 entry uploads. When you provide `onFileRetry`, failed rows render a retry button and
 return the complete entry to your upload queue handler. The component never
 starts, cancels, or retries a network request by itself.

--- a/packages/components/src/components/file-upload/file-upload-list.svelte
+++ b/packages/components/src/components/file-upload/file-upload-list.svelte
@@ -127,8 +127,8 @@
         <div class="cinder-file-upload__row-actions">
           {#if entry.status === 'uploading'}
             <span class="cinder-file-upload__status" data-status="uploading">Uploading</span>
-          {:else if entry.status === 'success'}
-            <span class="cinder-file-upload__status" data-status="success">
+          {:else if entry.status === 'ready'}
+            <span class="cinder-file-upload__status" data-status="ready">
               <svg
                 class="cinder-file-upload__status-icon"
                 aria-hidden="true"

--- a/packages/components/src/components/file-upload/file-upload.css
+++ b/packages/components/src/components/file-upload/file-upload.css
@@ -200,7 +200,7 @@
     white-space: nowrap;
   }
 
-  .cinder-file-upload__status[data-status='success'] {
+  .cinder-file-upload__status[data-status='ready'] {
     color: var(--cinder-color-success-fg);
   }
 

--- a/packages/components/src/components/file-upload/file-upload.test.ts
+++ b/packages/components/src/components/file-upload/file-upload.test.ts
@@ -452,7 +452,7 @@ describe('FileUpload validation and events', () => {
         id: 'upload',
         multiple: true,
         maxFiles: 1,
-        files: [{ id: 'existing', file: existingFile, status: 'success' }],
+        files: [{ id: 'existing', file: existingFile, status: 'ready' }],
         onReject,
       },
     });
@@ -543,7 +543,7 @@ describe('FileUpload validation and events', () => {
       props: {
         id: 'upload',
         multiple: true,
-        files: [{ id: 'existing', file: existingFile, status: 'success' }],
+        files: [{ id: 'existing', file: existingFile, status: 'ready' }],
         onFilesChange,
       },
     });
@@ -560,7 +560,7 @@ describe('FileUpload validation and events', () => {
   test('a declined controlled proposal is not retained when control is released', async () => {
     const existingFile = createFile('existing.txt', 'text/plain', 10);
     const selectedFile = createFile('selected.txt', 'text/plain', 10);
-    const entry = { id: 'existing', file: existingFile, status: 'success' as const };
+    const entry = { id: 'existing', file: existingFile, status: 'ready' as const };
     const result = render(FileUploadFormFixture, {
       props: { controlledFiles: [entry], onFilesChange: () => {} },
     });
@@ -612,8 +612,8 @@ describe('FileUpload validation and events', () => {
   test('picker focus return restores the latest controlled queue', async () => {
     const firstFile = createFile('first.txt', 'text/plain', 10);
     const secondFile = createFile('second.txt', 'text/plain', 10);
-    const firstEntry = { id: 'first', file: firstFile, status: 'success' as const };
-    const secondEntry = { id: 'second', file: secondFile, status: 'success' as const };
+    const firstEntry = { id: 'first', file: firstFile, status: 'ready' as const };
+    const secondEntry = { id: 'second', file: secondFile, status: 'ready' as const };
     const result = render(FileUpload, {
       props: { id: 'upload', multiple: true, files: [firstEntry] },
     });
@@ -635,8 +635,8 @@ describe('FileUpload validation and events', () => {
       props: {
         id: 'upload',
         files: [
-          { id: 'first', file: firstFile, status: 'success' },
-          { id: 'second', file: secondFile, status: 'success' },
+          { id: 'first', file: firstFile, status: 'ready' },
+          { id: 'second', file: secondFile, status: 'ready' },
         ],
       },
     });
@@ -654,7 +654,7 @@ describe('FileUpload validation and events', () => {
     const files = [firstFile, secondFile, thirdFile].map((file, index) => ({
       id: String(index),
       file,
-      status: 'success' as const,
+      status: 'ready' as const,
     }));
     const { container, rerender } = render(FileUpload, {
       props: { id: 'upload', multiple: true, maxFiles: 3, files },
@@ -676,7 +676,7 @@ describe('FileUpload validation and events', () => {
       props: {
         id: 'upload',
         accept: 'image/*',
-        files: [{ id: 'existing', file: existingFile, status: 'success' }],
+        files: [{ id: 'existing', file: existingFile, status: 'ready' }],
         onReject,
       },
     });
@@ -992,8 +992,8 @@ describe('FileUpload validation and events', () => {
         id: 'upload',
         multiple: true,
         files: [
-          { id: 'first', file: firstFile, status: 'success' },
-          { id: 'second', file: secondFile, status: 'success' },
+          { id: 'first', file: firstFile, status: 'ready' },
+          { id: 'second', file: secondFile, status: 'ready' },
         ],
         onFilesChange,
       },
@@ -1019,8 +1019,8 @@ describe('FileUpload validation and events', () => {
         id: 'upload',
         multiple: true,
         files: [
-          { id: 'first', file: firstFile, status: 'success' },
-          { id: 'second', file: secondFile, status: 'success' },
+          { id: 'first', file: firstFile, status: 'ready' },
+          { id: 'second', file: secondFile, status: 'ready' },
         ],
         onFilesChange,
       },
@@ -1041,12 +1041,12 @@ describe('FileUpload validation and events', () => {
     const firstEntry = {
       id: 'first',
       file: createFile('first.txt', 'text/plain', 10),
-      status: 'success' as const,
+      status: 'ready' as const,
     };
     const secondEntry = {
       id: 'second',
       file: createFile('second.txt', 'text/plain', 10),
-      status: 'success' as const,
+      status: 'ready' as const,
     };
     let rerender: ReturnType<typeof render>['rerender'];
     const onFilesChange = mock(() => {
@@ -1077,7 +1077,7 @@ describe('FileUpload validation and events', () => {
     const entry = {
       id: 'only',
       file: createFile('only.txt', 'text/plain', 10),
-      status: 'success' as const,
+      status: 'ready' as const,
     };
     let rerender: ReturnType<typeof render>['rerender'];
     const onFilesChange = mock(() => {
@@ -1103,7 +1103,7 @@ describe('FileUpload validation and events', () => {
 
   test('an adopted controlled removal announces after the row is removed', async () => {
     const file = createFile('report.txt', 'text/plain', 10);
-    const entry = { id: 'report', file, status: 'success' as const };
+    const entry = { id: 'report', file, status: 'ready' as const };
     let rerender: ReturnType<typeof render>['rerender'];
     const onFilesChange = mock(() => {
       void rerender({ id: 'upload', files: [], onFilesChange });
@@ -1166,7 +1166,7 @@ describe('FileUpload validation and events', () => {
 
   test('form reset restores the synchronized native files for a controlled queue', async () => {
     const file = createFile('report.txt', 'text/plain', 10);
-    const entry = { id: 'report', file, status: 'success' as const };
+    const entry = { id: 'report', file, status: 'ready' as const };
     const form = document.createElement('form');
     form.id = 'controlled-upload-form';
     document.body.append(form);
@@ -1187,8 +1187,8 @@ describe('FileUpload validation and events', () => {
   test('form reset restores the latest controlled queue after a same-task prop update', async () => {
     const firstFile = createFile('first.txt', 'text/plain', 10);
     const secondFile = createFile('second.txt', 'text/plain', 10);
-    const firstEntry = { id: 'first', file: firstFile, status: 'success' as const };
-    const secondEntry = { id: 'second', file: secondFile, status: 'success' as const };
+    const firstEntry = { id: 'first', file: firstFile, status: 'ready' as const };
+    const secondEntry = { id: 'second', file: secondFile, status: 'ready' as const };
     const { container } = render(FileUploadFormFixture, {
       props: { controlledFiles: [firstEntry], nextControlledFiles: [secondEntry] },
     });
@@ -1477,12 +1477,12 @@ describe('FileUpload file list rendering', () => {
 
   test('renders a file-type icon for known and unknown MIME types', () => {
     const files = [
-      { id: 'image', file: createFile('photo.png', 'image/png', 100), status: 'success' as const },
-      { id: 'sheet', file: createFile('report.csv', 'text/csv', 100), status: 'success' as const },
+      { id: 'image', file: createFile('photo.png', 'image/png', 100), status: 'ready' as const },
+      { id: 'sheet', file: createFile('report.csv', 'text/csv', 100), status: 'ready' as const },
       {
         id: 'unknown',
         file: createFile('archive.zip', 'application/zip', 100),
-        status: 'success' as const,
+        status: 'ready' as const,
       },
     ];
     const { container } = render(FileUpload, { props: { id: 'upload', files } });

--- a/packages/components/src/components/file-upload/file-upload.types.ts
+++ b/packages/components/src/components/file-upload/file-upload.types.ts
@@ -12,7 +12,7 @@ export type RejectedFile = {
   message: string;
 };
 
-export type FileUploadStatus = 'pending' | 'uploading' | 'success' | 'error';
+export type FileUploadStatus = 'pending' | 'uploading' | 'ready' | 'error';
 
 export type FileUploadEntry = {
   /** Stable key used for rendering. */


### PR DESCRIPTION
Implements [CIN-371](https://linear.app/lost-gradient/issue/CIN-371/reconcile-the-two-disagreeing-upload-status-models-onto-one-shared): renames `FileUploadStatus`'s `'success'` member to `'ready'` and makes chat's `chat-attachment.ts` import that union from `@lostgradient/cinder` instead of declaring its own duplicate. `'ready'` is canonical because chat creates non-code attachments directly as `'ready'` with no upload occurring — a state `'success'` cannot express.

- CSS kept in sync: `[data-status='success']` → `[data-status='ready']` alongside the component logic.
- No compatibility alias (pre-release clean break); patch changesets for both `@lostgradient/cinder` (migration note) and `@lostgradient/chat` (type source change).
- `grep -rn "'success'"` over `packages/*/src` has no remaining upload-status hits — the ~25 chat hits are the unrelated ToolResult/tool-call-group status model, untouched by design.
- No generated artifacts referenced the literal, so nothing needed regeneration.

Verification: cinder suite exit 0; chat suite 817/0; both typechecks 0 errors; `components:check`/`exports:check` OK.