### PR TITLE
fix(spectrogram): reduce dense plot render cap

### DIFF
--- a/.changeset/bright-spectrograms-render.md
+++ b/.changeset/bright-spectrograms-render.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Reduce the maximum visual density of large `Spectrogram` plots while preserving maximum aggregation within each sampled bucket. This prevents large SVG heatmaps from creating excessive DOM work during rendering.

--- a/packages/components/src/components/spectrogram/spectrogram.svelte
+++ b/packages/components/src/components/spectrogram/spectrogram.svelte
@@ -179,9 +179,10 @@
   // 10x10). A realistic STFT feed (a few hundred frames x 256 bins) can
   // produce tens of thousands of DOM nodes. Sample the plot the same way,
   // sized for visual density rather than the table's 10x10 accessibility
-  // limit: 400 x 256 keeps the worst case at 102,400 <rect> elements.
-  const maxPlotFrames = 400;
-  const maxPlotBins = 256;
+  // limit: 200 x 128 keeps the worst case at 25,600 <rect> elements while
+  // maximum aggregation preserves narrow transients inside every bucket.
+  const maxPlotFrames = 200;
+  const maxPlotBins = 128;
   const plotFrameStep = $derived(Math.max(1, Math.ceil(frames.length / maxPlotFrames)));
   const plotBinStep = $derived(Math.max(1, Math.ceil(binCount / maxPlotBins)));
   const plotFrames = $derived.by(() =>

--- a/packages/components/src/components/spectrogram/spectrogram.test.ts
+++ b/packages/components/src/components/spectrogram/spectrogram.test.ts
@@ -332,6 +332,8 @@ describe('Spectrogram', () => {
     const binStep = Math.max(1, Math.ceil(binCount / maxPlotBins));
     const expectedCellCount = Math.ceil(frameCount / frameStep) * Math.ceil(binCount / binStep);
 
+    expect(expectedCellCount).toBe(11_524);
+
     const cells = container.querySelectorAll('.cinder-spectrogram__cell');
     expect(expectedCellCount).toBe(11_524);
     expect(cells.length).toBe(expectedCellCount);

--- a/packages/components/src/components/spectrogram/spectrogram.test.ts
+++ b/packages/components/src/components/spectrogram/spectrogram.test.ts
@@ -333,8 +333,8 @@ describe('Spectrogram', () => {
     const expectedCellCount = Math.ceil(frameCount / frameStep) * Math.ceil(binCount / binStep);
 
     const cells = container.querySelectorAll('.cinder-spectrogram__cell');
+    expect(expectedCellCount).toBe(11_524);
     expect(cells.length).toBe(expectedCellCount);
-    expect(cells.length).toBe(11_524);
     expect(cells.length).toBeLessThanOrEqual(maxPlotFrames * maxPlotBins);
 
     const plotFrameCount = Math.ceil(frameCount / frameStep);

--- a/packages/components/src/components/spectrogram/spectrogram.test.ts
+++ b/packages/components/src/components/spectrogram/spectrogram.test.ts
@@ -326,14 +326,15 @@ describe('Spectrogram', () => {
       frames: denseFrames,
     });
 
-    const maxPlotFrames = 400;
-    const maxPlotBins = 256;
+    const maxPlotFrames = 200;
+    const maxPlotBins = 128;
     const frameStep = Math.max(1, Math.ceil(frameCount / maxPlotFrames));
     const binStep = Math.max(1, Math.ceil(binCount / maxPlotBins));
     const expectedCellCount = Math.ceil(frameCount / frameStep) * Math.ceil(binCount / binStep);
 
     const cells = container.querySelectorAll('.cinder-spectrogram__cell');
     expect(cells.length).toBe(expectedCellCount);
+    expect(cells.length).toBe(11_524);
     expect(cells.length).toBeLessThanOrEqual(maxPlotFrames * maxPlotBins);
 
     const plotFrameCount = Math.ceil(frameCount / frameStep);

--- a/packages/components/src/components/spectrogram/spectrogram.test.ts
+++ b/packages/components/src/components/spectrogram/spectrogram.test.ts
@@ -335,7 +335,6 @@ describe('Spectrogram', () => {
     expect(expectedCellCount).toBe(11_524);
 
     const cells = container.querySelectorAll('.cinder-spectrogram__cell');
-    expect(expectedCellCount).toBe(11_524);
     expect(cells.length).toBe(expectedCellCount);
     expect(cells.length).toBeLessThanOrEqual(maxPlotFrames * maxPlotBins);
 


### PR DESCRIPTION
## Summary

- Reduce the maximum dense Spectrogram plot from 400 × 256 to 200 × 128 sampled cells.
- Preserve maximum-value aggregation inside every sampled frame/bin bucket so narrow transients remain visible.
- Keep exact-count and contiguous-geometry assertions while cutting the repeated Linux CI render path from 25,929 SVG rectangles to 11,524.

## Root cause

Issue #1424 recorded the same dense-grid Spectrogram regression timing out after five seconds in three independent main-green runs, including scheduled run 32958154386 on current main. The test was exercising a production path that still created enough SVG nodes to become runner-speed dependent. This changes the production render budget; it does not increase a timeout, retry, wait, or threshold.

The issue also recorded intermittent hydration-smoke failures. Current main has independently passed that gate locally and in scheduled run 32958154386, so this pull request does not claim or introduce an unsupported hydration workaround.

## Validation

- `PATH=/Users/stevekinney/.bun/bin:$PATH bun run --filter=@lostgradient/cinder test -- src/components/spectrogram/spectrogram.test.ts`—25 passing on pinned Bun 1.3.13.
- Large-grid cases complete locally in roughly 352 ms and 295 ms after the repair.
- Exact rendered-cell count is 11,524; cap, geometry continuity, and maximum-bucket aggregation remain asserted.
- Independent exact-head review found no blockers.

Closes #1424