### PR TITLE
fix(ci): serialize hydration marker readiness

### DIFF
--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -267,16 +267,10 @@ describe('SvelteKit hydration route failure diagnostics', () => {
       hydrationMarkerPresent: 'unknown',
       hydrationMarkerValue: 'unknown',
     };
-    const waitFor = mock(async () => undefined);
-    const locator = mock(() => ({ waitFor }));
-    const page = {
-      locator,
-    };
+    const readiness = Promise.resolve();
 
-    await waitForSvelteKitHydrationMarker(page, '/dev-ssr-tabs', domObservation, 5_000);
+    await waitForSvelteKitHydrationMarker(readiness, domObservation);
 
-    expect(locator).toHaveBeenCalledWith('[data-dev-ssr-hydrated="true"]');
-    expect(waitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });
     expect(domObservation.hydrationMarkerPresent).toBe(true);
     expect(domObservation.hydrationMarkerValue).toBe('true');
   });
@@ -288,16 +282,11 @@ describe('SvelteKit hydration route failure diagnostics', () => {
       hydrationMarkerValue: 'unknown',
     };
     const readinessError = new Error('hydration readiness wait failed');
-    const waitFor = mock(async () => {
-      throw readinessError;
-    });
-    const page = { locator: mock(() => ({ waitFor })) };
+    const readiness = Promise.reject(readinessError);
 
-    await expect(
-      waitForSvelteKitHydrationMarker(page, '/chat-layout', domObservation, 5_000),
-    ).rejects.toBe(readinessError);
-    expect(page.locator).toHaveBeenCalledWith('[data-chat-layout-hydrated="true"]');
-    expect(waitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });
+    await expect(waitForSvelteKitHydrationMarker(readiness, domObservation)).rejects.toBe(
+      readinessError,
+    );
     expect(domObservation.hydrationMarkerPresent).toBe('unknown');
     expect(domObservation.hydrationMarkerValue).toBe('unknown');
   });

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -16,9 +16,6 @@ import {
   formatSvelteKitHydrationRouteFailure,
   formatSvelteKitHydrationRuntimeErrors,
   isBrowserCrashError,
-  observeSvelteKitHydrationMarker,
-  observeSvelteKitHydrationMarkerAlongside,
-  observeSvelteKitHydrationMarkerBestEffort,
   parseHydrationBrowserProcessIds,
   preoptimizeSvelteKitChatHydration,
   prepareSvelteKitChatHydrationDevServer,
@@ -30,6 +27,7 @@ import {
   stopDevelopmentServer,
   SVELTEKIT_HYDRATION_ROUTES,
   unreclaimedTeardownFailures,
+  waitForSvelteKitHydrationMarker,
   wrapSvelteKitHydrationRouteFailure,
   type SvelteKitChatHydrationDevServerOptions,
   type SvelteKitHydrationRouteDomObservation,
@@ -263,97 +261,45 @@ describe('SvelteKit hydration route failure diagnostics', () => {
     expect(captured.runtimeErrors.values).toEqual(['runtime error']);
   });
 
-  test('captures a present false marker before the hydration readiness wait fails', async () => {
+  test('waits for hydration marker state without a concurrent diagnostic page read', async () => {
     const domObservation: SvelteKitHydrationRouteDomObservation = {
       documentReadyState: 'interactive',
       hydrationMarkerPresent: 'unknown',
       hydrationMarkerValue: 'unknown',
     };
-    const marker = {
-      getAttribute: mock(async (attribute: string) => {
-        expect(attribute).toBe('data-dev-ssr-hydrated');
-        return 'false';
-      }),
-    };
+    const waitFor = mock(async () => undefined);
+    const locator = mock(() => ({ waitFor }));
     const page = {
-      $: mock(async (selector: string) => {
-        expect(selector).toBe('[data-dev-ssr-hydrated]');
-        return marker;
-      }),
+      locator,
     };
 
-    await observeSvelteKitHydrationMarker(page, '/dev-ssr-tabs', domObservation);
-    await expect(Promise.reject(new Error('hydration readiness wait failed'))).rejects.toThrow(
-      'hydration readiness wait failed',
-    );
+    await waitForSvelteKitHydrationMarker(page, '/dev-ssr-tabs', domObservation);
 
+    expect(locator).toHaveBeenCalledWith('[data-dev-ssr-hydrated="true"]');
+    expect(waitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });
     expect(domObservation.hydrationMarkerPresent).toBe(true);
-    expect(domObservation.hydrationMarkerValue).toBe('false');
+    expect(domObservation.hydrationMarkerValue).toBe('true');
   });
 
-  test('bounds a hydration marker protocol probe that never settles', async () => {
+  test('preserves an unknown marker snapshot when hydration readiness fails', async () => {
     const domObservation: SvelteKitHydrationRouteDomObservation = {
       documentReadyState: 'interactive',
       hydrationMarkerPresent: 'unknown',
       hydrationMarkerValue: 'unknown',
     };
-    const page = { $: mock(() => new Promise<null>(() => undefined)) };
+    const readinessError = new Error('hydration readiness wait failed');
+    const waitFor = mock(async () => {
+      throw readinessError;
+    });
+    const page = { locator: mock(() => ({ waitFor })) };
 
     await expect(
-      observeSvelteKitHydrationMarker(page, '/dev-ssr-tabs', domObservation, 1),
-    ).rejects.toThrow('hydration marker probe selector=[data-dev-ssr-hydrated] timed out');
-  });
-
-  test('bounds a hydration marker attribute read that never settles', async () => {
-    const domObservation: SvelteKitHydrationRouteDomObservation = {
-      documentReadyState: 'interactive',
-      hydrationMarkerPresent: 'unknown',
-      hydrationMarkerValue: 'unknown',
-    };
-    const page = {
-      $: mock(async () => ({ getAttribute: () => new Promise<string | null>(() => undefined) })),
-    };
-
-    await expect(
-      observeSvelteKitHydrationMarker(page, '/dev-ssr-tabs', domObservation, 1),
-    ).rejects.toThrow('hydration marker probe selector=[data-dev-ssr-hydrated] timed out');
-  });
-
-  test('records a hydration marker diagnostic failure without replacing the route assertion', async () => {
-    const domObservation: SvelteKitHydrationRouteDomObservation = {
-      documentReadyState: 'interactive',
-      hydrationMarkerPresent: 'unknown',
-      hydrationMarkerValue: 'unknown',
-    };
-    const page = { $: mock(() => new Promise<null>(() => undefined)) };
-
-    await observeSvelteKitHydrationMarkerBestEffort(page, '/dev-ssr-tabs', domObservation, 1);
-
-    expect(domObservation.diagnosticCaptureError).toContain(
-      'hydration marker probe selector=[data-dev-ssr-hydrated] timed out',
-    );
+      waitForSvelteKitHydrationMarker(page, '/chat-layout', domObservation),
+    ).rejects.toBe(readinessError);
+    expect(page.locator).toHaveBeenCalledWith('[data-chat-layout-hydrated="true"]');
+    expect(waitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });
     expect(domObservation.hydrationMarkerPresent).toBe('unknown');
     expect(domObservation.hydrationMarkerValue).toBe('unknown');
-  });
-
-  test('shares the hydration readiness window with the diagnostic probe', async () => {
-    const domObservation: SvelteKitHydrationRouteDomObservation = {
-      documentReadyState: 'interactive',
-      hydrationMarkerPresent: 'unknown',
-      hydrationMarkerValue: 'unknown',
-    };
-    const page = { $: mock(() => new Promise<null>(() => undefined)) };
-
-    await expect(
-      observeSvelteKitHydrationMarkerAlongside(
-        page,
-        '/dev-ssr-tabs',
-        domObservation,
-        Promise.reject(new Error('hydration readiness wait failed')),
-        50,
-      ),
-    ).rejects.toThrow('hydration readiness wait failed');
-    expect(domObservation.diagnosticCaptureError).toContain('hydration marker probe');
   });
 
   test('wraps route failures with route, network, runtime, and DOM state', () => {

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path';
 import { getPackFileName } from './publish-release.ts';
 import { packageTarballPath } from './report-package-weight.ts';
 import {
+  assertSvelteKitHydrationRouteContent,
   boundedDiagnosticSnapshot,
   bumpPackageVersion,
   captureSvelteKitHydrationRouteFailureSnapshot,
@@ -27,7 +28,6 @@ import {
   stopDevelopmentServer,
   SVELTEKIT_HYDRATION_ROUTES,
   unreclaimedTeardownFailures,
-  waitForSvelteKitHydrationMarker,
   wrapSvelteKitHydrationRouteFailure,
   type SvelteKitChatHydrationDevServerOptions,
   type SvelteKitHydrationRouteDomObservation,
@@ -267,10 +267,26 @@ describe('SvelteKit hydration route failure diagnostics', () => {
       hydrationMarkerPresent: 'unknown',
       hydrationMarkerValue: 'unknown',
     };
-    const readiness = Promise.resolve();
+    const markerWaitFor = mock(async () => undefined);
+    const contentWaitFor = mock(async () => undefined);
+    const rawElementLookup = mock(async () => null);
+    const page = {
+      $: rawElementLookup,
+      getByRole: mock(() => ({ waitFor: contentWaitFor })),
+      getByText: mock(() => ({ waitFor: contentWaitFor })),
+      locator: mock(() => ({ waitFor: markerWaitFor })),
+    };
 
-    await waitForSvelteKitHydrationMarker(readiness, domObservation);
+    await assertSvelteKitHydrationRouteContent(
+      page as never,
+      createBoundedDiagnosticCollection(),
+      '/chat-layout',
+      domObservation,
+    );
 
+    expect(page.locator).toHaveBeenCalledWith('[data-chat-layout-hydrated="true"]');
+    expect(markerWaitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });
+    expect(rawElementLookup).not.toHaveBeenCalled();
     expect(domObservation.hydrationMarkerPresent).toBe(true);
     expect(domObservation.hydrationMarkerValue).toBe('true');
   });
@@ -282,11 +298,26 @@ describe('SvelteKit hydration route failure diagnostics', () => {
       hydrationMarkerValue: 'unknown',
     };
     const readinessError = new Error('hydration readiness wait failed');
-    const readiness = Promise.reject(readinessError);
+    const markerWaitFor = mock(async () => {
+      throw readinessError;
+    });
+    const getByText = mock(() => ({ waitFor: mock(async () => undefined) }));
+    const page = {
+      getByText,
+      locator: mock(() => ({ waitFor: markerWaitFor })),
+    };
 
-    await expect(waitForSvelteKitHydrationMarker(readiness, domObservation)).rejects.toBe(
-      readinessError,
-    );
+    await expect(
+      assertSvelteKitHydrationRouteContent(
+        page as never,
+        createBoundedDiagnosticCollection(),
+        '/dev-ssr-tabs',
+        domObservation,
+      ),
+    ).rejects.toBe(readinessError);
+    expect(page.locator).toHaveBeenCalledWith('[data-dev-ssr-hydrated="true"]');
+    expect(markerWaitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });
+    expect(getByText).not.toHaveBeenCalled();
     expect(domObservation.hydrationMarkerPresent).toBe('unknown');
     expect(domObservation.hydrationMarkerValue).toBe('unknown');
   });

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -273,7 +273,7 @@ describe('SvelteKit hydration route failure diagnostics', () => {
       locator,
     };
 
-    await waitForSvelteKitHydrationMarker(page, '/dev-ssr-tabs', domObservation);
+    await waitForSvelteKitHydrationMarker(page, '/dev-ssr-tabs', domObservation, 5_000);
 
     expect(locator).toHaveBeenCalledWith('[data-dev-ssr-hydrated="true"]');
     expect(waitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });
@@ -294,7 +294,7 @@ describe('SvelteKit hydration route failure diagnostics', () => {
     const page = { locator: mock(() => ({ waitFor })) };
 
     await expect(
-      waitForSvelteKitHydrationMarker(page, '/chat-layout', domObservation),
+      waitForSvelteKitHydrationMarker(page, '/chat-layout', domObservation, 5_000),
     ).rejects.toBe(readinessError);
     expect(page.locator).toHaveBeenCalledWith('[data-chat-layout-hydrated="true"]');
     expect(waitFor).toHaveBeenCalledWith({ state: 'attached', timeout: 5_000 });

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2767,18 +2767,13 @@ type SvelteKitHydrationRouteFailureInput = {
   snapshot: SvelteKitHydrationRouteFailureSnapshot;
 };
 
-function hydrationMarkerForRoute(routePath: SvelteKitHydrationRoute): {
-  hydratedSelector: string;
-  selector: string;
-} {
+function hydrationMarkerForRoute(routePath: SvelteKitHydrationRoute): { selector: string } {
   if (routePath === '/chat-layout') {
     return {
-      hydratedSelector: '[data-chat-layout-hydrated="true"]',
       selector: '[data-chat-layout-hydrated]',
     };
   }
   return {
-    hydratedSelector: '[data-dev-ssr-hydrated="true"]',
     selector: '[data-dev-ssr-hydrated]',
   };
 }

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2654,7 +2654,7 @@ async function assertSvelteKitHydrationRouteContent(
   domObservation: SvelteKitHydrationRouteDomObservation,
 ): Promise<void> {
   if (routePath === '/chat-layout') {
-    await waitForSvelteKitHydrationMarker(page, routePath, domObservation);
+    await waitForSvelteKitHydrationMarker(page, routePath, domObservation, 5_000);
     await page.getByRole('heading', { name: 'Empty Chat hydration' }).waitFor({ timeout: 5_000 });
     await page.getByText('No messages yet').waitFor({ timeout: 5_000 });
     await page.getByRole('textbox', { name: 'Message' }).waitFor({ timeout: 5_000 });
@@ -2662,7 +2662,7 @@ async function assertSvelteKitHydrationRouteContent(
     return;
   }
 
-  await waitForSvelteKitHydrationMarker(page, routePath, domObservation);
+  await waitForSvelteKitHydrationMarker(page, routePath, domObservation, 5_000);
   if (routePath === '/dev-ssr-navigation') {
     await page.getByText('basicOrderWorkflow').waitFor({ timeout: 5_000 });
     return;
@@ -2786,7 +2786,7 @@ export async function waitForSvelteKitHydrationMarker(
   page: HydrationMarkerPage,
   routePath: SvelteKitHydrationRoute,
   domObservation: SvelteKitHydrationRouteDomObservation,
-  timeoutMs = 5_000,
+  timeoutMs: number,
 ): Promise<void> {
   const marker = hydrationMarkerForRoute(routePath);
   await page.locator(marker.hydratedSelector).waitFor({ state: 'attached', timeout: timeoutMs });

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2647,19 +2647,18 @@ async function assertSvelteKitHydrationRoute(
   }
 }
 
-async function assertSvelteKitHydrationRouteContent(
+export async function assertSvelteKitHydrationRouteContent(
   page: Page,
   errors: BoundedDiagnosticCollection,
   routePath: SvelteKitHydrationRoute,
   domObservation: SvelteKitHydrationRouteDomObservation,
 ): Promise<void> {
   if (routePath === '/chat-layout') {
-    await waitForSvelteKitHydrationMarker(
-      page
-        .locator('[data-chat-layout-hydrated="true"]')
-        .waitFor({ state: 'attached', timeout: 5_000 }),
-      domObservation,
-    );
+    await page
+      .locator('[data-chat-layout-hydrated="true"]')
+      .waitFor({ state: 'attached', timeout: 5_000 });
+    domObservation.hydrationMarkerPresent = true;
+    domObservation.hydrationMarkerValue = 'true';
     await page.getByRole('heading', { name: 'Empty Chat hydration' }).waitFor({ timeout: 5_000 });
     await page.getByText('No messages yet').waitFor({ timeout: 5_000 });
     await page.getByRole('textbox', { name: 'Message' }).waitFor({ timeout: 5_000 });
@@ -2667,10 +2666,11 @@ async function assertSvelteKitHydrationRouteContent(
     return;
   }
 
-  await waitForSvelteKitHydrationMarker(
-    page.locator('[data-dev-ssr-hydrated="true"]').waitFor({ state: 'attached', timeout: 5_000 }),
-    domObservation,
-  );
+  await page
+    .locator('[data-dev-ssr-hydrated="true"]')
+    .waitFor({ state: 'attached', timeout: 5_000 });
+  domObservation.hydrationMarkerPresent = true;
+  domObservation.hydrationMarkerValue = 'true';
   if (routePath === '/dev-ssr-navigation') {
     await page.getByText('basicOrderWorkflow').waitFor({ timeout: 5_000 });
     return;
@@ -2781,16 +2781,6 @@ function hydrationMarkerForRoute(routePath: SvelteKitHydrationRoute): {
     hydratedSelector: '[data-dev-ssr-hydrated="true"]',
     selector: '[data-dev-ssr-hydrated]',
   };
-}
-
-/** Wait for the route's hydration state without issuing a competing diagnostic page read. */
-export async function waitForSvelteKitHydrationMarker(
-  readiness: Promise<void>,
-  domObservation: SvelteKitHydrationRouteDomObservation,
-): Promise<void> {
-  await readiness;
-  domObservation.hydrationMarkerPresent = true;
-  domObservation.hydrationMarkerValue = 'true';
 }
 
 function unknownSvelteKitHydrationRouteFailureSnapshot(

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2654,14 +2654,7 @@ async function assertSvelteKitHydrationRouteContent(
   domObservation: SvelteKitHydrationRouteDomObservation,
 ): Promise<void> {
   if (routePath === '/chat-layout') {
-    await observeSvelteKitHydrationMarkerAlongside(
-      page,
-      routePath,
-      domObservation,
-      page.locator('[data-chat-layout-hydrated="true"]').waitFor({ timeout: 5_000 }),
-    );
-    domObservation.hydrationMarkerPresent = true;
-    domObservation.hydrationMarkerValue = 'true';
+    await waitForSvelteKitHydrationMarker(page, routePath, domObservation);
     await page.getByRole('heading', { name: 'Empty Chat hydration' }).waitFor({ timeout: 5_000 });
     await page.getByText('No messages yet').waitFor({ timeout: 5_000 });
     await page.getByRole('textbox', { name: 'Message' }).waitFor({ timeout: 5_000 });
@@ -2669,14 +2662,7 @@ async function assertSvelteKitHydrationRouteContent(
     return;
   }
 
-  await observeSvelteKitHydrationMarkerAlongside(
-    page,
-    routePath,
-    domObservation,
-    page.locator('[data-dev-ssr-hydrated="true"]').waitFor({ timeout: 5_000 }),
-  );
-  domObservation.hydrationMarkerPresent = true;
-  domObservation.hydrationMarkerValue = 'true';
+  await waitForSvelteKitHydrationMarker(page, routePath, domObservation);
   if (routePath === '/dev-ssr-navigation') {
     await page.getByText('basicOrderWorkflow').waitFor({ timeout: 5_000 });
     return;
@@ -2774,74 +2760,38 @@ type SvelteKitHydrationRouteFailureInput = {
 };
 
 function hydrationMarkerForRoute(routePath: SvelteKitHydrationRoute): {
-  attribute: string;
+  hydratedSelector: string;
   selector: string;
 } {
   if (routePath === '/chat-layout') {
     return {
-      attribute: 'data-chat-layout-hydrated',
+      hydratedSelector: '[data-chat-layout-hydrated="true"]',
       selector: '[data-chat-layout-hydrated]',
     };
   }
   return {
-    attribute: 'data-dev-ssr-hydrated',
+    hydratedSelector: '[data-dev-ssr-hydrated="true"]',
     selector: '[data-dev-ssr-hydrated]',
   };
 }
 
 type HydrationMarkerPage = {
-  $: (
-    selector: string,
-  ) => Promise<{ getAttribute: (attribute: string) => Promise<string | null> } | null>;
+  locator: (selector: string) => {
+    waitFor: (options: { state: 'attached'; timeout: number }) => Promise<void>;
+  };
 };
 
-export async function observeSvelteKitHydrationMarker(
+/** Wait for the route's hydration state without issuing a competing diagnostic page read. */
+export async function waitForSvelteKitHydrationMarker(
   page: HydrationMarkerPage,
   routePath: SvelteKitHydrationRoute,
   domObservation: SvelteKitHydrationRouteDomObservation,
   timeoutMs = 5_000,
 ): Promise<void> {
   const marker = hydrationMarkerForRoute(routePath);
-  const observation = await promiseWithTimeout(
-    (async () => {
-      const element = await page.$(marker.selector);
-      return {
-        present: element !== null,
-        value: element ? await element.getAttribute(marker.attribute) : null,
-      };
-    })(),
-    timeoutMs,
-    `hydration marker probe selector=${marker.selector}`,
-  );
-  domObservation.hydrationMarkerPresent = observation.present;
-  domObservation.hydrationMarkerValue = observation.value;
-}
-
-export async function observeSvelteKitHydrationMarkerBestEffort(
-  page: HydrationMarkerPage,
-  routePath: SvelteKitHydrationRoute,
-  domObservation: SvelteKitHydrationRouteDomObservation,
-  timeoutMs = 5_000,
-): Promise<void> {
-  try {
-    await observeSvelteKitHydrationMarker(page, routePath, domObservation, timeoutMs);
-  } catch (error) {
-    domObservation.diagnosticCaptureError = errorMessage(error);
-  }
-}
-
-export async function observeSvelteKitHydrationMarkerAlongside(
-  page: HydrationMarkerPage,
-  routePath: SvelteKitHydrationRoute,
-  domObservation: SvelteKitHydrationRouteDomObservation,
-  readiness: Promise<void>,
-  timeoutMs = 5_000,
-): Promise<void> {
-  const [, readinessResult] = await Promise.allSettled([
-    observeSvelteKitHydrationMarkerBestEffort(page, routePath, domObservation, timeoutMs),
-    readiness,
-  ]);
-  if (readinessResult?.status === 'rejected') throw readinessResult.reason;
+  await page.locator(marker.hydratedSelector).waitFor({ state: 'attached', timeout: timeoutMs });
+  domObservation.hydrationMarkerPresent = true;
+  domObservation.hydrationMarkerValue = 'true';
 }
 
 function unknownSvelteKitHydrationRouteFailureSnapshot(

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -2654,7 +2654,12 @@ async function assertSvelteKitHydrationRouteContent(
   domObservation: SvelteKitHydrationRouteDomObservation,
 ): Promise<void> {
   if (routePath === '/chat-layout') {
-    await waitForSvelteKitHydrationMarker(page, routePath, domObservation, 5_000);
+    await waitForSvelteKitHydrationMarker(
+      page
+        .locator('[data-chat-layout-hydrated="true"]')
+        .waitFor({ state: 'attached', timeout: 5_000 }),
+      domObservation,
+    );
     await page.getByRole('heading', { name: 'Empty Chat hydration' }).waitFor({ timeout: 5_000 });
     await page.getByText('No messages yet').waitFor({ timeout: 5_000 });
     await page.getByRole('textbox', { name: 'Message' }).waitFor({ timeout: 5_000 });
@@ -2662,7 +2667,10 @@ async function assertSvelteKitHydrationRouteContent(
     return;
   }
 
-  await waitForSvelteKitHydrationMarker(page, routePath, domObservation, 5_000);
+  await waitForSvelteKitHydrationMarker(
+    page.locator('[data-dev-ssr-hydrated="true"]').waitFor({ state: 'attached', timeout: 5_000 }),
+    domObservation,
+  );
   if (routePath === '/dev-ssr-navigation') {
     await page.getByText('basicOrderWorkflow').waitFor({ timeout: 5_000 });
     return;
@@ -2775,21 +2783,12 @@ function hydrationMarkerForRoute(routePath: SvelteKitHydrationRoute): {
   };
 }
 
-type HydrationMarkerPage = {
-  locator: (selector: string) => {
-    waitFor: (options: { state: 'attached'; timeout: number }) => Promise<void>;
-  };
-};
-
 /** Wait for the route's hydration state without issuing a competing diagnostic page read. */
 export async function waitForSvelteKitHydrationMarker(
-  page: HydrationMarkerPage,
-  routePath: SvelteKitHydrationRoute,
+  readiness: Promise<void>,
   domObservation: SvelteKitHydrationRouteDomObservation,
-  timeoutMs: number,
 ): Promise<void> {
-  const marker = hydrationMarkerForRoute(routePath);
-  await page.locator(marker.hydratedSelector).waitFor({ state: 'attached', timeout: timeoutMs });
+  await readiness;
   domObservation.hydrationMarkerPresent = true;
   domObservation.hydrationMarkerValue = 'true';
 }


### PR DESCRIPTION
## Summary

- replace the concurrent raw Playwright marker probe and readiness locator with one marker-state assertion
- wait for the hydrated attribute selector to be attached, preserving the existing 5-second bound without visibility/layout polling
- keep the downstream Chat, textbox, message-count, and dev-SSR interaction assertions unchanged

## Root cause

`e79c55d03` added `observeSvelteKitHydrationMarkerAlongside()`, which issued `page.$()` and `locator.waitFor()` concurrently against the same page. After that change, identical `main` commits alternated between `/chat-layout` and `/dev-ssr-tabs` marker failures while both the real wait and diagnostic page read stopped responding. Exact-main run 32975503114 reproduced the shared failure with `documentReadyState: complete` and no HTTP, request, console, page, or browser errors.

The marker is a state contract, not a visibility contract. The replacement waits for `[data-*-hydrated="true"]` with `state: attached`, then records the successful state. It does not increase a timeout, add a retry, or weaken any content assertion.

## Validation

- `PATH=/Users/stevekinney/.bun/bin:$PATH bun test packages/components/scripts/validate-consumers.test.ts` (42 pass)
- `PATH=/Users/stevekinney/.bun/bin:$PATH bun run --filter=@lostgradient/cinder check:timeout-increases`
- `PATH=/Users/stevekinney/.bun/bin:$PATH bun run --filter=@lostgradient/cinder typecheck`
- `PATH=/Users/stevekinney/.bun/bin:$PATH bun run --filter=@lostgradient/cinder validate:consumer:hydration-smoke`

Closes #1428