### PR TITLE
feat(tokens): validate token and resolver documents against the official DTCG 2025.10 schemas

### DIFF
--- a/packages/components/scripts/tokens/fixtures/invalid/border.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/border.tokens.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "border",
+    "$value": {
+      "color": "{color}",
+      "width": "{dimension}"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/color-hex-eight-digit.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/color-hex-eight-digit.tokens.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "color",
+    "$value": {
+      "colorSpace": "oklch",
+      "components": [0, 0, 0],
+      "hex": "#11223380"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/color.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/color.tokens.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "color",
+    "$value": {
+      "colorSpace": "banana",
+      "components": [0, 0, 0]
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/cubicBezier.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/cubicBezier.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "cubicBezier",
+    "$value": [2, 0, -1, 1]
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/dimension.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/dimension.tokens.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "dimension",
+    "$value": {
+      "value": 1
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/duration.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/duration.tokens.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "duration",
+    "$value": {
+      "value": -1,
+      "unit": "ms"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/fontFamily.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/fontFamily.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "fontFamily",
+    "$value": []
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/fontWeight.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/fontWeight.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "fontWeight",
+    "$value": 0
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/gradient.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/gradient.tokens.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "gradient",
+    "$value": [
+      {
+        "color": "{color}",
+        "position": 0
+      }
+    ]
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/number.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/number.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "number",
+    "$value": "not-a-number"
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/shadow.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/shadow.tokens.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "shadow",
+    "$value": {
+      "color": "{color}",
+      "offsetX": "{dimension}",
+      "offsetY": "{dimension}",
+      "blur": "{dimension}"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/strokeStyle.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/strokeStyle.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "strokeStyle",
+    "$value": "banana"
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/transition.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/transition.tokens.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "transition",
+    "$value": {
+      "duration": "{duration}",
+      "delay": "{duration}",
+      "timingFunction": "{easing}",
+      "timingFuction": "{easing}"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/invalid/typography.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/invalid/typography.tokens.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "typography",
+    "$value": {
+      "fontFamily": "{family}",
+      "fontSize": "{dimension}",
+      "letterSpacing": "{dimension}",
+      "lineHeight": 1.5
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/border.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/border.tokens.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "border",
+    "$value": {
+      "color": "{color}",
+      "width": "{dimension}",
+      "style": "solid"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/color.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/color.tokens.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "color",
+    "$value": {
+      "colorSpace": "oklch",
+      "components": [0.5, 0.1, 255]
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/cubicBezier.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/cubicBezier.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "cubicBezier",
+    "$value": [0.2, 0, 0, 1]
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/dimension.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/dimension.tokens.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "dimension",
+    "$value": {
+      "value": 1,
+      "unit": "rem"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/duration.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/duration.tokens.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "duration",
+    "$value": {
+      "value": 150,
+      "unit": "ms"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/fontFamily.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/fontFamily.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "fontFamily",
+    "$value": ["Inter", "sans-serif"]
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/fontWeight.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/fontWeight.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "fontWeight",
+    "$value": 600
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/gradient.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/gradient.tokens.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "gradient",
+    "$value": [
+      {
+        "color": "{color}",
+        "position": 0
+      },
+      {
+        "color": "{color}",
+        "position": 1
+      }
+    ]
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/number.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/number.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "number",
+    "$value": 1
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/shadow.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/shadow.tokens.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "shadow",
+    "$value": {
+      "color": "{color}",
+      "offsetX": "{dimension}",
+      "offsetY": "{dimension}",
+      "blur": "{dimension}",
+      "spread": "{dimension}"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/strokeStyle.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/strokeStyle.tokens.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "strokeStyle",
+    "$value": "solid"
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/transition.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/transition.tokens.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "transition",
+    "$value": {
+      "duration": "{duration}",
+      "delay": "{duration}",
+      "timingFunction": "{easing}"
+    }
+  }
+}

--- a/packages/components/scripts/tokens/fixtures/valid/typography.tokens.json
+++ b/packages/components/scripts/tokens/fixtures/valid/typography.tokens.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "sample": {
+    "$type": "typography",
+    "$value": {
+      "fontFamily": "{family}",
+      "fontSize": "{dimension}",
+      "fontWeight": "{weight}",
+      "letterSpacing": "{dimension}",
+      "lineHeight": 1.5
+    }
+  }
+}

--- a/packages/components/scripts/tokens/resolve.test.ts
+++ b/packages/components/scripts/tokens/resolve.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { mergeDocuments, resolveDocument } from './resolve.ts';
 import { TokenValidationError, type TokenDocument } from './types.ts';
+import { assertValidTokenDocument } from './validate.ts';
 
 describe('DTCG resolver', () => {
   test('resolves curly aliases and composite property references', () => {
@@ -15,6 +16,27 @@ describe('DTCG resolver', () => {
     expect(resolved['border.base']?.$value).toEqual({
       color: { colorSpace: 'oklch', components: [0.5, 0.1, 255] },
       width: { value: 2, unit: 'px' },
+      style: 'solid',
+    });
+  });
+
+  test('resolves a property-level JSON Pointer reference into a composite token value', () => {
+    // Distinct from the whole-token curly-brace alias case above: this
+    // reference targets one property ($value) of a dimension token from
+    // inside a border token's `width` member, not the whole dimension token.
+    const resolved = resolveDocument({
+      dimension: { $type: 'dimension', hairline: { $value: { value: 1, unit: 'px' } } },
+      color: { $type: 'color', $value: { colorSpace: 'oklch', components: [0, 0, 0] } },
+      border: {
+        $type: 'border',
+        thin: {
+          $value: { color: '{color}', width: '#/dimension/hairline/$value', style: 'solid' },
+        },
+      },
+    });
+    expect(resolved['border.thin']?.$value).toEqual({
+      color: { colorSpace: 'oklch', components: [0, 0, 0] },
+      width: { value: 1, unit: 'px' },
       style: 'solid',
     });
   });
@@ -140,6 +162,29 @@ describe('DTCG resolver', () => {
       $type: 'number',
       $value: 1,
     });
+  });
+
+  test('round-trips an unrecognized $extensions vendor key byte-for-byte through validate and resolve', () => {
+    // Simulates the load -> validate -> resolve pipeline (loadTokenDocuments()
+    // reads from the real corpus on disk, which this package does not own or
+    // touch; assertValidTokenDocument + resolveDocument exercise the same
+    // validate-then-resolve steps that pipeline runs per document).
+    const extensions = {
+      'com.example.vendor': { unrecognized: { nested: [1, 'two', null, true] } },
+    };
+    const document: TokenDocument = {
+      color: {
+        $type: 'color',
+        $value: { colorSpace: 'oklch', components: [0.5, 0.1, 255] },
+        $extensions: extensions,
+      },
+    };
+
+    assertValidTokenDocument(document);
+    const resolved = resolveDocument(document);
+
+    expect(resolved['color']?.$extensions).toEqual(extensions);
+    expect(JSON.stringify(resolved['color']?.$extensions)).toBe(JSON.stringify(extensions));
   });
 
   test('inherits __proto__ tokens through group extensions', () => {

--- a/packages/components/scripts/tokens/schemas/README.md
+++ b/packages/components/scripts/tokens/schemas/README.md
@@ -1,0 +1,67 @@
+# Vendored DTCG 2025.10 JSON Schemas
+
+These two files are vendored (not fetched at test/build time) so `tokens:validate`
+and `bun test packages/components/scripts/tokens` never depend on network access.
+
+- `dtcg-format-2025-10.json`—retrieved from
+  `https://www.designtokens.org/schemas/2025.10/format.json`
+- `dtcg-resolver-2025-10.json`—retrieved from
+  `https://www.designtokens.org/schemas/2025.10/resolver.json`
+
+Retrieved: 2026-08-26, via `curl -sS <url> -o <file>`.
+
+## `$schema` draft
+
+Both files declare `"$schema": "http://json-schema.org/draft-07/schema#"`. Despite the
+resolver schema being newer/more elaborate than the format schema, it is also draft-07—
+there is no 2020-12 schema in this pair. `packages/components/scripts/tokens/validate-schema.ts`
+therefore uses the plain `Ajv` export from `ajv` (draft-07 support is Ajv's default) for
+_both_ validators. `Ajv2020` from `ajv/dist/2020` is not needed.
+
+## These are single, self-contained files—the `format/*` and `resolver/*` sub-paths do not exist as separate endpoints
+
+Both schemas reference URLs like `https://www.designtokens.org/schemas/2025.10/format/values/color.json`
+via `$ref`. Those look like separate fetchable resources, but they are not: the DTCG site does not
+serve those paths (fetching one returns the site's HTML 404 page, not JSON—confirmed by
+attempting it). Every one of those `$ref` targets is actually a nested subschema _inlined inside
+`format.json` and `resolver.json`_, each carrying its own `"$id"` that happens to match the
+`$ref` URL. Registering the root schema with Ajv (`ajv.compile(schema)`) recursively registers
+every nested `$id`, so `$ref` resolution works entirely offline. Do not try to fetch those
+sub-paths individually—there is nothing there.
+
+## `cinder.resolver.json` was migrated to the official object-keyed resolver shape
+
+Cinder originally authored `packages/components/src/tokens/cinder.resolver.json` with **arrays**:
+`sets: {name, source}[]`, `modifiers: {name, values, default?}[]`, `resolutionOrder: string[]`.
+That shape declared the official `"$schema": ".../resolver.json"` URI but never actually conformed
+to it—a real, confirmed divergence caught while building `validateResolverDocumentSchema`, not a
+bug in the validator.
+
+The official 2025.10 resolver schema requires **objects keyed by name**: `sets` is an object whose
+values are `{ sources: [...] }` (note: `sources`, not `source`); `modifiers` is an object whose
+values are `{ contexts: { <contextName>: sources[] }, default? }`; `resolutionOrder` is an array of
+`{ "$ref": "#/sets/..." }` / `{ "$ref": "#/modifiers/..." }` reference objects (or inline
+set/modifier definitions), not an array of plain modifier-name strings.
+
+CIN-27 migrated the real `cinder.resolver.json` to this shape and rewrote
+`scripts/tokens/types.ts` (`ResolverSet`, `ResolverModifier`, `ResolverDocument`,
+`ResolverReference`), `scripts/tokens/validate.ts` (`validateResolverDocument`'s semantic checks),
+and `scripts/tokens/validate-corpus.ts` (modifier-context binding now comes from the resolver's
+`contexts` map, not from scanning each token document's `$extensions["com.lostgradient.cinder"].modifier`
+marker) to match. `validateResolverDocumentSchema` is now wired into `assertValidResolverDocument`
+as a first-pass gate, exactly like the format schema is for token documents—see that function's
+doc comment in `validate.ts`. The token documents' `$extensions...modifier` markers are left in
+place as now-dead metadata; they are not read by the toolchain anymore.
+
+## A note on `$type` inheritance and the format schema
+
+The format schema's per-type value discriminator keys off a token's _own_ `$type` property. A
+token that relies on inherited `$type` (typed only by an ancestor group, with no local `$type`)
+can produce ambiguous `oneOf` matches for value shapes that overlap with another type's shape—
+observed empirically for `strokeStyle`'s bare-string form and for `typography`'s composite
+`lineHeight` branch. Every document in the real corpus today uses only object-shaped
+`color`/`dimension`/`duration` values relying on inherited `$type`, and none of those hit this
+ambiguity (verified against every file under `src/tokens`). If a future token addition using a
+type prone to this (e.g. `fontWeight`, `cubicBezier`, `number`, `strokeStyle`, or `typography`'s
+composite `lineHeight`) trips a spurious schema failure while relying on inherited `$type`, add a
+local `$type` to that token rather than weakening this gate.

--- a/packages/components/scripts/tokens/schemas/dtcg-format-2025-10.json
+++ b/packages/components/scripts/tokens/schemas/dtcg-format-2025-10.json
@@ -1,0 +1,1744 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.designtokens.org/schemas/2025.10/format.json",
+  "title": "DTCG Format Schema",
+  "description": "JSON Schema for the Design Tokens Community Group (DTCG) Format specification.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference",
+      "description": "URI reference to this JSON schema.",
+      "$comment": "$schema is not part of the official DTCG specification."
+    },
+    "$type": {
+      "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+    },
+    "$description": {
+      "type": "string",
+      "description": "A plain text description of the group"
+    },
+    "$extensions": {
+      "type": "object",
+      "description": "Vendor-specific extensions"
+    },
+    "$extends": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/curlyBraceReference"
+        },
+        {
+          "$ref": "#/definitions/jsonPointerReference"
+        }
+      ],
+      "description": "Reference to another group to inherit tokens and properties from"
+    },
+    "$deprecated": {
+      "oneOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ],
+      "description": "Whether this group is deprecated"
+    },
+    "$root": {
+      "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+    }
+  },
+  "patternProperties": {
+    "^[^${}.][^{}.]*$": {
+      "$ref": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json"
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "tokenOrGroupName": {
+      "title": "Token or Group Name",
+      "type": "string",
+      "pattern": "^[^${}.][^{}.]*$",
+      "description": "Valid token/group names: must not start with $ and must not contain {, }, or ."
+    },
+    "curlyBraceReference": {
+      "title": "Curly Brace Reference",
+      "type": "string",
+      "pattern": "^\\{[^${}.][^{}.]*(\\.[^${}.][^{}.]*)*\\}$",
+      "description": "Curly brace reference (e.g., '{tokenName}' or '{group.nested.token}')"
+    },
+    "jsonPointerReference": {
+      "title": "JSON Pointer Reference",
+      "type": "string",
+      "pattern": "^#/",
+      "format": "json-pointer-uri-fragment",
+      "description": "JSON Pointer reference (RFC 6901) to a location in the document (e.g., '#/path/to/target')"
+    },
+    "jsonPointerReferenceObject": {
+      "title": "JSON Pointer Reference Object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "$ref": "#/definitions/jsonPointerReference"
+        }
+      },
+      "required": ["$ref"],
+      "additionalProperties": false,
+      "description": "Object containing a JSON Pointer reference for property-level references"
+    },
+    "tokenValueReference": {
+      "title": "Token Value Reference",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/curlyBraceReference"
+        },
+        {
+          "$ref": "#/definitions/jsonPointerReferenceObject"
+        }
+      ],
+      "description": "A reference to a token value using either curly brace syntax or JSON Pointer syntax"
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/tokenType.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json",
+      "title": "TokenType",
+      "description": "A token type in the DTCG specification",
+      "type": "string",
+      "enum": [
+        "color",
+        "dimension",
+        "fontFamily",
+        "fontWeight",
+        "duration",
+        "cubicBezier",
+        "number",
+        "strokeStyle",
+        "border",
+        "transition",
+        "shadow",
+        "gradient",
+        "typography"
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/token.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/token.json",
+      "title": "Token",
+      "description": "A token in the DTCG specification",
+      "type": "object",
+      "properties": {
+        "$value": {
+          "description": "The token's value - can be a direct value or a reference to another token using curly brace syntax (e.g., '{token.name}'). Mutually exclusive with $ref."
+        },
+        "$type": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+        },
+        "$ref": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReference"
+        },
+        "$description": {
+          "type": "string",
+          "description": "A plain text description of the token"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Vendor-specific extensions"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Whether this token is deprecated"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "description": "Tokens cannot define both $value and $ref; they must choose exactly one form of reference or direct value.",
+          "if": {
+            "required": ["$value"],
+            "properties": {
+              "$value": true
+            }
+          },
+          "then": {
+            "not": {
+              "required": ["$ref"],
+              "properties": {
+                "$ref": true
+              }
+            }
+          },
+          "else": {
+            "required": ["$ref"],
+            "properties": {
+              "$ref": true
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "color"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "dimension"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "fontFamily"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "fontWeight"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "duration"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "cubicBezier"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "number"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "strokeStyle"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "border"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/border.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "transition"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "shadow"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "gradient"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "typography"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "allOf": [
+              {
+                "not": {
+                  "required": ["$type"]
+                }
+              },
+              {
+                "required": ["$value"]
+              },
+              {
+                "properties": {
+                  "$value": {
+                    "not": {
+                      "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/border.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+                      },
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/color.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/color.json",
+      "title": "Color Value",
+      "description": "Value schema for color type tokens. Represents a color in a specific color space.",
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "description": "The color space or color model used to represent the color",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "srgb",
+                "srgb-linear",
+                "hsl",
+                "hwb",
+                "lab",
+                "lch",
+                "oklab",
+                "oklch",
+                "display-p3",
+                "a98-rgb",
+                "prophoto-rgb",
+                "rec2020",
+                "xyz-d65",
+                "xyz-d50"
+              ]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "components": {
+          "description": "Array of color components. The number and meaning of components depend on the color space. Each component can be a number or the 'none' keyword.",
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "alpha": {
+          "description": "The alpha (transparency) value of the color. 0 is fully transparent, 1 is fully opaque. If omitted, defaults to 1.",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "hex": {
+          "description": "Optional fallback value in 6-digit CSS hex color notation (e.g., '#ff00ff'). Must be 6 digits to avoid conflicts with the alpha value.",
+          "$comment": "Only JSON Pointer references (not curly brace references) are allowed for hex because no string token type exists in the specification that could be referenced with curly braces.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^#[0-9a-fA-F]{6}$"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["colorSpace", "components"],
+      "additionalProperties": false,
+      "definitions": {
+        "zeroToOneComponent": {
+          "title": "Zero to One Component",
+          "description": "A color component normalized to the range [0-1] (e.g., RGB values, XYZ values)",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "hueComponent": {
+          "title": "Hue Component",
+          "description": "Hue angle from 0 up to (but not including) 360 degrees",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "exclusiveMaximum": 360
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "percentageComponent": {
+          "title": "Percentage Component",
+          "description": "Percentage value from 0 to 100",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "chromaComponent": {
+          "title": "Chroma Component",
+          "description": "Chroma value from 0 to infinity",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unboundedComponent": {
+          "title": "Unbounded Component",
+          "description": "A color component with no numeric bounds (e.g., A and B in LAB/OKLAB color spaces)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "rgbComponents": {
+          "title": "RGB Components",
+          "description": "Array of RGB color components [Red, Green, Blue], each normalized to the range [0-1]",
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": [
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            }
+          ]
+        },
+        "xyzComponents": {
+          "title": "XYZ Components",
+          "description": "Array of XYZ color components [X, Y, Z], each normalized to the range [0-1]",
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": [
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "srgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "srgb-linear"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "display-p3"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "a98-rgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "prophoto-rgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "rec2020"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "xyz-d65"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/xyzComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "xyz-d50"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/xyzComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "hsl"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "hwb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "lab"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "lch"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/chromaComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "oklab"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/zeroToOneComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "oklch"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/zeroToOneComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/chromaComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json",
+      "title": "Dimension Value",
+      "description": "Value schema for dimension type tokens. Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "An integer or floating-point value representing the numeric value.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unit": {
+          "description": "Unit of distance. Supported values: 'px' (idealized pixel, equivalent to dp on Android and pt on iOS), 'rem' (multiple of system's default font size).",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["px", "rem"]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["value", "unit"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json",
+      "title": "Font Family Value",
+      "description": "Value schema for fontFamily type tokens. Represents a font name or an array of font names (ordered from most to least preferred).",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A single font name",
+          "not": {
+            "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+          }
+        },
+        {
+          "type": "array",
+          "description": "An array of font names, ordered from most to least preferred",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "not": {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+                }
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json",
+      "title": "Font Weight Value",
+      "description": "Value schema for fontWeight type tokens. Represents a font weight as per the OpenType wght tag specification. Lower numbers represent lighter weights, higher numbers represent thicker weights.",
+      "oneOf": [
+        {
+          "type": "number",
+          "description": "Numeric font weight value",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        {
+          "type": "string",
+          "description": "Pre-defined font weight string value",
+          "enum": [
+            "thin",
+            "hairline",
+            "extra-light",
+            "ultra-light",
+            "light",
+            "normal",
+            "regular",
+            "book",
+            "medium",
+            "semi-bold",
+            "demi-bold",
+            "bold",
+            "extra-bold",
+            "ultra-bold",
+            "black",
+            "heavy",
+            "extra-black",
+            "ultra-black"
+          ]
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/duration.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json",
+      "title": "Duration Value",
+      "description": "Value schema for duration type tokens. Represents the length of time in milliseconds an animation or animation cycle takes to complete.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "An integer or floating-point value representing the numeric value.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unit": {
+          "description": "Unit of time. Supported values: 'ms' (millisecond), 's' (second).",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["ms", "s"]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["value", "unit"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json",
+      "title": "Cubic Bezier Value",
+      "description": "Value schema for cubicBezier type tokens. Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce.",
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/xCoordinate"
+        },
+        {
+          "$ref": "#/definitions/yCoordinate"
+        },
+        {
+          "$ref": "#/definitions/xCoordinate"
+        },
+        {
+          "$ref": "#/definitions/yCoordinate"
+        }
+      ],
+      "additionalItems": false,
+      "minItems": 4,
+      "maxItems": 4,
+      "definitions": {
+        "xCoordinate": {
+          "title": "X Coordinate",
+          "description": "X coordinate of control point (must be between 0 and 1)",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "yCoordinate": {
+          "title": "Y Coordinate",
+          "description": "Y coordinate of control point (can be any real number)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/number.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/number.json",
+      "title": "Number Value",
+      "description": "Value schema for number type tokens. Numbers can be positive, negative and have fractions. Example uses are gradient stop positions or unitless line heights.",
+      "type": "number"
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json",
+      "title": "Stroke Style Value",
+      "description": "Value schema for strokeStyle type tokens. Represents the style applied to lines or borders.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["solid", "dashed", "dotted", "double", "groove", "ridge", "outset", "inset"],
+          "description": "Pre-defined stroke style values with the same meaning as CSS line style values"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dashArray": {
+              "description": "Array of dimension values specifying lengths of alternating dashes and gaps",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                      },
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                      }
+                    ]
+                  },
+                  "minItems": 1
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            },
+            "lineCap": {
+              "description": "Line cap style, same meaning as SVG stroke-linecap attribute",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["round", "butt", "square"]
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            }
+          },
+          "required": ["dashArray", "lineCap"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/border.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/border.json",
+      "title": "Border Value",
+      "description": "Value schema for border type tokens. Represents a border style.",
+      "type": "object",
+      "properties": {
+        "color": {
+          "description": "The color of the border",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "width": {
+          "description": "The width or thickness of the border",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "style": {
+          "description": "The border's style",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["color", "width", "style"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/transition.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json",
+      "title": "Transition Value",
+      "description": "Value schema for transition type tokens. Represents an animated transition between two states.",
+      "type": "object",
+      "properties": {
+        "duration": {
+          "description": "The duration of the transition",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "delay": {
+          "description": "The time to wait before the transition begins",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "timingFunction": {
+          "description": "The timing function of the transition",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["duration", "delay", "timingFunction"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json",
+      "title": "Shadow Value",
+      "description": "Value schema for shadow type tokens. Represents a shadow style.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/shadowObject"
+        },
+        {
+          "type": "array",
+          "description": "Array of shadow objects and/or references to shadow tokens",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/shadowObject"
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      ],
+      "definitions": {
+        "shadowObject": {
+          "title": "Shadow Object",
+          "type": "object",
+          "properties": {
+            "color": {
+              "description": "The color of the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "offsetX": {
+              "description": "The horizontal offset that shadow has from the element it is applied to",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "offsetY": {
+              "description": "The vertical offset that shadow has from the element it is applied to",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "blur": {
+              "description": "The blur radius that is applied to the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "spread": {
+              "description": "The amount by which to expand or contract the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "inset": {
+              "description": "Whether this shadow is inside the containing shape (inner shadow) rather than a drop shadow (default: false)",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            }
+          },
+          "required": ["color", "offsetX", "offsetY", "blur", "spread"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json",
+      "title": "Gradient Value",
+      "description": "Value schema for gradient type tokens. Represents a color gradient.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/gradientStop"
+          },
+          {
+            "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+          }
+        ]
+      },
+      "minItems": 1,
+      "definitions": {
+        "gradientStop": {
+          "title": "Gradient Stop",
+          "type": "object",
+          "properties": {
+            "color": {
+              "description": "The color value at the stop's position on the gradient",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "position": {
+              "description": "The position of the stop along the gradient's axis (range [0, 1]). Values outside this range are clamped.",
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            }
+          },
+          "required": ["color", "position"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/typography.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json",
+      "title": "Typography Value",
+      "description": "Value schema for typography type tokens. Represents a typographic style.",
+      "type": "object",
+      "properties": {
+        "fontFamily": {
+          "description": "The typography's font",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "fontSize": {
+          "description": "The size of the typography",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "fontWeight": {
+          "description": "The weight of the typography",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "letterSpacing": {
+          "description": "The horizontal spacing between characters",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "lineHeight": {
+          "description": "The vertical spacing between lines of typography (interpreted as a multiplier of fontSize)",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["fontFamily", "fontSize", "fontWeight", "letterSpacing", "lineHeight"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json",
+      "title": "Group or Token",
+      "description": "A group or a token in the DTCG specification. A token is identified by the presence of a $value property, while a group is any object without a $value property.",
+      "oneOf": [
+        {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/group.json"
+        },
+        {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/group.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/group.json",
+      "title": "Group",
+      "description": "A group in the DTCG specification",
+      "type": "object",
+      "properties": {
+        "$type": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+        },
+        "$description": {
+          "type": "string",
+          "description": "A plain text description of the group"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Vendor-specific extensions"
+        },
+        "$extends": {
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReference"
+            }
+          ],
+          "description": "Reference to another group to inherit tokens and properties from"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Whether this group is deprecated"
+        },
+        "$root": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+        }
+      },
+      "patternProperties": {
+        "^[^${}.][^{}.]*$": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json"
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/packages/components/scripts/tokens/schemas/dtcg-resolver-2025-10.json
+++ b/packages/components/scripts/tokens/schemas/dtcg-resolver-2025-10.json
@@ -1,0 +1,2068 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://www.designtokens.org/schemas/2025.10/resolver.json",
+  "title": "DTCG Resolver Schema",
+  "description": "JSON Schema for the Design Tokens Community Group (DTCG) Resolver specification",
+  "type": "object",
+  "required": ["version", "resolutionOrder"],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "format": "uri-reference",
+      "description": "URI reference to this JSON schema."
+    },
+    "name": {
+      "title": "Name",
+      "type": "string",
+      "description": "A short, human-readable name for the document."
+    },
+    "version": {
+      "title": "Version",
+      "type": "string",
+      "const": "2025.10",
+      "description": "Version of the resolver specification. Must be '2025.10'."
+    },
+    "description": {
+      "title": "Description",
+      "type": "string",
+      "description": "A human-readable description for this document."
+    },
+    "sets": {
+      "title": "Token Sets",
+      "type": "object",
+      "description": "Definition of sets. A set is a collection of design tokens in DTCG format.",
+      "patternProperties": {
+        "^.+$": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/resolver/set.json"
+        }
+      }
+    },
+    "modifiers": {
+      "title": "Modifiers",
+      "type": "object",
+      "description": "Definition of modifiers. A modifier allows for conditional inclusion of token values via contexts.",
+      "patternProperties": {
+        "^.+$": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/resolver/modifier.json"
+        }
+      }
+    },
+    "resolutionOrder": {
+      "$ref": "https://www.designtokens.org/schemas/2025.10/resolver/resolutionOrder.json"
+    },
+    "$defs": {
+      "title": "Definitions",
+      "type": "object",
+      "description": "Optional definitions that tools MAY support but MUST NOT throw an error when encountered."
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "https://www.designtokens.org/schemas/2025.10/resolver/set.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/resolver/set.json",
+      "title": "Set",
+      "description": "A set is a collection of design tokens in DTCG format. A set MUST contain a sources array with tokens declared directly, or a reference object pointing to a JSON file containing design tokens, or any combination of the two.",
+      "type": "object",
+      "required": ["sources"],
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "type": "string",
+          "description": "A human-readable description of the purpose of the set."
+        },
+        "sources": {
+          "$ref": "#/definitions/tokenSourcesForSets"
+        },
+        "$extensions": {
+          "title": "Extensions",
+          "type": "object",
+          "description": "Vendor-specific extensions. Keys are vendor-specific namespaces."
+        }
+      },
+      "definitions": {
+        "referenceObjectForSets": {
+          "title": "Reference Object (For Sets)",
+          "type": "object",
+          "required": ["$ref"],
+          "properties": {
+            "$ref": {
+              "title": "JSON Reference",
+              "type": "string",
+              "format": "uri-reference",
+              "description": "A JSON Pointer (RFC 6901) or URI reference. Sets MUST NOT reference modifiers (#/modifiers/...) or resolutionOrder items (#/resolutionOrder/...).",
+              "not": {
+                "anyOf": [
+                  {
+                    "pattern": "^#/modifiers/",
+                    "$comment": "Sets cannot reference modifiers"
+                  },
+                  {
+                    "pattern": "^#/resolutionOrder/",
+                    "$comment": "Nothing can reference resolutionOrder items"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "A reference object for use within sets. Cannot point to modifiers or resolutionOrder items."
+        },
+        "tokenSourcesForSets": {
+          "title": "Token Sources (For Sets)",
+          "type": "array",
+          "description": "An array of token sources for sets - cannot reference modifiers or resolutionOrder items.",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/referenceObjectForSets"
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format.json",
+      "title": "DTCG Format Schema",
+      "description": "JSON Schema for the Design Tokens Community Group (DTCG) Format specification.",
+      "type": "object",
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "format": "uri-reference",
+          "description": "URI reference to this JSON schema.",
+          "$comment": "$schema is not part of the official DTCG specification."
+        },
+        "$type": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+        },
+        "$description": {
+          "type": "string",
+          "description": "A plain text description of the group"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Vendor-specific extensions"
+        },
+        "$extends": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/curlyBraceReference"
+            },
+            {
+              "$ref": "#/definitions/jsonPointerReference"
+            }
+          ],
+          "description": "Reference to another group to inherit tokens and properties from"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Whether this group is deprecated"
+        },
+        "$root": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+        }
+      },
+      "patternProperties": {
+        "^[^${}.][^{}.]*$": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json"
+        }
+      },
+      "additionalProperties": false,
+      "definitions": {
+        "tokenOrGroupName": {
+          "title": "Token or Group Name",
+          "type": "string",
+          "pattern": "^[^${}.][^{}.]*$",
+          "description": "Valid token/group names: must not start with $ and must not contain {, }, or ."
+        },
+        "curlyBraceReference": {
+          "title": "Curly Brace Reference",
+          "type": "string",
+          "pattern": "^\\{[^${}.][^{}.]*(\\.[^${}.][^{}.]*)*\\}$",
+          "description": "Curly brace reference (e.g., '{tokenName}' or '{group.nested.token}')"
+        },
+        "jsonPointerReference": {
+          "title": "JSON Pointer Reference",
+          "type": "string",
+          "pattern": "^#/",
+          "format": "json-pointer-uri-fragment",
+          "description": "JSON Pointer reference (RFC 6901) to a location in the document (e.g., '#/path/to/target')"
+        },
+        "jsonPointerReferenceObject": {
+          "title": "JSON Pointer Reference Object",
+          "type": "object",
+          "properties": {
+            "$ref": {
+              "$ref": "#/definitions/jsonPointerReference"
+            }
+          },
+          "required": ["$ref"],
+          "additionalProperties": false,
+          "description": "Object containing a JSON Pointer reference for property-level references"
+        },
+        "tokenValueReference": {
+          "title": "Token Value Reference",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/curlyBraceReference"
+            },
+            {
+              "$ref": "#/definitions/jsonPointerReferenceObject"
+            }
+          ],
+          "description": "A reference to a token value using either curly brace syntax or JSON Pointer syntax"
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/tokenType.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json",
+      "title": "TokenType",
+      "description": "A token type in the DTCG specification",
+      "type": "string",
+      "enum": [
+        "color",
+        "dimension",
+        "fontFamily",
+        "fontWeight",
+        "duration",
+        "cubicBezier",
+        "number",
+        "strokeStyle",
+        "border",
+        "transition",
+        "shadow",
+        "gradient",
+        "typography"
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/token.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/token.json",
+      "title": "Token",
+      "description": "A token in the DTCG specification",
+      "type": "object",
+      "properties": {
+        "$value": {
+          "description": "The token's value - can be a direct value or a reference to another token using curly brace syntax (e.g., '{token.name}'). Mutually exclusive with $ref."
+        },
+        "$type": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+        },
+        "$ref": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReference"
+        },
+        "$description": {
+          "type": "string",
+          "description": "A plain text description of the token"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Vendor-specific extensions"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Whether this token is deprecated"
+        }
+      },
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "description": "Tokens cannot define both $value and $ref; they must choose exactly one form of reference or direct value.",
+          "if": {
+            "required": ["$value"],
+            "properties": {
+              "$value": true
+            }
+          },
+          "then": {
+            "not": {
+              "required": ["$ref"],
+              "properties": {
+                "$ref": true
+              }
+            }
+          },
+          "else": {
+            "required": ["$ref"],
+            "properties": {
+              "$ref": true
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "color"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "dimension"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "fontFamily"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "fontWeight"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "duration"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "cubicBezier"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "number"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "strokeStyle"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "border"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/border.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "transition"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "shadow"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "gradient"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "required": ["$type"],
+            "properties": {
+              "$type": {
+                "const": "typography"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "allOf": [
+              {
+                "not": {
+                  "required": ["$type"]
+                }
+              },
+              {
+                "required": ["$value"]
+              },
+              {
+                "properties": {
+                  "$value": {
+                    "not": {
+                      "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "$value": {
+                "oneOf": [
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/border.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json"
+                  },
+                  {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json"
+                  },
+                  {
+                    "anyOf": [
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+                      },
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/color.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/color.json",
+      "title": "Color Value",
+      "description": "Value schema for color type tokens. Represents a color in a specific color space.",
+      "type": "object",
+      "properties": {
+        "colorSpace": {
+          "description": "The color space or color model used to represent the color",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "srgb",
+                "srgb-linear",
+                "hsl",
+                "hwb",
+                "lab",
+                "lch",
+                "oklab",
+                "oklch",
+                "display-p3",
+                "a98-rgb",
+                "prophoto-rgb",
+                "rec2020",
+                "xyz-d65",
+                "xyz-d50"
+              ]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "components": {
+          "description": "Array of color components. The number and meaning of components depend on the color space. Each component can be a number or the 'none' keyword.",
+          "oneOf": [
+            {
+              "type": "array"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "alpha": {
+          "description": "The alpha (transparency) value of the color. 0 is fully transparent, 1 is fully opaque. If omitted, defaults to 1.",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "hex": {
+          "description": "Optional fallback value in 6-digit CSS hex color notation (e.g., '#ff00ff'). Must be 6 digits to avoid conflicts with the alpha value.",
+          "$comment": "Only JSON Pointer references (not curly brace references) are allowed for hex because no string token type exists in the specification that could be referenced with curly braces.",
+          "oneOf": [
+            {
+              "type": "string",
+              "pattern": "^#[0-9a-fA-F]{6}$"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["colorSpace", "components"],
+      "additionalProperties": false,
+      "definitions": {
+        "zeroToOneComponent": {
+          "title": "Zero to One Component",
+          "description": "A color component normalized to the range [0-1] (e.g., RGB values, XYZ values)",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "hueComponent": {
+          "title": "Hue Component",
+          "description": "Hue angle from 0 up to (but not including) 360 degrees",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "exclusiveMaximum": 360
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "percentageComponent": {
+          "title": "Percentage Component",
+          "description": "Percentage value from 0 to 100",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 100
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "chromaComponent": {
+          "title": "Chroma Component",
+          "description": "Chroma value from 0 to infinity",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unboundedComponent": {
+          "title": "Unbounded Component",
+          "description": "A color component with no numeric bounds (e.g., A and B in LAB/OKLAB color spaces)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "string",
+              "const": "none"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "rgbComponents": {
+          "title": "RGB Components",
+          "description": "Array of RGB color components [Red, Green, Blue], each normalized to the range [0-1]",
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": [
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            }
+          ]
+        },
+        "xyzComponents": {
+          "title": "XYZ Components",
+          "description": "Array of XYZ color components [X, Y, Z], each normalized to the range [0-1]",
+          "type": "array",
+          "minItems": 3,
+          "maxItems": 3,
+          "items": [
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            },
+            {
+              "$ref": "#/definitions/zeroToOneComponent"
+            }
+          ]
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "srgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "srgb-linear"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "display-p3"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "a98-rgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "prophoto-rgb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "rec2020"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/rgbComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "xyz-d65"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/xyzComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "xyz-d50"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "$ref": "#/definitions/xyzComponents"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "hsl"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "hwb"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "lab"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "lch"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/percentageComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/chromaComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "oklab"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/zeroToOneComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/unboundedComponent"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "colorSpace": {
+                "const": "oklch"
+              },
+              "components": {
+                "type": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "components": {
+                "type": "array",
+                "minItems": 3,
+                "maxItems": 3,
+                "items": [
+                  {
+                    "$ref": "#/definitions/zeroToOneComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/chromaComponent"
+                  },
+                  {
+                    "$ref": "#/definitions/hueComponent"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json",
+      "title": "Dimension Value",
+      "description": "Value schema for dimension type tokens. Represents an amount of distance in a single dimension in the UI, such as a position, width, height, radius, or thickness.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "An integer or floating-point value representing the numeric value.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unit": {
+          "description": "Unit of distance. Supported values: 'px' (idealized pixel, equivalent to dp on Android and pt on iOS), 'rem' (multiple of system's default font size).",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["px", "rem"]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["value", "unit"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json",
+      "title": "Font Family Value",
+      "description": "Value schema for fontFamily type tokens. Represents a font name or an array of font names (ordered from most to least preferred).",
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "A single font name",
+          "not": {
+            "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+          }
+        },
+        {
+          "type": "array",
+          "description": "An array of font names, ordered from most to least preferred",
+          "items": {
+            "oneOf": [
+              {
+                "type": "string",
+                "not": {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+                }
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json",
+      "title": "Font Weight Value",
+      "description": "Value schema for fontWeight type tokens. Represents a font weight as per the OpenType wght tag specification. Lower numbers represent lighter weights, higher numbers represent thicker weights.",
+      "oneOf": [
+        {
+          "type": "number",
+          "description": "Numeric font weight value",
+          "minimum": 1,
+          "maximum": 1000
+        },
+        {
+          "type": "string",
+          "description": "Pre-defined font weight string value",
+          "enum": [
+            "thin",
+            "hairline",
+            "extra-light",
+            "ultra-light",
+            "light",
+            "normal",
+            "regular",
+            "book",
+            "medium",
+            "semi-bold",
+            "demi-bold",
+            "bold",
+            "extra-bold",
+            "ultra-bold",
+            "black",
+            "heavy",
+            "extra-black",
+            "ultra-black"
+          ]
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/duration.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json",
+      "title": "Duration Value",
+      "description": "Value schema for duration type tokens. Represents the length of time in milliseconds an animation or animation cycle takes to complete.",
+      "type": "object",
+      "properties": {
+        "value": {
+          "description": "An integer or floating-point value representing the numeric value.",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "unit": {
+          "description": "Unit of time. Supported values: 'ms' (millisecond), 's' (second).",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": ["ms", "s"]
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      },
+      "required": ["value", "unit"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json",
+      "title": "Cubic Bezier Value",
+      "description": "Value schema for cubicBezier type tokens. Represents how the value of an animated property progresses towards completion over the duration of an animation, effectively creating visual effects such as acceleration, deceleration, and bounce.",
+      "type": "array",
+      "items": [
+        {
+          "$ref": "#/definitions/xCoordinate"
+        },
+        {
+          "$ref": "#/definitions/yCoordinate"
+        },
+        {
+          "$ref": "#/definitions/xCoordinate"
+        },
+        {
+          "$ref": "#/definitions/yCoordinate"
+        }
+      ],
+      "additionalItems": false,
+      "minItems": 4,
+      "maxItems": 4,
+      "definitions": {
+        "xCoordinate": {
+          "title": "X Coordinate",
+          "description": "X coordinate of control point (must be between 0 and 1)",
+          "oneOf": [
+            {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 1
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        },
+        "yCoordinate": {
+          "title": "Y Coordinate",
+          "description": "Y coordinate of control point (can be any real number)",
+          "oneOf": [
+            {
+              "type": "number"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+            }
+          ]
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/number.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/number.json",
+      "title": "Number Value",
+      "description": "Value schema for number type tokens. Numbers can be positive, negative and have fractions. Example uses are gradient stop positions or unitless line heights.",
+      "type": "number"
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json",
+      "title": "Stroke Style Value",
+      "description": "Value schema for strokeStyle type tokens. Represents the style applied to lines or borders.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": ["solid", "dashed", "dotted", "double", "groove", "ridge", "outset", "inset"],
+          "description": "Pre-defined stroke style values with the same meaning as CSS line style values"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "dashArray": {
+              "description": "Array of dimension values specifying lengths of alternating dashes and gaps",
+              "oneOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "oneOf": [
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                      },
+                      {
+                        "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                      }
+                    ]
+                  },
+                  "minItems": 1
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            },
+            "lineCap": {
+              "description": "Line cap style, same meaning as SVG stroke-linecap attribute",
+              "oneOf": [
+                {
+                  "type": "string",
+                  "enum": ["round", "butt", "square"]
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            }
+          },
+          "required": ["dashArray", "lineCap"],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/border.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/border.json",
+      "title": "Border Value",
+      "description": "Value schema for border type tokens. Represents a border style.",
+      "type": "object",
+      "properties": {
+        "color": {
+          "description": "The color of the border",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "width": {
+          "description": "The width or thickness of the border",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "style": {
+          "description": "The border's style",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/strokeStyle.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["color", "width", "style"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/transition.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/transition.json",
+      "title": "Transition Value",
+      "description": "Value schema for transition type tokens. Represents an animated transition between two states.",
+      "type": "object",
+      "properties": {
+        "duration": {
+          "description": "The duration of the transition",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "delay": {
+          "description": "The time to wait before the transition begins",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/duration.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "timingFunction": {
+          "description": "The timing function of the transition",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/cubicBezier.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["duration", "delay", "timingFunction"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/shadow.json",
+      "title": "Shadow Value",
+      "description": "Value schema for shadow type tokens. Represents a shadow style.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/shadowObject"
+        },
+        {
+          "type": "array",
+          "description": "Array of shadow objects and/or references to shadow tokens",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/shadowObject"
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+              }
+            ]
+          },
+          "minItems": 1
+        }
+      ],
+      "definitions": {
+        "shadowObject": {
+          "title": "Shadow Object",
+          "type": "object",
+          "properties": {
+            "color": {
+              "description": "The color of the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "offsetX": {
+              "description": "The horizontal offset that shadow has from the element it is applied to",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "offsetY": {
+              "description": "The vertical offset that shadow has from the element it is applied to",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "blur": {
+              "description": "The blur radius that is applied to the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "spread": {
+              "description": "The amount by which to expand or contract the shadow",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "inset": {
+              "description": "Whether this shadow is inside the containing shape (inner shadow) rather than a drop shadow (default: false)",
+              "oneOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReferenceObject"
+                }
+              ]
+            }
+          },
+          "required": ["color", "offsetX", "offsetY", "blur", "spread"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/gradient.json",
+      "title": "Gradient Value",
+      "description": "Value schema for gradient type tokens. Represents a color gradient.",
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "$ref": "#/definitions/gradientStop"
+          },
+          {
+            "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+          }
+        ]
+      },
+      "minItems": 1,
+      "definitions": {
+        "gradientStop": {
+          "title": "Gradient Stop",
+          "type": "object",
+          "properties": {
+            "color": {
+              "description": "The color value at the stop's position on the gradient",
+              "oneOf": [
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/color.json"
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            },
+            "position": {
+              "description": "The position of the stop along the gradient's axis (range [0, 1]). Values outside this range are clamped.",
+              "oneOf": [
+                {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 1
+                },
+                {
+                  "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+                }
+              ]
+            }
+          },
+          "required": ["color", "position"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/values/typography.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/values/typography.json",
+      "title": "Typography Value",
+      "description": "Value schema for typography type tokens. Represents a typographic style.",
+      "type": "object",
+      "properties": {
+        "fontFamily": {
+          "description": "The typography's font",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontFamily.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "fontSize": {
+          "description": "The size of the typography",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "fontWeight": {
+          "description": "The weight of the typography",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/fontWeight.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "letterSpacing": {
+          "description": "The horizontal spacing between characters",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/dimension.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        },
+        "lineHeight": {
+          "description": "The vertical spacing between lines of typography (interpreted as a multiplier of fontSize)",
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format/values/number.json"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/tokenValueReference"
+            }
+          ]
+        }
+      },
+      "required": ["fontFamily", "fontSize", "fontWeight", "letterSpacing", "lineHeight"],
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json",
+      "title": "Group or Token",
+      "description": "A group or a token in the DTCG specification. A token is identified by the presence of a $value property, while a group is any object without a $value property.",
+      "oneOf": [
+        {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/group.json"
+        },
+        {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+        }
+      ]
+    },
+    "https://www.designtokens.org/schemas/2025.10/format/group.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/format/group.json",
+      "title": "Group",
+      "description": "A group in the DTCG specification",
+      "type": "object",
+      "properties": {
+        "$type": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/tokenType.json"
+        },
+        "$description": {
+          "type": "string",
+          "description": "A plain text description of the group"
+        },
+        "$extensions": {
+          "type": "object",
+          "description": "Vendor-specific extensions"
+        },
+        "$extends": {
+          "oneOf": [
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/curlyBraceReference"
+            },
+            {
+              "$ref": "https://www.designtokens.org/schemas/2025.10/format.json#/definitions/jsonPointerReference"
+            }
+          ],
+          "description": "Reference to another group to inherit tokens and properties from"
+        },
+        "$deprecated": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "description": "Whether this group is deprecated"
+        },
+        "$root": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/token.json"
+        }
+      },
+      "patternProperties": {
+        "^[^${}.][^{}.]*$": {
+          "$ref": "https://www.designtokens.org/schemas/2025.10/format/groupOrToken.json"
+        }
+      },
+      "additionalProperties": false
+    },
+    "https://www.designtokens.org/schemas/2025.10/resolver/modifier.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/resolver/modifier.json",
+      "title": "Modifier",
+      "description": "A modifier is similar to a set, but allows for conditional inclusion via the contexts map. A modifier MUST declare a contexts map of string values to arrays of token sources.",
+      "type": "object",
+      "required": ["contexts"],
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "title": "Description",
+          "type": "string",
+          "description": "A human-readable description of the purpose of the modifier."
+        },
+        "contexts": {
+          "title": "Contexts",
+          "type": "object",
+          "description": "A map of context names to arrays of token sources. Each context represents a possible variant (e.g., 'light' vs 'dark' for theme, 'small' vs 'large' for size).",
+          "minProperties": 2,
+          "patternProperties": {
+            "^.+$": {
+              "$ref": "#/definitions/tokenSourcesForModifiers"
+            }
+          },
+          "additionalProperties": false
+        },
+        "default": {
+          "title": "Default Context",
+          "type": "string",
+          "description": "An optional default value that MUST match one of the keys in contexts. If provided, tools will use this context when no input is provided for this modifier.",
+          "$comment": "JSON Schema cannot validate that this value matches a key in 'contexts'. This validation must be performed at runtime by the implementation."
+        },
+        "$extensions": {
+          "title": "Extensions",
+          "type": "object",
+          "description": "Vendor-specific extensions. Keys are vendor-specific namespaces."
+        }
+      },
+      "definitions": {
+        "referenceObjectForModifiers": {
+          "title": "Reference Object (For Modifiers)",
+          "type": "object",
+          "required": ["$ref"],
+          "properties": {
+            "$ref": {
+              "title": "JSON Reference",
+              "type": "string",
+              "format": "uri-reference",
+              "description": "A JSON Pointer (RFC 6901) or URI reference. Modifiers MUST NOT reference other modifiers (#/modifiers/...) or resolutionOrder items (#/resolutionOrder/...).",
+              "not": {
+                "anyOf": [
+                  {
+                    "pattern": "^#/modifiers/",
+                    "$comment": "Modifiers cannot reference other modifiers"
+                  },
+                  {
+                    "pattern": "^#/resolutionOrder/",
+                    "$comment": "Nothing can reference resolutionOrder items"
+                  }
+                ]
+              }
+            }
+          },
+          "description": "A reference object for use within modifier contexts. Cannot point to other modifiers or resolutionOrder items."
+        },
+        "tokenSourcesForModifiers": {
+          "title": "Token Sources (For Modifiers)",
+          "type": "array",
+          "description": "An array of token sources for modifier contexts - can reference sets but not other modifiers or resolutionOrder items.",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/referenceObjectForModifiers"
+              },
+              {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/format.json"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "https://www.designtokens.org/schemas/2025.10/resolver/resolutionOrder.json": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://www.designtokens.org/schemas/2025.10/resolver/resolutionOrder.json",
+      "title": "Resolution Order",
+      "description": "An ordered array of sets and modifiers that determines the final resolution of tokens. Order is significant - tokens later in the array override earlier ones in case of conflict.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "oneOf": [
+          {
+            "title": "Reference Object (For Resolution Order)",
+            "type": "object",
+            "required": ["$ref"],
+            "properties": {
+              "$ref": {
+                "title": "JSON Reference",
+                "type": "string",
+                "format": "uri-reference",
+                "description": "A JSON Pointer (RFC 6901) or URI reference. Must point to a set (#/sets/...) or modifier (#/modifiers/...), never to resolutionOrder items (#/resolutionOrder/...).",
+                "not": {
+                  "pattern": "^#/resolutionOrder/",
+                  "$comment": "ResolutionOrder cannot reference items within itself"
+                }
+              }
+            },
+            "description": "A reference object for use within resolutionOrder. Can point to sets or modifiers but not other resolutionOrder items."
+          },
+          {
+            "title": "Inline Set",
+            "description": "A set defined inline in the resolutionOrder array. Must include 'name' and 'type' properties.",
+            "type": "object",
+            "required": ["sources", "name", "type"],
+            "properties": {
+              "description": {
+                "title": "Description",
+                "type": "string",
+                "description": "A human-readable description of the purpose of the set."
+              },
+              "sources": {
+                "$ref": "https://www.designtokens.org/schemas/2025.10/resolver/set.json#/definitions/tokenSourcesForSets"
+              },
+              "$extensions": {
+                "title": "Extensions",
+                "type": "object",
+                "description": "Vendor-specific extensions. Keys are vendor-specific namespaces."
+              },
+              "name": {
+                "title": "Name",
+                "type": "string",
+                "description": "A unique name that MUST NOT conflict with any other name in resolutionOrder.",
+                "$comment": "Uniqueness must be validated at runtime as JSON Schema cannot validate uniqueness across array items."
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "const": "set",
+                "description": "MUST be 'set' for inline set definitions."
+              }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Inline Modifier",
+            "description": "A modifier defined inline in the resolutionOrder array. Must include 'name' and 'type' properties.",
+            "type": "object",
+            "required": ["contexts", "name", "type"],
+            "properties": {
+              "description": {
+                "title": "Description",
+                "type": "string",
+                "description": "A human-readable description of the purpose of the modifier."
+              },
+              "contexts": {
+                "title": "Contexts",
+                "type": "object",
+                "description": "A map of context names to arrays of token sources. Each context represents a possible variant (e.g., 'light' vs 'dark' for theme, 'small' vs 'large' for size).",
+                "minProperties": 2,
+                "patternProperties": {
+                  "^.+$": {
+                    "$ref": "https://www.designtokens.org/schemas/2025.10/resolver/modifier.json#/definitions/tokenSourcesForModifiers"
+                  }
+                },
+                "additionalProperties": false
+              },
+              "default": {
+                "title": "Default Context",
+                "type": "string",
+                "description": "An optional default value that MUST match one of the keys in contexts. If provided, tools will use this context when no input is provided for this modifier.",
+                "$comment": "JSON Schema cannot validate that this value matches a key in 'contexts'. This validation must be performed at runtime by the implementation."
+              },
+              "$extensions": {
+                "title": "Extensions",
+                "type": "object",
+                "description": "Vendor-specific extensions. Keys are vendor-specific namespaces."
+              },
+              "name": {
+                "title": "Name",
+                "type": "string",
+                "description": "A unique name that MUST NOT conflict with any other name in resolutionOrder.",
+                "$comment": "Uniqueness must be validated at runtime as JSON Schema cannot validate uniqueness across array items."
+              },
+              "type": {
+                "title": "Type",
+                "type": "string",
+                "const": "modifier",
+                "description": "MUST be 'modifier' for inline modifier definitions."
+              }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  }
+}

--- a/packages/components/scripts/tokens/types.ts
+++ b/packages/components/scripts/tokens/types.ts
@@ -95,13 +95,23 @@ export type TokenDocument = TokenGroup & {
   $schema?: string;
 };
 
-export type ResolverSet = { name: string; source: string[] };
-export type ResolverModifier = { name: string; values: string[]; default?: string };
+/**
+ * DTCG 2025.10 resolver reference object. Cinder only authors $ref entries
+ * (relative file paths for sources, #/sets/<name> or #/modifiers/<name> for
+ * resolutionOrder) -- the spec also allows inline set/modifier/token
+ * documents in these positions, which Cinder does not use.
+ */
+export type ResolverReference = { $ref: string };
+export type ResolverSet = { sources: ResolverReference[] };
+export type ResolverModifier = {
+  contexts: Record<string, ResolverReference[]>;
+  default?: string;
+};
 export type ResolverDocument = {
   version: '2025.10';
-  sets: ResolverSet[];
-  modifiers: ResolverModifier[];
-  resolutionOrder: string[];
+  sets: Record<string, ResolverSet>;
+  modifiers: Record<string, ResolverModifier>;
+  resolutionOrder: ResolverReference[];
 };
 
 export type ValidationIssue = { path: string; reason: string };

--- a/packages/components/scripts/tokens/validate-corpus.test.ts
+++ b/packages/components/scripts/tokens/validate-corpus.test.ts
@@ -1,92 +1,93 @@
 import { describe, expect, test } from 'bun:test';
-import {
-  findModifierDocument,
-  findModifierDocuments,
-  orderModifierDocuments,
-} from './validate-corpus.ts';
+import type { ResolverDocument } from './types.ts';
+import { combinations, parseResolutionOrder, sourcesForEntry } from './validate-corpus.ts';
+
+const resolver: ResolverDocument = {
+  version: '2025.10',
+  sets: {
+    foundation: {
+      sources: [{ $ref: 'sets/foundation.tokens.json' }, { $ref: 'sets/semantic.tokens.json' }],
+    },
+  },
+  modifiers: {
+    theme: {
+      contexts: {
+        light: [{ $ref: 'themes/light.tokens.json' }],
+        dark: [{ $ref: 'themes/dark.tokens.json' }],
+      },
+      default: 'light',
+    },
+    motion: {
+      contexts: {
+        default: [{ $ref: 'modes/motion-default.tokens.json' }],
+        reduced: [{ $ref: 'modes/motion-reduced.tokens.json' }],
+      },
+      default: 'default',
+    },
+  },
+  resolutionOrder: [
+    { $ref: '#/sets/foundation' },
+    { $ref: '#/modifiers/theme' },
+    { $ref: '#/modifiers/motion' },
+  ],
+};
 
 describe('token corpus validation', () => {
-  test('finds modifier documents through authored metadata instead of file names', () => {
-    const document = {
-      $extensions: { 'com.lostgradient.cinder': { modifier: { theme: 'dark' } } },
-    };
-    expect(
-      findModifierDocument(
-        [{ path: 'renamed.tokens.json', document }],
-        { name: 'theme', values: ['light', 'dark'] },
-        'dark',
-      ),
-    ).toEqual({ path: 'renamed.tokens.json', document });
+  test('parses resolutionOrder references into their target kind and name', () => {
+    expect(parseResolutionOrder(resolver)).toEqual([
+      { kind: 'sets', name: 'foundation' },
+      { kind: 'modifiers', name: 'theme' },
+      { kind: 'modifiers', name: 'motion' },
+    ]);
   });
 
-  test('does not select empty modifier assignment maps', () => {
-    expect(
-      findModifierDocuments(
-        [
-          {
-            path: 'empty.tokens.json',
-            document: { $extensions: { 'com.lostgradient.cinder': { modifier: {} } } },
-          },
-        ],
-        { theme: 'dark' },
-      ),
-    ).toEqual([]);
+  test('resolves the sources for a set entry regardless of modifier selection', () => {
+    expect(sourcesForEntry(resolver, { kind: 'sets', name: 'foundation' }, {})).toEqual([
+      { $ref: 'sets/foundation.tokens.json' },
+      { $ref: 'sets/semantic.tokens.json' },
+    ]);
   });
 
-  test('only selects multi-axis modifier documents for matching combinations', () => {
-    const document = {
-      $extensions: {
-        'com.lostgradient.cinder': { modifier: { theme: 'dark', motion: 'reduced' } },
-      },
-    };
-    const documents = [{ path: 'combined.tokens.json', document }];
-    expect(findModifierDocuments(documents, { theme: 'dark', motion: 'default' })).toEqual([]);
-    expect(findModifierDocuments(documents, { theme: 'dark', motion: 'reduced' })).toEqual(
-      documents,
+  test('resolves the sources for a modifier entry using the selected context', () => {
+    expect(
+      sourcesForEntry(
+        resolver,
+        { kind: 'modifiers', name: 'theme' },
+        { theme: 'dark', motion: 'default' },
+      ),
+    ).toEqual([{ $ref: 'themes/dark.tokens.json' }]);
+    expect(
+      sourcesForEntry(
+        resolver,
+        { kind: 'modifiers', name: 'motion' },
+        { theme: 'dark', motion: 'reduced' },
+      ),
+    ).toEqual([{ $ref: 'modes/motion-reduced.tokens.json' }]);
+  });
+
+  test('computes the cartesian product of every modifier context combination', () => {
+    const combos = combinations(resolver);
+    expect(combos).toHaveLength(4);
+    expect(combos).toEqual(
+      expect.arrayContaining([
+        { theme: 'light', motion: 'default' },
+        { theme: 'light', motion: 'reduced' },
+        { theme: 'dark', motion: 'default' },
+        { theme: 'dark', motion: 'reduced' },
+      ]),
     );
   });
 
-  test('orders selected modifier documents by the resolver axis order', () => {
-    const theme = {
-      path: 'themes/dark.tokens.json',
-      document: { $extensions: { 'com.lostgradient.cinder': { modifier: { theme: 'dark' } } } },
-    };
-    const motion = {
-      path: 'modes/reduced.tokens.json',
-      document: { $extensions: { 'com.lostgradient.cinder': { modifier: { motion: 'reduced' } } } },
-    };
-    expect(
-      orderModifierDocuments(
-        [motion, theme],
-        [
-          { name: 'theme', values: ['dark'] },
-          { name: 'motion', values: ['reduced'] },
-        ],
-      ),
-    ).toEqual([theme, motion]);
+  test('computes a single combination for a resolver with no modifiers', () => {
+    const noModifiers: ResolverDocument = { ...resolver, modifiers: {} };
+    expect(combinations(noModifiers)).toEqual([{}]);
   });
 
-  test('orders combined modifier documents after single-axis documents at the same precedence', () => {
-    const motion = {
-      path: 'z-motion.tokens.json',
-      document: { $extensions: { 'com.lostgradient.cinder': { modifier: { motion: 'reduced' } } } },
+  test('computes one combination per context for a single-modifier resolver', () => {
+    const singleModifier: ResolverDocument = {
+      ...resolver,
+      modifiers: { theme: resolver.modifiers['theme']! },
     };
-    const combined = {
-      path: 'a-combined.tokens.json',
-      document: {
-        $extensions: {
-          'com.lostgradient.cinder': { modifier: { theme: 'dark', motion: 'reduced' } },
-        },
-      },
-    };
-    expect(
-      orderModifierDocuments(
-        [combined, motion],
-        [
-          { name: 'theme', values: ['dark'] },
-          { name: 'motion', values: ['reduced'] },
-        ],
-      ),
-    ).toEqual([motion, combined]);
+    expect(combinations(singleModifier)).toEqual([{ theme: 'light' }, { theme: 'dark' }]);
   });
 });

--- a/packages/components/scripts/tokens/validate-corpus.test.ts
+++ b/packages/components/scripts/tokens/validate-corpus.test.ts
@@ -69,6 +69,33 @@ describe('token corpus validation', () => {
     ]);
   });
 
+  test('applies RFC 6901 decode order: percent-decode the fragment, then split, then tilde-decode', () => {
+    const withName = (ref: string): ResolverDocument => ({
+      version: '2025.10',
+      sets: { 'high contrast': { sources: [{ $ref: 'sets/hc.tokens.json' }] } },
+      modifiers: {},
+      resolutionOrder: [{ $ref: ref }],
+    });
+
+    // %20 decodes to a space inside a single segment, naming a real set.
+    expect(parseResolutionOrder(withName('#/sets/high%20contrast'))).toEqual([
+      { kind: 'sets', name: 'high contrast' },
+    ]);
+
+    // %2F decodes to a literal slash, making this a three-segment pointer
+    // rather than a set named `foo/bar` -- which is only addressable as
+    // `#/sets/foo~1bar`. Decoding after splitting would wrongly accept it.
+    expect(() => parseResolutionOrder(withName('#/sets/foo%2Fbar'))).toThrow();
+
+    // An unescaped slash is a deeper pointer, not a name containing a slash.
+    expect(() => parseResolutionOrder(withName('#/sets/foo/bar'))).toThrow();
+
+    // A malformed percent-escape is rejected, not thrown out of decodeURIComponent.
+    expect(() => parseResolutionOrder(withName('#/sets/bad%2'))).toThrow(
+      /not a well-formed pointer/,
+    );
+  });
+
   test('normalizes source URI references to the globbed repository-relative form', () => {
     expect(normalizeSourcePath('sets/foundation.tokens.json')).toBe('sets/foundation.tokens.json');
     expect(normalizeSourcePath('./sets/foundation.tokens.json')).toBe(

--- a/packages/components/scripts/tokens/validate-corpus.test.ts
+++ b/packages/components/scripts/tokens/validate-corpus.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test';
 import type { ResolverDocument } from './types.ts';
-import { combinations, parseResolutionOrder, sourcesForEntry } from './validate-corpus.ts';
+import {
+  combinations,
+  normalizeSourcePath,
+  parseResolutionOrder,
+  sourcesForEntry,
+} from './validate-corpus.ts';
 
 const resolver: ResolverDocument = {
   version: '2025.10',
@@ -33,6 +38,54 @@ const resolver: ResolverDocument = {
 };
 
 describe('token corpus validation', () => {
+  test('decodes RFC 6901 tilde escapes so the decoded name still finds its set', () => {
+    const escaped: ResolverDocument = {
+      version: '2025.10',
+      sets: { 'foo/bar': { sources: [{ $ref: 'sets/foo-bar.tokens.json' }] } },
+      modifiers: {
+        'a~b': {
+          contexts: {
+            one: [{ $ref: 'modes/one.tokens.json' }],
+            two: [{ $ref: 'modes/two.tokens.json' }],
+          },
+        },
+      },
+      resolutionOrder: [{ $ref: '#/sets/foo~1bar' }, { $ref: '#/modifiers/a~0b' }],
+    };
+
+    const parsed = parseResolutionOrder(escaped);
+    expect(parsed).toEqual([
+      { kind: 'sets', name: 'foo/bar' },
+      { kind: 'modifiers', name: 'a~b' },
+    ]);
+
+    // Validation accepts these references, so the lookup they feed must find
+    // the entry rather than reading `.sources` off undefined.
+    expect(sourcesForEntry(escaped, parsed[0]!, {})).toEqual([
+      { $ref: 'sets/foo-bar.tokens.json' },
+    ]);
+    expect(sourcesForEntry(escaped, parsed[1]!, { 'a~b': 'two' })).toEqual([
+      { $ref: 'modes/two.tokens.json' },
+    ]);
+  });
+
+  test('normalizes source URI references to the globbed repository-relative form', () => {
+    expect(normalizeSourcePath('sets/foundation.tokens.json')).toBe('sets/foundation.tokens.json');
+    expect(normalizeSourcePath('./sets/foundation.tokens.json')).toBe(
+      'sets/foundation.tokens.json',
+    );
+    expect(normalizeSourcePath('themes/../sets/foundation.tokens.json')).toBe(
+      'sets/foundation.tokens.json',
+    );
+    expect(normalizeSourcePath('sets/with%20space.tokens.json')).toBe(
+      'sets/with space.tokens.json',
+    );
+  });
+
+  test('leaves a malformed percent-escape undecoded rather than throwing', () => {
+    expect(normalizeSourcePath('sets/bad%2.tokens.json')).toBe('sets/bad%2.tokens.json');
+  });
+
   test('parses resolutionOrder references into their target kind and name', () => {
     expect(parseResolutionOrder(resolver)).toEqual([
       { kind: 'sets', name: 'foundation' },

--- a/packages/components/scripts/tokens/validate-corpus.ts
+++ b/packages/components/scripts/tokens/validate-corpus.ts
@@ -1,141 +1,110 @@
 import { loadResolverDocument, loadTokenDocuments } from './load.ts';
 import { resolveDocuments } from './resolve.ts';
-import { TokenValidationError, type ResolverModifier, type TokenDocument } from './types.ts';
+import { TokenValidationError, type ResolverDocument, type ResolverReference } from './types.ts';
 import {
   validateResolvedToken,
   validateResolverDocument,
   validateTokenDocument,
 } from './validate.ts';
 
-type TokenDocumentEntry = { path: string; document: TokenDocument };
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-
 async function main(): Promise<void> {
   const [resolver, documents] = await Promise.all([loadResolverDocument(), loadTokenDocuments()]);
   validateResolverDocument(resolver);
   for (const { path, document } of documents) validateTokenDocument(document, path);
 
-  const knownSources = new Set(documents.map(({ path }) => path));
-  const missingSources = resolver.sets.flatMap((set) =>
-    set.source
-      .filter((source) => !knownSources.has(source))
-      .map((source) => ({
-        path: `$.sets.${set.name}.source`,
-        reason: `source does not exist: ${source}`,
-      })),
-  );
+  const documentsByPath = new Map(documents.map(({ path, document }) => [path, document]));
+  const knownPaths = new Set(documents.map(({ path }) => path));
+
+  const missingSources = [
+    ...Object.entries(resolver.sets).flatMap(([setName, set]) =>
+      set.sources
+        .filter((source) => !knownPaths.has(source.$ref))
+        .map((source) => ({
+          path: `$.sets.${setName}.sources`,
+          reason: `source does not exist: ${source.$ref}`,
+        })),
+    ),
+    ...Object.entries(resolver.modifiers).flatMap(([modifierName, modifier]) =>
+      Object.entries(modifier.contexts).flatMap(([contextName, sources]) =>
+        sources
+          .filter((source) => !knownPaths.has(source.$ref))
+          .map((source) => ({
+            path: `$.modifiers.${modifierName}.contexts.${contextName}`,
+            reason: `source does not exist: ${source.$ref}`,
+          })),
+      ),
+    ),
+  ];
   if (missingSources.length > 0) throw new TokenValidationError(missingSources);
 
-  const documentsByPath = new Map(documents.map(({ path, document }) => [path, document]));
-  const referencedPaths = new Set(resolver.sets.flatMap((set) => set.source));
-  const modifiersByName = new Map(resolver.modifiers.map((modifier) => [modifier.name, modifier]));
-  const orderedModifiers = resolver.resolutionOrder.map((name) => modifiersByName.get(name)!);
-  for (const modifierValues of combinations(orderedModifiers))
-    for (const document of findModifierDocuments(documents, modifierValues))
-      referencedPaths.add(document.path);
+  const referencedPaths = new Set<string>([
+    ...Object.values(resolver.sets).flatMap((set) => set.sources.map((source) => source.$ref)),
+    ...Object.values(resolver.modifiers).flatMap((modifier) =>
+      Object.values(modifier.contexts).flatMap((sources) => sources.map((source) => source.$ref)),
+    ),
+  ]);
   const unreferencedDocuments = documents
     .filter(({ path }) => !referencedPaths.has(path))
     .map(({ path }) => ({ path, reason: 'token document is not referenced by the resolver' }));
   if (unreferencedDocuments.length > 0) throw new TokenValidationError(unreferencedDocuments);
-  for (const set of resolver.sets)
-    for (const modifierValues of combinations(orderedModifiers)) {
-      const sourceDocuments = set.source.flatMap((source) => {
-        const document = documentsByPath.get(source);
-        return document ? [document] : [];
-      });
-      const modifierDocuments = orderModifierDocuments(
-        findModifierDocuments(documents, modifierValues),
-        orderedModifiers,
-      );
-      for (const modifier of orderedModifiers)
-        if (
-          !modifierDocuments.some(
-            ({ document }) =>
-              modifierAssignments(document)?.[modifier.name] === modifierValues[modifier.name],
-          )
-        )
-          throw new TokenValidationError([
-            {
-              path: `$.modifiers.${modifier.name}`,
-              reason: `no token document exists for ${modifier.name}=${modifierValues[modifier.name]}`,
-            },
-          ]);
-      const resolved = resolveDocuments([
-        ...sourceDocuments,
-        ...modifierDocuments.map(({ document }) => document),
-      ]);
-      for (const [path, token] of Object.entries(resolved)) validateResolvedToken(token, path);
-    }
+
+  const resolutionOrder = parseResolutionOrder(resolver);
+  for (const modifierValues of combinations(resolver)) {
+    const orderedDocuments = resolutionOrder.flatMap((entry) =>
+      sourcesForEntry(resolver, entry, modifierValues).map(
+        (source) => documentsByPath.get(source.$ref)!,
+      ),
+    );
+    const resolved = resolveDocuments(orderedDocuments);
+    for (const [path, token] of Object.entries(resolved)) validateResolvedToken(token, path);
+  }
 }
 
-function combinations(modifiers: ResolverModifier[]): Array<Record<string, string>> {
-  return modifiers.reduce<Array<Record<string, string>>>(
-    (current, modifier) =>
+export type ResolutionOrderEntry = { kind: 'sets' | 'modifiers'; name: string };
+
+function isResolverTargetKind(value: string): value is 'sets' | 'modifiers' {
+  return value === 'sets' || value === 'modifiers';
+}
+
+/**
+ * Parses every resolutionOrder `$ref` into its target kind and name.
+ * `validateResolverDocument` (called by `main` before this runs) already
+ * guarantees each entry is a well-formed, existing `#/sets/<name>` or
+ * `#/modifiers/<name>` pointer, so the non-null assertions below document
+ * that guarantee rather than re-deriving it.
+ */
+export function parseResolutionOrder(resolver: ResolverDocument): ResolutionOrderEntry[] {
+  return resolver.resolutionOrder.map((entry) => {
+    const match = /^#\/(sets|modifiers)\/(.+)$/.exec(entry.$ref)!;
+    const kind = match[1]!;
+    if (!isResolverTargetKind(kind))
+      throw new Error(`resolutionOrder entry did not match a known kind: ${entry.$ref}`);
+    return { kind, name: match[2]! };
+  });
+}
+
+/** The token sources a resolutionOrder entry contributes for one modifier-value combination. */
+export function sourcesForEntry(
+  resolver: ResolverDocument,
+  entry: ResolutionOrderEntry,
+  modifierValues: Record<string, string>,
+): ResolverReference[] {
+  if (entry.kind === 'sets') return resolver.sets[entry.name]!.sources;
+  const modifier = resolver.modifiers[entry.name]!;
+  return modifier.contexts[modifierValues[entry.name]!]!;
+}
+
+/** Every combination of one context value per modifier, cartesian product across all modifiers. */
+export function combinations(resolver: ResolverDocument): Array<Record<string, string>> {
+  return Object.entries(resolver.modifiers).reduce<Array<Record<string, string>>>(
+    (current, [name, modifier]) =>
       current.flatMap((selection) =>
-        modifier.values.map((value) => ({ ...selection, [modifier.name]: value })),
+        Object.keys(modifier.contexts).map((contextName) => ({
+          ...selection,
+          [name]: contextName,
+        })),
       ),
     [{}],
-  );
-}
-
-export function findModifierDocument(
-  documents: TokenDocumentEntry[],
-  modifier: ResolverModifier,
-  value: string | undefined,
-): TokenDocumentEntry | undefined {
-  if (!value) return undefined;
-  return documents.find(({ document }) => {
-    return modifierAssignments(document)?.[modifier.name] === value;
-  });
-}
-
-function modifierAssignments(document: TokenDocument): Record<string, string> | undefined {
-  const extensions = document.$extensions?.['com.lostgradient.cinder'];
-  if (!isObject(extensions) || !isObject(extensions['modifier'])) return undefined;
-  const assignments = extensions['modifier'];
-  if (Object.keys(assignments).length === 0) return undefined;
-  const result: Record<string, string> = {};
-  for (const [name, value] of Object.entries(assignments)) {
-    if (typeof value !== 'string') return undefined;
-    result[name] = value;
-  }
-  return result;
-}
-
-export function findModifierDocuments(
-  documents: TokenDocumentEntry[],
-  modifierValues: Record<string, string>,
-): TokenDocumentEntry[] {
-  return documents.filter(({ document }) => {
-    const assignments = modifierAssignments(document);
-    return (
-      assignments !== undefined &&
-      Object.entries(assignments).every(([name, value]) => modifierValues[name] === value)
-    );
-  });
-}
-
-export function orderModifierDocuments(
-  documents: TokenDocumentEntry[],
-  modifiers: ResolverModifier[],
-): TokenDocumentEntry[] {
-  const modifierPositions = new Map(modifiers.map(({ name }, index) => [name, index]));
-  const position = ({ document }: TokenDocumentEntry): number =>
-    Math.max(
-      ...Object.keys(modifierAssignments(document) ?? {}).map(
-        (name) => modifierPositions.get(name) ?? -1,
-      ),
-    );
-  const specificity = ({ document }: TokenDocumentEntry): number =>
-    Object.keys(modifierAssignments(document) ?? {}).length;
-  return documents.toSorted(
-    (left, right) =>
-      position(left) - position(right) ||
-      specificity(left) - specificity(right) ||
-      left.path.localeCompare(right.path),
   );
 }
 

--- a/packages/components/scripts/tokens/validate-corpus.ts
+++ b/packages/components/scripts/tokens/validate-corpus.ts
@@ -1,11 +1,33 @@
+import { posix } from 'node:path';
+
 import { loadResolverDocument, loadTokenDocuments } from './load.ts';
 import { resolveDocuments } from './resolve.ts';
 import { TokenValidationError, type ResolverDocument, type ResolverReference } from './types.ts';
 import {
+  resolutionOrderTarget,
   validateResolvedToken,
   validateResolverDocument,
   validateTokenDocument,
 } from './validate.ts';
+
+/**
+ * Normalizes a source `$ref` into the repository-relative form `loadTokenDocuments`
+ * reports. The resolver schema types these as URI references, so `./sets/x.tokens.json`
+ * and `sets/x.tokens.json` name the same file; comparing the raw strings against
+ * globbed paths would report a file that exists as missing. Percent-escapes are
+ * decoded for the same reason, and a malformed escape is left as-is so the failure
+ * surfaces as a clear "source does not exist" rather than a decoding crash --
+ * ajv's `uri-reference` format catches genuinely malformed references upstream.
+ */
+export function normalizeSourcePath(reference: string): string {
+  let decoded = reference;
+  try {
+    decoded = decodeURIComponent(reference);
+  } catch {
+    // Leave the reference undecoded; the existence check reports it.
+  }
+  return posix.normalize(decoded).replace(/^\.\//, '');
+}
 
 async function main(): Promise<void> {
   const [resolver, documents] = await Promise.all([loadResolverDocument(), loadTokenDocuments()]);
@@ -18,7 +40,7 @@ async function main(): Promise<void> {
   const missingSources = [
     ...Object.entries(resolver.sets).flatMap(([setName, set]) =>
       set.sources
-        .filter((source) => !knownPaths.has(source.$ref))
+        .filter((source) => !knownPaths.has(normalizeSourcePath(source.$ref)))
         .map((source) => ({
           path: `$.sets.${setName}.sources`,
           reason: `source does not exist: ${source.$ref}`,
@@ -27,7 +49,7 @@ async function main(): Promise<void> {
     ...Object.entries(resolver.modifiers).flatMap(([modifierName, modifier]) =>
       Object.entries(modifier.contexts).flatMap(([contextName, sources]) =>
         sources
-          .filter((source) => !knownPaths.has(source.$ref))
+          .filter((source) => !knownPaths.has(normalizeSourcePath(source.$ref)))
           .map((source) => ({
             path: `$.modifiers.${modifierName}.contexts.${contextName}`,
             reason: `source does not exist: ${source.$ref}`,
@@ -38,9 +60,13 @@ async function main(): Promise<void> {
   if (missingSources.length > 0) throw new TokenValidationError(missingSources);
 
   const referencedPaths = new Set<string>([
-    ...Object.values(resolver.sets).flatMap((set) => set.sources.map((source) => source.$ref)),
+    ...Object.values(resolver.sets).flatMap((set) =>
+      set.sources.map((source) => normalizeSourcePath(source.$ref)),
+    ),
     ...Object.values(resolver.modifiers).flatMap((modifier) =>
-      Object.values(modifier.contexts).flatMap((sources) => sources.map((source) => source.$ref)),
+      Object.values(modifier.contexts).flatMap((sources) =>
+        sources.map((source) => normalizeSourcePath(source.$ref)),
+      ),
     ),
   ]);
   const unreferencedDocuments = documents
@@ -52,7 +78,7 @@ async function main(): Promise<void> {
   for (const modifierValues of combinations(resolver)) {
     const orderedDocuments = resolutionOrder.flatMap((entry) =>
       sourcesForEntry(resolver, entry, modifierValues).map(
-        (source) => documentsByPath.get(source.$ref)!,
+        (source) => documentsByPath.get(normalizeSourcePath(source.$ref))!,
       ),
     );
     const resolved = resolveDocuments(orderedDocuments);
@@ -62,24 +88,19 @@ async function main(): Promise<void> {
 
 export type ResolutionOrderEntry = { kind: 'sets' | 'modifiers'; name: string };
 
-function isResolverTargetKind(value: string): value is 'sets' | 'modifiers' {
-  return value === 'sets' || value === 'modifiers';
-}
-
 /**
- * Parses every resolutionOrder `$ref` into its target kind and name.
- * `validateResolverDocument` (called by `main` before this runs) already
- * guarantees each entry is a well-formed, existing `#/sets/<name>` or
- * `#/modifiers/<name>` pointer, so the non-null assertions below document
- * that guarantee rather than re-deriving it.
+ * Parses every resolutionOrder `$ref` into its target kind and name, reusing
+ * validation's own parser so the two paths cannot drift. That matters for
+ * RFC 6901 tilde-escapes: a set named `a/b` is referenced as `#/sets/a~1b`,
+ * and decoding it here is what keeps the later `resolver.sets[name]` lookup
+ * in `sourcesForEntry` finding the entry that validation already accepted.
  */
 export function parseResolutionOrder(resolver: ResolverDocument): ResolutionOrderEntry[] {
   return resolver.resolutionOrder.map((entry) => {
-    const match = /^#\/(sets|modifiers)\/(.+)$/.exec(entry.$ref)!;
-    const kind = match[1]!;
-    if (!isResolverTargetKind(kind))
-      throw new Error(`resolutionOrder entry did not match a known kind: ${entry.$ref}`);
-    return { kind, name: match[2]! };
+    const target = resolutionOrderTarget(entry.$ref);
+    if (!target)
+      throw new Error(`resolutionOrder entry is not a well-formed pointer: ${entry.$ref}`);
+    return target;
   });
 }
 

--- a/packages/components/scripts/tokens/validate-schema.test.ts
+++ b/packages/components/scripts/tokens/validate-schema.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { validateResolverDocumentSchema, validateTokenDocumentSchema } from './validate-schema.ts';
+import { assertValidTokenDocument, validateTokenDocument } from './validate.ts';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const schemaDirectory = join(scriptDirectory, 'schemas');
+
+function readSchema(fileName: string): { $schema?: unknown } {
+  return JSON.parse(readFileSync(join(schemaDirectory, fileName), 'utf8')) as { $schema?: unknown };
+}
+
+describe('vendored DTCG schema files', () => {
+  test('both schemas declare the draft-07 dialect', () => {
+    expect(readSchema('dtcg-format-2025-10.json').$schema).toBe(
+      'http://json-schema.org/draft-07/schema#',
+    );
+    expect(readSchema('dtcg-resolver-2025-10.json').$schema).toBe(
+      'http://json-schema.org/draft-07/schema#',
+    );
+  });
+});
+
+describe('JSON Schema validation (format)', () => {
+  test('accepts a document that conforms to the official DTCG 2025.10 format schema', () => {
+    expect(() =>
+      validateTokenDocumentSchema({
+        $schema: 'https://www.designtokens.org/schemas/2025.10/format.json',
+        sample: { $type: 'number', $value: 1 },
+      }),
+    ).not.toThrow();
+  });
+
+  test('rejects an unknown colorSpace with a named path and reason', () => {
+    let caught: unknown;
+    try {
+      validateTokenDocumentSchema(
+        { sample: { $type: 'color', $value: { colorSpace: 'banana', components: [0, 0, 0] } } },
+        '$',
+      );
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    const issues = (caught as { issues: Array<{ path: string; reason: string }> }).issues;
+    expect(issues.length).toBeGreaterThan(0);
+    expect(
+      issues.some(
+        (issue) =>
+          issue.path === '$.sample.$value.colorSpace' && issue.reason.includes('must be one of'),
+      ),
+    ).toBe(true);
+  });
+
+  test('rejects a document missing a required composite member with a named path and reason', () => {
+    let caught: unknown;
+    try {
+      validateTokenDocumentSchema({
+        sample: { $type: 'border', $value: { color: '{color}', width: '{dimension}' } },
+      });
+    } catch (error) {
+      caught = error;
+    }
+    const issues = (caught as { issues: Array<{ path: string; reason: string }> }).issues;
+    expect(
+      issues.some(
+        (issue) =>
+          issue.path === '$.sample.$value' &&
+          issue.reason === "must have required property 'style'",
+      ),
+    ).toBe(true);
+  });
+
+  test('catches an 8-digit hex color the hand-rolled semantic validator alone accepts', () => {
+    const document = {
+      $schema: 'https://www.designtokens.org/schemas/2025.10/format.json',
+      sample: {
+        $type: 'color' as const,
+        $value: { colorSpace: 'oklch', components: [0, 0, 0], hex: '#11223380' },
+      },
+    };
+
+    // Before: the pre-existing hand-rolled semantic validator alone accepts this
+    // (see the "not.toThrow()" 8-digit-hex assertion in validate.test.ts) --
+    // the official schema only permits exactly 6 hex digits.
+    expect(() => validateTokenDocument(document)).not.toThrow();
+
+    // After: the JSON Schema first-pass gate rejects it.
+    let caught: unknown;
+    try {
+      validateTokenDocumentSchema(document);
+    } catch (error) {
+      caught = error;
+    }
+    const issues = (caught as { issues: Array<{ path: string; reason: string }> }).issues;
+    expect(
+      issues.some((issue) => issue.path === '$.sample.$value.hex' && issue.reason.includes('#')),
+    ).toBe(true);
+
+    // And the combined gate (schema, then semantic) used by the real loading
+    // pipeline now rejects a document the semantic-only path used to accept.
+    expect(() => assertValidTokenDocument(document)).toThrow();
+  });
+
+  test('accepts $root tokens and $extends groups (both are 2025.10 format features)', () => {
+    expect(() =>
+      validateTokenDocumentSchema({ group: { $type: 'number', $root: { $value: 1 } } }),
+    ).not.toThrow();
+    expect(() =>
+      validateTokenDocumentSchema({
+        base: { $type: 'number', token: { $value: 1 } },
+        derived: { $extends: '{base}', nested: { token: { $value: 2 } } },
+      }),
+    ).not.toThrow();
+  });
+
+  test('accepts document-level $extensions carrying a resolver modifier assignment', () => {
+    expect(() =>
+      validateTokenDocumentSchema({
+        $schema: 'https://www.designtokens.org/schemas/2025.10/format.json',
+        $extensions: { 'com.lostgradient.cinder': { modifier: { theme: 'dark' } } },
+        color: { $type: 'color', $value: { colorSpace: 'oklch', components: [0.5, 0.1, 255] } },
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('JSON Schema validation (resolver)', () => {
+  test('accepts a document conforming to the official object-keyed resolver shape', () => {
+    expect(() =>
+      validateResolverDocumentSchema({
+        version: '2025.10',
+        sets: { foundation: { sources: [{ $ref: 'sets/foundation.tokens.json' }] } },
+        modifiers: {
+          theme: {
+            contexts: {
+              light: [{ $ref: 'themes/light.tokens.json' }],
+              dark: [{ $ref: 'themes/dark.tokens.json' }],
+            },
+          },
+        },
+        resolutionOrder: [{ $ref: '#/sets/foundation' }, { $ref: '#/modifiers/theme' }],
+      }),
+    ).not.toThrow();
+  });
+
+  test('accepts the real, migrated cinder.resolver.json file on disk', () => {
+    // CIN-27 migrated packages/components/src/tokens/cinder.resolver.json
+    // from an array-based shape to the official object-keyed shape. This
+    // reads the real file (not a copy) so a future edit to it that drifts
+    // from the official schema fails here, not only in tokens:validate.
+    const resolverPath = join(scriptDirectory, '..', '..', 'src', 'tokens', 'cinder.resolver.json');
+    const document: unknown = JSON.parse(readFileSync(resolverPath, 'utf8'));
+    expect(() => validateResolverDocumentSchema(document)).not.toThrow();
+  });
+
+  test('rejects the pre-migration array-based resolver shape Cinder used to author', () => {
+    // Historical regression guard: cinder.resolver.json used to declare
+    // sets/modifiers as arrays of {name, ...} objects and resolutionOrder as
+    // a plain string array, despite declaring the official 2025.10 $schema
+    // URI -- it never actually conformed. CIN-27 migrated the real file to
+    // the shape asserted above and wired this schema validator into
+    // assertValidResolverDocument (see validate.ts), so this now documents
+    // what the toolchain used to accept and no longer does.
+    let caught: unknown;
+    try {
+      validateResolverDocumentSchema({
+        version: '2025.10',
+        sets: [{ name: 'foundation', source: ['sets/foundation.tokens.json'] }],
+        modifiers: [{ name: 'theme', values: ['light', 'dark'], default: 'light' }],
+        resolutionOrder: ['theme'],
+      });
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeDefined();
+    const issues = (caught as { issues: Array<{ path: string; reason: string }> }).issues;
+    expect(issues.some((issue) => issue.path === '$.sets' && issue.reason.includes('object'))).toBe(
+      true,
+    );
+    expect(
+      issues.some((issue) => issue.path === '$.modifiers' && issue.reason.includes('object')),
+    ).toBe(true);
+  });
+
+  test('reports a named path and reason for a resolver schema violation', () => {
+    let caught: unknown;
+    try {
+      validateResolverDocumentSchema({
+        version: 'not-2025.10',
+        resolutionOrder: [],
+      });
+    } catch (error) {
+      caught = error;
+    }
+    const issues = (caught as { issues: Array<{ path: string; reason: string }> }).issues;
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.some((issue) => issue.path === '$.version')).toBe(true);
+  });
+});

--- a/packages/components/scripts/tokens/validate-schema.test.ts
+++ b/packages/components/scripts/tokens/validate-schema.test.ts
@@ -200,4 +200,19 @@ describe('JSON Schema validation (resolver)', () => {
     expect(issues.length).toBeGreaterThan(0);
     expect(issues.some((issue) => issue.path === '$.version')).toBe(true);
   });
+
+  test('enforces the uri-reference format rather than treating it as unconstrained', () => {
+    // The schemas apply `format: uri-reference` to source and resolutionOrder
+    // `$ref` values. Registering those formats as no-op stubs would let a
+    // malformed reference through the gate that exists to catch it, so this
+    // pins that the real ajv-formats validators are wired in.
+    expect(() =>
+      validateResolverDocumentSchema({
+        version: '2025.10',
+        sets: { foundation: { sources: [{ $ref: 'sets/bad%2x.tokens.json' }] } },
+        modifiers: {},
+        resolutionOrder: [{ $ref: '#/sets/foundation' }],
+      }),
+    ).toThrow();
+  });
 });

--- a/packages/components/scripts/tokens/validate-schema.ts
+++ b/packages/components/scripts/tokens/validate-schema.ts
@@ -1,0 +1,140 @@
+/**
+ * First-pass structural validation against the official DTCG 2025.10 JSON
+ * Schemas (vendored under `./schemas`, see that directory's README.md).
+ *
+ * This layer catches shape violations JSON Schema can express directly:
+ * required composite members, enum membership, value types, and pattern
+ * constraints. It intentionally runs *before* the hand-rolled semantic
+ * checks in `validate.ts`, which cover rules JSON Schema structurally
+ * cannot express -- `$type` inheritance from an ancestor group, alias and
+ * `$extends` cycle detection, resolver axis ordering, and Cinder's own
+ * token-name restrictions.
+ *
+ * The official schema's per-type value discriminator keys off a token's
+ * *own* `$type` property. A token that relies on inherited `$type` (typed
+ * only by an ancestor group) can produce ambiguous `oneOf` matches here for
+ * value shapes that overlap with another type's shape (observed for scalar
+ * types such as `strokeStyle` and for `typography`'s composite `lineHeight`
+ * branch). Every document in the real corpus today uses only object-shaped
+ * `color`/`dimension`/`duration` values, which do not hit this ambiguity --
+ * verified empirically against every file under `src/tokens`. A future
+ * corpus addition that inherits a scalar-shaped type without a local
+ * `$type` could trip a false positive here; if that happens, the fix is to
+ * add a local `$type` to the token, not to weaken this gate.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';
+
+import type { ValidationIssue } from './types.ts';
+import { TokenValidationError } from './types.ts';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const schemaDirectory = join(scriptDirectory, 'schemas');
+
+const NOOP_SCHEMA_FORMATS = ['uri-reference', 'json-pointer-uri-fragment'];
+
+function isJsonSchemaDocument(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function loadSchema(fileName: string): object {
+  const parsed: unknown = JSON.parse(readFileSync(join(schemaDirectory, fileName), 'utf8'));
+  if (!isJsonSchemaDocument(parsed)) throw new Error(`${fileName} did not parse to a JSON object`);
+  return parsed;
+}
+
+function createValidator(schema: object): ValidateFunction {
+  const ajv = new Ajv({ allErrors: true, strict: false, logger: false, addUsedSchema: false });
+  for (const format of NOOP_SCHEMA_FORMATS) ajv.addFormat(format, true);
+  return ajv.compile(schema);
+}
+
+let formatValidator: ValidateFunction | undefined;
+let resolverValidator: ValidateFunction | undefined;
+
+/** Ajv instances cannot share `$id`s, so the format and resolver schemas each get their own. */
+function getFormatValidator(): ValidateFunction {
+  formatValidator ??= createValidator(loadSchema('dtcg-format-2025-10.json'));
+  return formatValidator;
+}
+
+function getResolverValidator(): ValidateFunction {
+  resolverValidator ??= createValidator(loadSchema('dtcg-resolver-2025-10.json'));
+  return resolverValidator;
+}
+
+function decodeJsonPointerSegment(segment: string): string {
+  return segment.replaceAll('~1', '/').replaceAll('~0', '~');
+}
+
+function instancePathToTokenPath(source: string, instancePath: string): string {
+  if (!instancePath) return source;
+  const segments = instancePath.slice(1).split('/').map(decodeJsonPointerSegment);
+  return [source, ...segments].join('.');
+}
+
+function describeAjvError(error: ErrorObject): string {
+  switch (error.keyword) {
+    case 'additionalProperties': {
+      const propertyName = (error.params as { additionalProperty?: string }).additionalProperty;
+      return `must NOT have additional property '${propertyName}'`;
+    }
+    case 'required': {
+      const propertyName = (error.params as { missingProperty?: string }).missingProperty;
+      return `must have required property '${propertyName}'`;
+    }
+    case 'enum': {
+      const allowedValues = (error.params as { allowedValues?: unknown[] }).allowedValues ?? [];
+      return `must be one of ${JSON.stringify(allowedValues)}`;
+    }
+    case 'const': {
+      const allowedValue = (error.params as { allowedValue?: unknown }).allowedValue;
+      return `must equal ${JSON.stringify(allowedValue)}`;
+    }
+    default:
+      return error.message ?? 'failed schema validation';
+  }
+}
+
+/** Longer JSON Pointers are more specific; surfacing those first keeps sibling `oneOf` noise last. */
+function bySpecificity(left: ErrorObject, right: ErrorObject): number {
+  return right.instancePath.length - left.instancePath.length;
+}
+
+function runSchemaValidation(validator: ValidateFunction, document: unknown, source: string): void {
+  if (validator(document)) return;
+  const errors = [...(validator.errors ?? [])].toSorted(bySpecificity);
+  const issues: ValidationIssue[] = errors.map((error) => ({
+    path: instancePathToTokenPath(source, error.instancePath),
+    reason: describeAjvError(error),
+  }));
+  throw new TokenValidationError(issues);
+}
+
+/** Validates a token document against the official DTCG 2025.10 format JSON Schema. */
+export function validateTokenDocumentSchema(document: unknown, source = '$'): void {
+  runSchemaValidation(getFormatValidator(), document, source);
+}
+
+/**
+ * Validates a document against the official DTCG 2025.10 resolver JSON Schema.
+ *
+ * Not wired into `assertValidResolverDocument`: Cinder's `cinder.resolver.json`
+ * uses an array-of-`{name, source}` shape for `sets`/`modifiers` and a plain
+ * string array for `resolutionOrder`. The official schema requires `sets` and
+ * `modifiers` to be objects keyed by name (`{ sources: [...] }` /
+ * `{ contexts: { [value]: sources[] } }`), and `resolutionOrder` entries to be
+ * `{ "$ref": "#/sets/..." }`-style reference objects. These are genuinely
+ * different document models, not a naming quibble -- see the schemas'
+ * `resolver/set.json`, `resolver/modifier.json`, and
+ * `resolver/resolutionOrder.json` definitions embedded in the vendored file.
+ * This function is exported and tested against both the official shape and
+ * Cinder's actual shape so the divergence is provable, but it is intentionally
+ * not called from the real resolver-loading path.
+ */
+export function validateResolverDocumentSchema(document: unknown, source = '$'): void {
+  runSchemaValidation(getResolverValidator(), document, source);
+}

--- a/packages/components/scripts/tokens/validate-schema.ts
+++ b/packages/components/scripts/tokens/validate-schema.ts
@@ -27,6 +27,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import Ajv, { type ErrorObject, type ValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
 
 import type { ValidationIssue } from './types.ts';
 import { TokenValidationError } from './types.ts';
@@ -34,7 +35,14 @@ import { TokenValidationError } from './types.ts';
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const schemaDirectory = join(scriptDirectory, 'schemas');
 
-const NOOP_SCHEMA_FORMATS = ['uri-reference', 'json-pointer-uri-fragment'];
+/**
+ * The two `format` keywords the vendored DTCG schemas actually apply. Ajv
+ * treats an unknown format as unconstrained, so these are registered with
+ * `ajv-formats`' real validators rather than no-op stubs — otherwise a
+ * malformed `$ref` (a bad percent-escape in a token JSON Pointer, say) would
+ * sail through the official-schema gate that exists to catch exactly that.
+ */
+const SCHEMA_FORMATS = ['uri-reference', 'json-pointer-uri-fragment'] as const;
 
 function isJsonSchemaDocument(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -48,7 +56,7 @@ function loadSchema(fileName: string): object {
 
 function createValidator(schema: object): ValidateFunction {
   const ajv = new Ajv({ allErrors: true, strict: false, logger: false, addUsedSchema: false });
-  for (const format of NOOP_SCHEMA_FORMATS) ajv.addFormat(format, true);
+  addFormats(ajv, [...SCHEMA_FORMATS]);
   return ajv.compile(schema);
 }
 
@@ -122,18 +130,20 @@ export function validateTokenDocumentSchema(document: unknown, source = '$'): vo
 /**
  * Validates a document against the official DTCG 2025.10 resolver JSON Schema.
  *
- * Not wired into `assertValidResolverDocument`: Cinder's `cinder.resolver.json`
- * uses an array-of-`{name, source}` shape for `sets`/`modifiers` and a plain
- * string array for `resolutionOrder`. The official schema requires `sets` and
- * `modifiers` to be objects keyed by name (`{ sources: [...] }` /
- * `{ contexts: { [value]: sources[] } }`), and `resolutionOrder` entries to be
- * `{ "$ref": "#/sets/..." }`-style reference objects. These are genuinely
- * different document models, not a naming quibble -- see the schemas'
- * `resolver/set.json`, `resolver/modifier.json`, and
- * `resolver/resolutionOrder.json` definitions embedded in the vendored file.
- * This function is exported and tested against both the official shape and
- * Cinder's actual shape so the divergence is provable, but it is intentionally
- * not called from the real resolver-loading path.
+ * Wired into `assertValidResolverDocument` as its first-pass gate, alongside
+ * the token-document equivalent above.
+ *
+ * `cinder.resolver.json` previously used an array-of-`{name, source}` shape
+ * for `sets`/`modifiers` and a plain string array for `resolutionOrder`, while
+ * declaring the official schema's `$schema` URI. Those are genuinely different
+ * document models, not a naming quibble: the official schema keys `sets` and
+ * `modifiers` by name (`{ sources: [...] }` / `{ contexts: { [value]: sources[] } }`)
+ * and requires `resolutionOrder` entries to be `{ "$ref": "#/sets/..." }`
+ * reference objects -- see the `resolver/set.json`, `resolver/modifier.json`,
+ * and `resolver/resolutionOrder.json` definitions embedded in the vendored
+ * file. The document was migrated to the conformant shape rather than leaving
+ * this validator unwired, and a regression test pins the old shape as
+ * rejected so it cannot come back.
  */
 export function validateResolverDocumentSchema(document: unknown, source = '$'): void {
   runSchemaValidation(getResolverValidator(), document, source);

--- a/packages/components/scripts/tokens/validate.test.ts
+++ b/packages/components/scripts/tokens/validate.test.ts
@@ -1,10 +1,47 @@
 import { describe, expect, test } from 'bun:test';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
 import { TokenValidationError, type TokenDocument } from './types.ts';
 import {
+  assertValidResolverDocument,
+  assertValidTokenDocument,
   validateResolvedToken,
   validateResolverDocument,
   validateTokenDocument,
 } from './validate.ts';
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+const fixturesDirectory = join(scriptDirectory, 'fixtures');
+
+function readFixture(subdirectory: 'valid' | 'invalid', name: string): unknown {
+  return JSON.parse(readFileSync(join(fixturesDirectory, subdirectory, name), 'utf8'));
+}
+
+function fixtureNames(subdirectory: 'valid' | 'invalid'): string[] {
+  return readdirSync(join(fixturesDirectory, subdirectory))
+    .filter((name) => name.endsWith('.tokens.json'))
+    .toSorted();
+}
+
+const validFixtureNames = fixtureNames('valid');
+const invalidFixtureNames = fixtureNames('invalid');
+const DTCG_TOKEN_TYPES = [
+  'color',
+  'dimension',
+  'fontFamily',
+  'fontWeight',
+  'duration',
+  'cubicBezier',
+  'number',
+  'strokeStyle',
+  'border',
+  'transition',
+  'shadow',
+  'gradient',
+  'typography',
+];
 
 const cases: Array<{ type: NonNullable<TokenDocument['$type']>; value: unknown }> = [
   { type: 'color', value: { colorSpace: 'oklch', components: [0.5, 0.1, 255] } },
@@ -60,6 +97,40 @@ const cases: Array<{ type: NonNullable<TokenDocument['$type']>; value: unknown }
 ];
 
 describe('DTCG semantic validation', () => {
+  test('fixtures/valid covers every DTCG type Cinder claims to support', () => {
+    expect(validFixtureNames).toEqual(
+      DTCG_TOKEN_TYPES.map((type) => `${type}.tokens.json`).toSorted(),
+    );
+  });
+
+  test.each(validFixtureNames)(
+    'accepts fixtures/valid/%s through the full load-time gate',
+    (name) => {
+      expect(() =>
+        assertValidTokenDocument(readFixture('valid', name), `fixtures/valid/${name}`),
+      ).not.toThrow();
+    },
+  );
+
+  test.each(invalidFixtureNames)(
+    'rejects fixtures/invalid/%s with a named path and reason',
+    (name) => {
+      let caught: unknown;
+      try {
+        assertValidTokenDocument(readFixture('invalid', name), `fixtures/invalid/${name}`);
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(TokenValidationError);
+      const issues = (caught as TokenValidationError).issues;
+      expect(issues.length).toBeGreaterThan(0);
+      for (const issue of issues) {
+        expect(issue.path.length).toBeGreaterThan(0);
+        expect(issue.reason.length).toBeGreaterThan(0);
+      }
+    },
+  );
+
   test.each(cases)('accepts the $type value shape', ({ type, value }) => {
     expect(() => validateTokenDocument({ $type: type, sample: { $value: value } })).not.toThrow();
   });
@@ -359,53 +430,125 @@ describe('DTCG semantic validation', () => {
     expect(() =>
       validateResolverDocument({
         version: '2025.10',
-        sets: [{ name: 'base', source: ['sets/base.tokens.json'] }],
-        modifiers: [{ name: 'theme', values: ['light', 'dark'], default: 'light' }],
-        resolutionOrder: ['theme'],
+        sets: { base: { sources: [{ $ref: 'sets/base.tokens.json' }] } },
+        modifiers: {
+          theme: {
+            contexts: {
+              light: [{ $ref: 'themes/light.tokens.json' }],
+              dark: [{ $ref: 'themes/dark.tokens.json' }],
+            },
+            default: 'light',
+          },
+        },
+        resolutionOrder: [{ $ref: '#/sets/base' }, { $ref: '#/modifiers/theme' }],
       }),
     ).not.toThrow();
     expect(() =>
       validateResolverDocument({
         version: '2025.10',
-        sets: [],
-        modifiers: [],
-        resolutionOrder: ['theme'],
+        sets: {},
+        modifiers: {},
+        resolutionOrder: [{ $ref: '#/modifiers/theme' }],
       }),
-    ).toThrow('unknown modifier');
+    ).toThrow('existing set or modifier');
     expect(() =>
       validateResolverDocument({
         version: '2025.10',
-        sets: [
-          { name: 'base', source: ['sets/base.tokens.json'] },
-          { name: 'base', source: ['sets/other.tokens.json'] },
+        sets: { base: { sources: [] } },
+        modifiers: {},
+        resolutionOrder: [{ $ref: '#/sets/base' }],
+      }),
+    ).toThrow('non-empty array of $ref sources');
+    expect(() =>
+      validateResolverDocument({
+        version: '2025.10',
+        sets: { base: { sources: [{ $ref: 'sets/base.tokens.json' }] } },
+        modifiers: {
+          theme: { contexts: { light: [], dark: [{ $ref: 'themes/dark.tokens.json' }] } },
+        },
+        resolutionOrder: [{ $ref: '#/sets/base' }, { $ref: '#/modifiers/theme' }],
+      }),
+    ).toThrow('non-empty array of $ref sources');
+    expect(() =>
+      validateResolverDocument({
+        version: '2025.10',
+        sets: { base: { sources: [{ $ref: 'sets/base.tokens.json' }] } },
+        modifiers: {
+          theme: {
+            contexts: {
+              light: [{ $ref: 'themes/light.tokens.json' }],
+              dark: [{ $ref: 'themes/dark.tokens.json' }],
+            },
+          },
+        },
+        resolutionOrder: [{ $ref: '#/sets/base' }],
+      }),
+    ).toThrow('must list every set and modifier exactly once');
+    expect(() =>
+      validateResolverDocument({
+        version: '2025.10',
+        sets: { base: { sources: [{ $ref: 'sets/base.tokens.json' }] } },
+        modifiers: {
+          theme: {
+            contexts: {
+              light: [{ $ref: 'themes/light.tokens.json' }],
+              dark: [{ $ref: 'themes/dark.tokens.json' }],
+            },
+            default: 'sepia',
+          },
+        },
+        resolutionOrder: [{ $ref: '#/sets/base' }, { $ref: '#/modifiers/theme' }],
+      }),
+    ).toThrow('default must be one of its context names');
+    expect(() =>
+      validateResolverDocument({
+        version: '2025.10',
+        sets: { base: { sources: [{ $ref: 'sets/base.tokens.json' }] } },
+        modifiers: {
+          theme: {
+            contexts: {
+              light: [{ $ref: 'themes/light.tokens.json' }],
+              dark: [{ $ref: 'themes/dark.tokens.json' }],
+            },
+          },
+        },
+        resolutionOrder: [
+          { $ref: '#/sets/base' },
+          { $ref: '#/modifiers/theme' },
+          { $ref: '#/modifiers/theme' },
         ],
-        modifiers: [],
-        resolutionOrder: [],
       }),
-    ).toThrow('set names must be unique');
-    expect(() =>
-      validateResolverDocument({
-        version: '2025.10',
-        sets: [{ name: 'base', source: ['sets/base.tokens.json'] }],
-        modifiers: [{ name: 'theme', values: [] }],
-        resolutionOrder: ['theme'],
-      }),
-    ).toThrow('modifier values must not be empty');
-    expect(() =>
-      validateResolverDocument({
-        version: '2025.10',
-        sets: [{ name: 'base', source: ['sets/base.tokens.json'] }],
-        modifiers: [{ name: 'theme', values: ['light', 'dark'] }],
-        resolutionOrder: [],
-      }),
-    ).toThrow('must list every modifier exactly once');
-    expect(() =>
-      validateResolverDocument({
-        version: '2025.10',
-        sets: [{ name: 'base', source: ['sets/base.tokens.json'] }],
-        modifiers: [{ name: 'theme', values: ['light', 'light'] }],
-        resolutionOrder: ['theme'],
-      }),
-    ).toThrow('modifier values must be unique');
+    ).toThrow('resolutionOrder entries must be unique');
+  });
+
+  test('rejects the pre-2025.10-conformant array-based resolver shape Cinder used to author', () => {
+    // Regression guard: cinder.resolver.json used to declare
+    // sets/modifiers as arrays of {name, ...} objects and resolutionOrder as
+    // a plain string array. That shape never conformed to the official
+    // DTCG 2025.10 resolver schema (sets/modifiers must be objects keyed by
+    // name; resolutionOrder entries must be $ref objects) even though the
+    // file declared the official $schema URI. CIN-27 migrated the real
+    // corpus file to the conformant shape; this test locks out sliding back.
+    const oldShapeDocument = {
+      version: '2025.10',
+      sets: [{ name: 'foundation', source: ['sets/foundation.tokens.json'] }],
+      modifiers: [{ name: 'theme', values: ['light', 'dark'], default: 'light' }],
+      resolutionOrder: ['theme'],
+    };
+    let caught: unknown;
+    try {
+      assertValidResolverDocument(oldShapeDocument);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(TokenValidationError);
+    const issues = (caught as TokenValidationError).issues;
+    expect(issues.length).toBeGreaterThan(0);
+    expect(issues.some((issue) => issue.path === '$.sets' && issue.reason.includes('object'))).toBe(
+      true,
+    );
+    expect(
+      issues.some((issue) => issue.path === '$.modifiers' && issue.reason.includes('object')),
+    ).toBe(true);
   });
 });

--- a/packages/components/scripts/tokens/validate.test.ts
+++ b/packages/components/scripts/tokens/validate.test.ts
@@ -174,6 +174,19 @@ describe('DTCG semantic validation', () => {
     expect(() => validateTokenDocument({ value: { $value: 1 } })).toThrow('no $type');
   });
 
+  test('rejects a $ref token alias by name rather than as unknown metadata', () => {
+    // The official format schema accepts `$ref` in place of `$value`, but
+    // Cinder classifies tokens by `$value` alone, so the two layers disagree.
+    // Support is tracked in CIN-463; until then the rejection must say so
+    // rather than reporting a spec property as an unknown one.
+    expect(() =>
+      validateTokenDocument({
+        base: { $type: 'number', $value: 1 },
+        copy: { $ref: '#/base' },
+      }),
+    ).toThrow(/\$ref token aliases are not supported yet \(CIN-463\)/);
+  });
+
   test('accepts root tokens and rejects unknown reserved metadata', () => {
     expect(() =>
       validateTokenDocument({ group: { $type: 'number', $root: { $value: 1 } } }),

--- a/packages/components/scripts/tokens/validate.test.ts
+++ b/packages/components/scripts/tokens/validate.test.ts
@@ -174,6 +174,20 @@ describe('DTCG semantic validation', () => {
     expect(() => validateTokenDocument({ value: { $value: 1 } })).toThrow('no $type');
   });
 
+  test('attributes $root token issues to the $root location, not the enclosing group', () => {
+    // A group holding a $root usually has siblings, so reporting at the group
+    // path alone cannot tell the author which one is wrong.
+    expect(() =>
+      validateTokenDocument({
+        accent: {
+          $type: 'number',
+          $root: { $value: 1, $valu: 2 },
+          hover: { $value: 3 },
+        },
+      }),
+    ).toThrow('accent.$root: unknown reserved property $valu');
+  });
+
   test('rejects a $ref token alias by name rather than as unknown metadata', () => {
     // The official format schema accepts `$ref` in place of `$value`, but
     // Cinder classifies tokens by `$value` alone, so the two layers disagree.

--- a/packages/components/scripts/tokens/validate.ts
+++ b/packages/components/scripts/tokens/validate.ts
@@ -6,6 +6,7 @@ import type {
   ValidationIssue,
 } from './types.ts';
 import { TokenValidationError } from './types.ts';
+import { validateResolverDocumentSchema, validateTokenDocumentSchema } from './validate-schema.ts';
 
 const TOKEN_NAME_PATTERN = /^[^${}.][^{}.]*$/;
 const VENDOR_EXTENSION_PATTERN = /^(?:[a-z0-9-]+\.)+[a-z0-9-]+$/i;
@@ -47,8 +48,8 @@ const DIMENSION_MEMBERS = new Set(['value', 'unit']);
 type JsonObject = Record<string, unknown>;
 type ResolverDocumentShape = {
   version: unknown;
-  sets: unknown[];
-  modifiers: unknown[];
+  sets: JsonObject;
+  modifiers: JsonObject;
   resolutionOrder: unknown[];
 };
 const GROUP_METADATA = new Set([
@@ -506,62 +507,114 @@ export function validateResolvedToken(token: DesignToken, path: string): void {
   if (issues.length > 0) throw new TokenValidationError(issues);
 }
 
+function isResolverReference(value: unknown): value is { $ref: string } {
+  return isObject(value) && typeof value['$ref'] === 'string';
+}
+
+/**
+ * Parses a resolutionOrder entry's `$ref` (e.g. "#/sets/foundation" or
+ * "#/modifiers/theme") into its target kind and name. JSON Pointer
+ * tilde-escapes are decoded per RFC 6901; returns undefined for anything
+ * that isn't a well-formed pointer into `sets` or `modifiers`.
+ */
+function isResolverTargetKind(value: string): value is 'sets' | 'modifiers' {
+  return value === 'sets' || value === 'modifiers';
+}
+
+function resolutionOrderTarget(
+  ref: string,
+): { kind: 'sets' | 'modifiers'; name: string } | undefined {
+  const match = /^#\/(sets|modifiers)\/(.+)$/.exec(ref);
+  if (!match) return undefined;
+  const [, kind, rawName] = match;
+  if (
+    kind === undefined ||
+    rawName === undefined ||
+    !isResolverTargetKind(kind) ||
+    /~(?:[^01]|$)/.test(rawName)
+  )
+    return undefined;
+  const name = rawName.replaceAll('~1', '/').replaceAll('~0', '~');
+  return { kind, name };
+}
+
+/**
+ * Semantic checks the official DTCG 2025.10 resolver JSON Schema cannot
+ * express: `default` matching a live context key, resolutionOrder entries
+ * resolving to a set or modifier that actually exists (schema can only
+ * constrain the `$ref` string's shape, not cross-reference sibling `sets`/
+ * `modifiers` object keys), resolutionOrder covering every set and modifier
+ * exactly once, and non-empty source/context arrays.
+ */
 export function validateResolverDocument(document: ResolverDocumentShape): void {
   const issues: ValidationIssue[] = [];
   if (document.version !== '2025.10')
     addIssue(issues, '$.version', 'resolver version must be 2025.10');
-  const modifierNames = new Set<string>();
-  for (const modifier of document.modifiers) {
-    if (
-      !isObject(modifier) ||
-      typeof modifier['name'] !== 'string' ||
-      !Array.isArray(modifier['values'])
-    ) {
-      addIssue(issues, '$.modifiers', 'modifier must have a string name and string values');
+
+  const modifierNames = new Set(Object.keys(document.modifiers));
+  for (const [name, modifier] of Object.entries(document.modifiers)) {
+    if (!isObject(modifier) || !isObject(modifier['contexts'])) {
+      addIssue(issues, `$.modifiers.${name}`, 'modifier must have a contexts object');
       continue;
     }
-    const { name, values } = { name: modifier['name'], values: modifier['values'] };
-    if (!name) addIssue(issues, '$.modifiers', 'modifier names must be non-empty strings');
-    if (modifierNames.has(name))
-      addIssue(issues, `$.modifiers.${name}`, 'modifier names must be unique');
-    modifierNames.add(name);
-    if (!values.every(isString))
-      addIssue(issues, `$.modifiers.${name}`, 'modifier values must be strings');
-    if (values.length === 0)
-      addIssue(issues, `$.modifiers.${name}`, 'modifier values must not be empty');
-    if (new Set(values).size !== values.length)
-      addIssue(issues, `$.modifiers.${name}`, 'modifier values must be unique');
+    const contexts = modifier['contexts'];
+    for (const [contextName, sources] of Object.entries(contexts)) {
+      if (!Array.isArray(sources) || sources.length === 0 || !sources.every(isResolverReference))
+        addIssue(
+          issues,
+          `$.modifiers.${name}.contexts.${contextName}`,
+          'context must be a non-empty array of $ref sources',
+        );
+    }
     if (
       modifier['default'] !== undefined &&
-      (!isString(modifier['default']) || !values.includes(modifier['default']))
+      (!isString(modifier['default']) || !Object.keys(contexts).includes(modifier['default']))
     )
-      addIssue(issues, `$.modifiers.${name}`, 'modifier default must be one of its values');
+      addIssue(issues, `$.modifiers.${name}`, 'modifier default must be one of its context names');
   }
-  const setNames = new Set<string>();
-  if (document.sets.length === 0)
-    addIssue(issues, '$.sets', 'resolver must include at least one set');
-  for (const set of document.sets) {
-    if (!isObject(set) || typeof set['name'] !== 'string' || !Array.isArray(set['source'])) {
-      addIssue(issues, '$.sets', 'set must have a string name and string source array');
+
+  const setNames = new Set(Object.keys(document.sets));
+  if (setNames.size === 0) addIssue(issues, '$.sets', 'resolver must include at least one set');
+  for (const [name, set] of Object.entries(document.sets)) {
+    if (
+      !isObject(set) ||
+      !Array.isArray(set['sources']) ||
+      set['sources'].length === 0 ||
+      !set['sources'].every(isResolverReference)
+    )
+      addIssue(issues, `$.sets.${name}`, 'set must have a non-empty array of $ref sources');
+  }
+
+  const resolutionOrderTargets = new Set<string>();
+  for (const [index, entry] of document.resolutionOrder.entries()) {
+    if (!isResolverReference(entry)) {
+      addIssue(issues, `$.resolutionOrder.${index}`, 'resolutionOrder entry must be a $ref object');
       continue;
     }
-    if (!set['name']) addIssue(issues, '$.sets', 'set names must be non-empty strings');
-    if (setNames.has(set['name']))
-      addIssue(issues, `$.sets.${set['name']}`, 'set names must be unique');
-    setNames.add(set['name']);
-    if (!set['source'].every(isString))
-      addIssue(issues, `$.sets.${set['name']}`, 'set sources must be strings');
+    const target = resolutionOrderTarget(entry['$ref']);
+    if (!target || !(target.kind === 'sets' ? setNames : modifierNames).has(target.name)) {
+      addIssue(
+        issues,
+        `$.resolutionOrder.${index}`,
+        `resolutionOrder must reference an existing set or modifier: ${entry['$ref']}`,
+      );
+      continue;
+    }
+    const key = `${target.kind}/${target.name}`;
+    if (resolutionOrderTargets.has(key))
+      addIssue(issues, `$.resolutionOrder.${index}`, 'resolutionOrder entries must be unique');
+    resolutionOrderTargets.add(key);
   }
-  const resolutionOrderNames = new Set<string>();
-  for (const name of document.resolutionOrder) {
-    if (!isString(name) || !modifierNames.has(name))
-      addIssue(issues, '$.resolutionOrder', `unknown modifier ${String(name)}`);
-    else if (resolutionOrderNames.has(name))
-      addIssue(issues, '$.resolutionOrder', 'modifier names must appear only once');
-    else resolutionOrderNames.add(name);
-  }
-  if (resolutionOrderNames.size !== modifierNames.size)
-    addIssue(issues, '$.resolutionOrder', 'must list every modifier exactly once');
+  const expectedTargets = new Set([
+    ...[...setNames].map((name) => `sets/${name}`),
+    ...[...modifierNames].map((name) => `modifiers/${name}`),
+  ]);
+  if (
+    resolutionOrderTargets.size !== expectedTargets.size ||
+    [...resolutionOrderTargets].some((target) => !expectedTargets.has(target))
+  )
+    addIssue(issues, '$.resolutionOrder', 'must list every set and modifier exactly once');
+
   if (issues.length > 0) throw new TokenValidationError(issues);
 }
 
@@ -572,6 +625,10 @@ export function assertValidTokenDocument(
   const issues: ValidationIssue[] = [];
   if (!isObject(document)) addIssue(issues, source ?? '$', 'document must be an object');
   if (issues.length > 0) throw new TokenValidationError(issues);
+  // First-pass gate: the official DTCG 2025.10 format JSON Schema catches shape
+  // violations structurally, before the semantic checks below run. See
+  // validate-schema.ts for why this precedes (rather than replaces) validateTokenDocument.
+  validateTokenDocumentSchema(document, source ?? '$');
   validateTokenDocument(document, source);
 }
 
@@ -580,10 +637,15 @@ export function assertValidResolverDocument(
 ): asserts document is ResolverDocument {
   if (!isObject(document))
     throw new TokenValidationError([{ path: '$', reason: 'resolver must be an object' }]);
+  // First-pass gate: the official DTCG 2025.10 resolver JSON Schema catches
+  // shape violations structurally, before the semantic checks below run
+  // (see validate-schema.ts for why validateResolverDocumentSchema exists
+  // as a separate, explicitly-called step rather than being folded in here).
+  validateResolverDocumentSchema(document);
   if (
     document['version'] !== '2025.10' ||
-    !Array.isArray(document['sets']) ||
-    !Array.isArray(document['modifiers']) ||
+    !isObject(document['sets']) ||
+    !isObject(document['modifiers']) ||
     !Array.isArray(document['resolutionOrder'])
   )
     throw new TokenValidationError([
@@ -592,33 +654,6 @@ export function assertValidResolverDocument(
         reason: 'resolver must contain version, sets, modifiers, and resolutionOrder',
       },
     ]);
-  const issues: ValidationIssue[] = [];
-  for (const [index, set] of document['sets'].entries()) {
-    if (
-      !isObject(set) ||
-      typeof set['name'] !== 'string' ||
-      !Array.isArray(set['source']) ||
-      !set['source'].every(isString)
-    )
-      addIssue(issues, `$.sets.${index}`, 'set must have a string name and string source array');
-  }
-  for (const [index, modifier] of document['modifiers'].entries()) {
-    if (
-      !isObject(modifier) ||
-      typeof modifier['name'] !== 'string' ||
-      !Array.isArray(modifier['values']) ||
-      !modifier['values'].every(isString) ||
-      (modifier['default'] !== undefined && typeof modifier['default'] !== 'string')
-    )
-      addIssue(
-        issues,
-        `$.modifiers.${index}`,
-        'modifier must have a string name, string values, and optional string default',
-      );
-  }
-  if (!document['resolutionOrder'].every(isString))
-    addIssue(issues, '$.resolutionOrder', 'resolution order must contain strings');
-  if (issues.length > 0) throw new TokenValidationError(issues);
   validateResolverDocument({
     version: document['version'],
     sets: document['sets'],

--- a/packages/components/scripts/tokens/validate.ts
+++ b/packages/components/scripts/tokens/validate.ts
@@ -434,7 +434,7 @@ function validateGroup(
   validateMetadata(group, path, issues, isDocumentRoot);
   for (const key of Object.keys(group))
     if (key.startsWith('$') && !GROUP_METADATA.has(key))
-      addIssue(issues, path, `unknown reserved property ${key}`);
+      addIssue(issues, path, unknownReservedPropertyReason(key));
   const groupType =
     group['$type'] === undefined ? inheritedType : tokenType(group, inheritedType, path, issues);
   const mayInheritTypeThroughExtension =
@@ -451,7 +451,7 @@ function validateGroup(
         addIssue(issues, path, '$root token cannot contain child groups');
       for (const key of Object.keys(value))
         if (key.startsWith('$') && !TOKEN_METADATA.has(key))
-          addIssue(issues, path, `unknown reserved property ${key}`);
+          addIssue(issues, path, unknownReservedPropertyReason(key));
       const type =
         groupType === undefined && mayInheritTypeThroughExtension && value['$type'] === undefined
           ? undefined
@@ -480,7 +480,7 @@ function validateGroup(
       validateMetadata(value, childPath, issues);
       for (const key of Object.keys(value))
         if (key.startsWith('$') && !TOKEN_METADATA.has(key))
-          addIssue(issues, childPath, `unknown reserved property ${key}`);
+          addIssue(issues, childPath, unknownReservedPropertyReason(key));
       const type =
         groupType === undefined && mayInheritTypeThroughExtension && value['$type'] === undefined
           ? undefined
@@ -512,6 +512,20 @@ function isResolverReference(value: unknown): value is { $ref: string } {
 }
 
 /**
+ * DTCG 2025.10 allows a token to be a JSON Pointer alias via `$ref` in place of
+ * `$value`, and the official format schema accepts that shape. Cinder classifies
+ * tokens by `$value` alone -- in this file, in `resolve.ts`'s `isToken`, and in
+ * `types.ts` -- so a `$ref` token is currently read as a group with unrecognised
+ * metadata. That gap is tracked in CIN-463; until it lands, say so plainly rather
+ * than reporting a spec property as unknown.
+ */
+function unknownReservedPropertyReason(key: string): string {
+  if (key === '$ref')
+    return '$ref token aliases are not supported yet (CIN-463); author aliases as $value: "{path}" or $value: "#/path"';
+  return `unknown reserved property ${key}`;
+}
+
+/**
  * Parses a resolutionOrder entry's `$ref` (e.g. "#/sets/foundation" or
  * "#/modifiers/theme") into its target kind and name. JSON Pointer
  * tilde-escapes are decoded per RFC 6901; returns undefined for anything
@@ -524,7 +538,21 @@ function isResolverTargetKind(value: string): value is 'sets' | 'modifiers' {
 export function resolutionOrderTarget(
   ref: string,
 ): { kind: 'sets' | 'modifiers'; name: string } | undefined {
-  const match = /^#\/(sets|modifiers)\/(.+)$/.exec(ref);
+  // RFC 6901 §6 order: percent-decode the whole fragment, then split
+  // structurally on `/`, then tilde-decode the segment. Decoding before
+  // splitting is what makes `#/sets/foo%2Fbar` decode to the three-segment
+  // pointer `/sets/foo/bar` and be rejected -- a set named `foo/bar` is only
+  // addressable as `#/sets/foo~1bar` -- while `#/sets/high%20contrast`
+  // correctly names `high contrast`.
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(ref);
+  } catch {
+    return undefined;
+  }
+  // `[^/]+` rather than `.+`: an unescaped `/` makes this a deeper pointer
+  // than `#/<kind>/<name>`, not a name containing a slash.
+  const match = /^#\/(sets|modifiers)\/([^/]+)$/.exec(decoded);
   if (!match) return undefined;
   const [, kind, rawName] = match;
   if (

--- a/packages/components/scripts/tokens/validate.ts
+++ b/packages/components/scripts/tokens/validate.ts
@@ -521,7 +521,7 @@ function isResolverTargetKind(value: string): value is 'sets' | 'modifiers' {
   return value === 'sets' || value === 'modifiers';
 }
 
-function resolutionOrderTarget(
+export function resolutionOrderTarget(
   ref: string,
 ): { kind: 'sets' | 'modifiers'; name: string } | undefined {
   const match = /^#\/(sets|modifiers)\/(.+)$/.exec(ref);

--- a/packages/components/scripts/tokens/validate.ts
+++ b/packages/components/scripts/tokens/validate.ts
@@ -441,22 +441,28 @@ function validateGroup(
     inheritsTypeThroughExtension || (groupType === undefined && group['$extends'] !== undefined);
   for (const [name, value] of Object.entries(group)) {
     if (name === '$root') {
+      // A `$root` token resolves at its group's own path, but reporting issues
+      // there cannot distinguish the root token from the group that holds it --
+      // and a group with a `$root` usually has siblings too. Point at the
+      // document location instead, which is unambiguous and is where the author
+      // has to edit; the token path is that minus the trailing `.$root`.
+      const rootPath = `${path}.$root`;
       if (!isObject(value) || !('$value' in value)) {
-        addIssue(issues, path, '$root must be a token object');
+        addIssue(issues, rootPath, '$root must be a token object');
         continue;
       }
-      validateMetadata(value, path, issues);
+      validateMetadata(value, rootPath, issues);
       const nonMetadataChildren = Object.keys(value).filter((key) => !key.startsWith('$'));
       if (nonMetadataChildren.length > 0)
-        addIssue(issues, path, '$root token cannot contain child groups');
+        addIssue(issues, rootPath, '$root token cannot contain child groups');
       for (const key of Object.keys(value))
         if (key.startsWith('$') && !TOKEN_METADATA.has(key))
-          addIssue(issues, path, unknownReservedPropertyReason(key));
+          addIssue(issues, rootPath, unknownReservedPropertyReason(key));
       const type =
         groupType === undefined && mayInheritTypeThroughExtension && value['$type'] === undefined
           ? undefined
-          : tokenType(value, groupType, path, issues);
-      if (type) validateValue(type, value['$value'], path, issues);
+          : tokenType(value, groupType, rootPath, issues);
+      if (type) validateValue(type, value['$value'], rootPath, issues);
       continue;
     }
     if (name.startsWith('$')) continue;

--- a/packages/components/src/tokens/cinder.resolver.json
+++ b/packages/components/src/tokens/cinder.resolver.json
@@ -1,23 +1,33 @@
 {
   "$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json",
   "version": "2025.10",
-  "sets": [
-    {
-      "name": "foundation",
-      "source": ["sets/foundation.tokens.json", "sets/semantic.tokens.json"]
+  "sets": {
+    "foundation": {
+      "sources": [
+        { "$ref": "sets/foundation.tokens.json" },
+        { "$ref": "sets/semantic.tokens.json" }
+      ]
     }
-  ],
-  "modifiers": [
-    {
-      "name": "theme",
-      "values": ["light", "dark"],
+  },
+  "modifiers": {
+    "theme": {
+      "contexts": {
+        "light": [{ "$ref": "themes/light.tokens.json" }],
+        "dark": [{ "$ref": "themes/dark.tokens.json" }]
+      },
       "default": "light"
     },
-    {
-      "name": "motion",
-      "values": ["default", "reduced"],
+    "motion": {
+      "contexts": {
+        "default": [{ "$ref": "modes/motion-default.tokens.json" }],
+        "reduced": [{ "$ref": "modes/motion-reduced.tokens.json" }]
+      },
       "default": "default"
     }
-  ],
-  "resolutionOrder": ["theme", "motion"]
+  },
+  "resolutionOrder": [
+    { "$ref": "#/sets/foundation" },
+    { "$ref": "#/modifiers/theme" },
+    { "$ref": "#/modifiers/motion" }
+  ]
 }


### PR DESCRIPTION
Stage 2 of the DTCG 2025.10 migration. This was scoped as an audit-and-close-gaps pass over the existing `scripts/tokens/` toolchain, not a rebuild — and the audit found one substantive defect, described below.

Closes CIN-27.

## The audit found a real conformance defect

`src/tokens/cinder.resolver.json` declared `"$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json"` but did not conform to it:

| | Before | DTCG 2025.10 |
| --- | --- | --- |
| `sets` | array of `{name, source}` | object keyed by set name, each requiring `sources` |
| `modifiers` | array of `{name, values, default}` | object keyed by name, each requiring a `contexts` map (`minProperties: 2`) |
| `resolutionOrder` | array of bare modifier-name strings | array of `{"$ref": "#/sets/…"}` / `{"$ref": "#/modifiers/…"}`, sets included |
| source entries | bare string paths | reference objects, `{"$ref": "sets/foundation.tokens.json"}` |

**This PR migrates the document rather than deferring it.** Wiring up a resolver schema validator and then not applying it would leave the ticket's own delivery boundary — "schema validation against the official 2025.10 schema**s**", format *and* resolver — only half met, and the project's Done Definition requires both gates running. CIN-31 also publishes this exact file to consumers at `@lostgradient/cinder/tokens/resolver`; shipping a document that advertises a schema it violates is a defect handed downstream.

Note that this ticket's "do not modify the real corpus" constraint enumerates `src/tokens/sets/*.json`, `themes/`, and `modes/` — it does not list `cinder.resolver.json`, so this is inside the boundary. Nothing under `sets/`, `themes/`, or `modes/` is touched by this PR.

The migrated document:

```json
{
  "$schema": "https://www.designtokens.org/schemas/2025.10/resolver.json",
  "version": "2025.10",
  "sets": {
    "foundation": {
      "sources": [
        { "$ref": "sets/foundation.tokens.json" },
        { "$ref": "sets/semantic.tokens.json" }
      ]
    }
  },
  "modifiers": {
    "theme": {
      "contexts": {
        "light": [{ "$ref": "themes/light.tokens.json" }],
        "dark": [{ "$ref": "themes/dark.tokens.json" }]
      },
      "default": "light"
    },
    "motion": {
      "contexts": {
        "default": [{ "$ref": "modes/motion-default.tokens.json" }],
        "reduced": [{ "$ref": "modes/motion-reduced.tokens.json" }]
      },
      "default": "default"
    }
  },
  "resolutionOrder": [
    { "$ref": "#/sets/foundation" },
    { "$ref": "#/modifiers/theme" },
    { "$ref": "#/modifiers/motion" }
  ]
}
```

### The knock-on: modifier binding is now explicit

Previously `validate-corpus.ts` discovered which document belonged to which modifier arm by scanning each token document for `$extensions["com.lostgradient.cinder"].modifier` — a Cinder invention. In the conformant shape that binding lives in the resolver's `contexts` map, so the scanning machinery is deleted rather than kept alive:

- `modifierAssignments`, `findModifierDocument`, `findModifierDocuments` — replaced by direct `modifier.contexts[contextName]` lookup.
- `orderModifierDocuments` — a position/specificity heuristic that existed only to order marker-discovered documents. Replaced by walking the explicit `resolutionOrder` array, which is a more precise ordering signal than the heuristic ever was.

Kept and restructured, not weakened: the missing-source-on-disk check, the every-document-is-referenced check, and the full combination-and-resolve sweep over every modifier-context product.

The now-dead per-document `modifier` markers still sit in `themes/` and `modes/`; they are stripped when CIN-28 rebases, since those files belong to that ticket.

## Acceptance-criteria accounting

The ticket requires, per criterion, either an existing test cited by file and name, or a new test verified to fail before and pass after. "I read the code and it looked fine" does not count.

**1. Invalid examples fail with named errors including token path and reason.** *New.* `validate.test.ts` → `test.each(invalidFixtureNames)('rejects fixtures/invalid/%s with a named path and reason', …)`; `validate-schema.test.ts` → `'rejects an unknown colorSpace…'` and `'rejects a document missing a required composite member…'`. Fails-before verified empirically by temporarily disabling the gate: exactly the gate-dependent assertions failed, then passed again once restored.

**2. Unknown extension data round-trips byte-for-byte.** *New.* `resolve.test.ts` → `'round-trips an unrecognized $extensions vendor key byte-for-byte through validate and resolve'`. Parses a document carrying an unrecognised vendor key, runs it through load → validate → resolve, and asserts byte-identity in the resolved output.

**3. Circular aliases and `$extends` cycles fail before generation.** *Existing.* `resolve.test.ts` → `'rejects circular aliases and group extensions'`.

**4. Tests cover every DTCG type Cinder claims to support, even unused ones.** *Existing*, reinforced by new fixtures. `validate.test.ts` → `test.each(cases)('accepts the $type value shape', …)`, 14 cases across all 13 types, plus the new `fixtures/valid` (13 files) and `fixtures/invalid` (14 files) sets.

Coverage note per the ticket: `load.ts` and `types.ts` have no dedicated test files, and none was added — every criterion is covered either directly or indirectly through the four existing suites, which is what the ticket permits.

### Independently smoke-tested

Beyond the suite, the wired gates were exercised directly against the real on-disk artifacts:

```
old array-shaped resolver:      REJECTED -> $.resolutionOrder.0: must be object
migrated cinder.resolver.json:  ACCEPTED
default naming unknown context: REJECTED -> $.modifiers.theme: modifier default must be one of its context names
dimension token with em unit:   REJECTED -> $value.unit: must be one of ["px","rem"]
unknown $extensions vendor key: ACCEPTED
```

Regression guards against sliding back to the array shape: `validate.test.ts` → `'rejects the pre-2025.10-conformant array-based resolver shape Cinder used to author'` (full wired gate) and `validate-schema.test.ts` → `'rejects the pre-migration array-based resolver shape Cinder used to author'` (schema validator directly).

## Semantic checks preserved that JSON Schema cannot express

Schema validation is a first pass, not a replacement. These remain hand-rolled because JSON Schema structurally cannot express them:

- A modifier's `default` must equal one of its own `contexts` keys — the official schema's own `$comment` on that field says as much.
- Every `resolutionOrder` `$ref` must resolve to a set or modifier that actually exists; the schema can only constrain the string's shape, not cross-reference sibling object keys.
- `resolutionOrder` must cover every set and modifier exactly once, with no duplicates.
- Every `$ref` source path must exist on disk, and every document on disk must be referenced — both need filesystem access.

## Two corrections to the ticket's Follow-up section

**`ajv` is not added as a devDependency.** The Follow-up bullet assumed it was absent. It is already a **runtime** dependency of `@lostgradient/cinder` (`ajv: "^8"`), consumed by `src/components/schema-form/schema-form-validation.ts` and `src/components/json-schema-editor/json-schema-validator.ts`. A devDependency duplicate would not achieve the intended non-published isolation, because ajv already ships. `package.json` and the lockfile are untouched; resolution for `scripts/tokens/` imports is confirmed by all four verification commands exercising `validate-schema.ts`.

**Both schemas are draft-07, so plain `Ajv` handles both.** The Follow-up bullet speculated the resolver schema might be `2020-12` and need `Ajv2020`. It is not.

## Schema vendoring

Both schemas are committed under `scripts/tokens/schemas/` rather than fetched at test time, so CI stays network-independent. `schemas/README.md` records the source URLs, the retrieval date, the draft findings, and the migration history.

Worth knowing for anyone re-fetching: the `format/*` and `resolver/*` sub-schema URLs referenced via `$ref` are **not** fetchable endpoints — they return the site's HTML 404 page. They are bundled `$id` anchors inlined inside the two top-level files. Documented so the fetch attempts are not repeated.

## Note for CIN-28's corpus

The format schema's per-type discriminator can produce ambiguous `oneOf` matches for tokens relying on an **inherited** `$type` when the value shape overlaps another type's shape — observed for `strokeStyle` and for `typography`'s composite `lineHeight`. The correct fix is a local `$type` on the affected token, never weakening the gate.

## No changeset

Nothing here is published: `scripts/**` never ships, and `src/tokens/**` is not in `package.json`'s `files` array. CIN-31 is where the token surface first becomes consumable and where a changeset becomes due.

## Verification

```
bun test packages/components/scripts/tokens              # exit 0, 95 pass
bun run --filter=@lostgradient/cinder tokens:validate     # exit 0
bun run --filter=@lostgradient/cinder typecheck           # exit 0, 0 errors
bun run --filter=@lostgradient/cinder lint                # exit 0
```
