### PR TITLE
Bump Bun version pin to 1.4.0

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -84,7 +84,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: 1.3.13
+  BUN_VERSION: 1.4.0
 
 jobs:
   scope:

--- a/.github/workflows/changeset-guard.yaml
+++ b/.github/workflows/changeset-guard.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/deploy-playground.yaml
+++ b/.github/workflows/deploy-playground.yaml
@@ -85,7 +85,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BUN_VERSION: 1.3.13
+  BUN_VERSION: 1.4.0
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
   # Pass the token through the environment (quoted "$VERCEL_TOKEN" in the steps)

--- a/.github/workflows/labs-chat-room.yaml
+++ b/.github/workflows/labs-chat-room.yaml
@@ -33,7 +33,7 @@ permissions:
   contents: read
 
 env:
-  BUN_VERSION: 1.3.13
+  BUN_VERSION: 1.4.0
 
 concurrency:
   group: labs-chat-room-${{ github.ref }}

--- a/.github/workflows/main-green.yaml
+++ b/.github/workflows/main-green.yaml
@@ -22,7 +22,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name != 'push' }}
 
 env:
-  BUN_VERSION: 1.3.13
+  BUN_VERSION: 1.4.0
   # main-green is the full-execution safety net for environment/time-dependent
   # breakage on otherwise-unchanged code (nightly cron, pushes that don't touch
   # a given package). A restored .turbo cache would let turbo replay those cache

--- a/.github/workflows/main-red-watch.yaml
+++ b/.github/workflows/main-red-watch.yaml
@@ -97,7 +97,7 @@ jobs:
         if: github.event_name != 'workflow_run'
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: '1.3.13'
+          bun-version: '1.4.0'
 
       - name: Check branch protection
         id: protection

--- a/.github/workflows/release-manual.yaml
+++ b/.github/workflows/release-manual.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.4.0
 
       - name: Verify tag matches selected package version
         env:
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.4.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.4.0
 
       - name: Setup Node
         uses: actions/setup-node@v7

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  BUN_VERSION: 1.3.13
+  BUN_VERSION: 1.4.0
   TURBO_SCM_BASE: origin/${{ github.base_ref }}
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
   TURBO_TEAM: ${{ vars.TURBO_TEAM }}

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "stylelint-use-logical": "^2.1.3",
     "turbo": "2.10.5"
   },
-  "packageManager": "bun@1.3.13",
+  "packageManager": "bun@1.4.0",
   "engines": {
     "bun": ">=1.3.0"
   }


### PR DESCRIPTION
## Summary

- Bumps the pinned Bun version from `1.3.13` to `1.4.0` across every CI workflow and `package.json`'s `packageManager` field.
- Updates `package.json` (`packageManager: bun@1.4.0`) and the `BUN_VERSION` env var / `bun-version` step input in every `.github/workflows/*.yaml` file that pins Bun: `unit-tests.yaml`, `browser-tests.yaml`, `deploy-playground.yaml`, `labs-chat-room.yaml`, `main-green.yaml`, `release-manual.yaml` (two occurrences), `release.yaml`, `main-red-watch.yaml`, and `changeset-guard.yaml`.
- No other lines in these files were touched. The `engines.bun` floor (`>=1.3.0`) in `package.json` is unrelated (a minimum, not a pin) and was left as-is.
- Repo-wide search confirmed no other actual Bun version pin was missed; the only other `1.3.13` matches are historical comments, a changelog entry, and a value-agnostic test fixture, none of which affect the actual Bun version used.

## Test plan

- `grep -rn '1\.3\.13'` repo-wide confirms all ten intended pins were updated and no other real pin remains.
- `bun run lint` — exit 0 (turbo cache hits, only pre-existing warnings).
- `bun run typecheck` — exit 0 (0 errors, only pre-existing warnings).
- `bun run test` — 11112/11113 tests passed. One failure, `MegaMenu > updates explicit direction after a class or style mutation`, is a pre-existing flake unrelated to this change: it passes in isolation (both the single test and the full file), and the failure mode matches the documented cross-file `ResizeObserver`/state-bleed issue already called out in `packages/components/bunfig.toml`'s comments about serial test execution. Local `bun` was already `1.4.0` (via `mise`) before this change, and neither `bun run test` nor `bun run lint`/`typecheck` consume the `packageManager` field or the CI YAML files, so this diff cannot have caused it.