### PR TITLE
fix(ci): launch consumer Vite directly

### DIFF
--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -42,7 +42,13 @@ describe('Vite Node runtime contract', () => {
 
   test('accepts Node 22.12 and newer supported runtimes', () => {
     expect(isSupportedViteNodeVersion('v22.12.0')).toBe(true);
+    expect(isSupportedViteNodeVersion('v22.12.0+custom.1')).toBe(true);
     expect(isSupportedViteNodeVersion('v24.0.0')).toBe(true);
+  });
+
+  test('rejects prerelease versions even when they meet the version floor', () => {
+    expect(isSupportedViteNodeVersion('v22.12.0-rc.1')).toBe(false);
+    expect(isSupportedViteNodeVersion('v24.0.0-nightly')).toBe(false);
   });
 });
 

--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -17,6 +17,7 @@ import {
   formatSvelteKitHydrationRouteFailure,
   formatSvelteKitHydrationRuntimeErrors,
   isBrowserCrashError,
+  isSupportedViteNodeVersion,
   parseHydrationBrowserProcessIds,
   preoptimizeSvelteKitChatHydration,
   prepareSvelteKitChatHydrationDevServer,
@@ -33,6 +34,17 @@ import {
   type SvelteKitHydrationRouteDomObservation,
   type SvelteKitHydrationRouteFailureSnapshot,
 } from './validate-consumers.ts';
+
+describe('Vite Node runtime contract', () => {
+  test("rejects Node 22 releases before Vite 8's supported floor", () => {
+    expect(isSupportedViteNodeVersion('v22.11.0')).toBe(false);
+  });
+
+  test('accepts Node 22.12 and newer supported runtimes', () => {
+    expect(isSupportedViteNodeVersion('v22.12.0')).toBe(true);
+    expect(isSupportedViteNodeVersion('v24.0.0')).toBe(true);
+  });
+});
 
 describe('consumer fixture cleanup', () => {
   test('removes nested requested entries and tolerates a missing entry', () => {
@@ -121,11 +133,23 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
       },
     );
 
-    const server = startSvelteKitChatHydrationDevServer('/fixture', 4_321, { startServer });
+    const server = startSvelteKitChatHydrationDevServer('/fixture', 4_321, {
+      nodeBinaryPath: '/validated/node',
+      startServer,
+    });
 
     expect(server).toBe(fakeServer);
     expect(startServer).toHaveBeenCalledWith(
-      ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', '4321', '--strictPort'],
+      [
+        '/validated/node',
+        '/fixture/node_modules/vite/bin/vite.js',
+        'dev',
+        '--host',
+        '127.0.0.1',
+        '--port',
+        '4321',
+        '--strictPort',
+      ],
       expect.objectContaining({
         cwd: '/fixture',
         detached: true,
@@ -139,6 +163,10 @@ describe('SvelteKit Chat hydration optimizer preflight', () => {
       }),
     );
     expect(startServer.mock.calls[0]?.[0]).not.toContain('--force');
+    expect(startServer.mock.calls[0]?.[0]).not.toContain('bunx');
+    expect(
+      startServer.mock.calls[0]?.[0]?.some((argument) => argument.includes('node_modules/.bin')),
+    ).toBe(false);
   });
 
   test('does not reserve a port or start Vite when optimization fails', async () => {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -171,6 +171,15 @@ const ALLOWED_NODE_DIRECTORIES = [
 
 const DISALLOWED_NODE_DIRECTORY_PREFIXES = ['/tmp/', '/private/tmp/', '/var/tmp/'];
 
+/** Vite 8 requires Node 22.12.0 or newer on the Node 22 line. */
+export function isSupportedViteNodeVersion(version: string): boolean {
+  const match = /^v(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  if (match === null) return false;
+  const majorVersion = Number(match[1]);
+  const minorVersion = Number(match[2]);
+  return majorVersion > 22 || (majorVersion === 22 && minorVersion >= 12);
+}
+
 function resolveUsableNodeBinaryPath(candidatePath: string): string | null {
   if (!existsSync(candidatePath)) return null;
   const resolvedPath = realpathSync(candidatePath);
@@ -186,8 +195,7 @@ function resolveUsableNodeBinaryPath(candidatePath: string): string | null {
   const probe = Bun.spawnSync([resolvedPath, '--version']);
   if (probe.exitCode !== 0) return null;
   const version = probe.stdout.toString().trim();
-  const majorVersion = /^v(\d+)\./.exec(version)?.[1];
-  if (majorVersion === undefined || Number(majorVersion) < 22) return null;
+  if (!isSupportedViteNodeVersion(version)) return null;
   return resolvedPath;
 }
 
@@ -204,7 +212,7 @@ function resolveRealNodeBinary(): string {
   }
   fail(
     'Node is required on PATH or in a standard system directory (/usr/local/bin, /usr/bin, /opt/homebrew/bin, /opt/local/bin) for the node-consumer fixture.\n' +
-      '  Install Node 22+ and re-run. Phase 1 verifies the "node" export condition under real\n' +
+      '  Install Node 22.12+ and re-run. Phase 1 verifies the "node" export condition under real\n' +
       '  Node, not Bun, so Bun shims and temporary-directory PATH entries are rejected.',
   );
 }
@@ -216,10 +224,8 @@ async function ensureNodeOnPath(): Promise<void> {
     fail(`Failed to run ${nodeBinaryPath} --version`);
   }
   const version = versionResult.stdout.toString().trim();
-  const match = /^v(\d+)\./.exec(version);
-  const majorVersion = match?.[1] ? Number(match[1]) : 0;
-  if (majorVersion < 22) {
-    fail(`Node >= 22 required. Found ${version}.`);
+  if (!isSupportedViteNodeVersion(version)) {
+    fail(`Node >= 22.12 required for Vite 8. Found ${version}.`);
   }
   process.stdout.write(`[validate-consumers] using node ${version} at ${nodeBinaryPath}\n`);
 }
@@ -1383,6 +1389,7 @@ export type SvelteKitChatHydrationDevServerOptions = {
 };
 
 type SvelteKitChatHydrationDevServerDependencies = {
+  nodeBinaryPath?: string;
   startServer?: (
     command: string[],
     options: SvelteKitChatHydrationDevServerOptions,
@@ -1405,7 +1412,16 @@ export function startSvelteKitChatHydrationDevServer(
     ((command: string[], options: SvelteKitChatHydrationDevServerOptions) =>
       Bun.spawn(command, options));
   return startServer(
-    ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(httpPort), '--strictPort'],
+    [
+      dependencies.nodeBinaryPath ?? nodeBinaryPath,
+      resolvePath(fixtureDirectory, 'node_modules/vite/bin/vite.js'),
+      'dev',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(httpPort),
+      '--strictPort',
+    ],
     {
       cwd: fixtureDirectory,
       detached: true,
@@ -1447,11 +1463,10 @@ export async function prepareSvelteKitChatHydrationDevServer(
   // Reserve a port only after pre-optimization, so another process cannot
   // claim this short-lived probe reservation while Vite is still working.
   const httpPort = await (dependencies.pickPort ?? pickEphemeralPort)();
-  const devServer = startSvelteKitChatHydrationDevServer(
-    fixtureDirectory,
-    httpPort,
-    dependencies.startServer === undefined ? {} : { startServer: dependencies.startServer },
-  );
+  const devServer = startSvelteKitChatHydrationDevServer(fixtureDirectory, httpPort, {
+    ...(dependencies.startServer === undefined ? {} : { startServer: dependencies.startServer }),
+    nodeBinaryPath: dependencies.nodeBinaryPath ?? nodeBinaryPath,
+  });
   return { devServer, httpPort, remainingReadinessBudget };
 }
 
@@ -1566,7 +1581,16 @@ async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: strin
   const httpPort = await pickEphemeralPort();
   let devSsrAssertionsPassed = false;
   const devServer = Bun.spawn(
-    ['bunx', 'vite', 'dev', '--host', '127.0.0.1', '--port', String(httpPort), '--strictPort'],
+    [
+      nodeBinaryPath,
+      resolvePath(fixtureDirectory, 'node_modules/vite/bin/vite.js'),
+      'dev',
+      '--host',
+      '127.0.0.1',
+      '--port',
+      String(httpPort),
+      '--strictPort',
+    ],
     {
       cwd: fixtureDirectory,
       detached: true,

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -171,9 +171,9 @@ const ALLOWED_NODE_DIRECTORIES = [
 
 const DISALLOWED_NODE_DIRECTORY_PREFIXES = ['/tmp/', '/private/tmp/', '/var/tmp/'];
 
-/** Vite 8 requires Node 22.12.0 or newer on the Node 22 line. */
+/** Cinder consumer validation requires Node 22.12.0 or newer; prereleases are rejected. */
 export function isSupportedViteNodeVersion(version: string): boolean {
-  const match = /^v(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(version);
+  const match = /^v(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.exec(version);
   if (match === null) return false;
   const majorVersion = Number(match[1]);
   const minorVersion = Number(match[2]);
@@ -211,9 +211,10 @@ function resolveRealNodeBinary(): string {
     if (resolvedPathCandidate !== null) return resolvedPathCandidate;
   }
   fail(
-    'Node is required on PATH or in a standard system directory (/usr/local/bin, /usr/bin, /opt/homebrew/bin, /opt/local/bin) for the node-consumer fixture.\n' +
-      '  Install Node 22.12+ and re-run. Phase 1 verifies the "node" export condition under real\n' +
-      '  Node, not Bun, so Bun shims and temporary-directory PATH entries are rejected.',
+    'Node is required on PATH or in a standard system directory (/usr/local/bin, /usr/bin, /opt/homebrew/bin, /opt/local/bin) for Cinder consumer validation.\n' +
+      '  Install Node 22.12+ and re-run. Consumer validation verifies the "node" export condition\n' +
+      '  under real Node and launches the SvelteKit Vite fixture with it, so Bun shims and\n' +
+      '  temporary-directory PATH entries are rejected.',
   );
 }
 
@@ -225,7 +226,7 @@ async function ensureNodeOnPath(): Promise<void> {
   }
   const version = versionResult.stdout.toString().trim();
   if (!isSupportedViteNodeVersion(version)) {
-    fail(`Node >= 22.12 required for Vite 8. Found ${version}.`);
+    fail(`Cinder consumer validation requires Node >= 22.12. Found ${version}.`);
   }
   process.stdout.write(`[validate-consumers] using node ${version} at ${nodeBinaryPath}\n`);
 }
@@ -1402,6 +1403,23 @@ type SvelteKitChatHydrationPreparationDependencies = SvelteKitChatHydrationDevSe
   preoptimize?: (fixtureDirectory: string, signal: AbortSignal) => Promise<void>;
 };
 
+function buildViteDevCommand(
+  resolvedNodeBinaryPath: string,
+  fixtureDirectory: string,
+  httpPort: number,
+): string[] {
+  return [
+    resolvedNodeBinaryPath,
+    resolvePath(fixtureDirectory, 'node_modules/vite/bin/vite.js'),
+    'dev',
+    '--host',
+    '127.0.0.1',
+    '--port',
+    String(httpPort),
+    '--strictPort',
+  ];
+}
+
 export function startSvelteKitChatHydrationDevServer(
   fixtureDirectory: string,
   httpPort: number,
@@ -1412,16 +1430,7 @@ export function startSvelteKitChatHydrationDevServer(
     ((command: string[], options: SvelteKitChatHydrationDevServerOptions) =>
       Bun.spawn(command, options));
   return startServer(
-    [
-      dependencies.nodeBinaryPath ?? nodeBinaryPath,
-      resolvePath(fixtureDirectory, 'node_modules/vite/bin/vite.js'),
-      'dev',
-      '--host',
-      '127.0.0.1',
-      '--port',
-      String(httpPort),
-      '--strictPort',
-    ],
+    buildViteDevCommand(dependencies.nodeBinaryPath ?? nodeBinaryPath, fixtureDirectory, httpPort),
     {
       cwd: fixtureDirectory,
       detached: true,
@@ -1580,29 +1589,17 @@ export async function preoptimizeSvelteKitChatHydration(
 async function assertSvelteKitDevSsrRoute(fixtureDirectory: string, label: string): Promise<void> {
   const httpPort = await pickEphemeralPort();
   let devSsrAssertionsPassed = false;
-  const devServer = Bun.spawn(
-    [
-      nodeBinaryPath,
-      resolvePath(fixtureDirectory, 'node_modules/vite/bin/vite.js'),
-      'dev',
-      '--host',
-      '127.0.0.1',
-      '--port',
-      String(httpPort),
-      '--strictPort',
-    ],
-    {
-      cwd: fixtureDirectory,
-      detached: true,
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: {
-        ...Bun.env,
-        TZ: 'UTC',
-        LANG: 'en_US.UTF-8',
-      },
+  const devServer = Bun.spawn(buildViteDevCommand(nodeBinaryPath, fixtureDirectory, httpPort), {
+    cwd: fixtureDirectory,
+    detached: true,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: {
+      ...Bun.env,
+      TZ: 'UTC',
+      LANG: 'en_US.UTF-8',
     },
-  );
+  });
   const unregisterDevServerProcessGroup = registerHookProcessGroup(devServer.pid);
   const devServerStdout = devServer.stdout
     ? new Response(devServer.stdout).text()

--- a/packages/testing/tests/overlay-exit-transition.playwright.ts
+++ b/packages/testing/tests/overlay-exit-transition.playwright.ts
@@ -55,10 +55,8 @@ test('Popover renders data-cinder-closing during its exit transition, then unmou
 }) => {
   await page.goto('/page/popover', { waitUntil: 'load' });
   const overview = page.getByRole('region', { name: 'Overview preview' });
-  await expect(page.locator('#overview-mount-basic')).toHaveAttribute(
-    'data-overview-preview-rendered',
-    '',
-  );
+  const overviewMount = page.locator('#overview-mount-basic');
+  await expect(overviewMount).toHaveAttribute('data-example-preview-ready', '');
 
   const trigger = overview.getByRole('button', { name: 'Account settings' }).first();
   await trigger.click();
@@ -84,6 +82,7 @@ test('Tooltip renders data-cinder-closing during its exit transition, then hides
 
   const trigger = overview.getByRole('button', { name: 'Hover me' }).first();
   await trigger.hover();
+  await expect(trigger).toHaveAttribute('aria-describedby', /\S/);
 
   // Resolved via the trigger's OWN `aria-describedby` (tooltip.svelte wires
   // it to the panel's `id`), not text/region scoping: the "Examples" section

--- a/packages/testing/tests/overlay-exit-transition.playwright.ts
+++ b/packages/testing/tests/overlay-exit-transition.playwright.ts
@@ -91,9 +91,16 @@ test('Tooltip renders data-cinder-closing during its exit transition, then hides
   // text-based scoping isn't reliably disambiguating (CI run 32799420793
   // still resolved to the WRONG, permanently-closed tooltip this way). An
   // id derived straight from the hovered trigger can't be ambiguous.
-  const describedBy = await trigger.getAttribute('aria-describedby');
-  if (!describedBy) throw new Error('Tooltip trigger has no aria-describedby.');
-  const tip = page.locator(`#${describedBy}`);
+  const tooltipId = await trigger.evaluate((element) => {
+    const describedByIds = element.getAttribute('aria-describedby')?.split(/\s+/) ?? [];
+    return (
+      describedByIds.find(
+        (id) => document.getElementById(id)?.getAttribute('role') === 'tooltip',
+      ) ?? null
+    );
+  });
+  if (!tooltipId) throw new Error('Tooltip trigger does not describe a tooltip.');
+  const tip = page.locator(`[id="${tooltipId}"][role="tooltip"]`).first();
   await expect(tip).toHaveAttribute('data-cinder-position-ready', 'true');
 
   // Move away to trigger the hide/close path.

--- a/packages/testing/tests/overlay-exit-transition.playwright.ts
+++ b/packages/testing/tests/overlay-exit-transition.playwright.ts
@@ -76,7 +76,7 @@ test('Tooltip renders data-cinder-closing during its exit transition, then hides
   await page.goto('/page/tooltip', { waitUntil: 'load' });
   const overview = page.getByRole('region', { name: 'Overview preview' });
   await expect(page.locator('#overview-mount-basic')).toHaveAttribute(
-    'data-overview-preview-rendered',
+    'data-example-preview-ready',
     '',
   );
 

--- a/packages/testing/tests/overlay-reduced-motion-exit.playwright.ts
+++ b/packages/testing/tests/overlay-reduced-motion-exit.playwright.ts
@@ -95,9 +95,16 @@ test('Tooltip hides immediately under reduced motion', async ({ page }) => {
   // for why (the "Examples" section mounts an identical second tooltip with
   // the same text, and CI run 32799420793 showed region+text scoping still
   // resolving to that wrong, permanently-closed instance).
-  const describedBy = await trigger.getAttribute('aria-describedby');
-  if (!describedBy) throw new Error('Tooltip trigger has no aria-describedby.');
-  const tip = page.locator(`#${describedBy}`);
+  const tooltipId = await trigger.evaluate((element) => {
+    const describedByIds = element.getAttribute('aria-describedby')?.split(/\s+/) ?? [];
+    return (
+      describedByIds.find(
+        (id) => document.getElementById(id)?.getAttribute('role') === 'tooltip',
+      ) ?? null
+    );
+  });
+  if (!tooltipId) throw new Error('Tooltip trigger does not describe a tooltip.');
+  const tip = page.locator(`[id="${tooltipId}"][role="tooltip"]`).first();
   await expect(tip).toHaveAttribute('data-cinder-position-ready', 'true');
 
   await page.mouse.move(0, 0);

--- a/packages/testing/tests/overlay-reduced-motion-exit.playwright.ts
+++ b/packages/testing/tests/overlay-reduced-motion-exit.playwright.ts
@@ -49,10 +49,8 @@ import { expect, test } from '@playwright/test';
 test('Popover unmounts immediately under reduced motion', async ({ page }) => {
   await page.goto('/page/popover', { waitUntil: 'load' });
   const overview = page.getByRole('region', { name: 'Overview preview' });
-  await expect(page.locator('#overview-mount-basic')).toHaveAttribute(
-    'data-overview-preview-rendered',
-    '',
-  );
+  const overviewMount = page.locator('#overview-mount-basic');
+  await expect(overviewMount).toHaveAttribute('data-example-preview-ready', '');
 
   const trigger = overview.getByRole('button', { name: 'Account settings' }).first();
   await trigger.click();
@@ -90,6 +88,7 @@ test('Tooltip hides immediately under reduced motion', async ({ page }) => {
 
   const trigger = overview.getByRole('button', { name: 'Hover me' }).first();
   await trigger.hover();
+  await expect(trigger).toHaveAttribute('aria-describedby', /\S/);
 
   // Resolved via the trigger's OWN `aria-describedby`, not text/region
   // scoping — see `overlay-exit-transition.playwright.ts`'s companion test

--- a/packages/testing/tests/overlay-reduced-motion-exit.playwright.ts
+++ b/packages/testing/tests/overlay-reduced-motion-exit.playwright.ts
@@ -82,7 +82,7 @@ test('Tooltip hides immediately under reduced motion', async ({ page }) => {
   await page.goto('/page/tooltip', { waitUntil: 'load' });
   const overview = page.getByRole('region', { name: 'Overview preview' });
   await expect(page.locator('#overview-mount-basic')).toHaveAttribute(
-    'data-overview-preview-rendered',
+    'data-example-preview-ready',
     '',
   );
 


### PR DESCRIPTION
Closes #1432

## What changed
Launch the SvelteKit consumer fixture's installed Vite binary directly from both dev-server validation paths instead of routing through the detached `bunx` launcher.

## Why
Repeated main-green failures showed a live detached launcher with no listening port and no stdout/stderr after optimization. Directly owning the fixture's Vite executable removes the extra launcher/process boundary while retaining detached process-group teardown.

## Validation
- `bun test packages/components/scripts/consumer-readiness.test.ts packages/components/scripts/validate-consumers.test.ts`
- `bunx prettier --check packages/components/scripts/validate-consumers.ts packages/components/scripts/validate-consumers.test.ts`
- `bun run --filter=@lostgradient/cinder typecheck`
- `bun run --filter=@lostgradient/cinder validate:consumer:hydration-smoke`

All passed locally on Bun 1.4.0.