### PR TITLE
fix(tokens): harden the generator against divergent overrides and pipe corruption

### DIFF
--- a/packages/components/scripts/tokens/generate-artifacts.test.ts
+++ b/packages/components/scripts/tokens/generate-artifacts.test.ts
@@ -753,3 +753,100 @@ describe('CIN-30 review round 14', () => {
     );
   });
 });
+
+describe('CIN-470: toTableCell escapes pipes by backslash parity, not unconditionally', () => {
+  /**
+   * Counts the STRUCTURAL number of GFM column delimiters in a row: a `|` is a
+   * delimiter unless it is preceded by an odd run of backslashes (GFM's own
+   * left-to-right backslash pairing -- the same rule `toTableCell` targets),
+   * in which case it is an escaped, literal pipe inside a cell. Asserting this
+   * count -- not a literal backslash count in the row's text, which is easy to
+   * miscount by hand -- is what actually proves the row is well-formed.
+   */
+  function countRowDelimiters(row: string): number {
+    let count = 0;
+    let backslashRun = 0;
+    for (const character of row) {
+      if (character === '\\') {
+        backslashRun += 1;
+        continue;
+      }
+      if (character === '|' && backslashRun % 2 === 0) count += 1;
+      backslashRun = 0;
+    }
+    return count;
+  }
+
+  // `cssRecipe` is emitted verbatim by `serializeEntryValue` (cssRecipe > alias >
+  // typed `$value`, see generate.ts), so it is the clean way to inject an exact
+  // string into a cell without a typed `$value`/serialization detour.
+  function recipeEntry(
+    path: string,
+    cssProperty: string,
+    cssRecipe: string,
+  ): [string, CorpusEntry] {
+    return [
+      path,
+      {
+        path,
+        value: undefined,
+        type: 'color',
+        description: undefined,
+        cssProperty,
+        cssRecipe,
+      },
+    ];
+  }
+
+  function tableSection(cssProperty: string): DocSection {
+    return { slug: 'pipe-test', headings: ['Pipe test'], cssProperties: [cssProperty] };
+  }
+
+  function rowFor(table: string, cssProperty: string): string {
+    const row = table.split('\n').find((line) => line.includes(cssProperty));
+    if (!row) throw new Error(`No row found for "${cssProperty}" in:\n${table}`);
+    return row;
+  }
+
+  test('a bare pipe still produces a well-formed 3-column row (4 delimiters)', async () => {
+    const baseIndex = new Map<string, CorpusEntry>([
+      recipeEntry('test.bare', '--test-bare', 'foo|bar'),
+    ]);
+    const table = await renderDocTable(tableSection('--test-bare'), baseIndex, (value) => value);
+    expect(countRowDelimiters(rowFor(table, '--test-bare'))).toBe(4);
+  });
+
+  test('a value already containing an escaped pipe is not double-escaped into a malformed row', async () => {
+    // Pre-fix, `.replaceAll('|', '\\|')` turned this already-escaped `foo\|bar`
+    // into `foo\\|bar`: GFM reads the leading `\\` as an escaped backslash,
+    // leaving the `|` a live, unescaped column delimiter -- a 5-delimiter row
+    // the drift parser (`extractDocTokens`) still silently accepted.
+    const baseIndex = new Map<string, CorpusEntry>([
+      recipeEntry('test.escaped', '--test-escaped', 'foo\\|bar'),
+    ]);
+    const table = await renderDocTable(tableSection('--test-escaped'), baseIndex, (value) => value);
+    expect(countRowDelimiters(rowFor(table, '--test-escaped'))).toBe(4);
+  });
+
+  test('both cases decode back to their original values through the drift parser inverse', async () => {
+    // Mirrors `tokens-doc-drift.test.ts`'s `extractDocTokens` decode exactly,
+    // so this test fails the same way that test would if the two sides ever
+    // disagreed again.
+    const decode = (body: string): string =>
+      body.replace(
+        /(\\*)\|/g,
+        (_match, backslashes: string) => '\\'.repeat(Math.floor(backslashes.length / 2)) + '|',
+      );
+
+    for (const raw of ['foo|bar', 'foo\\|bar']) {
+      const baseIndex = new Map<string, CorpusEntry>([recipeEntry('test.rt', '--test-rt', raw)]);
+      const table = await renderDocTable(tableSection('--test-rt'), baseIndex, (value) => value);
+      const row = rowFor(table, '--test-rt');
+      // Extract the value cell's code-span body the same way extractDocTokens
+      // does: everything between the second pair of backtick-delimited cells.
+      const cellMatch = /\|\s*`--test-rt`\s*\|\s*`(.+?)`\s*\|/.exec(row);
+      expect(cellMatch?.[1]).toBeDefined();
+      expect(decode(cellMatch![1]!)).toBe(raw);
+    }
+  });
+});

--- a/packages/components/scripts/tokens/generate-artifacts.ts
+++ b/packages/components/scripts/tokens/generate-artifacts.ts
@@ -612,11 +612,37 @@ function toCodeSpan(content: string): string {
   return `${fence}${padding}${content}${padding}${fence}`;
 }
 
+/**
+ * Escapes a `|` in a cell body so GFM always reads it as a literal pipe, never a
+ * column delimiter -- WITHOUT double-escaping a value that already contains a
+ * `\|` (a value that, taken alone, is itself a legally-escaped pipe).
+ *
+ * Unconditionally appending a backslash (`.replaceAll('|', '\\|')`, this
+ * function's predecessor) turns an already-escaped `foo\|bar` into
+ * `foo\\|bar`: GFM's left-to-right backslash pairing reads the two leading
+ * backslashes as one escaped backslash, leaving the `|` unescaped after all --
+ * a malformed row (see this file's git history for the CIN-470 fix, and
+ * `tokens-doc-drift.test.ts`'s `extractDocTokens`, which decodes the inverse
+ * of exactly this).
+ *
+ * Naively conditioning on "escape only when the existing run is already odd"
+ * is not the fix: `foo|bar` (0 backslashes) and `foo\|bar` (1 backslash) would
+ * both then encode to the identical cell text `foo\|bar`, which no decoder can
+ * un-collapse back to two different originals -- and `tokens-doc-drift.test.ts`
+ * must decode ANY corpus value back to itself, not just the ones the corpus
+ * happens to contain today. So the run of backslashes immediately preceding
+ * each `|` is DOUBLED first (protecting every backslash that was already
+ * there, the same way any backslash-escaping scheme must protect its own
+ * escape character) and only THEN is the escaping backslash for the pipe
+ * itself appended -- a run of length `k` becomes `2k + 1`, always odd (GFM
+ * escaped), and losslessly invertible: `extractDocTokens` recovers `k` as
+ * `(2k + 1 - 1) / 2`.
+ */
 function toTableCell(text: string): string {
   return text
     .replaceAll(/\s*[\r\n]\s*/g, ' ')
     .trim()
-    .replaceAll('|', '\\|');
+    .replace(/(\\*)\|/g, (_match, backslashes: string) => `${backslashes}${backslashes}\\|`);
 }
 
 export async function renderDocTable(

--- a/packages/components/scripts/tokens/generate-artifacts.ts
+++ b/packages/components/scripts/tokens/generate-artifacts.ts
@@ -645,18 +645,31 @@ function toTableCell(text: string): string {
     .replace(/(\\*)\|/g, (_match, backslashes: string) => `${backslashes}${backslashes}\\|`);
 }
 
-// Known gap, tracked in CIN-488: this pipe-escaping is correct for the plain-text
-// `description` column, but `renderDocTable` below also runs the `cssProperty`
-// and `value` columns through it before wrapping them in a code span
-// (`toCodeSpan`). A pipe inside a code span never needs escaping (GFM table
-// parsers respect code-span boundaries when splitting on `|`), and escapes
-// aren't interpreted inside one -- so the inserted backslashes render as
-// LITERAL characters, corrupting a value like `foo\|bar` into a visible
-// `foo\\\|bar`. Deferred rather than reworked this late in review: fixing it
-// means splitting this function's newline-normalization (shared) from its
-// pipe-escaping (description-only) and updating `tokens-doc-drift.test.ts`'s
-// decoder to match; nothing in the real corpus contains a `\` or `|` in any
-// value today.
+// Known gap, tracked in CIN-488: the GFM spec's own table example (a pipe
+// inside a code span, escaped as `` `\|` ``) confirms this escaping IS
+// required -- a code span does not protect a cell's `|` from being read as a
+// column delimiter, so `toCodeSpan`'s callers below are right to escape
+// first. But CommonMark also never interprets backslash escapes INSIDE a
+// code span (its content renders exactly as written), so the escaping
+// backslashes this function inserts to survive row-splitting are never
+// consumed -- they render as literal characters in the `cssProperty`/`value`
+// columns. A value's escaping thus becomes visible in the rendered doc: one
+// backslash in the source value (`foo\|bar`) displays as three
+// (`foo\\\|bar`) once GFM's row-split escaping and this function's own
+// escaping compose. This is a structural GFM limitation (escaping a pipe for
+// row-splitting and displaying that pipe unescaped inside a code span are
+// mutually exclusive), not a simple bug -- there is no encoding of this
+// function's output that both survives row-splitting AND renders back to the
+// exact original bytes inside a code span. `tokens-doc-drift.test.ts`'s
+// decoder still round-trips correctly (it reads the MARKDOWN SOURCE, not the
+// rendered HTML), so no corpus value is silently corrupted -- only a human
+// reading the rendered `docs/tokens.md` page would see the extra
+// backslashes. Deferred rather than reworked this late in review: nothing in
+// the real corpus contains a `\` or `|` in any value today, and a real fix
+// means choosing a different rendering strategy for such values (e.g.
+// falling back to the description column's plain-escaped style instead of a
+// code span) rather than a change to this function's escaping math, which is
+// already correct for its actual job of keeping row-splitting safe.
 
 export async function renderDocTable(
   section: DocSection,

--- a/packages/components/scripts/tokens/generate-artifacts.ts
+++ b/packages/components/scripts/tokens/generate-artifacts.ts
@@ -645,6 +645,19 @@ function toTableCell(text: string): string {
     .replace(/(\\*)\|/g, (_match, backslashes: string) => `${backslashes}${backslashes}\\|`);
 }
 
+// Known gap, tracked in CIN-488: this pipe-escaping is correct for the plain-text
+// `description` column, but `renderDocTable` below also runs the `cssProperty`
+// and `value` columns through it before wrapping them in a code span
+// (`toCodeSpan`). A pipe inside a code span never needs escaping (GFM table
+// parsers respect code-span boundaries when splitting on `|`), and escapes
+// aren't interpreted inside one -- so the inserted backslashes render as
+// LITERAL characters, corrupting a value like `foo\|bar` into a visible
+// `foo\\\|bar`. Deferred rather than reworked this late in review: fixing it
+// means splitting this function's newline-normalization (shared) from its
+// pipe-escaping (description-only) and updating `tokens-doc-drift.test.ts`'s
+// decoder to match; nothing in the real corpus contains a `\` or `|` in any
+// value today.
+
 export async function renderDocTable(
   section: DocSection,
   baseIndex: Map<string, CorpusEntry>,

--- a/packages/components/scripts/tokens/generate.test.ts
+++ b/packages/components/scripts/tokens/generate.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
 
 import {
+  assertResolutionOrderMatchesCssBlockStructure,
   assertUniqueCssProperties,
+  assertUniqueOverrideCssProperties,
   buildGeneratedOutputs,
   buildResolvedContexts,
   buildTokensBaseCss,
@@ -1768,5 +1770,220 @@ describe('CIN-30 review round 14: the uniqueness key includes $type', () => {
     ]);
 
     expect(() => assertUniqueCssProperties(entries)).not.toThrow();
+  });
+});
+
+describe('CIN-469 finding 3: the uniqueness guard runs per override block, not only on baseIndex', () => {
+  function overrideEntry(path: string, value: number): CorpusEntry {
+    return {
+      path,
+      value,
+      type: 'number',
+      description: undefined,
+      // Deliberately undefined -- an override document typically restates only
+      // `$value`, not the inherited `cssProperty` extension. The guard has to
+      // resolve it from `baseIndex`, or every override entry is silently
+      // skipped as property-less.
+      cssProperty: undefined,
+      cssRecipe: undefined,
+    };
+  }
+
+  test('two override entries sharing a base cssProperty with DIFFERENT override values are rejected', () => {
+    const baseIndex = new Map<string, CorpusEntry>([
+      ['swatch.a', { ...overrideEntry('swatch.a', 1), cssProperty: '--test-swatch' }],
+      ['alias.a', { ...overrideEntry('alias.a', 1), cssProperty: '--test-swatch' }],
+    ]);
+    // `$extends` gave these two base paths the SAME cssProperty with IDENTICAL
+    // base values -- assertUniqueCssProperties already lets that through (see
+    // "G1: one cssProperty shared with an IDENTICAL value is allowed" above).
+    // A theme override then explicitly diverges them.
+    const darkOverrides = new Map<string, CorpusEntry>([
+      ['swatch.a', overrideEntry('swatch.a', 2)],
+      ['alias.a', overrideEntry('alias.a', 3)],
+    ]);
+
+    expect(() => assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark')).toThrow(
+      /\[theme\.dark\].*--test-swatch is claimed with conflicting values/,
+    );
+  });
+
+  test('only ONE of two cssProperty-sharing paths being overridden is not a conflict', () => {
+    const baseIndex = new Map<string, CorpusEntry>([
+      ['swatch.a', { ...overrideEntry('swatch.a', 1), cssProperty: '--test-swatch' }],
+      ['alias.a', { ...overrideEntry('alias.a', 1), cssProperty: '--test-swatch' }],
+    ]);
+    const darkOverrides = new Map<string, CorpusEntry>([
+      ['swatch.a', overrideEntry('swatch.a', 2)],
+    ]);
+
+    expect(() =>
+      assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark'),
+    ).not.toThrow();
+  });
+
+  test('the full buildTokensBaseCss pipeline rejects a theme override that diverges two $extends-shared paths', async () => {
+    const colorValue = (lightness: number) => ({
+      colorSpace: 'oklch',
+      components: [lightness, 0.1, 250],
+    });
+    const baseDocument: TokenDocument = {
+      swatch: {
+        $type: 'color',
+        a: {
+          $value: colorValue(0.5),
+          $extensions: { 'com.lostgradient.cinder': { cssProperty: '--test-shared-swatch' } },
+        },
+      },
+      // No own "a" key: an EMPTY "a: {}" would itself be a (childless) token
+      // GROUP, not an absent member, so `resolveExtends`'s "copy missing
+      // members" branch would skip it (the group already "has" a, even though
+      // it is empty) and `alias.a` would never inherit swatch.a's identity.
+      alias: { $extends: '{swatch}' },
+    };
+    const themeDarkDocument: TokenDocument = {
+      swatch: { a: { $value: colorValue(0.2) } },
+      alias: { a: { $value: colorValue(0.9) } },
+    };
+    const resolver: ResolverDocument = {
+      version: '2025.10',
+      sets: { foundation: { sources: [{ $ref: 'base.json' }] } },
+      modifiers: {
+        theme: {
+          contexts: { light: [{ $ref: 'theme-light.json' }], dark: [{ $ref: 'theme-dark.json' }] },
+          default: 'light',
+        },
+        motion: {
+          contexts: {
+            default: [{ $ref: 'motion-default.json' }],
+            reduced: [{ $ref: 'motion-default.json' }],
+            'forced-reduced-motion': [{ $ref: 'motion-default.json' }],
+          },
+          default: 'default',
+        },
+      },
+      resolutionOrder: [
+        { $ref: '#/sets/foundation' },
+        { $ref: '#/modifiers/theme' },
+        { $ref: '#/modifiers/motion' },
+      ],
+    };
+    const documentsByPath = new Map<string, TokenDocument>([
+      ['base.json', baseDocument],
+      ['theme-light.json', {}],
+      ['theme-dark.json', themeDarkDocument],
+      ['motion-default.json', {}],
+    ]);
+
+    await expect(buildTokensBaseCss(resolver, documentsByPath)).rejects.toThrow(
+      /\[theme\.dark\].*--test-shared-swatch is claimed with conflicting values/,
+    );
+  });
+});
+
+describe('CIN-469 finding 4: a $root JSON Pointer alias normalizes like a group.base one', () => {
+  // Mirrors resolve.test.ts's "resolves a property-level JSON Pointer through a
+  // group's $root token" and "resolves #/$root/$value against the document-level
+  // $root" fixtures (lines 77-78 and 86-87) -- both forms tokens:validate accepts.
+  test("#/group/$root/$value resolves against the group's own path", () => {
+    const baseIndex = new Map<string, CorpusEntry>([
+      [
+        'group',
+        {
+          path: 'group',
+          value: 1,
+          type: 'number',
+          description: undefined,
+          cssProperty: '--test-group-root',
+          cssRecipe: undefined,
+        },
+      ],
+    ]);
+    expect(resolveAlias('#/group/$root/$value', baseIndex)).toBe('var(--test-group-root)');
+  });
+
+  test('#/$root/$value resolves against the document-level root (empty path)', () => {
+    const baseIndex = new Map<string, CorpusEntry>([
+      [
+        '',
+        {
+          path: '',
+          value: 1,
+          type: 'number',
+          description: undefined,
+          cssProperty: '--test-document-root',
+          cssRecipe: undefined,
+        },
+      ],
+    ]);
+    expect(resolveAlias('#/$root/$value', baseIndex)).toBe('var(--test-document-root)');
+  });
+
+  test('#/group/$root with no trailing /$value is left to fail the lookup, not silently normalized', () => {
+    // Unlike the /$value form above, a bare `#/group/$root` names the token
+    // OBJECT (resolve.ts resolves it as such), not its `$value` -- normalizing
+    // it here would make the generator accept a shape tokens:validate does not
+    // treat as a whole-token value alias.
+    const baseIndex = new Map<string, CorpusEntry>([
+      [
+        'group',
+        {
+          path: 'group',
+          value: 1,
+          type: 'number',
+          description: undefined,
+          cssProperty: '--test-group-root',
+          cssRecipe: undefined,
+        },
+      ],
+    ]);
+    expect(() => resolveAlias('#/group/$root', baseIndex)).toThrow(
+      /does not resolve to a base token/,
+    );
+  });
+});
+
+describe('CIN-469 finding 5: resolutionOrder is validated against the fixed CSS block structure', () => {
+  function resolverWithOrder(refs: string[]): ResolverDocument {
+    return {
+      version: '2025.10',
+      sets: { foundation: { sources: [{ $ref: 'base.json' }] } },
+      modifiers: {
+        theme: { contexts: { light: [{ $ref: 'theme.json' }] }, default: 'light' },
+        motion: { contexts: { default: [{ $ref: 'motion.json' }] }, default: 'default' },
+      },
+      resolutionOrder: refs.map((ref) => ({ $ref: ref })),
+    };
+  }
+
+  test('the corpus resolutionOrder (foundation, theme, motion) passes', () => {
+    const resolver = resolverWithOrder([
+      '#/sets/foundation',
+      '#/modifiers/theme',
+      '#/modifiers/motion',
+    ]);
+    expect(() => assertResolutionOrderMatchesCssBlockStructure(resolver)).not.toThrow();
+  });
+
+  test('motion before theme is rejected -- tokens-base.css always emits theme blocks first', () => {
+    const resolver = resolverWithOrder([
+      '#/sets/foundation',
+      '#/modifiers/motion',
+      '#/modifiers/theme',
+    ]);
+    expect(() => assertResolutionOrderMatchesCssBlockStructure(resolver)).toThrow(
+      /"motion" before "theme"/,
+    );
+  });
+
+  test('a modifier before a set is rejected -- :root always assembles every "sets" entry unconditionally', () => {
+    const resolver = resolverWithOrder([
+      '#/modifiers/theme',
+      '#/sets/foundation',
+      '#/modifiers/motion',
+    ]);
+    expect(() => assertResolutionOrderMatchesCssBlockStructure(resolver)).toThrow(
+      /interleaves a "sets" entry after a "modifiers" entry/,
+    );
   });
 });

--- a/packages/components/scripts/tokens/generate.test.ts
+++ b/packages/components/scripts/tokens/generate.test.ts
@@ -1882,6 +1882,29 @@ describe('CIN-469 finding 3: the uniqueness guard runs per override block, not o
     );
   });
 
+  test('an override restating a DIFFERENT cssProperty than its base is still compared under the base property, matching emission', () => {
+    // `renderOverrideDeclarations` always emits an override under its BASE
+    // token's `cssProperty` -- it never honors a `cssProperty` an override
+    // document happens to restate. Here "alias.a" restates "--test-other"
+    // instead of its base "--test-swatch", but generation still writes it
+    // to "--test-swatch". Grouping/resolving by the override's own restated
+    // property would wrongly treat "alias.a" as claiming "--test-other" and
+    // miss that it actually collides with "swatch.a" on "--test-swatch".
+    const baseIndex = new Map<string, CorpusEntry>([
+      ['swatch.a', { ...overrideEntry('swatch.a', 1), cssProperty: '--test-swatch' }],
+      ['alias.a', { ...overrideEntry('alias.a', 1), cssProperty: '--test-swatch' }],
+    ]);
+    const darkOverrides = new Map<string, CorpusEntry>([
+      ['alias.a', { ...overrideEntry('alias.a', 2), cssProperty: '--test-other' }],
+    ]);
+
+    expect(() =>
+      assertUniqueOverrideCssProperties(darkOverrides, baseIndex, baseIndex, 'theme.dark'),
+    ).toThrow(
+      /\[theme\.dark\].*--test-swatch is claimed with conflicting values by alias\.a, swatch\.a/,
+    );
+  });
+
   test('the full buildTokensBaseCss pipeline rejects a theme override that diverges two $extends-shared paths', async () => {
     const colorValue = (lightness: number) => ({
       colorSpace: 'oklch',

--- a/packages/components/scripts/tokens/generate.test.ts
+++ b/packages/components/scripts/tokens/generate.test.ts
@@ -1803,9 +1803,9 @@ describe('CIN-469 finding 3: the uniqueness guard runs per override block, not o
       ['alias.a', overrideEntry('alias.a', 3)],
     ]);
 
-    expect(() => assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark')).toThrow(
-      /\[theme\.dark\].*--test-swatch is claimed with conflicting values/,
-    );
+    expect(() =>
+      assertUniqueOverrideCssProperties(darkOverrides, baseIndex, baseIndex, 'theme.dark'),
+    ).toThrow(/\[theme\.dark\].*--test-swatch is claimed with conflicting values/);
   });
 
   test('overriding only ONE of two cssProperty-sharing paths is still a conflict if the other keeps a different base value', () => {
@@ -1825,7 +1825,9 @@ describe('CIN-469 finding 3: the uniqueness guard runs per override block, not o
       ['swatch.a', overrideEntry('swatch.a', 2)],
     ]);
 
-    expect(() => assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark')).toThrow(
+    expect(() =>
+      assertUniqueOverrideCssProperties(darkOverrides, baseIndex, baseIndex, 'theme.dark'),
+    ).toThrow(
       /\[theme\.dark\].*--test-swatch is claimed with conflicting values by alias\.a, swatch\.a/,
     );
   });
@@ -1844,8 +1846,40 @@ describe('CIN-469 finding 3: the uniqueness guard runs per override block, not o
     ]);
 
     expect(() =>
-      assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark'),
+      assertUniqueOverrideCssProperties(darkOverrides, baseIndex, baseIndex, 'theme.dark'),
     ).not.toThrow();
+  });
+
+  test('a claimant already changed by an EARLIER modifier in the composed scope is compared against its scope value, not raw base', () => {
+    // "swatch.a" and "alias.a" share a cssProperty at base value 1. The
+    // THEME already changed BOTH to 2 (part of this block's composed
+    // scope). MOTION's own override map here restates only "swatch.a",
+    // changing it back to 1 -- "alias.a" is untouched by motion, so its
+    // effective value in this scope is 2 (from theme), NOT its raw base
+    // value of 1. Comparing against raw baseIndex would wrongly see 1 vs 1
+    // (no conflict); the real combination disagrees (1 vs 2).
+    const baseIndex = new Map<string, CorpusEntry>([
+      ['swatch.a', { ...overrideEntry('swatch.a', 1), cssProperty: '--test-swatch' }],
+      ['alias.a', { ...overrideEntry('alias.a', 1), cssProperty: '--test-swatch' }],
+    ]);
+    const themeComposedScope = new Map<string, CorpusEntry>([
+      ['swatch.a', overrideEntry('swatch.a', 2)],
+      ['alias.a', overrideEntry('alias.a', 2)],
+    ]);
+    const motionOverrides = new Map<string, CorpusEntry>([
+      ['swatch.a', overrideEntry('swatch.a', 1)],
+    ]);
+
+    expect(() =>
+      assertUniqueOverrideCssProperties(
+        motionOverrides,
+        baseIndex,
+        themeComposedScope,
+        'motion.reduced',
+      ),
+    ).toThrow(
+      /\[motion\.reduced\].*--test-swatch is claimed with conflicting values by alias\.a, swatch\.a/,
+    );
   });
 
   test('the full buildTokensBaseCss pipeline rejects a theme override that diverges two $extends-shared paths', async () => {

--- a/packages/components/scripts/tokens/generate.test.ts
+++ b/packages/components/scripts/tokens/generate.test.ts
@@ -1919,11 +1919,15 @@ describe('CIN-469 finding 4: a $root JSON Pointer alias normalizes like a group.
     expect(resolveAlias('#/$root/$value', baseIndex)).toBe('var(--test-document-root)');
   });
 
-  test('#/group/$root with no trailing /$value is left to fail the lookup, not silently normalized', () => {
-    // Unlike the /$value form above, a bare `#/group/$root` names the token
-    // OBJECT (resolve.ts resolves it as such), not its `$value` -- normalizing
-    // it here would make the generator accept a shape tokens:validate does not
-    // treat as a whole-token value alias.
+  test('a bare #/group/$root (no trailing /$value) resolves the same way as the /$value form', () => {
+    // resolve.ts's own resolveReference extracts $value for a bare
+    // `#/group/$root` too -- "a bare `#/group/$root` alias names the root
+    // token's whole identity and must extract $value, exactly like the
+    // ordinary whole-token case" (see resolve.ts's comment on this exact
+    // redirect, and resolve.test.ts's "resolves a $ref alias that targets a
+    // group root token", which asserts `$ref: '#/group/$root'` resolves
+    // successfully). `wholeTokenIndexPath` matches that: both forms
+    // normalize to the same indexed path.
     const baseIndex = new Map<string, CorpusEntry>([
       [
         'group',
@@ -1937,9 +1941,7 @@ describe('CIN-469 finding 4: a $root JSON Pointer alias normalizes like a group.
         },
       ],
     ]);
-    expect(() => resolveAlias('#/group/$root', baseIndex)).toThrow(
-      /does not resolve to a base token/,
-    );
+    expect(resolveAlias('#/group/$root', baseIndex)).toBe('var(--test-group-root)');
   });
 });
 

--- a/packages/components/scripts/tokens/generate.test.ts
+++ b/packages/components/scripts/tokens/generate.test.ts
@@ -1962,6 +1962,71 @@ describe('CIN-469 finding 3: the uniqueness guard runs per override block, not o
       /\[theme\.dark\].*--test-shared-swatch is claimed with conflicting values/,
     );
   });
+
+  test('a motion override that only agrees with LIGHT is still rejected -- dark+reduced is an equally reachable combination', async () => {
+    // The motion blocks apply regardless of which [data-theme] is active, so
+    // checking a motion override only against the light-defaulted scope can
+    // miss a conflict that only shows up combined with dark. Here "alias.a"
+    // is never touched by the reduced-motion override, so its effective
+    // value tracks whichever theme is active (0.5 light, 0.2 dark) -- and
+    // "swatch.a"'s motion override (0.5) agrees with LIGHT but silently
+    // diverges from DARK.
+    const colorValue = (lightness: number) => ({
+      colorSpace: 'oklch',
+      components: [lightness, 0.1, 250],
+    });
+    const baseDocument: TokenDocument = {
+      swatch: {
+        $type: 'color',
+        a: {
+          $value: colorValue(0.5),
+          $extensions: { 'com.lostgradient.cinder': { cssProperty: '--test-shared-swatch' } },
+        },
+      },
+      alias: { $extends: '{swatch}' },
+    };
+    const themeDarkDocument: TokenDocument = {
+      swatch: { $type: 'color', a: { $value: colorValue(0.2) } },
+      alias: { $type: 'color', a: { $value: colorValue(0.2) } },
+    };
+    const motionReducedDocument: TokenDocument = {
+      swatch: { $type: 'color', a: { $value: colorValue(0.5) } },
+    };
+    const resolver: ResolverDocument = {
+      version: '2025.10',
+      sets: { foundation: { sources: [{ $ref: 'base.json' }] } },
+      modifiers: {
+        theme: {
+          contexts: { light: [{ $ref: 'theme-light.json' }], dark: [{ $ref: 'theme-dark.json' }] },
+          default: 'light',
+        },
+        motion: {
+          contexts: {
+            default: [{ $ref: 'motion-default.json' }],
+            reduced: [{ $ref: 'motion-reduced.json' }],
+            'forced-reduced-motion': [{ $ref: 'motion-default.json' }],
+          },
+          default: 'default',
+        },
+      },
+      resolutionOrder: [
+        { $ref: '#/sets/foundation' },
+        { $ref: '#/modifiers/theme' },
+        { $ref: '#/modifiers/motion' },
+      ],
+    };
+    const documentsByPath = new Map<string, TokenDocument>([
+      ['base.json', baseDocument],
+      ['theme-light.json', {}],
+      ['theme-dark.json', themeDarkDocument],
+      ['motion-default.json', {}],
+      ['motion-reduced.json', motionReducedDocument],
+    ]);
+
+    await expect(buildTokensBaseCss(resolver, documentsByPath)).rejects.toThrow(
+      /\[motion\.reduced \(dark theme\)\].*--test-shared-swatch is claimed with conflicting values/,
+    );
+  });
 });
 
 describe('CIN-469 finding 4: a $root JSON Pointer alias normalizes like a group.base one', () => {
@@ -2069,6 +2134,33 @@ describe('CIN-469 finding 5: resolutionOrder is validated against the fixed CSS 
     ]);
     expect(() => assertResolutionOrderMatchesCssBlockStructure(resolver)).toThrow(
       /interleaves a "sets" entry after a "modifiers" entry/,
+    );
+  });
+
+  test('a third modifier is rejected -- the override-block template only knows how to emit theme and motion', () => {
+    // `buildTokensBaseCss` hardcodes `theme`/`motion` for CSS emission, but
+    // `modifierValuesForCombo`'s default-fill would still bake a third
+    // modifier's default-context documents into every resolved-context
+    // snapshot -- so a schema-valid resolver adding one would make the
+    // published snapshots disagree with the generated CSS for every
+    // combination, not just a specific value collision.
+    const resolver: ResolverDocument = {
+      version: '2025.10',
+      sets: { foundation: { sources: [{ $ref: 'base.json' }] } },
+      modifiers: {
+        theme: { contexts: { light: [{ $ref: 'theme.json' }] }, default: 'light' },
+        motion: { contexts: { default: [{ $ref: 'motion.json' }] }, default: 'default' },
+        density: { contexts: { comfortable: [{ $ref: 'density.json' }] }, default: 'comfortable' },
+      },
+      resolutionOrder: [
+        { $ref: '#/sets/foundation' },
+        { $ref: '#/modifiers/theme' },
+        { $ref: '#/modifiers/motion' },
+        { $ref: '#/modifiers/density' },
+      ],
+    };
+    expect(() => assertResolutionOrderMatchesCssBlockStructure(resolver)).toThrow(
+      /declares modifier\(s\) "density".*only knows how to emit "theme" and "motion"/,
     );
   });
 });

--- a/packages/components/scripts/tokens/generate.test.ts
+++ b/packages/components/scripts/tokens/generate.test.ts
@@ -1808,13 +1808,39 @@ describe('CIN-469 finding 3: the uniqueness guard runs per override block, not o
     );
   });
 
-  test('only ONE of two cssProperty-sharing paths being overridden is not a conflict', () => {
+  test('overriding only ONE of two cssProperty-sharing paths is still a conflict if the other keeps a different base value', () => {
+    // "alias.a" is never restated in this context, so its effective value
+    // stays at its BASE value (1) -- but "swatch.a" is overridden to 2. The
+    // two paths sharing "--test-swatch" now genuinely disagree (1 vs 2), the
+    // same class of artifact-disagreement bug this guard exists to catch,
+    // just reached because one claimant was silently absent from the
+    // override map rather than both being explicitly restated with
+    // different values. Comparing only the paths PRESENT in `overrides`
+    // would miss this -- the base claimant must be pulled in too.
     const baseIndex = new Map<string, CorpusEntry>([
       ['swatch.a', { ...overrideEntry('swatch.a', 1), cssProperty: '--test-swatch' }],
       ['alias.a', { ...overrideEntry('alias.a', 1), cssProperty: '--test-swatch' }],
     ]);
     const darkOverrides = new Map<string, CorpusEntry>([
       ['swatch.a', overrideEntry('swatch.a', 2)],
+    ]);
+
+    expect(() => assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark')).toThrow(
+      /\[theme\.dark\].*--test-swatch is claimed with conflicting values by alias\.a, swatch\.a/,
+    );
+  });
+
+  test("overriding only ONE of two cssProperty-sharing paths is fine when the override MATCHES the other one's base value", () => {
+    // No genuine divergence here: "swatch.a" is overridden to 1, which is
+    // exactly what "alias.a" (never restated in this context) already has
+    // as its base value -- both paths agree on "--test-swatch" throughout
+    // this context, so there is nothing to reject.
+    const baseIndex = new Map<string, CorpusEntry>([
+      ['swatch.a', { ...overrideEntry('swatch.a', 1), cssProperty: '--test-swatch' }],
+      ['alias.a', { ...overrideEntry('alias.a', 1), cssProperty: '--test-swatch' }],
+    ]);
+    const darkOverrides = new Map<string, CorpusEntry>([
+      ['swatch.a', overrideEntry('swatch.a', 1)],
     ]);
 
     expect(() =>

--- a/packages/components/scripts/tokens/generate.test.ts
+++ b/packages/components/scripts/tokens/generate.test.ts
@@ -2027,6 +2027,70 @@ describe('CIN-469 finding 3: the uniqueness guard runs per override block, not o
       /\[motion\.reduced \(dark theme\)\].*--test-shared-swatch is claimed with conflicting values/,
     );
   });
+
+  test('a motion override that only agrees with the non-default theme is still rejected -- neither theme scope is assumed to be "light"', async () => {
+    // theme.default is DARK here (schema-valid, if unusual) -- an earlier
+    // version of this fix wrongly assumed the default-filled scope was
+    // always "light" and only added an explicit "dark" counterpart to check
+    // alongside it, which would validate dark TWICE here and leave light
+    // entirely unchecked. Both theme scopes must be built explicitly by
+    // name, not by assuming which one the default happens to be.
+    const colorValue = (lightness: number) => ({
+      colorSpace: 'oklch',
+      components: [lightness, 0.1, 250],
+    });
+    const baseDocument: TokenDocument = {
+      swatch: {
+        $type: 'color',
+        a: {
+          $value: colorValue(0.5),
+          $extensions: { 'com.lostgradient.cinder': { cssProperty: '--test-shared-swatch' } },
+        },
+      },
+      alias: { $extends: '{swatch}' },
+    };
+    const themeLightDocument: TokenDocument = {
+      swatch: { $type: 'color', a: { $value: colorValue(0.9) } },
+      alias: { $type: 'color', a: { $value: colorValue(0.9) } },
+    };
+    const motionReducedDocument: TokenDocument = {
+      swatch: { $type: 'color', a: { $value: colorValue(0.5) } },
+    };
+    const resolver: ResolverDocument = {
+      version: '2025.10',
+      sets: { foundation: { sources: [{ $ref: 'base.json' }] } },
+      modifiers: {
+        theme: {
+          contexts: { light: [{ $ref: 'theme-light.json' }], dark: [{ $ref: 'theme-dark.json' }] },
+          default: 'dark',
+        },
+        motion: {
+          contexts: {
+            default: [{ $ref: 'motion-default.json' }],
+            reduced: [{ $ref: 'motion-reduced.json' }],
+            'forced-reduced-motion': [{ $ref: 'motion-default.json' }],
+          },
+          default: 'default',
+        },
+      },
+      resolutionOrder: [
+        { $ref: '#/sets/foundation' },
+        { $ref: '#/modifiers/theme' },
+        { $ref: '#/modifiers/motion' },
+      ],
+    };
+    const documentsByPath = new Map<string, TokenDocument>([
+      ['base.json', baseDocument],
+      ['theme-light.json', themeLightDocument],
+      ['theme-dark.json', {}],
+      ['motion-default.json', {}],
+      ['motion-reduced.json', motionReducedDocument],
+    ]);
+
+    await expect(buildTokensBaseCss(resolver, documentsByPath)).rejects.toThrow(
+      /\[motion\.reduced \(light theme\)\].*--test-shared-swatch is claimed with conflicting values/,
+    );
+  });
 });
 
 describe('CIN-469 finding 4: a $root JSON Pointer alias normalizes like a group.base one', () => {

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -978,6 +978,30 @@ export function assertResolutionOrderMatchesCssBlockStructure(resolver: Resolver
         'override block order from resolutionOrder.',
     );
   }
+  // `buildTokensBaseCss`'s override-block template is hardcoded to exactly two
+  // modifiers, "theme" and "motion" -- it never reads `resolver.modifiers` generically,
+  // so a third modifier's context documents would never reach ANY emitted CSS block,
+  // while `buildResolvedContexts`/`modifierValuesForCombo` fill every declared
+  // modifier (including a third one, at its own default) when composing each resolved
+  // snapshot's document scope. A third modifier whose default context overrides
+  // anything the base sets don't would then make a published resolved-context
+  // snapshot disagree with what the actual CSS renders, for every combination, not just
+  // a cross-modifier edge case -- the same class of artifact/CSS disagreement this
+  // whole guard exists to prevent, just triggered structurally instead of by a specific
+  // value collision. Reject a third modifier here rather than silently generating CSS
+  // that can't express it.
+  const unsupportedModifiers = Object.keys(resolver.modifiers).filter(
+    (name) => name !== 'theme' && name !== 'motion',
+  );
+  if (unsupportedModifiers.length > 0) {
+    throw new Error(
+      `resolver declares modifier(s) ${unsupportedModifiers.map((name) => `"${name}"`).join(', ')}, ` +
+        'but tokens-base.css\'s override-block template only knows how to emit "theme" and ' +
+        '"motion" -- add support for the new modifier to buildTokensBaseCss (and to ' +
+        "buildResolvedContexts's published combos) before adding it to the resolver, or the " +
+        'generated CSS and published resolved-context snapshots will silently disagree.',
+    );
+  }
 }
 
 export async function buildTokensBaseCss(
@@ -1133,17 +1157,76 @@ export async function buildTokensBaseCss(
   );
   assertUniqueOverrideCssProperties(lightOverrides, baseIndex, lightScopeIndex, 'theme.light');
   assertUniqueOverrideCssProperties(darkOverrides, baseIndex, darkScopeIndex, 'theme.dark');
+  // The motion blocks above default the THEME axis (via `modifierValuesForContext`)
+  // to its own declared default -- light -- so `reducedMotionScopeIndex`/
+  // `forcedReducedMotionScopeIndex` only compose light+motion. But unlike theme
+  // (which always cascades BEFORE motion, so a theme block's own internal
+  // consistency never depends on which motion state is active), the motion
+  // blocks are emitted as a fixed `@media`/attribute selector that applies
+  // regardless of which `[data-theme]` is active -- dark+reduced and
+  // dark+forced-reduced-motion are just as reachable at runtime as their
+  // light counterparts. Checking only against the light-composed scope can
+  // miss a real conflict that only shows up under dark: an unoverridden
+  // sibling's effective value differs between themes, so a motion override
+  // that happens to agree with LIGHT's value can still silently diverge from
+  // DARK's -- the published dark-theme resolved-context snapshot would then
+  // disagree with what the cascade actually renders. Re-run the same guard
+  // against a dark-composed scope for each motion block to catch that.
+  const darkReducedMotionScopeDocuments = documentsForResolutionOrder(
+    resolver,
+    documentsByPath,
+    modifierValuesForCombo(resolver, {
+      name: 'dark-reduced-motion',
+      theme: 'dark',
+      motion: 'reduced',
+    }),
+  );
+  const darkReducedMotionScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(
+    mergeAndExpandExtends(darkReducedMotionScopeDocuments),
+    '',
+    undefined,
+    darkReducedMotionScopeIndex,
+  );
+  const darkForcedReducedMotionScopeDocuments = documentsForResolutionOrder(
+    resolver,
+    documentsByPath,
+    modifierValuesForCombo(resolver, {
+      name: 'dark-forced-reduced-motion',
+      theme: 'dark',
+      motion: 'forced-reduced-motion',
+    }),
+  );
+  const darkForcedReducedMotionScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(
+    mergeAndExpandExtends(darkForcedReducedMotionScopeDocuments),
+    '',
+    undefined,
+    darkForcedReducedMotionScopeIndex,
+  );
   assertUniqueOverrideCssProperties(
     reducedMotionOverrides,
     baseIndex,
     reducedMotionScopeIndex,
-    'motion.reduced',
+    'motion.reduced (light theme)',
+  );
+  assertUniqueOverrideCssProperties(
+    reducedMotionOverrides,
+    baseIndex,
+    darkReducedMotionScopeIndex,
+    'motion.reduced (dark theme)',
   );
   assertUniqueOverrideCssProperties(
     forcedReducedMotionOverrides,
     baseIndex,
     forcedReducedMotionScopeIndex,
-    'motion.forced-reduced-motion',
+    'motion.forced-reduced-motion (light theme)',
+  );
+  assertUniqueOverrideCssProperties(
+    forcedReducedMotionOverrides,
+    baseIndex,
+    darkForcedReducedMotionScopeIndex,
+    'motion.forced-reduced-motion (dark theme)',
   );
 
   // A per-context resolver, each built from the SAME composed scope used for `$extends` above --

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -1141,37 +1141,40 @@ export async function buildTokensBaseCss(
   collectEntries(mergeAndExpandExtends(lightScopeDocuments), '', undefined, lightScopeIndex);
   const darkScopeIndex = new Map<string, CorpusEntry>();
   collectEntries(mergeAndExpandExtends(darkScopeDocuments), '', undefined, darkScopeIndex);
-  const reducedMotionScopeIndex = new Map<string, CorpusEntry>();
-  collectEntries(
-    mergeAndExpandExtends(reducedMotionScopeDocuments),
-    '',
-    undefined,
-    reducedMotionScopeIndex,
-  );
-  const forcedReducedMotionScopeIndex = new Map<string, CorpusEntry>();
-  collectEntries(
-    mergeAndExpandExtends(forcedReducedMotionScopeDocuments),
-    '',
-    undefined,
-    forcedReducedMotionScopeIndex,
-  );
   assertUniqueOverrideCssProperties(lightOverrides, baseIndex, lightScopeIndex, 'theme.light');
   assertUniqueOverrideCssProperties(darkOverrides, baseIndex, darkScopeIndex, 'theme.dark');
-  // The motion blocks above default the THEME axis (via `modifierValuesForContext`)
-  // to its own declared default -- light -- so `reducedMotionScopeIndex`/
-  // `forcedReducedMotionScopeIndex` only compose light+motion. But unlike theme
+  // The motion blocks are emitted as a fixed `@media`/attribute selector that
+  // applies regardless of which `[data-theme]` is active -- unlike theme
   // (which always cascades BEFORE motion, so a theme block's own internal
-  // consistency never depends on which motion state is active), the motion
-  // blocks are emitted as a fixed `@media`/attribute selector that applies
-  // regardless of which `[data-theme]` is active -- dark+reduced and
-  // dark+forced-reduced-motion are just as reachable at runtime as their
-  // light counterparts. Checking only against the light-composed scope can
-  // miss a real conflict that only shows up under dark: an unoverridden
-  // sibling's effective value differs between themes, so a motion override
-  // that happens to agree with LIGHT's value can still silently diverge from
-  // DARK's -- the published dark-theme resolved-context snapshot would then
-  // disagree with what the cascade actually renders. Re-run the same guard
-  // against a dark-composed scope for each motion block to catch that.
+  // consistency never depends on which motion state is active), a motion
+  // block's internal consistency must hold under EVERY theme it can combine
+  // with at runtime. `reducedMotionScopeDocuments`/`forcedReducedMotionScopeDocuments`
+  // above (used for `$extends` lookup and nested-reference resolution) compose
+  // motion with the THEME axis defaulted to `resolver.modifiers.theme.default`
+  // (`modifierValuesForContext`'s fill), which is 'light' in the corpus today
+  // but is not schema-guaranteed to be -- an earlier version of this fix
+  // wrongly assumed that default-filled scope WAS "light" and built only an
+  // explicit "dark" counterpart to check alongside it, which would silently
+  // validate the SAME theme twice (and leave light entirely unchecked) if
+  // `theme.default` were ever changed to 'dark'. Build BOTH theme scopes
+  // explicitly by name for the guard, instead of treating either as "whatever
+  // the default happens to be".
+  const lightReducedMotionScopeDocuments = documentsForResolutionOrder(
+    resolver,
+    documentsByPath,
+    modifierValuesForCombo(resolver, {
+      name: 'light-reduced-motion',
+      theme: 'light',
+      motion: 'reduced',
+    }),
+  );
+  const lightReducedMotionScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(
+    mergeAndExpandExtends(lightReducedMotionScopeDocuments),
+    '',
+    undefined,
+    lightReducedMotionScopeIndex,
+  );
   const darkReducedMotionScopeDocuments = documentsForResolutionOrder(
     resolver,
     documentsByPath,
@@ -1187,6 +1190,22 @@ export async function buildTokensBaseCss(
     '',
     undefined,
     darkReducedMotionScopeIndex,
+  );
+  const lightForcedReducedMotionScopeDocuments = documentsForResolutionOrder(
+    resolver,
+    documentsByPath,
+    modifierValuesForCombo(resolver, {
+      name: 'light-forced-reduced-motion',
+      theme: 'light',
+      motion: 'forced-reduced-motion',
+    }),
+  );
+  const lightForcedReducedMotionScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(
+    mergeAndExpandExtends(lightForcedReducedMotionScopeDocuments),
+    '',
+    undefined,
+    lightForcedReducedMotionScopeIndex,
   );
   const darkForcedReducedMotionScopeDocuments = documentsForResolutionOrder(
     resolver,
@@ -1207,7 +1226,7 @@ export async function buildTokensBaseCss(
   assertUniqueOverrideCssProperties(
     reducedMotionOverrides,
     baseIndex,
-    reducedMotionScopeIndex,
+    lightReducedMotionScopeIndex,
     'motion.reduced (light theme)',
   );
   assertUniqueOverrideCssProperties(
@@ -1219,7 +1238,7 @@ export async function buildTokensBaseCss(
   assertUniqueOverrideCssProperties(
     forcedReducedMotionOverrides,
     baseIndex,
-    forcedReducedMotionScopeIndex,
+    lightForcedReducedMotionScopeIndex,
     'motion.forced-reduced-motion (light theme)',
   );
   assertUniqueOverrideCssProperties(
@@ -1228,6 +1247,21 @@ export async function buildTokensBaseCss(
     darkForcedReducedMotionScopeIndex,
     'motion.forced-reduced-motion (dark theme)',
   );
+
+  // Known gap, tracked in CIN-489: the four calls above only catch a conflict
+  // when TWO paths share one cssProperty and disagree across theme scopes.
+  // They say nothing about a SINGLE motion-overridden path (a unique
+  // cssProperty) whose own serialized value could legitimately differ
+  // between light and dark -- e.g. a property-level $ref or composite value
+  // nested-referencing a color token that varies by theme. The motion blocks
+  // below are emitted ONCE each (theme-agnostic selectors), serialized from
+  // exactly one resolver -- if such a value existed, the single emitted
+  // declaration could only ever be correct for one theme, while the
+  // published per-theme resolved-context snapshots would resolve it
+  // correctly per-theme, silently disagreeing with the CSS. Deferred rather
+  // than reworked this late in review: nothing in the real corpus's motion
+  // token documents contains a $ref or a theme-varying nested reference
+  // today (every value is a literal duration).
 
   // A per-context resolver, each built from the SAME composed scope used for `$extends` above --
   // a nested reference inside a context's composite value may target a token that a DIFFERENT

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -827,10 +827,116 @@ export function assertUniqueCssProperties(entries: Map<string, CorpusEntry>): vo
   throw new Error(`Conflicting cssProperty mappings in the token corpus: ${detail}`);
 }
 
+/**
+ * The same conflict {@link assertUniqueCssProperties} catches for `baseIndex`,
+ * applied to ONE override block (a theme or motion context) in isolation.
+ * `$extends` can legitimately give two base paths the same `cssProperty` with
+ * IDENTICAL base values (assertUniqueCssProperties already lets that through) --
+ * but nothing stopped a theme or motion override from then explicitly
+ * diverging those two paths to DIFFERENT values, because the base-only guard
+ * ran exactly once, against `baseIndex`, and never again against an override
+ * block.
+ *
+ * An override token does not always restate its own `cssProperty` extension --
+ * it is inherited, immutable metadata; an override document typically states
+ * only a new `$value` -- so grouping by `entry.cssProperty` alone would skip
+ * most override entries as property-less. `baseIndex` supplies whichever
+ * `cssProperty` (and `$type`, needed for the same type-directed fingerprint
+ * `assertUniqueCssProperties` already keys on) an override entry left
+ * unstated, so the same two-paths-one-property conflict this guards against
+ * at the base level is caught here too.
+ */
+export function assertUniqueOverrideCssProperties(
+  overrides: Map<string, CorpusEntry>,
+  baseIndex: Map<string, CorpusEntry>,
+  blockName: string,
+): void {
+  const resolved = new Map<string, CorpusEntry>();
+  for (const [path, entry] of overrides) {
+    const base = baseIndex.get(path);
+    resolved.set(path, {
+      ...entry,
+      cssProperty: entry.cssProperty ?? base?.cssProperty,
+      type: entry.type ?? base?.type,
+    });
+  }
+  try {
+    assertUniqueCssProperties(resolved);
+  } catch (error) {
+    if (error instanceof Error)
+      throw new Error(`[${blockName}] ${error.message}`, { cause: error });
+    throw error;
+  }
+}
+
+/**
+ * `tokens-base.css`'s block structure is FIXED, not derived from
+ * `resolver.resolutionOrder`: `:root` is always assembled from every `sets`
+ * entry (regardless of where it sits in `resolutionOrder`), and the theme
+ * override blocks (`[data-theme='dark']`/`[data-theme='light']`) are always
+ * emitted before the motion override blocks (the `prefers-reduced-motion`
+ * media block and the `data-reduced-motion='on'` override) -- see
+ * `buildTokensBaseCss`'s `darkDeclarations`/`lightDeclarations` vs.
+ * `reducedMotionDeclarations`/`forcedReducedMotionDeclarations` ordering in
+ * the template below.
+ *
+ * DECISION (CIN-469 finding 5): rather than deriving CSS block order from
+ * `resolutionOrder` at generation time -- a bigger, riskier change for a PR
+ * whose whole point is a no-diff, tests-and-generator-only fix -- this
+ * generator keeps its fixed block structure and instead REJECTS a resolver
+ * document whose `resolutionOrder` the fixed structure cannot faithfully
+ * express: every `sets` entry must precede every `modifiers` entry (so
+ * `:root`'s "every set, unconditionally" assembly matches what
+ * `resolutionOrder` actually says the base layer is), and the `theme`
+ * modifier must precede the `motion` modifier (so theme-before-motion block
+ * emission matches cascade precedence, i.e. a motion override still wins over
+ * a theme override for a token both touch, the same way "last non-`:root`
+ * block wins" already works today). `cinder.resolver.json`'s current
+ * `resolutionOrder` -- foundation, then theme, then motion -- already
+ * satisfies this, so the guard is presently a no-op; it exists so a future
+ * resolver edit that would silently desync `resolutionOrder` from emission
+ * order fails loudly at generate time instead of shipping a CSS cascade that
+ * disagrees with the resolver's own stated precedence. If `resolutionOrder`
+ * ever legitimately needs a different shape, deriving block order for real
+ * -- not just validating it -- is the follow-up.
+ */
+export function assertResolutionOrderMatchesCssBlockStructure(resolver: ResolverDocument): void {
+  const order = parseResolutionOrder(resolver);
+  const lastSetsIndex = order.reduce(
+    (last, entry, index) => (entry.kind === 'sets' ? index : last),
+    -1,
+  );
+  const firstModifierIndex = order.findIndex((entry) => entry.kind === 'modifiers');
+  if (firstModifierIndex !== -1 && lastSetsIndex > firstModifierIndex) {
+    throw new Error(
+      'resolver\'s resolutionOrder interleaves a "sets" entry after a "modifiers" entry, but ' +
+        'tokens-base.css always assembles :root from every "sets" entry unconditionally, ' +
+        'regardless of position -- reorder resolutionOrder so every "sets" entry precedes every ' +
+        '"modifiers" entry, or teach buildTokensBaseCss to derive :root membership from position.',
+    );
+  }
+  const themeIndex = order.findIndex(
+    (entry) => entry.kind === 'modifiers' && entry.name === 'theme',
+  );
+  const motionIndex = order.findIndex(
+    (entry) => entry.kind === 'modifiers' && entry.name === 'motion',
+  );
+  if (themeIndex !== -1 && motionIndex !== -1 && themeIndex > motionIndex) {
+    throw new Error(
+      'resolver\'s resolutionOrder has "motion" before "theme", but tokens-base.css always ' +
+        "emits the theme override blocks ([data-theme='dark']/[data-theme='light']) before the " +
+        'motion override blocks (prefers-reduced-motion / data-reduced-motion) -- reorder ' +
+        'resolutionOrder so "theme" precedes "motion", or teach buildTokensBaseCss to derive ' +
+        'override block order from resolutionOrder.',
+    );
+  }
+}
+
 export async function buildTokensBaseCss(
   resolver: ResolverDocument,
   documentsByPath: Map<string, TokenDocument>,
 ): Promise<string> {
+  assertResolutionOrderMatchesCssBlockStructure(resolver);
   // Every set the resolver orders, not just `foundation`. Naming one set here would
   // silently drop a second set's tokens from `:root` while the resolved snapshots --
   // which walk `resolutionOrder` -- still exposed them, and an override targeting one
@@ -948,6 +1054,19 @@ export async function buildTokensBaseCss(
     '',
     undefined,
     forcedReducedMotionOverrides,
+  );
+
+  // Per-block, not just once for `baseIndex`: `$extends` can legitimately give
+  // two base paths the same `cssProperty` with identical base values, and a
+  // theme or motion override can then explicitly diverge them to different
+  // values -- see `assertUniqueOverrideCssProperties`'s docstring.
+  assertUniqueOverrideCssProperties(lightOverrides, baseIndex, 'theme.light');
+  assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark');
+  assertUniqueOverrideCssProperties(reducedMotionOverrides, baseIndex, 'motion.reduced');
+  assertUniqueOverrideCssProperties(
+    forcedReducedMotionOverrides,
+    baseIndex,
+    'motion.forced-reduced-motion',
   );
 
   // A per-context resolver, each built from the SAME composed scope used for `$extends` above --

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -802,11 +802,14 @@ export function assertUniqueCssProperties(entries: Map<string, CorpusEntry>): vo
     // distinct property-level `$ref` tokens sharing this `cssProperty` and
     // resolving to the identical literal hash to two different pointer
     // strings and get wrongly rejected as conflicting, even though matching
-    // emitted values is exactly what this guard is supposed to permit.
-    // Fixing it means resolving property-level refs before this fingerprint
-    // runs -- deferred rather than reworked this late in review; nothing in
-    // the real corpus has two property-level `$ref` tokens sharing a
-    // `cssProperty`.
+    // emitted values is exactly what this guard is supposed to permit. The
+    // same applies to a whole-token `$ref` alias -- `toEntry` records its raw
+    // reference STRING as `.value` (it has no `$value` of its own), so two
+    // whole-token aliases to different targets that themselves share this
+    // `cssProperty` hit the identical false-rejection. Fixing either means
+    // resolving the ref before this fingerprint runs -- deferred rather than
+    // reworked this late in review; nothing in the real corpus has two `$ref`
+    // tokens of either form sharing a `cssProperty`.
     const emitted = JSON.stringify({
       type: entry.type,
       value: entry.value,

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -851,9 +851,35 @@ export function assertUniqueOverrideCssProperties(
   baseIndex: Map<string, CorpusEntry>,
   blockName: string,
 ): void {
-  const resolved = new Map<string, CorpusEntry>();
+  // Comparing only the paths PRESENT in `overrides` misses a base claimant
+  // that shares a `cssProperty` with an overridden path but is not itself
+  // overridden in this context (e.g. `$extends` gives "alias.a" and
+  // "swatch.a" the same property; a context overrides only "alias.a"). That
+  // claimant's effective value in this context is still its BASE value,
+  // unchanged -- but it never entered the comparison, so a divergence
+  // between the two was invisible here even though the emitted CSS changes
+  // the one shared custom property for both. Build the comparison from
+  // every base claimant of a `cssProperty` touched by this context, not
+  // just the ones this context happens to restate.
+  const basePathsByCssProperty = new Map<string, string[]>();
+  for (const [path, entry] of baseIndex) {
+    if (!entry.cssProperty) continue;
+    const paths = basePathsByCssProperty.get(entry.cssProperty) ?? [];
+    paths.push(path);
+    basePathsByCssProperty.set(entry.cssProperty, paths);
+  }
+  const relevantPaths = new Set<string>();
   for (const [path, entry] of overrides) {
+    relevantPaths.add(path);
+    const cssProperty = entry.cssProperty ?? baseIndex.get(path)?.cssProperty;
+    if (!cssProperty) continue;
+    for (const sibling of basePathsByCssProperty.get(cssProperty) ?? []) relevantPaths.add(sibling);
+  }
+  const resolved = new Map<string, CorpusEntry>();
+  for (const path of relevantPaths) {
     const base = baseIndex.get(path);
+    const entry = overrides.get(path) ?? base;
+    if (!entry) continue;
     resolved.set(path, {
       ...entry,
       cssProperty: entry.cssProperty ?? base?.cssProperty,

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -849,18 +849,27 @@ export function assertUniqueCssProperties(entries: Map<string, CorpusEntry>): vo
 export function assertUniqueOverrideCssProperties(
   overrides: Map<string, CorpusEntry>,
   baseIndex: Map<string, CorpusEntry>,
+  scopeIndex: Map<string, CorpusEntry>,
   blockName: string,
 ): void {
   // Comparing only the paths PRESENT in `overrides` misses a base claimant
   // that shares a `cssProperty` with an overridden path but is not itself
-  // overridden in this context (e.g. `$extends` gives "alias.a" and
-  // "swatch.a" the same property; a context overrides only "alias.a"). That
-  // claimant's effective value in this context is still its BASE value,
-  // unchanged -- but it never entered the comparison, so a divergence
-  // between the two was invisible here even though the emitted CSS changes
-  // the one shared custom property for both. Build the comparison from
-  // every base claimant of a `cssProperty` touched by this context, not
-  // just the ones this context happens to restate.
+  // overridden in THIS block -- e.g. `$extends` gives "alias.a" and
+  // "swatch.a" the same property, and this block overrides only "alias.a".
+  // That claimant's effective value in this context is NOT necessarily its
+  // raw base value: `documentsForResolutionOrder` composes each block's
+  // scope from base PLUS whichever other modifier's document this block's
+  // context implicitly includes (e.g. the `motion.reduced` block's scope
+  // includes the default THEME document too) -- so a sibling untouched by
+  // THIS block may already have been changed by a DIFFERENT modifier's
+  // override earlier in that composed scope. Falling back to raw
+  // `baseIndex` ignores that intermediate composition and can miss a real
+  // divergence (light changes both paths 1 -> 2, motion changes only one
+  // back to 1 -- comparing against base "1" for the untouched path sees no
+  // conflict, even though the light+motion combination actually holds 1 and
+  // 2). `scopeIndex` -- the FULLY composed, already-resolved-by-precedence
+  // corpus for this exact block's scope -- is what an unoverridden sibling's
+  // effective value must come from instead.
   const basePathsByCssProperty = new Map<string, string[]>();
   for (const [path, entry] of baseIndex) {
     if (!entry.cssProperty) continue;
@@ -878,7 +887,12 @@ export function assertUniqueOverrideCssProperties(
   const resolved = new Map<string, CorpusEntry>();
   for (const path of relevantPaths) {
     const base = baseIndex.get(path);
-    const entry = overrides.get(path) ?? base;
+    // This block's own override wins; otherwise the path's value already
+    // resolved into this block's fully composed scope (which may itself
+    // reflect a DIFFERENT modifier's override applied earlier in that
+    // scope's resolution order); only fall back to the raw base entry if
+    // the path is somehow absent from the composed scope entirely.
+    const entry = overrides.get(path) ?? scopeIndex.get(path) ?? base;
     if (!entry) continue;
     resolved.set(path, {
       ...entry,
@@ -1085,13 +1099,42 @@ export async function buildTokensBaseCss(
   // Per-block, not just once for `baseIndex`: `$extends` can legitimately give
   // two base paths the same `cssProperty` with identical base values, and a
   // theme or motion override can then explicitly diverge them to different
-  // values -- see `assertUniqueOverrideCssProperties`'s docstring.
-  assertUniqueOverrideCssProperties(lightOverrides, baseIndex, 'theme.light');
-  assertUniqueOverrideCssProperties(darkOverrides, baseIndex, 'theme.dark');
-  assertUniqueOverrideCssProperties(reducedMotionOverrides, baseIndex, 'motion.reduced');
+  // values -- see `assertUniqueOverrideCssProperties`'s docstring. Each
+  // block's `scopeIndex` is the SAME fully composed scope already used for
+  // `$extends` lookup and nested-reference resolution above (base plus
+  // whichever other modifier's document this block's context implicitly
+  // includes), so an unoverridden sibling's comparison value reflects any
+  // OTHER modifier's override already baked into that scope, not just base.
+  const lightScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(mergeAndExpandExtends(lightScopeDocuments), '', undefined, lightScopeIndex);
+  const darkScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(mergeAndExpandExtends(darkScopeDocuments), '', undefined, darkScopeIndex);
+  const reducedMotionScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(
+    mergeAndExpandExtends(reducedMotionScopeDocuments),
+    '',
+    undefined,
+    reducedMotionScopeIndex,
+  );
+  const forcedReducedMotionScopeIndex = new Map<string, CorpusEntry>();
+  collectEntries(
+    mergeAndExpandExtends(forcedReducedMotionScopeDocuments),
+    '',
+    undefined,
+    forcedReducedMotionScopeIndex,
+  );
+  assertUniqueOverrideCssProperties(lightOverrides, baseIndex, lightScopeIndex, 'theme.light');
+  assertUniqueOverrideCssProperties(darkOverrides, baseIndex, darkScopeIndex, 'theme.dark');
+  assertUniqueOverrideCssProperties(
+    reducedMotionOverrides,
+    baseIndex,
+    reducedMotionScopeIndex,
+    'motion.reduced',
+  );
   assertUniqueOverrideCssProperties(
     forcedReducedMotionOverrides,
     baseIndex,
+    forcedReducedMotionScopeIndex,
     'motion.forced-reduced-motion',
   );
 

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -1002,6 +1002,19 @@ export function assertResolutionOrderMatchesCssBlockStructure(resolver: Resolver
         'generated CSS and published resolved-context snapshots will silently disagree.',
     );
   }
+  // Known gap, tracked in CIN-491: this function validates modifier NAMES and
+  // ORDERING, but never inspects whether motion.default's own context
+  // document is actually empty. buildTokensBaseCss assembles :root
+  // exclusively from `sets` and only emits motion declarations for `reduced`
+  // and `forced-reduced-motion` -- motion.default's document is never read
+  // for CSS emission at all -- while buildResolvedContexts DOES include it
+  // when composing the default-motion resolved-context snapshots. A
+  // non-empty motion.default override would therefore reach the published
+  // JSON but never the generated CSS, the same class of silent disagreement
+  // the third-modifier rejection above exists to prevent, just for an
+  // existing modifier's default CONTENT rather than its existence. Deferred:
+  // modes/motion-default.tokens.json is deliberately empty today (its own
+  // $description explains why), and nothing else in the corpus overrides it.
 }
 
 export async function buildTokensBaseCss(
@@ -1143,6 +1156,15 @@ export async function buildTokensBaseCss(
   collectEntries(mergeAndExpandExtends(darkScopeDocuments), '', undefined, darkScopeIndex);
   assertUniqueOverrideCssProperties(lightOverrides, baseIndex, lightScopeIndex, 'theme.light');
   assertUniqueOverrideCssProperties(darkOverrides, baseIndex, darkScopeIndex, 'theme.dark');
+  // Known gap, tracked in CIN-490 (the symmetric case of CIN-489): these two
+  // calls validate each theme override's scope filled with the DEFAULT
+  // motion context. If a light/dark override contained a reference to a
+  // token that motion.reduced/motion.forced-reduced-motion changes, the
+  // theme declaration would serialize once from the default-motion value
+  // while the reduced-motion resolved snapshots re-resolve it under reduced
+  // motion -- silently disagreeing, for a path with a unique cssProperty
+  // where the uniqueness guard is a no-op. Deferred: confirmed no theme
+  // document contains a $ref at all today.
   // The motion blocks are emitted as a fixed `@media`/attribute selector that
   // applies regardless of which `[data-theme]` is active -- unlike theme
   // (which always cascades BEFORE motion, so a theme block's own internal

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -877,10 +877,18 @@ export function assertUniqueOverrideCssProperties(
     paths.push(path);
     basePathsByCssProperty.set(entry.cssProperty, paths);
   }
+  // `renderOverrideDeclarations` always emits an override under its BASE
+  // token's `cssProperty` -- it never honors a `cssProperty` an override
+  // document happens to restate (that only ever originates from a document
+  // echoing inherited extension data, not a real per-context property
+  // change). Grouping or resolving by an override's own restated
+  // `cssProperty` instead of its base's would let this guard separate two
+  // claimants that generation actually emits to the SAME property, missing
+  // the exact conflict it exists to catch.
   const relevantPaths = new Set<string>();
   for (const [path, entry] of overrides) {
     relevantPaths.add(path);
-    const cssProperty = entry.cssProperty ?? baseIndex.get(path)?.cssProperty;
+    const cssProperty = baseIndex.get(path)?.cssProperty ?? entry.cssProperty;
     if (!cssProperty) continue;
     for (const sibling of basePathsByCssProperty.get(cssProperty) ?? []) relevantPaths.add(sibling);
   }
@@ -896,7 +904,7 @@ export function assertUniqueOverrideCssProperties(
     if (!entry) continue;
     resolved.set(path, {
       ...entry,
-      cssProperty: entry.cssProperty ?? base?.cssProperty,
+      cssProperty: base?.cssProperty ?? entry.cssProperty,
       type: entry.type ?? base?.type,
     });
   }

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -978,6 +978,21 @@ export function assertResolutionOrderMatchesCssBlockStructure(resolver: Resolver
         'override block order from resolutionOrder.',
     );
   }
+  // Known gap, tracked in CIN-493 (a pre-existing cinder architecture question,
+  // not something CIN-469/470 introduced): this check -- and every guard built
+  // on top of it -- assumes emitting motion's block after theme's in SOURCE
+  // ORDER is sufficient for motion to win on a shared property. That only
+  // holds when both declarations target the SAME element. Cinder's theme
+  // blocks use a bare `[data-theme='dark']`/`[data-theme='light']` selector
+  // (not `:root`-scoped) specifically so a theme can be scoped to a subtree
+  // (see docs/theming.md); the motion blocks are always `:root`-anchored with
+  // no scoped variant. For a token overridden by BOTH theme and motion,
+  // inside a theme-scoped subtree, ordinary CSS inheritance (not specificity,
+  // not source order) makes the descendant's own declared theme value win
+  // over the merely-inherited :root motion value -- the opposite of what the
+  // resolved snapshots model. Deferred: confirmed no token path is overridden
+  // by both a theme document and a motion document in the real corpus today
+  // (verified by direct path-set intersection).
   // `buildTokensBaseCss`'s override-block template is hardcoded to exactly two
   // modifiers, "theme" and "motion" -- it never reads `resolver.modifiers` generically,
   // so a third modifier's context documents would never reach ANY emitted CSS block,
@@ -1269,6 +1284,18 @@ export async function buildTokensBaseCss(
     darkForcedReducedMotionScopeIndex,
     'motion.forced-reduced-motion (dark theme)',
   );
+
+  // Known gap, tracked in CIN-492: the four calls above check only the
+  // light-composed and dark-composed scopes. Cinder also supports a third,
+  // fully-supported theme state -- "system" mode, where NO [data-theme]
+  // attribute is set and :root's color-scheme: light dark follows the OS
+  // preference (see docs/theming.md's pre-paint script). In that mode
+  // neither theme block's selector matches anything, so an element sees
+  // only :root's BASE declarations plus whatever motion adds -- a scope
+  // distinct from either light-composed or dark-composed. Deferred: nothing
+  // in the real corpus's motion documents can trigger a conflict against
+  // this unthemed scope today (see CIN-489's confirmation that motion
+  // documents don't reference anything theme-varying).
 
   // Known gap, tracked in CIN-489: the four calls above only catch a conflict
   // when TWO paths share one cssProperty and disagree across theme scopes.

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -113,13 +113,22 @@ function extractDocTokens(markdown: string): { duplicates: string[]; tokens: Map
     if (!match[1] || !match[3]) continue;
     if (tokens.has(match[1])) duplicates.push(match[1]);
     // Undo the generator's Markdown-table pipe escaping before comparing. The
-    // generator writes `\|` so GFM does not read the pipe as a column delimiter,
-    // while the corpus side holds the raw `|` -- decoding here keeps both sides
-    // of this comparison talking about the same value.
+    // generator's `toTableCell` (generate-artifacts.ts) doubles the run of
+    // backslashes immediately preceding each `|` before appending the
+    // escaping backslash -- a run of `k` backslashes becomes `2k + 1` -- so
+    // that it is losslessly invertible for ANY corpus value, not just ones
+    // with no pre-existing backslash before a pipe. This is the exact inverse:
+    // a run of `m` backslashes (always odd -- GFM's left-to-right pairing
+    // always reads the trailing one as escaping the pipe) recovers `(m - 1) /
+    // 2` original backslashes plus the literal pipe.
     // match[3] is the span body; strip the single space of padding toCodeSpan adds
     // when the content starts or ends with a backtick, then undo pipe escaping.
     const body = match[3].replace(/^ (?=`)/, '').replace(/(?<=`) $/, '');
-    tokens.set(match[1], normalizeTokenValue(body.replaceAll('\\|', '|')));
+    const decoded = body.replace(
+      /(\\*)\|/g,
+      (_match, backslashes: string) => '\\'.repeat(Math.floor(backslashes.length / 2)) + '|',
+    );
+    tokens.set(match[1], normalizeTokenValue(decoded));
   }
   return { duplicates: duplicates.toSorted(), tokens };
 }

--- a/packages/components/src/styles/tokens-doc-drift.test.ts
+++ b/packages/components/src/styles/tokens-doc-drift.test.ts
@@ -124,6 +124,19 @@ function extractDocTokens(markdown: string): { duplicates: string[]; tokens: Map
     // match[3] is the span body; strip the single space of padding toCodeSpan adds
     // when the content starts or ends with a backtick, then undo pipe escaping.
     const body = match[3].replace(/^ (?=`)/, '').replace(/(?<=`) $/, '');
+    // The encoder (`toTableCell`) always produces an ODD backslash run before
+    // an escaped pipe (a run of `k` becomes `2k + 1`, which is odd for every
+    // `k >= 0`). A row this regex captured with an EVEN run (0, 2, 4, ...)
+    // immediately before a `|` should therefore never occur in correctly
+    // generated output -- decoding it anyway via a blind `floor(len / 2)`
+    // would silently accept a malformed row and could mask a future
+    // regression in the encoder's pipe-escaping. Fail loudly instead.
+    const evenRunPipe = /(?<!\\)(?:\\\\)*\|/.exec(body);
+    if (evenRunPipe)
+      throw new Error(
+        `${match[1]}: doc table cell has an unescaped pipe (even backslash run) at index ` +
+          `${evenRunPipe.index} -- malformed row, not a valid encoder output: ${JSON.stringify(body)}`,
+      );
     const decoded = body.replace(
       /(\\*)\|/g,
       (_match, backslashes: string) => '\\'.repeat(Math.floor(backslashes.length / 2)) + '|',
@@ -170,6 +183,27 @@ describe('docs/tokens.md drift', () => {
       missingFromCorpus: [],
       mismatchedValues: [],
     });
+  });
+
+  test('extractDocTokens fails loudly on a malformed row with an unescaped (even-run) pipe', () => {
+    // The encoder always produces an ODD backslash run before an escaped
+    // pipe (2k + 1 for any k >= 0). A cell body containing a pipe preceded
+    // by an EVEN run (0, 2, ...) could never come from correctly generated
+    // output -- decoding it anyway would silently accept a malformed row and
+    // could mask a future regression in the encoder's own pipe escaping.
+    const zeroBackslashes = '| `--cinder-example` | `foo|bar` |\n';
+    expect(() => extractDocTokens(zeroBackslashes)).toThrow(/unescaped pipe/);
+
+    const evenBackslashes = '| `--cinder-example` | `foo\\\\|bar` |\n';
+    expect(() => extractDocTokens(evenBackslashes)).toThrow(/unescaped pipe/);
+
+    // The legitimate, correctly-encoded form (odd run) must still decode
+    // without throwing.
+    const oddBackslashes = '| `--cinder-example` | `foo\\|bar` |\n';
+    expect(() => extractDocTokens(oddBackslashes)).not.toThrow();
+    expect(extractDocTokens(oddBackslashes).tokens.get('--cinder-example')).toBe(
+      normalizeTokenValue('foo|bar'),
+    );
   });
 
   test('keeps exact token references in focused guides current', async () => {


### PR DESCRIPTION
## Summary

Covers CIN-469 and CIN-470, deferred follow-ups from the DTCG 2025.10 migration project's review cycle.

**CIN-469** — hardens the token generator:
- **Findings 1-2 (stale, verified not fixed):** `assertUniqueCssProperties` already fingerprints `{ type, value, cssRecipe }` and its docstring already matches — confirmed on the current tree before doing anything, no change needed.
- **Finding 3:** the duplicate-`cssProperty` uniqueness guard now also runs per emitted theme/motion override block, not just the base index, so a `$extends`-shared property that diverges under an override is caught.
- **Finding 4:** superseded by fixes already merged in PR #1441 (`wholeTokenIndexPath` now normalizes `#/group/$root` and `#/group/$root/$value` identically) — confirmed via rebase, no separate work needed here.
- **Finding 5:** CSS block order vs. `resolutionOrder` — decided and documented explicitly (validation-rule path, not deriving order) rather than silently picked.

**CIN-470** — fixes `toTableCell`'s pipe escaping in generated docs tables from unconditional (double-escapes an already-escaped pipe) to backslash-parity-aware, verified directly inside `renderDocTable` per the ticket's own warning that an isolated probe disagreed with the real path. Updated the drift-parser decode side (`extractDocTokens`) to match.

**Invariant:** both tickets require `tokens:generate` to produce no diff — confirmed clean against the real corpus.

## Test plan
- [x] `bun run --filter=@lostgradient/cinder test scripts/tokens` — 285 pass
- [x] `bun run --filter=@lostgradient/cinder tokens:check` — clean, no diff
- [x] `bun run --filter=@lostgradient/cinder typecheck` — clean
- [x] `bun run --filter=@lostgradient/cinder test` (full package suite) — 11,395 pass
- [x] `bun run --filter=@lostgradient/cinder lint:invariants` — clean

Closes CIN-469
Closes CIN-470

https://claude.ai/code/session_01YCXKoeECfk5EGGxT9g3zZu