### PR TITLE
Fix undeclared easing token in chat entry-frame

### DIFF
--- a/packages/chat/src/lib/components/chat/message/entry-frame.svelte
+++ b/packages/chat/src/lib/components/chat/message/entry-frame.svelte
@@ -120,7 +120,7 @@
     inline-size: 1rem;
     block-size: 1rem;
     margin-inline-start: var(--cinder-space-2);
-    transition: transform var(--cinder-duration-fast) var(--cinder-ease-out);
+    transition: transform var(--cinder-duration-fast) var(--cinder-ease-standard);
   }
 
   .chat-entry-frame-shell :global(.cinder-collapsible__panel-inner) {


### PR DESCRIPTION
## Summary

`main-green` has been red since #1471 landed. #1473 fixed the first cause (InlineConfirm's viewport `@media`); this fixes the second, which surfaced on the very next run.

`entry-frame.svelte` styled the collapsible chevron with `var(--cinder-ease-out)` — not a declared token. The valid motion tokens are `ease-standard`, `ease-decelerate`, `ease-accelerate`, `ease-in-out`, and `ease-spring`; there is no `ease-out`. The undeclared variable silently fell back to the CSS default `ease` curve, so the bug was invisible at runtime but failed the audit.

The replacement is `--cinder-ease-standard`, matching `collapsible.css:90` — which styles this same `.cinder-collapsible__chevron` element with an otherwise identical `transition: transform var(--cinder-duration-fast) …` rule. That makes the override consistent with the component it overrides rather than picking a new curve.

This was the only `--cinder-ease-out` reference in the repository.

## Why no changeset

`entry-frame.svelte` arrived in #1468 on 2026-08-29, and `@lostgradient/chat@0.13.0` has not published — the release PR (#1406) has been blocked since 08-21. The broken curve never reached users, so there is nothing to announce. It ships correctly in 0.13.0.

## Verification

Run in a clean worktree off `origin/main` (`813c51f5`), matching `main-green`'s `Source audits (chat)` step exactly, including `--strict`:

- `bun run --filter=@lostgradient/chat platform:audit -- --strict` — pass
- `bun run --filter=@lostgradient/chat colors:audit -- --strict` — pass
- `bun run --filter=@lostgradient/chat tokens:audit -- --strict` — pass

`tokens:audit` goes from `unresolved: 3 reference(s) — ABOVE baseline (2)` to `unresolved: 2 reference(s) — at baseline (2)`, verified by exit code (`0`), not by reading output.

## Note, not addressed here

The two remaining unresolved references are the grandfathered baseline entries — `--cinder-text-3xs` and `--cinder-text-4xs` in `chat-jump-controls.svelte:139,147`. They are within baseline and unrelated to this failure, so I left them alone rather than expanding scope or touching the baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbEcbbzejHmM77KousLXYy
