### PR TITLE
Teach the tokens consumer fixture about non-representable tokens

### DIFF
--- a/packages/components/fixtures/tokens-consumer/check.mjs
+++ b/packages/components/fixtures/tokens-consumer/check.mjs
@@ -39,6 +39,10 @@ import light from '@lostgradient/cinder/tokens/resolved/light' with { type: 'jso
 import dark from '@lostgradient/cinder/tokens/resolved/dark' with { type: 'json' };
 import lightReducedMotion from '@lostgradient/cinder/tokens/resolved/light-reduced-motion' with { type: 'json' };
 import darkReducedMotion from '@lostgradient/cinder/tokens/resolved/dark-reduced-motion' with { type: 'json' };
+import colorsSet from '@lostgradient/cinder/tokens/sets/colors' with { type: 'json' };
+import componentsSet from '@lostgradient/cinder/tokens/sets/components' with { type: 'json' };
+import foundationSet from '@lostgradient/cinder/tokens/sets/foundation' with { type: 'json' };
+import semanticSet from '@lostgradient/cinder/tokens/sets/semantic' with { type: 'json' };
 import { TOKEN_REGISTRY } from '@lostgradient/cinder/tokens/registry';
 
 const CINDER_NAMESPACE = 'com.lostgradient.cinder';
@@ -49,6 +53,51 @@ const RESOLVED_CONTEXTS = [
   ['light-reduced-motion', lightReducedMotion],
   ['dark-reduced-motion', darkReducedMotion],
 ];
+
+/**
+ * Tokens whose real CSS value has no DTCG representation -- `carousel.slide-size`
+ * (a bare percentage), `carousel.aspect-ratio` (a ratio), `code-block.height`
+ * (the `auto` keyword), `spinner.indicator` (`currentColor`). Each carries a
+ * nominal `$value` placeholder with `cssRecipe` governing emission, and the
+ * generator deliberately omits them from the resolved contexts so a generic
+ * consumer cannot apply the placeholder literally (see `generate.ts`, which
+ * skips any token whose extensions set `nonRepresentableValue`).
+ *
+ * They stay in the registry, because the registry advertises the custom
+ * property surface rather than resolved values. So the resolved contexts hold
+ * exactly the registry's tokens MINUS these -- asserted as a set below, not a
+ * count, so that both an unexpected omission and a stale exclusion fail.
+ */
+const NON_REPRESENTABLE_PATHS = collectNonRepresentablePaths([
+  colorsSet,
+  componentsSet,
+  foundationSet,
+  semanticSet,
+]);
+
+function collectNonRepresentablePaths(documents) {
+  const found = new Set();
+
+  const visit = (node, trail) => {
+    if (!node || typeof node !== 'object') return;
+
+    if ('$value' in node) {
+      if (node.$extensions?.[CINDER_NAMESPACE]?.nonRepresentableValue === true) {
+        found.add(trail.join('.'));
+      }
+      return;
+    }
+
+    for (const [key, child] of Object.entries(node)) {
+      if (key.startsWith('$')) continue;
+      visit(child, [...trail, key]);
+    }
+  };
+
+  for (const document of documents) visit(document, []);
+
+  return found;
+}
 
 /** The index describes the surface and agrees with what shipped. */
 assert.equal(tokenIndex.version, '2025.10', 'token index declares the DTCG version');
@@ -94,12 +143,29 @@ assert.equal(
  * carried neither `cssProperty` nor a description, because resolution replaced
  * overridden tokens wholesale.
  */
+assert.ok(
+  NON_REPRESENTABLE_PATHS.size > 0,
+  'the corpus still flags non-representable tokens (guards against a silently emptied exclusion set)',
+);
+
+for (const path of NON_REPRESENTABLE_PATHS) {
+  assert.ok(
+    TOKEN_REGISTRY.pathToCssProperty[path],
+    `non-representable token ${path} is still advertised by the registry`,
+  );
+}
+
+const EXPECTED_RESOLVED_PATHS = TOKEN_REGISTRY.entries
+  .map((entry) => entry.path)
+  .filter((path) => !NON_REPRESENTABLE_PATHS.has(path))
+  .sort();
+
 for (const [name, context] of RESOLVED_CONTEXTS) {
   const paths = Object.keys(context);
-  assert.equal(
-    paths.length,
-    TOKEN_REGISTRY.entries.length,
-    `${name} resolves every token in the registry`,
+  assert.deepEqual(
+    [...paths].sort(),
+    EXPECTED_RESOLVED_PATHS,
+    `${name} resolves every registry token except the non-representable ones`,
   );
 
   for (const path of paths) {


### PR DESCRIPTION
## Summary

The `release` run for #1406 aborted here, so **nothing published** — `main` now carries 0.13.0/0.25.0 in `package.json` while npm still serves `@lostgradient/chat@0.12.0` and `@lostgradient/cinder@0.24.8`.

`tokens-consumer` asserted that each resolved context holds exactly as many paths as the registry has entries. CIN-472 (#1444) broke that premise: four tokens now carry `nonRepresentableValue`, and `generate.ts:1541` deliberately omits them from the resolved contexts.

| Token | Real CSS value | Why it can't be resolved |
| -- | -- | -- |
| `carousel.slide-size` | `100%` | a bare percentage has no DTCG dimension form |
| `carousel.aspect-ratio` | `16 / 9` | a ratio has no DTCG dimension form |
| `code-block.height` | `auto` | DTCG dimension has no keyword form |
| `spinner.indicator` | `currentColor` | context-inheriting, not a literal |

Omitting them is the *point*: a generic consumer applying the placeholder `$value` literally would collapse the code block to zero height, or paint a fixed color over `currentColor`. They stay in the registry because it advertises the custom-property surface, not resolved values.

So the assertion was stale, not the tokens — `304 !== 308`.

## Approach

Derive the exclusion set from the corpus `$extensions` rather than hardcoding four paths, and compare **sorted path sets** instead of lengths.

This is strictly stronger than what it replaces. The old check compared counts, so an unexpectedly-missing token and a stale exclusion could cancel out and pass. The new one fails on either and names the offending path. It also asserts the exclusion set is non-empty and that every excluded token is still registry-advertised, so the guard can't be silently emptied into a no-op.

## Why this went unnoticed

It only fires on a real publish. `release` went green on every push since #1444 landed on Aug 28 — none of those actually published. #1406 merging produced the first true release attempt since, which aborted here.

## Verification

Run in a clean worktree off `origin/main` (`e1b631bf`) — the real gate, packing and installing the actual tarball, not a workspace resolve:

```
bun run --filter=@lostgradient/cinder validate:consumer
```

`tokens-consumer` now reports:

```
[validate-consumers] tokens-consumer — ok: 308 tokens across 4 resolved contexts,
9 source documents, 308 public properties declared across 2 stylesheet(s).
```

## Heads up: this is not the last blocker

With `tokens-consumer` passing, `validate:consumer` proceeds and then fails at the **next** step, `typescript-consumer` → `generate-readme-usage-examples`, with `no-heading` for 15 components added in #1471/#1472: `donut-chart`, `find-bar`, `form`, `guidance-region`, `host-provider`, `inline-confirm`, `key-value-editor`, `modal-region`, `parameter-field`, `policy-lock`, `setting-row`, `shortcut-field`, `terminal-frame`, `terminal-output`, `zoom-pan-viewer`.

Their READMEs have a title and description but no `## Usage` section. That needs 15 authored Svelte examples that type-check under `tsc + svelte-check` — deliberately out of scope here, and it gates `main-green` too (step `validate:consumer:readme-usage-examples`), not just the release.

## No changeset

`packages/components/fixtures/` is not in the package's `files`, so this is repository tooling and changes no published artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbEcbbzejHmM77KousLXYy
