### PR TITLE
Add the missing README Usage sections for fifteen components

### DIFF
--- a/packages/components/src/components/donut-chart/README.md
+++ b/packages/components/src/components/donut-chart/README.md
@@ -12,3 +12,19 @@ Use a bar chart when precise comparison matters more than the part-to-whole rela
   onSeriesClick={(datum) => selectStatus(datum)}
 />
 ```
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { DonutChart } from '@lostgradient/cinder/donut-chart';
+  const data = [
+    { label: 'Build', value: 42 },
+    { label: 'Review', value: 28 },
+    { label: 'Test', value: 18 },
+    { label: 'Docs', value: 12 },
+  ];
+</script>
+
+<DonutChart label="Workload" {data} centerLabel="Tasks" valueLabels />
+```

--- a/packages/components/src/components/find-bar/README.md
+++ b/packages/components/src/components/find-bar/README.md
@@ -1,3 +1,13 @@
 # FindBar
 
 Docked find-in-document controls for a host-provided search backend.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { FindBar } from '@lostgradient/cinder/find-bar';
+</script>
+
+<FindBar value="terminal" activeIndex={1} matchCount={4} />
+```

--- a/packages/components/src/components/form/README.md
+++ b/packages/components/src/components/form/README.md
@@ -3,3 +3,23 @@
 Form is a thin native form root that exposes asynchronous submission state to its child snippet and ignores duplicate submissions while the current handler is pending.
 
 Use native validation and form controls as usual. The component owns only submit coordination; it does not replace native serialization, validation, or reset behavior.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { Form } from '@lostgradient/cinder/form';
+  import { Input } from '@lostgradient/cinder/input';
+  import { Button } from '@lostgradient/cinder/button';
+</script>
+
+<Form onSubmit={() => undefined}>
+  {#snippet children({ submitting })}
+    <Input id="form-name" label="Name" value="" disabled={submitting}>
+      {#snippet leading()}{/snippet}
+      {#snippet trailing()}{/snippet}
+    </Input>
+    <Button type="submit" disabled={submitting}>Save</Button>
+  {/snippet}
+</Form>
+```

--- a/packages/components/src/components/guidance-region/README.md
+++ b/packages/components/src/components/guidance-region/README.md
@@ -1,3 +1,30 @@
 # GuidanceRegion
 
 `GuidanceRegion` provides a context-scoped claim registry. Claims are filtered by version windows and can be dismissed or reset through a consumer-owned storage adapter.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { Button } from '@lostgradient/cinder/button';
+  import {
+    GuidanceRegion,
+    type GuidanceClaim,
+    useGuidance,
+  } from '@lostgradient/cinder/guidance-region';
+
+  const claims = [
+    { id: 'welcome', anchor: 'workspace-start', content: 'Start by exploring the workspace.' },
+  ] satisfies GuidanceClaim[];
+  let anchor: HTMLElement;
+</script>
+
+<GuidanceRegion {claims} version="1.0.0" anchorResolver={() => anchor}>
+  {#snippet children()}
+    {@const guidance = useGuidance()}
+    <span bind:this={anchor}>
+      <Button onclick={() => guidance.claim('welcome')}>Show welcome guidance</Button>
+    </span>
+  {/snippet}
+</GuidanceRegion>
+```

--- a/packages/components/src/components/host-provider/README.md
+++ b/packages/components/src/components/host-provider/README.md
@@ -5,3 +5,15 @@ Supplies a desktop host platform to descendant Cinder surfaces. It defaults to `
 `safeHeaderLeft` and `safeHeaderRight` publish the host-provided titlebar insets for Cinder's internal drag-region handshake. Both default to `0px`; desktop hosts should set them from the actual native window controls rather than copying OS-specific spacing into application CSS.
 
 HostProvider is the shared coordination boundary for desktop-aware Cinder surfaces. It renders a `display: contents` provider node, so it does not create a layout box.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { HostProvider } from '@lostgradient/cinder/host-provider';
+</script>
+
+<HostProvider platform="macos" safeHeaderLeft="4rem" safeHeaderRight="1rem">
+  <p>Desktop-aware application surface</p>
+</HostProvider>
+```

--- a/packages/components/src/components/inline-confirm/README.md
+++ b/packages/components/src/components/inline-confirm/README.md
@@ -1,3 +1,13 @@
 # InlineConfirm
 
 `InlineConfirm` keeps a confirmation in document flow for reversible actions. It uses a labelled `role="group"`, focuses Cancel on open, and restores focus to the trigger when dismissed.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { InlineConfirm } from '@lostgradient/cinder/inline-confirm';
+</script>
+
+<InlineConfirm prompt="Remove this workspace?" confirmLabel="Remove workspace" open destructive />
+```

--- a/packages/components/src/components/key-value-editor/README.md
+++ b/packages/components/src/components/key-value-editor/README.md
@@ -7,3 +7,17 @@
 ```
 
 The component owns row addition, removal, and change reporting. The consumer owns key validation and the policy that determines which keys are secret.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { KeyValueEditor } from '@lostgradient/cinder/key-value-editor';
+  let entries = $state([
+    { key: 'HOST', value: 'localhost' },
+    { key: 'PORT', value: '3000' },
+  ]);
+</script>
+
+<KeyValueEditor bind:entries />
+```

--- a/packages/components/src/components/modal-region/README.md
+++ b/packages/components/src/components/modal-region/README.md
@@ -1,3 +1,19 @@
 # ModalRegion
 
 Mount `ModalRegion` once in a context boundary and call `useModal().openModal` or `useModal().confirm` from descendants. State is scoped to the region and safe during SSR.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { Button } from '@lostgradient/cinder/button';
+  import { ModalRegion, useModal } from '@lostgradient/cinder/modal-region';
+</script>
+
+<ModalRegion>
+  {#snippet children()}
+    {@const modal = useModal()}
+    <Button onclick={() => modal.confirm({ title: 'Confirm action' })}>Open confirmation</Button>
+  {/snippet}
+</ModalRegion>
+```

--- a/packages/components/src/components/parameter-field/README.md
+++ b/packages/components/src/components/parameter-field/README.md
@@ -3,3 +3,13 @@
 Displays an inherited base parameter and an optional local override. Overrides can be reset to the base value and may carry Unsaved or Experimental badges.
 
 Use the default output for a read-only summary, or provide a child snippet to render a `NumberInput`, `Slider`, or another numeric editor. The snippet receives the effective `value`, whether it is `overridden`, and a `setOverride` callback.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { ParameterField } from '@lostgradient/cinder/parameter-field';
+</script>
+
+<ParameterField id="timeout" label="Timeout" base={30} unit="seconds" />
+```

--- a/packages/components/src/components/policy-lock/README.md
+++ b/packages/components/src/components/policy-lock/README.md
@@ -1,3 +1,13 @@
 # PolicyLock
 
 PolicyLock explains why a setting is managed, names the policy source when available, and displays the policy scope as a Badge. Use it with SettingRow when a setting is visible but not locally editable.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { PolicyLock } from '@lostgradient/cinder/policy-lock';
+</script>
+
+<PolicyLock id="retention-policy" reason="Managed by your organization" source="Security policy" />
+```

--- a/packages/components/src/components/setting-row/README.md
+++ b/packages/components/src/components/setting-row/README.md
@@ -1,3 +1,21 @@
 # SettingRow
 
 SettingRow arranges settings-page guidance and a control while publishing FormField context to composed Input, Toggle, or Select controls. It supports advisory, error, managed-policy, and optional disclosure content without duplicating those semantics at each call site.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { Input } from '@lostgradient/cinder/input';
+  import { SettingRow } from '@lostgradient/cinder/setting-row';
+</script>
+
+<SettingRow id="display-name" label="Display name" description="Shown to collaborators.">
+  {#snippet control()}
+    <Input id="display-name" value="" placeholder="Ada Lovelace">
+      {#snippet leading()}{/snippet}
+      {#snippet trailing()}{/snippet}
+    </Input>
+  {/snippet}
+</SettingRow>
+```

--- a/packages/components/src/components/shortcut-field/README.md
+++ b/packages/components/src/components/shortcut-field/README.md
@@ -1,3 +1,13 @@
 # ShortcutField
 
 An accessible read-only keyboard shortcut recorder. Focus the field, press a combination, or press Escape to cancel capture.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { ShortcutField } from '@lostgradient/cinder/shortcut-field';
+</script>
+
+<ShortcutField label="Open command palette" value={['Meta', 'K']} />
+```

--- a/packages/components/src/components/terminal-frame/README.md
+++ b/packages/components/src/components/terminal-frame/README.md
@@ -9,3 +9,18 @@ Use `TerminalOutput` for read-only ANSI streams. Use `TerminalFrame` when the ch
   <PtyRenderer />
 </TerminalFrame>
 ```
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { TerminalFrame } from '@lostgradient/cinder/terminal-frame';
+</script>
+
+<TerminalFrame title="Build shell" status="connected">
+  {#snippet children()}
+    <pre style="margin: 0;">$ bun run build
+Build complete.</pre>
+  {/snippet}
+</TerminalFrame>
+```

--- a/packages/components/src/components/terminal-output/README.md
+++ b/packages/components/src/components/terminal-output/README.md
@@ -5,3 +5,14 @@ Read-only ANSI process output. It supports SGR 16-color foregrounds, bold/reset,
 ```svelte
 <TerminalOutput aria-label="Build output" value={'\u001b[32mready\u001b[0m\n'} />
 ```
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { TerminalOutput } from '@lostgradient/cinder/terminal-output';
+  const value = '\u001b[32mPASS\u001b[0m build\n\u001b[33mWARN\u001b[0m cache miss';
+</script>
+
+<TerminalOutput {value} />
+```

--- a/packages/components/src/components/zoom-pan-viewer/README.md
+++ b/packages/components/src/components/zoom-pan-viewer/README.md
@@ -1,3 +1,21 @@
 # ZoomPanViewer
 
 An accessible viewport for panning and zooming images, SVGs, and Mermaid diagrams.
+
+## Usage
+
+```svelte
+<script lang="ts">
+  import { ZoomPanViewer } from '@lostgradient/cinder/zoom-pan-viewer';
+</script>
+
+<ZoomPanViewer ariaLabel="Architecture diagram">
+  {#snippet children()}
+    <div
+      style="min-width: 36rem; min-height: 12rem; padding: 3rem; background: var(--cinder-surface-raised);"
+    >
+      Architecture diagram
+    </div>
+  {/snippet}
+</ZoomPanViewer>
+```


### PR DESCRIPTION
## Summary

Fifteen components added across #1469, #1471, and #1472 shipped READMEs with a title and a description but no `## Usage` section. The README compile gate reports `no-heading` for each, which fails `validate:consumer` at its `typescript-consumer` step — blocking **both** the release and `main-green` (which runs `validate:consumer:readme-usage-examples`).

`donut-chart`, `find-bar`, `form`, `guidance-region`, `host-provider`, `inline-confirm`, `key-value-editor`, `modal-region`, `parameter-field`, `policy-lock`, `setting-row`, `shortcut-field`, `terminal-frame`, `terminal-output`, `zoom-pan-viewer`.

## These examples are not invented

Each of the fifteen already had exactly one authored example in its `<component>.examples.json`. Despite its name, `generate-readme-usage-examples.mjs` only *validates* the README fence — it never writes it. So these sections are transcribed from the existing authored examples rather than newly written.

That matters for review: the usage shown is the component author's, and the README now agrees with the examples corpus instead of being a second, independently-drifting source of truth.

## Verification

```
bun run --filter=@lostgradient/cinder validate:consumer:readme-usage-examples
```

Exit code `0`, against the real packed tarball:

```
[validate-consumers] typescript-consumer OK (gates 1–3 green).
[validate-consumers] readme usage examples smoke passed.
```

Every fence is genuinely compile-checked, not merely present — the gate materializes each one as a standalone `.svelte` file that the existing `svelte-check --threshold error` pass picks up.

## No changeset

Component READMEs *do* ship (`src/components/**/*.md` is in `files`), so this would normally warrant one. It doesn't here: all fifteen components arrived after the release stalled on 2026-08-21 and are absent from the published `0.24.8`, so this documentation has never shipped and lands with the components themselves in `0.25.0`.

## Release context

This is the last of four independent blockers between `main` and a published release, found one behind the other:

1. InlineConfirm viewport `@media` — #1473, merged
2. Chat `--cinder-ease-out` undeclared token — #1474
3. `tokens-consumer` stale non-representable assertion — #1476
4. these missing `## Usage` sections — this PR

The common cause is that #1469/#1471/#1472 landed large component batches while the release PR sat unmerged since 08-21, so no real publish ever exercised these gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbEcbbzejHmM77KousLXYy
