### PR TITLE
fix: trim published Cinder artifact whitespace

### DIFF
--- a/packages/components/scripts/build.ts
+++ b/packages/components/scripts/build.ts
@@ -427,7 +427,10 @@ const browserBuildResult = await Bun.build({
     asset: '[name]-[hash].[ext]',
   },
   sourcemap: 'external',
-  minify: false,
+  // Published browser artifacts do not need formatting whitespace. Keep
+  // identifiers and syntax intact for readable stack traces while avoiding
+  // duplicating source-formatting bytes alongside the retained Svelte source.
+  minify: { whitespace: true, identifiers: false, syntax: false },
   plugins: [
     cssImportPlugin({
       perComponentStyleSpecifiers,
@@ -513,7 +516,9 @@ const perComponentServerBuildResult = await Bun.build({
     asset: '[name]-[hash].[ext]',
   },
   sourcemap: 'external',
-  minify: false,
+  // Match the browser artifacts: trim formatting without mangling identifiers
+  // or rewriting syntax so server stack traces stay useful.
+  minify: { whitespace: true, identifiers: false, syntax: false },
   plugins: [serverCssNoopPlugin, sveltePlugin({ generate: 'server' })],
 });
 


### PR DESCRIPTION
## Summary

- trim formatting whitespace from published browser and server JavaScript artifacts
- preserve identifiers and syntax for readable stack traces
- reduce the exact Cinder tarball from 26.55 MB to 22.68 MB unpacked without changing its file or export surface

## Verification

- `bun test packages/components/scripts/pack-for-publish.test.ts packages/components/scripts/report-package-weight.test.ts`
- `bun run --filter=@lostgradient/cinder build`
- `bun run --filter=@lostgradient/cinder package:weight:check`
- `bun run --filter=@lostgradient/cinder validate:consumer`

The packed consumer matrix passed for Node resolution, TypeScript, minimum/latest Svelte, SvelteKit SSR/hydration, all 451 examples, and the 308-token registry contract.