### PR TITLE
Restore cinder's unpacked weight budget to 26 MB

### DIFF
--- a/packages/components/scripts/report-package-weight.ts
+++ b/packages/components/scripts/report-package-weight.ts
@@ -55,20 +55,25 @@ const budgetsByPackage: Record<string, PackageWeightBudgets> = {
   // pinning them exactly, matching this file's existing convention for
   // every other package.
   //
-  // Crossed again on 2026-08-31 by the same mechanism: 23 components landed
-  // since the measurement above (194 -> 200 published components), taking the
-  // 0.25.0 pack to 5.34 MB packed / 26.55 MB unpacked / 4,835 files and
-  // breaching the 26 MB unpacked cap alone — packed, fileCount, and
-  // largestEntrypoint all still sat well under budget, and the largest entries
-  // are all load-bearing output (the dist/index.js barrel, the 200-component
-  // exports map in package.json, and the components.json manifest that
-  // validate:consumer resolves against). ~176 KB and ~10 files per new
-  // component, in line with the per-component norm this comment already
-  // documents, so this is organic growth rather than bloat. Raised to 30 MB
-  // to restore roughly the same proportional headroom as the resets above.
+  // Appeared to be crossed again on 2026-08-31 at 5.34 MB packed / 26.55 MB
+  // unpacked / 4,835 files, which failed the release job's "Check validated
+  // Cinder package artifact budget" step and left 0.25.0 unpublished. That
+  // reading was NOT organic growth: the emitted artifacts carried padding
+  // whitespace, and trimming it in build.ts (#1480) took the same 0.25.0 pack
+  // to 4.94 MB packed / 22.68 MB unpacked, which published cleanly under this
+  // 26 MB cap. The cap was briefly raised to 30 MB (#1481) on the mistaken
+  // reading that 26.55 MB was legitimate component growth with nothing
+  // removable; #1480 disproved that by removing 3.87 MB. Restored to 26 MB,
+  // which keeps roughly the ~15% headroom over the measured pack that every
+  // other reset in this comment used.
+  //
+  // The lesson for the next breach: check whether the emitted bytes are
+  // padded before concluding the package legitimately outgrew its budget.
+  // A largest-files listing shows which files are big, not whether their
+  // contents are wasteful.
   '@lostgradient/cinder': {
     packedBytes: 6_000_000,
-    unpackedBytes: 30_000_000,
+    unpackedBytes: 26_000_000,
     fileCount: 5_200,
     largestEntrypointBytes: 2_500_000,
   },


### PR DESCRIPTION
## Why

#1481 raised this cap from 26 MB to 30 MB on a diagnosis that turned out to be wrong, and I'd rather not leave a weakened anti-bloat guard behind.

The 26.55 MB reading that failed the release job's `Check validated Cinder package artifact budget` step was **not** organic component growth. I concluded from the largest-files listing that nothing was removable without losing load-bearing content. #1480 disproved that: it enabled whitespace-only minification in `build.ts` and removed **3.87 MB**.

```diff
- minify: false,
+ minify: { whitespace: true, identifiers: false, syntax: false },
```

Identifiers and syntax are left intact so stack traces stay readable — only formatting bytes go, which the package was carrying alongside the retained Svelte source.

That took the same `0.25.0` pack from 5.34 MB packed / 26.55 MB unpacked to **4.94 MB packed / 22.68 MB unpacked**, and it published cleanly under the original 26 MB cap on `285755257` — before #1481 merged. The raise contributed nothing to unblocking the publish.

## Why 26 MB and not 30

| | value | headroom over measured |
|---|---|---|
| measured (0.25.0, clean build) | 22.68 MB | — |
| 26 MB (restored) | 26 MB | ~15% |
| 30 MB (#1481) | 30 MB | ~32% |

Every other reset recorded in that comment sits at roughly 15% headroom over the measured pack. 30 MB is about double that, which weakens the guard for no reason now that the padding is gone.

## Verification

Measured against a real pack on this branch, checked by exit code:

```
packed:   4.94 MB
unpacked: 22.68 MB
files:    4835
package:weight:check → exit 0
```

Matches the CI numbers from #1480's release run exactly. `report-package-weight.test.ts` passes 12/12, and the changeset guard exits 0.

One trap worth recording, since it nearly produced a wrong conclusion a second time: an initial local run reported the old 26.55 MB, because `dist/` predated #1480 and the build **hash-skipped** rather than rebuilding. The numbers above come from a clean rebuild after removing `dist/`. A stale `dist/` will silently reproduce the pre-#1480 measurement.

## Comment

The comment above the budget now records what actually happened, including the misdiagnosis, so the next breach starts by checking whether the emitted bytes are padded rather than assuming the package outgrew its cap. A largest-files listing shows which files are big — not whether their contents are wasteful.

No changeset: scripts-only, no published behavior change.

https://claude.ai/code/session_012oFomkXeF8z1U46aaWJtKL