### PR TITLE
Pin first-party fixture overrides and bound fixture installs (CIN-504)

### DIFF
--- a/packages/components/scripts/validate-consumers.test.ts
+++ b/packages/components/scripts/validate-consumers.test.ts
@@ -20,6 +20,7 @@ import {
   isBrowserCrashError,
   isSupportedViteNodeVersion,
   parseHydrationBrowserProcessIds,
+  pinFirstPartyFixtureOverrides,
   preoptimizeSvelteKitChatHydration,
   prepareSvelteKitChatHydrationDevServer,
   recordBoundedDiagnostic,
@@ -36,6 +37,72 @@ import {
   type SvelteKitHydrationRouteDomObservation,
   type SvelteKitHydrationRouteFailureSnapshot,
 } from './validate-consumers.ts';
+
+describe('first-party fixture overrides', () => {
+  test('pins a file: cinder dependency into overrides', () => {
+    const dependencies: Record<string, unknown> = {
+      '@lostgradient/cinder': 'file:/tmp/lostgradient-cinder-0.25.0.tgz',
+    };
+    const overrides: Record<string, unknown> = {};
+
+    pinFirstPartyFixtureOverrides(dependencies, overrides);
+
+    expect(overrides).toEqual({
+      '@lostgradient/cinder': 'file:/tmp/lostgradient-cinder-0.25.0.tgz',
+    });
+  });
+
+  test('pins chat too, so its cinder peer cannot resolve from the registry', () => {
+    // The CIN-504 regression: chat declares `"@lostgradient/cinder": "^0.25.0"`
+    // as a peer. A direct file: dependency does not constrain that peer edge, so
+    // once 0.25.0 existed on the registry the install resolved it from the
+    // network and hung. Both first-party packages must be pinned.
+    const dependencies: Record<string, unknown> = {
+      '@lostgradient/cinder': 'file:/tmp/lostgradient-cinder-0.25.0.tgz',
+      '@lostgradient/chat': 'file:/tmp/lostgradient-chat-0.13.1.tgz',
+      '@lostgradient/markdown': 'file:/tmp/lostgradient-markdown-0.4.0.tgz',
+    };
+    const overrides: Record<string, unknown> = {
+      '@lostgradient/markdown': 'file:/tmp/lostgradient-markdown-0.4.0.tgz',
+    };
+
+    pinFirstPartyFixtureOverrides(dependencies, overrides);
+
+    expect(overrides['@lostgradient/cinder']).toBe('file:/tmp/lostgradient-cinder-0.25.0.tgz');
+    expect(overrides['@lostgradient/chat']).toBe('file:/tmp/lostgradient-chat-0.13.1.tgz');
+  });
+
+  test('preserves unrelated overrides already present', () => {
+    const dependencies: Record<string, unknown> = {
+      '@lostgradient/cinder': 'file:/tmp/cinder.tgz',
+    };
+    const overrides: Record<string, unknown> = { svelte: '5.56.6' };
+
+    pinFirstPartyFixtureOverrides(dependencies, overrides);
+
+    expect(overrides['svelte']).toBe('5.56.6');
+  });
+
+  test('leaves a registry-resolved first-party dependency alone', () => {
+    // A fixture that deliberately installs the published package must keep
+    // resolving from the registry, so only file: specifiers are pinned.
+    const dependencies: Record<string, unknown> = { '@lostgradient/cinder': '^0.25.0' };
+    const overrides: Record<string, unknown> = {};
+
+    pinFirstPartyFixtureOverrides(dependencies, overrides);
+
+    expect(overrides).toEqual({});
+  });
+
+  test('adds nothing for a first-party package the fixture does not depend on', () => {
+    const dependencies: Record<string, unknown> = { '@lostgradient/cinder': 'file:/tmp/c.tgz' };
+    const overrides: Record<string, unknown> = {};
+
+    pinFirstPartyFixtureOverrides(dependencies, overrides);
+
+    expect(Object.keys(overrides)).toEqual(['@lostgradient/cinder']);
+  });
+});
 
 describe('à la carte CSS contract', () => {
   test('allows global component token declarations but rejects accordion selectors', () => {

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -25,6 +25,7 @@ import {
   runHookCommand,
   signalHookProcessGroup,
   withLocalValidationGateLock,
+  type HookCommandResult,
 } from './husky/utilities.ts';
 import {
   containsUpstreamSpecifier,
@@ -135,6 +136,99 @@ class ValidationError extends Error {
 
 function fail(message: string): never {
   throw new ValidationError(message);
+}
+
+/**
+ * Package names whose fixture dependency edges must always resolve to the
+ * locally packed tarball rather than to whatever the registry happens to hold.
+ */
+const FIRST_PARTY_FIXTURE_PACKAGE_NAMES = ['@lostgradient/cinder', '@lostgradient/chat'] as const;
+
+/**
+ * Pins first-party packages in `overrides` as well as in `dependencies`.
+ *
+ * A direct `file:` dependency constrains only the top-level edge. It does NOT
+ * constrain a transitive *peer* range: `@lostgradient/chat` declares a peer on
+ * `@lostgradient/cinder`, so the moment a version satisfying that range exists
+ * on the registry, `bun install` resolves the peer from the network instead of
+ * the tarball under test. That is wrong on its own terms — the fixture would be
+ * validating published bytes rather than the staged ones this run just packed —
+ * and in CI it hung, consuming release.yaml's entire 45-minute job budget (see
+ * CIN-504; onset matched the 0.25.0 publish to the second, because `^0.25.0`
+ * had no published match until that moment).
+ *
+ * The neighbouring chat-peer loop already guards the mirror-image case, where
+ * the peer range names a version that does not exist *yet* during a same-train
+ * release. This closes the opposite case: the version now existing.
+ *
+ * Only `file:` specifiers are pinned, so a fixture that intentionally resolves
+ * a first-party package from the registry is left alone.
+ */
+export function pinFirstPartyFixtureOverrides(
+  dependencies: Record<string, unknown>,
+  overrides: Record<string, unknown>,
+): void {
+  for (const packageName of FIRST_PARTY_FIXTURE_PACKAGE_NAMES) {
+    const specifier = dependencies[packageName];
+    if (typeof specifier === 'string' && specifier.startsWith('file:')) {
+      overrides[packageName] = specifier;
+    }
+  }
+}
+
+/**
+ * Upper bound for a single fixture `bun install`.
+ *
+ * This is a diagnostic bound, not a tuning knob. A healthy fixture install
+ * finishes in seconds, so anything approaching this limit is a hang to
+ * investigate rather than a slow install to wait longer for — do not raise it
+ * to get a run green. It exists because `bun install` reaches the network and
+ * can stall indefinitely; before this bound, such a stall ran out the whole
+ * 45-minute job and surfaced as a bare "cancelled" with no output at all,
+ * because the streams are piped and never printed when the job is killed.
+ */
+const FIXTURE_INSTALL_TIMEOUT_MILLISECONDS = 10 * 60 * 1_000;
+
+/** `runHookCommand` reports an aborted (timed-out) child with this exit code. */
+const FIXTURE_INSTALL_ABORTED_EXIT_CODE = 130;
+
+/**
+ * Runs one fixture `bun install` under {@link FIXTURE_INSTALL_TIMEOUT_MILLISECONDS}.
+ *
+ * Callers keep their own non-zero-exit handling; this owns only the timeout,
+ * which it reports with whatever output the child managed to produce so a hang
+ * leaves evidence behind instead of a silent job kill.
+ */
+async function runFixtureInstall(
+  fixtureLabel: string,
+  fixtureDirectory: string,
+  options: { extraArguments?: readonly string[]; streamOutput?: boolean } = {},
+): Promise<HookCommandResult> {
+  const streamOutput = options.streamOutput ?? false;
+  const result = await runHookCommand(
+    'bun',
+    ['install', '--no-save', ...(options.extraArguments ?? [])],
+    {
+      cwd: fixtureDirectory,
+      signal: AbortSignal.timeout(FIXTURE_INSTALL_TIMEOUT_MILLISECONDS),
+      ...(streamOutput ? {} : { stdout: 'pipe' as const, stderr: 'pipe' as const }),
+    },
+  );
+
+  if (result.exitCode === FIXTURE_INSTALL_ABORTED_EXIT_CODE) {
+    fail(
+      `${fixtureLabel} bun install did not finish within ` +
+        `${FIXTURE_INSTALL_TIMEOUT_MILLISECONDS / 60_000} minutes and was terminated. ` +
+        'A healthy fixture install completes in seconds, so this is a hang rather than a slow ' +
+        'install — the usual cause is dependency resolution escaping to the registry.' +
+        (streamOutput
+          ? ''
+          : `
+stdout:\n${result.stdout}\nstderr:\n${result.stderr}`),
+    );
+  }
+
+  return result;
 }
 
 export function removeFixtureEntries(fixtureDirectory: string, entries: readonly string[]): void {
@@ -966,6 +1060,7 @@ function injectTarballIntoFixture(
       dependencies[dependencyName] = version;
     }
   }
+  pinFirstPartyFixtureOverrides(dependencies, overrides);
   writeFileSync(manifestPath, JSON.stringify(parsed, null, 2) + '\n');
   return () => writeFileSync(manifestPath, originalContent);
 }
@@ -987,11 +1082,7 @@ async function runStylesConsumerFixture(): Promise<void> {
 
   try {
     removeFixtureEntries(fixtureDirectory, ['node_modules', 'dist']);
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
+    const installResult = await runFixtureInstall('styles-consumer', fixtureDirectory);
     if (installResult.exitCode !== 0) {
       fail(`styles-consumer bun install failed:\n${installResult.stdout}\n${installResult.stderr}`);
     }
@@ -1114,11 +1205,7 @@ async function runSveltePeerCompatibilityFixture(
 
   try {
     removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
+    const installResult = await runFixtureInstall(`typescript-consumer ${label}`, fixtureDirectory);
     if (installResult.exitCode !== 0) {
       fail(
         `typescript-consumer ${label} bun install failed for svelte@${svelteVersion}:\n${installResult.stdout}\n${installResult.stderr}`,
@@ -1145,11 +1232,7 @@ async function runTypescriptCompatibilityFixture(
 
   try {
     removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
+    const installResult = await runFixtureInstall(`typescript-consumer ${label}`, fixtureDirectory);
     if (installResult.exitCode !== 0) {
       fail(
         `typescript-consumer ${label} bun install failed for typescript@${typescriptVersion}:\n${installResult.stdout}\n${installResult.stderr}`,
@@ -1795,15 +1878,9 @@ async function runSveltekitFixture(label = 'workspace', svelteVersion?: string):
     // These tarballs are rebuilt repeatedly at the same path and version during
     // local validation. Bypass Bun's package cache so hydration always exercises
     // the bytes produced by this run rather than a stale earlier pack.
-    const installResult = await runHookCommand(
-      'bun',
-      ['install', '--no-save', '--force', '--no-cache'],
-      {
-        cwd: fixtureDirectory,
-        stdout: 'pipe',
-        stderr: 'pipe',
-      },
-    );
+    const installResult = await runFixtureInstall(`sveltekit-consumer ${label}`, fixtureDirectory, {
+      extraArguments: ['--force', '--no-cache'],
+    });
     if (installResult.exitCode !== 0) {
       fail(
         `sveltekit-consumer ${label} bun install failed:\n${installResult.stdout}\n${installResult.stderr}`,
@@ -3187,11 +3264,7 @@ async function runNodeFixture(): Promise<void> {
 
   try {
     removeFixtureEntries(fixtureDirectory, ['node_modules', 'dist']);
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
+    const installResult = await runFixtureInstall('node-consumer', fixtureDirectory);
     if (installResult.exitCode !== 0) {
       fail(`node-consumer bun install failed:\n${installResult.stdout}\n${installResult.stderr}`);
     }
@@ -3268,11 +3341,7 @@ async function runManifestConsumerFixture(): Promise<void> {
 
   try {
     await rm(join(fixtureDirectory, 'node_modules'), { recursive: true, force: true });
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
+    const installResult = await runFixtureInstall('manifest-consumer', fixtureDirectory);
     if (installResult.exitCode !== 0) {
       fail(
         `manifest-consumer bun install failed:\n${installResult.stdout}\n${installResult.stderr}`,
@@ -3316,11 +3385,7 @@ async function runTokensConsumerFixture(): Promise<void> {
 
   try {
     await rm(join(fixtureDirectory, 'node_modules'), { recursive: true, force: true });
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
+    const installResult = await runFixtureInstall('tokens-consumer', fixtureDirectory);
     if (installResult.exitCode !== 0) {
       fail(`tokens-consumer bun install failed:\n${installResult.stdout}\n${installResult.stderr}`);
     }
@@ -3369,11 +3434,7 @@ async function runTypescriptConsumerFixture(): Promise<void> {
 
   try {
     removeFixtureEntries(fixtureDirectory, ['node_modules', 'src/generated']);
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
-      stdout: 'pipe',
-      stderr: 'pipe',
-    });
+    const installResult = await runFixtureInstall('typescript-consumer', fixtureDirectory);
     if (installResult.exitCode !== 0) {
       fail(
         `typescript-consumer bun install failed:\n${installResult.stdout}\n${installResult.stderr}`,
@@ -3417,8 +3478,8 @@ async function runExamplesConsumerFixture(): Promise<void> {
       'src/generated',
       'src/routes/+page.svelte',
     ]);
-    const installResult = await runHookCommand('bun', ['install', '--no-save'], {
-      cwd: fixtureDirectory,
+    const installResult = await runFixtureInstall('examples-consumer', fixtureDirectory, {
+      streamOutput: true,
     });
     if (installResult.exitCode !== 0) {
       fail(`examples-consumer bun install failed with exit ${installResult.exitCode}`);


### PR DESCRIPTION
Closes CIN-504.

## Why

Every `release.yaml` run since `0.25.0` published dies at the 45-minute job cap in `Validate Cinder package artifact`, stalling at:

```
sveltekit-consumer latest tested Svelte 5: installing…
```

Nothing is waiting to publish today, so nothing is currently broken — but the next release cannot ship.

## It is not a code regression

Re-running the *exact run* that had succeeded in 1021s reproduced the hang at 2716s on the same commit:

| commit | when | result |
| --- | --- | --- |
| `285755257` | 18:09 | success, 1021s |
| `285755257` (re-run) | 21:1x | **hang, 2716s** |

Same commit, same workflow, opposite outcome. The cause is environmental and commit-independent.

## Root cause

Onset matches the publish to the second:

```
0.25.0 published to npm      18:26:00.679Z
last successful job ended    18:26:22      (that job performed the publish)
first hanging job started    18:26:25
```

`@lostgradient/chat` declares `peerDependencies: { "@lostgradient/cinder": "^0.25.0" }`. `injectTarballIntoFixture` wrote `overrides` entries only for workspace dependency packages, leaving cinder and chat with `dependencies` entries alone.

A direct `file:` dependency constrains only the top-level edge — **it does not constrain a transitive peer range**. While the registry topped out at `0.24.8` that peer had no published match, so resolution stayed local. The moment `0.25.0` existed it became satisfiable, and `bun install --no-cache` went to the network for it. That is wrong on its own terms: the fixture would be validating published bytes rather than the staged tarball the run just packed.

The neighbouring chat-peer loop already guards the mirror-image case — a peer naming a version that does not exist *yet* during a same-train release. This closes the opposite case: the version now existing.

## Changes

**`pinFirstPartyFixtureOverrides`** pins both first-party packages in `overrides` as well as `dependencies`, so every edge stays on the local tarball whatever the registry holds. Only `file:` specifiers are pinned, so a fixture that deliberately resolves a published package is untouched.

**`runFixtureInstall`** bounds all nine fixture installs with a 10-minute timeout and reports a hang with whatever output the child produced. The installs previously had no timeout and piped both streams, so a stall consumed the entire job budget and printed nothing — **four separate 45-minute failures produced zero diagnostic output.** Call sites keep their own non-zero-exit messages; the helper owns only the timeout. `examples-consumer` streams rather than pipes, and that behavior is preserved.

The 10-minute bound is diagnostic, not a tuning knob. Healthy fixture installs finish in seconds, and a timeout aborts the script, so a run can spend at most one and still land ~24 min into a 45-minute budget. It is commented as not to be raised to turn a run green.

## Verification

Checked by exit code, not by grepping output:

- `bun run --filter=@lostgradient/cinder validate:consumer` → **exit 0**, "all checks passed", including `examples-consumer OK — 451 example entries each rendered exactly once`
- `typecheck` → 0 errors across 6,653 files
- `lint` → 0 errors
- `validate-consumers.test.ts` → 51 pass / 0 fail, including a regression test that names this mechanism

## What this PR cannot prove

The registry-resolution fix is **unverified against the actual failure.** The hang has never reproduced outside CI — a full `validate:consumer` passes locally in both the broken and fixed states — and `validate:consumer` runs only on the release path, so no pull request exercises it.

Confirming the fix requires watching a `release.yaml` run on `main` after merge: the job should complete `Validate Cinder package artifact` and finish in under 25 minutes (healthy runs were 16–18 min). If it hangs again, the second change guarantees we get diagnostic output this time instead of another silent 45-minute kill.

## No changeset

Scripts-only, no published behavior change. A pending changeset would also divert `release` to the version-PR path.

https://claude.ai/code/session_012oFomkXeF8z1U46aaWJtKL