### PR TITLE
fix(playground): warm the page server renderer before advertising readiness

### DIFF
--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -2151,6 +2151,28 @@ describe('warmPageServerRenderer', () => {
   });
 
   /**
+   * `loadPageServerRenderer` resolves a build failure against its last-good renderer
+   * instead of rejecting, so the catch never fires. The HTTP server listens (answering
+   * /ping with 503) before the warmup runs, so a request can populate the memo first and
+   * make that last-good exist. Treating the fallback as a successful warmup would
+   * advertise readiness behind a stale renderer and silently contradict the contract that
+   * a failed warmup leaves the first request to rebuild.
+   */
+  it('treats a last-good fallback as an unsuccessful warmup and drops the memo', async () => {
+    let resetCalls = 0;
+
+    await warmPageServerRenderer(
+      async () => ({ renderers: {}, usedFallback: true }),
+      () => {
+        resetCalls += 1;
+      },
+      stable,
+    );
+
+    expect(resetCalls).toBe(1);
+  });
+
+  /**
    * A warmup failure must not be fatal and must not be cached. `loadPageServerRenderer`
    * resolves build errors against its last-good renderer, and at startup there is no
    * last-good — so a genuine failure rejects. Caching that rejected promise would

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -80,6 +80,8 @@ import {
   resolveRendererLoad,
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
+  type PageServerRendererLoadResult,
+  type PageServerRenderers,
 } from './ssr-renderer.ts';
 
 describe('eagerPrebuildComponents', () => {
@@ -2081,6 +2083,15 @@ describe('/page/:name server-rendering surfaces', () => {
 });
 
 describe('warmPageServerRenderer', () => {
+  /**
+   * Minimal renderers matching the real `PageServerRenderers` shape. Typed rather
+   * than `{}` so a stub cannot drift from the loader's contract undetected.
+   */
+  const renderers = {
+    renderComponentPageBody: () => ({ body: '', head: '' }),
+    renderLandingBody: () => ({ body: '', head: '' }),
+  } as unknown as PageServerRenderers;
+
   /** Runs the work and reports a stable generation, like an undisturbed startup. */
   const stable = async <T>(
     work: () => Promise<T>,
@@ -2105,7 +2116,7 @@ describe('warmPageServerRenderer', () => {
     await warmPageServerRenderer(
       async () => {
         loadCalls += 1;
-        return {};
+        return { renderers, usedFallback: false };
       },
       () => {
         resetCalls += 1;
@@ -2135,7 +2146,7 @@ describe('warmPageServerRenderer', () => {
     await warmPageServerRenderer(
       async () => {
         loadCalls += 1;
-        return {};
+        return { renderers, usedFallback: false };
       },
       () => {
         resetCalls += 1;
@@ -2162,7 +2173,7 @@ describe('warmPageServerRenderer', () => {
     let resetCalls = 0;
 
     await warmPageServerRenderer(
-      async () => ({ renderers: {}, usedFallback: true }),
+      async () => ({ renderers, usedFallback: true }),
       () => {
         resetCalls += 1;
       },
@@ -2170,6 +2181,30 @@ describe('warmPageServerRenderer', () => {
     );
 
     expect(resetCalls).toBe(1);
+  });
+
+  /**
+   * A discard must target THIS load. A concurrent `/page/:name` request can install a
+   * newer promise in the memo while the warmup is still in flight; resetting
+   * unconditionally would throw away that newer build and leave the first crawl request
+   * to start a third one — reintroducing the cold compile this warmup exists to remove.
+   */
+  it('discards only its own load, passing the promise it installed', async () => {
+    let seen: unknown = 'not-called';
+    let installed: unknown;
+
+    await warmPageServerRenderer(
+      () => {
+        installed = Promise.resolve({ renderers, usedFallback: true });
+        return installed as Promise<PageServerRendererLoadResult>;
+      },
+      (expected) => {
+        seen = expected;
+      },
+      stable,
+    );
+
+    expect(seen).toBe(installed);
   });
 
   /**

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -62,6 +62,7 @@ import {
   rewriteRepositoryRelativeReadmeLinks,
   runConcurrentStartupWarmup,
   runGenerationCheckedWarmup,
+  warmPageServerRenderer,
   warmupInstabilityReasons,
 } from './playground-server.ts';
 import { configureRequestIdleTimeout } from './port-scanner.ts';
@@ -2077,4 +2078,57 @@ describe('/page/:name server-rendering surfaces', () => {
     // page's.
     expect(preview.length).toBeLessThan(canonical.length / 2);
   }, 60_000);
+});
+
+describe('warmPageServerRenderer', () => {
+  /**
+   * `startServer`'s warmup prepared only the SHELL renderer, so `/ping` reported
+   * ready while `page-server-entry.ts` was still uncompiled and the first
+   * `GET /page/:name` paid a full uncached `Bun.build()`. `validate-playground.ts`
+   * crawls every route under a fixed 5s timeout with no warmup and no retry, so
+   * the alphabetically-first component absorbed that compile and intermittently
+   * blew the budget — turning main red after a merge, since that crawl runs only
+   * on main and never on pull requests.
+   */
+  it('compiles the page server renderer so the first request does not pay for it', async () => {
+    let loadCalls = 0;
+    let resetCalls = 0;
+
+    await warmPageServerRenderer(
+      async () => {
+        loadCalls += 1;
+        return {};
+      },
+      () => {
+        resetCalls += 1;
+      },
+    );
+
+    expect(loadCalls).toBe(1);
+    expect(resetCalls).toBe(0);
+  });
+
+  /**
+   * A warmup failure must not be fatal and must not be cached. `loadPageServerRenderer`
+   * resolves build errors against its last-good renderer, and at startup there is no
+   * last-good — so a genuine failure rejects. Caching that rejected promise would
+   * poison every later request, so the memo slot is dropped and the first real request
+   * retries exactly as it did before this warmup existed.
+   */
+  it('drops the memo slot on failure instead of caching a rejection, and does not throw', async () => {
+    let resetCalls = 0;
+
+    const warmup = warmPageServerRenderer(
+      async () => {
+        throw new Error('page server bundle failed');
+      },
+      () => {
+        resetCalls += 1;
+      },
+    );
+
+    expect(warmup).resolves.toBeUndefined();
+    await warmup;
+    expect(resetCalls).toBe(1);
+  });
 });

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -74,9 +74,11 @@ import {
   formatBuildLogs,
   isPageServerRenderers,
   isShellServerRendererModule,
+  loadPageServerRenderer,
   rendererWarmupAttemptDecision,
   rendererWarmupNeedsCacheInvalidation,
   rendererWarmupNeedsPrebuild,
+  resetPageServerRendererPromise,
   resolveRendererLoad,
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
@@ -2080,6 +2082,38 @@ describe('/page/:name server-rendering surfaces', () => {
     // page's.
     expect(preview.length).toBeLessThan(canonical.length / 2);
   }, 60_000);
+});
+
+describe('loadPageServerRenderer memo identity', () => {
+  /**
+   * The targeted reset compares promise IDENTITY, so the loader must hand callers
+   * the exact promise it memoizes. An `async` wrapper would instead return a fresh
+   * promise that merely adopts the stored one, `expected` could never match, every
+   * targeted reset would be silently suppressed, and a rejected or last-good memo
+   * would never clear. This runs the REAL loader and reset together -- a stubbed
+   * reset cannot observe this, which is how the bug shipped the first time.
+   */
+  it('returns the memoized promise itself, so a targeted reset can match it', async () => {
+    resetPageServerRendererPromise();
+    const first = loadPageServerRenderer();
+    const second = loadPageServerRenderer();
+    try {
+      expect(second).toBe(first);
+
+      // Discarding a DIFFERENT promise must leave the memo alone...
+      resetPageServerRendererPromise(Promise.resolve() as never);
+      expect(loadPageServerRenderer()).toBe(first);
+
+      // ...and discarding the memoized one must clear it.
+      resetPageServerRendererPromise(first);
+      const third = loadPageServerRenderer();
+      expect(third).not.toBe(first);
+      await Promise.allSettled([third]);
+    } finally {
+      resetPageServerRendererPromise();
+      await Promise.allSettled([first]);
+    }
+  });
 });
 
 describe('warmPageServerRenderer', () => {

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -2082,7 +2082,12 @@ describe('/page/:name server-rendering surfaces', () => {
 
 describe('warmPageServerRenderer', () => {
   /** Runs the work and reports a stable generation, like an undisturbed startup. */
-  const stable = async (work) => ({ value: await work(), instabilityReasons: [] });
+  const stable = async <T>(
+    work: () => Promise<T>,
+  ): Promise<{ value: T; instabilityReasons: string[] }> => ({
+    value: await work(),
+    instabilityReasons: [],
+  });
 
   /**
    * `startServer`'s warmup prepared only the SHELL renderer, so `/ping` reported

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -2081,6 +2081,9 @@ describe('/page/:name server-rendering surfaces', () => {
 });
 
 describe('warmPageServerRenderer', () => {
+  /** Runs the work and reports a stable generation, like an undisturbed startup. */
+  const stable = async (work) => ({ value: await work(), instabilityReasons: [] });
+
   /**
    * `startServer`'s warmup prepared only the SHELL renderer, so `/ping` reported
    * ready while `page-server-entry.ts` was still uncompiled and the first
@@ -2102,10 +2105,77 @@ describe('warmPageServerRenderer', () => {
       () => {
         resetCalls += 1;
       },
+      stable,
     );
 
     expect(loadCalls).toBe(1);
     expect(resetCalls).toBe(0);
+  });
+
+  /**
+   * Awaiting the load alone is not enough. If a watched source changes mid-build,
+   * `invalidateCachesForChange` advances the generation and clears the memo slot,
+   * and `loadPageServerRenderer` declines to publish its stale result as last-good
+   * — but still RESOLVES the await. Readiness would then be advertised behind an
+   * empty memo and the first request would recompile, reproducing the very timeout
+   * this warmup exists to prevent. Only a build that ends on the generation it
+   * started is known to still be in the memo, so an unstable attempt is retried.
+   */
+  it('retries when the build raced a source change instead of accepting a cleared memo', async () => {
+    let loadCalls = 0;
+    let resetCalls = 0;
+    let checkedAttempts = 0;
+
+    await warmPageServerRenderer(
+      async () => {
+        loadCalls += 1;
+        return {};
+      },
+      () => {
+        resetCalls += 1;
+      },
+      // Unstable on the first attempt only, stable on the retry. The attempt is
+      // counted BEFORE the work runs -- reading loadCalls afterwards would already
+      // see the increment and report the first attempt as stable.
+      async (work) => {
+        checkedAttempts += 1;
+        const attempt = checkedAttempts;
+        return {
+          value: await work(),
+          instabilityReasons: attempt === 1 ? ['source changed during warmup'] : [],
+        };
+      },
+    );
+
+    expect(loadCalls).toBe(2);
+    expect(resetCalls).toBe(0);
+  });
+
+  /**
+   * If it never stabilizes, the memo may hold a renderer built against a
+   * superseded generation — worse than no memo, because the request path would
+   * serve it rather than rebuild. Drop the slot instead of advertising readiness
+   * behind it. Readiness itself is not refused: an uncompiled page renderer is a
+   * latency problem, not a correctness one, and the request path already rebuilds.
+   */
+  it('drops the memo when the warmup never stabilizes, without refusing readiness', async () => {
+    let loadCalls = 0;
+    let resetCalls = 0;
+
+    await warmPageServerRenderer(
+      async () => {
+        loadCalls += 1;
+        return {};
+      },
+      () => {
+        resetCalls += 1;
+      },
+      async (work) => ({ value: await work(), instabilityReasons: ['still changing'] }),
+      3,
+    );
+
+    expect(loadCalls).toBe(3);
+    expect(resetCalls).toBe(1);
   });
 
   /**
@@ -2125,10 +2195,10 @@ describe('warmPageServerRenderer', () => {
       () => {
         resetCalls += 1;
       },
+      stable,
     );
 
-    expect(warmup).resolves.toBeUndefined();
-    await warmup;
+    await expect(warmup).resolves.toBeUndefined();
     expect(resetCalls).toBe(1);
   });
 });

--- a/packages/playground/src/playground-server.test.ts
+++ b/packages/playground/src/playground-server.test.ts
@@ -2118,52 +2118,17 @@ describe('warmPageServerRenderer', () => {
   });
 
   /**
-   * Awaiting the load alone is not enough. If a watched source changes mid-build,
-   * `invalidateCachesForChange` advances the generation and clears the memo slot,
-   * and `loadPageServerRenderer` declines to publish its stale result as last-good
-   * — but still RESOLVES the await. Readiness would then be advertised behind an
-   * empty memo and the first request would recompile, reproducing the very timeout
-   * this warmup exists to prevent. Only a build that ends on the generation it
-   * started is known to still be in the memo, so an unstable attempt is retried.
+   * Awaiting the load proves nothing about the memo. If a watched source changes
+   * mid-build, `invalidateCachesForChange` advances the generation and clears the
+   * memo slot, and `loadPageServerRenderer` declines to publish its stale result
+   * as last-good — but still RESOLVES the await. Accepting that would advertise
+   * readiness behind an empty or superseded memo, and a superseded one is worse
+   * than none: the request path would serve it instead of rebuilding.
+   *
+   * Dropped rather than retried — a retry budget is forbidden by AGENTS.md, and
+   * the cost of not retrying is one cold compile, which was the status quo.
    */
-  it('retries when the build raced a source change instead of accepting a cleared memo', async () => {
-    let loadCalls = 0;
-    let resetCalls = 0;
-    let checkedAttempts = 0;
-
-    await warmPageServerRenderer(
-      async () => {
-        loadCalls += 1;
-        return {};
-      },
-      () => {
-        resetCalls += 1;
-      },
-      // Unstable on the first attempt only, stable on the retry. The attempt is
-      // counted BEFORE the work runs -- reading loadCalls afterwards would already
-      // see the increment and report the first attempt as stable.
-      async (work) => {
-        checkedAttempts += 1;
-        const attempt = checkedAttempts;
-        return {
-          value: await work(),
-          instabilityReasons: attempt === 1 ? ['source changed during warmup'] : [],
-        };
-      },
-    );
-
-    expect(loadCalls).toBe(2);
-    expect(resetCalls).toBe(0);
-  });
-
-  /**
-   * If it never stabilizes, the memo may hold a renderer built against a
-   * superseded generation — worse than no memo, because the request path would
-   * serve it rather than rebuild. Drop the slot instead of advertising readiness
-   * behind it. Readiness itself is not refused: an uncompiled page renderer is a
-   * latency problem, not a correctness one, and the request path already rebuilds.
-   */
-  it('drops the memo when the warmup never stabilizes, without refusing readiness', async () => {
+  it('drops the memo when the build raced a source change, rather than accepting it', async () => {
     let loadCalls = 0;
     let resetCalls = 0;
 
@@ -2175,11 +2140,13 @@ describe('warmPageServerRenderer', () => {
       () => {
         resetCalls += 1;
       },
-      async (work) => ({ value: await work(), instabilityReasons: ['still changing'] }),
-      3,
+      async (work) => ({
+        value: await work(),
+        instabilityReasons: ['source changed during warmup'],
+      }),
     );
 
-    expect(loadCalls).toBe(3);
+    expect(loadCalls).toBe(1);
     expect(resetCalls).toBe(1);
   });
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1354,9 +1354,6 @@ export async function runGenerationCheckedWarmup<T>(
   };
 }
 
-/** Matches the shell renderer's warmup retry budget in {@link startServer}. */
-const RENDERER_WARMUP_MAX_ATTEMPTS = 5;
-
 /**
  * Compile the documentation-page server renderer before readiness is advertised.
  *
@@ -1379,9 +1376,16 @@ const RENDERER_WARMUP_MAX_ATTEMPTS = 5;
  * the build is in flight, `invalidateCachesForChange` advances the generation and
  * clears the memo slot, and `loadPageServerRenderer` then declines to publish its
  * now-stale result as last-good -- but still RESOLVES this await. Readiness would
- * be advertised behind an empty memo, and the first request would recompile,
- * reproducing the exact timeout this exists to prevent. Only a build that ends on
- * the generation it started is known to still be in the memo.
+ * be advertised behind an empty (or superseded) memo, and the first request would
+ * recompile, reproducing the exact timeout this exists to prevent. Only a build
+ * that ends on the generation it started is known to still be in the memo.
+ *
+ * An invalidated warmup is NOT retried. Retrying would buy a warm memo in the
+ * racy case at the cost of a retry budget, which AGENTS.md forbids adding, and
+ * the racy case is not the one this fixes: CI starts the server against a static
+ * checkout, so the first attempt is stable there. Dropping the memo instead keeps
+ * the correctness guarantee (readiness never sits behind a stale renderer) and
+ * costs, at worst, the single cold compile that was the status quo.
  *
  * Failure is deliberately NOT fatal. `loadPageServerRenderer` already resolves
  * build errors against its last-good renderer, and at startup there is no
@@ -1397,33 +1401,30 @@ export async function warmPageServerRenderer(
     value: T;
     instabilityReasons: string[];
   }> = runGenerationCheckedWarmup,
-  maxAttempts: number = RENDERER_WARMUP_MAX_ATTEMPTS,
 ): Promise<void> {
-  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
-    let instabilityReasons: string[];
-    try {
-      ({ instabilityReasons } = await runChecked(loadRenderer));
-    } catch (error) {
-      console.warn(
-        '[playground] page server renderer warmup failed; the first /page request will retry:',
-        error,
-      );
-      resetRenderer();
-      return;
-    }
-    // A stable build is the only one whose memo is guaranteed to still hold it.
-    if (instabilityReasons.length === 0) return;
+  let instabilityReasons: string[];
+  try {
+    ({ instabilityReasons } = await runChecked(loadRenderer));
+  } catch (error) {
     console.warn(
-      `[playground] page renderer warmup invalidated on attempt ${attempt + 1}/${maxAttempts}: ${instabilityReasons.join('; ')}`,
+      '[playground] page server renderer warmup failed; the first /page request will retry:',
+      error,
     );
+    resetRenderer();
+    return;
   }
-  // Never advertise readiness behind a memo that may hold a renderer built
-  // against a superseded generation -- that is worse than no memo, because the
-  // request path would serve it instead of rebuilding. Dropping the slot
-  // restores exactly the pre-warmup behaviour for this (CI-improbable) case.
+  if (instabilityReasons.length === 0) return;
+  // The build raced a source change, so the memo either was cleared outright by
+  // `invalidateCachesForChange` or still holds a renderer compiled against a
+  // superseded generation. Drop it rather than advertise readiness behind it: a
+  // stale memo is worse than an empty one, because the request path would serve
+  // it instead of rebuilding. Deliberately NOT retried -- retrying would trade a
+  // real correctness guarantee for a latency optimisation, and AGENTS.md forbids
+  // adding a retry budget outright. An unwarmed page renderer costs one cold
+  // compile on the first request, which is exactly the pre-existing behaviour.
   resetRenderer();
   console.warn(
-    '[playground] page renderer warmup did not stabilize; the first /page request will rebuild',
+    `[playground] page renderer warmup invalidated (${instabilityReasons.join('; ')}); the first /page request will rebuild`,
   );
 }
 

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -119,6 +119,7 @@ import {
   loadShellServerRenderer,
   rendererWarmupAttemptDecision,
   rendererWarmupNeedsCacheInvalidation,
+  resetPageServerRendererPromise,
   resetShellRendererWarmupState,
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
@@ -1353,6 +1354,45 @@ export async function runGenerationCheckedWarmup<T>(
   };
 }
 
+/**
+ * Compile the documentation-page server renderer before readiness is advertised.
+ *
+ * `startServer`'s warmup already prepares the SHELL renderer, whose own comment
+ * promises requests "must never pay the cold Svelte server compilation cost on
+ * the first navigation". That guarantee did not actually cover `GET /page/:name`:
+ * {@link loadPageServerRenderer} is memoized only on its first CALL, and its one
+ * call site is the request handler itself. So `/ping` answered 200 -- flipping
+ * `startupReady` -- while `page-server-entry.ts` was still uncompiled, and the
+ * first page request paid a full uncached `Bun.build()` of that entry.
+ *
+ * That is a latency gap, not a correctness one, but `validate-playground.ts`
+ * crawls every route under a fixed 5s `AbortSignal.timeout` with no warmup and
+ * no retry, so the alphabetically-first component absorbed the entire compile
+ * and intermittently blew the budget -- turning main red after a merge, since
+ * that crawl runs only on main and never on pull requests.
+ *
+ * Failure is deliberately NOT fatal. `loadPageServerRenderer` already resolves
+ * build errors against its last-good renderer, and at startup there is no
+ * last-good, so a genuine failure rejects. Caching that rejection would poison
+ * every later request, so the memo slot is dropped and the first real request
+ * retries exactly as it does today -- this only moves a successful compile
+ * earlier, it never makes a broken build worse.
+ */
+export async function warmPageServerRenderer(
+  loadRenderer: () => Promise<unknown> = loadPageServerRenderer,
+  resetRenderer: () => void = resetPageServerRendererPromise,
+): Promise<void> {
+  try {
+    await loadRenderer();
+  } catch (error) {
+    console.warn(
+      '[playground] page server renderer warmup failed; the first /page request will retry:',
+      error,
+    );
+    resetRenderer();
+  }
+}
+
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */
 export async function startServer(port: number = PORT): Promise<PlaygroundServer> {
   startupReady = false;
@@ -1508,6 +1548,7 @@ export async function startServer(port: number = PORT): Promise<PlaygroundServer
     await dispose();
     throw new Error('[playground] shell renderer invalidated repeatedly; refusing readiness');
   }
+  await warmPageServerRenderer();
   startupReady = true;
   return {
     port: actualPort,

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -123,6 +123,7 @@ import {
   resetShellRendererWarmupState,
   setPreparedShellServerRenderer,
   shellBuildSucceeded,
+  type PageServerRendererLoadResult,
   type ShellServerRendererLoadResult,
 } from './ssr-renderer.ts';
 import {
@@ -1397,23 +1398,33 @@ export async function runGenerationCheckedWarmup<T>(
  * earlier, it never makes a broken build worse.
  */
 export async function warmPageServerRenderer(
-  loadRenderer: () => Promise<unknown> = loadPageServerRenderer,
-  resetRenderer: () => void = resetPageServerRendererPromise,
+  loadRenderer: () => Promise<PageServerRendererLoadResult> = loadPageServerRenderer,
+  resetRenderer: (
+    expected?: Promise<PageServerRendererLoadResult>,
+  ) => void = resetPageServerRendererPromise,
   runChecked: <T>(work: () => Promise<T>) => Promise<{
     value: T;
     instabilityReasons: string[];
   }> = runGenerationCheckedWarmup,
 ): Promise<void> {
+  // Held so a discard can target THIS load specifically. A concurrent `/page/:name`
+  // request can install a newer promise in the memo while this warmup is in flight;
+  // resetting unconditionally would throw away that newer build and force the first
+  // crawl request to start a third one.
+  let pending: Promise<PageServerRendererLoadResult> | undefined;
   let instabilityReasons: string[];
-  let value: unknown;
+  let value: PageServerRendererLoadResult;
   try {
-    ({ value, instabilityReasons } = await runChecked(loadRenderer));
+    ({ value, instabilityReasons } = await runChecked(() => {
+      pending = loadRenderer();
+      return pending;
+    }));
   } catch (error) {
     console.warn(
       '[playground] page server renderer warmup failed; the first /page request will retry:',
       error,
     );
-    resetRenderer();
+    resetRenderer(pending);
     return;
   }
   // A last-good fallback RESOLVES rather than rejects, so the catch above never sees
@@ -1422,11 +1433,11 @@ export async function warmPageServerRenderer(
   // last-good -- contradicting this function's own contract that a failure leaves the
   // first request to rebuild. Reachable because the HTTP server listens (answering /ping
   // with 503) before the warmup runs, so a request can populate the memo first.
-  if ((value as { usedFallback?: unknown } | undefined)?.usedFallback === true) {
+  if (value.usedFallback) {
     console.warn(
       '[playground] page server renderer warmup fell back to the last-good renderer; the first /page request will rebuild',
     );
-    resetRenderer();
+    resetRenderer(pending);
     return;
   }
   if (instabilityReasons.length === 0) return;
@@ -1438,7 +1449,7 @@ export async function warmPageServerRenderer(
   // real correctness guarantee for a latency optimisation, and AGENTS.md forbids
   // adding a retry budget outright. An unwarmed page renderer costs one cold
   // compile on the first request, which is exactly the pre-existing behaviour.
-  resetRenderer();
+  resetRenderer(pending);
   console.warn(
     `[playground] page renderer warmup invalidated (${instabilityReasons.join('; ')}); the first /page request will rebuild`,
   );

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -438,7 +438,9 @@ async function renderComponentPage(
       console.error(`[playground] featured example SSR failed for ${componentName}:`, error);
     }
     try {
-      const { renderComponentPageBody } = await loadPageServerRenderer();
+      const {
+        renderers: { renderComponentPageBody },
+      } = await loadPageServerRenderer();
       const rendered = renderComponentPageBody({
         componentName,
         documentation,
@@ -1403,12 +1405,26 @@ export async function warmPageServerRenderer(
   }> = runGenerationCheckedWarmup,
 ): Promise<void> {
   let instabilityReasons: string[];
+  let value: unknown;
   try {
-    ({ instabilityReasons } = await runChecked(loadRenderer));
+    ({ value, instabilityReasons } = await runChecked(loadRenderer));
   } catch (error) {
     console.warn(
       '[playground] page server renderer warmup failed; the first /page request will retry:',
       error,
+    );
+    resetRenderer();
+    return;
+  }
+  // A last-good fallback RESOLVES rather than rejects, so the catch above never sees
+  // it. Without this check a failed warmup build is indistinguishable from a successful
+  // one, and readiness would be advertised behind whatever renderer happened to be
+  // last-good -- contradicting this function's own contract that a failure leaves the
+  // first request to rebuild. Reachable because the HTTP server listens (answering /ping
+  // with 503) before the warmup runs, so a request can populate the memo first.
+  if ((value as { usedFallback?: unknown } | undefined)?.usedFallback === true) {
+    console.warn(
+      '[playground] page server renderer warmup fell back to the last-good renderer; the first /page request will rebuild',
     );
     resetRenderer();
     return;

--- a/packages/playground/src/playground-server.ts
+++ b/packages/playground/src/playground-server.ts
@@ -1354,6 +1354,9 @@ export async function runGenerationCheckedWarmup<T>(
   };
 }
 
+/** Matches the shell renderer's warmup retry budget in {@link startServer}. */
+const RENDERER_WARMUP_MAX_ATTEMPTS = 5;
+
 /**
  * Compile the documentation-page server renderer before readiness is advertised.
  *
@@ -1371,6 +1374,15 @@ export async function runGenerationCheckedWarmup<T>(
  * and intermittently blew the budget -- turning main red after a merge, since
  * that crawl runs only on main and never on pull requests.
  *
+ * Runs behind the same generation/pending-rebuild validation the shell renderer
+ * uses. Awaiting the load alone is not enough: if a watched source changes while
+ * the build is in flight, `invalidateCachesForChange` advances the generation and
+ * clears the memo slot, and `loadPageServerRenderer` then declines to publish its
+ * now-stale result as last-good -- but still RESOLVES this await. Readiness would
+ * be advertised behind an empty memo, and the first request would recompile,
+ * reproducing the exact timeout this exists to prevent. Only a build that ends on
+ * the generation it started is known to still be in the memo.
+ *
  * Failure is deliberately NOT fatal. `loadPageServerRenderer` already resolves
  * build errors against its last-good renderer, and at startup there is no
  * last-good, so a genuine failure rejects. Caching that rejection would poison
@@ -1381,16 +1393,38 @@ export async function runGenerationCheckedWarmup<T>(
 export async function warmPageServerRenderer(
   loadRenderer: () => Promise<unknown> = loadPageServerRenderer,
   resetRenderer: () => void = resetPageServerRendererPromise,
+  runChecked: <T>(work: () => Promise<T>) => Promise<{
+    value: T;
+    instabilityReasons: string[];
+  }> = runGenerationCheckedWarmup,
+  maxAttempts: number = RENDERER_WARMUP_MAX_ATTEMPTS,
 ): Promise<void> {
-  try {
-    await loadRenderer();
-  } catch (error) {
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    let instabilityReasons: string[];
+    try {
+      ({ instabilityReasons } = await runChecked(loadRenderer));
+    } catch (error) {
+      console.warn(
+        '[playground] page server renderer warmup failed; the first /page request will retry:',
+        error,
+      );
+      resetRenderer();
+      return;
+    }
+    // A stable build is the only one whose memo is guaranteed to still hold it.
+    if (instabilityReasons.length === 0) return;
     console.warn(
-      '[playground] page server renderer warmup failed; the first /page request will retry:',
-      error,
+      `[playground] page renderer warmup invalidated on attempt ${attempt + 1}/${maxAttempts}: ${instabilityReasons.join('; ')}`,
     );
-    resetRenderer();
   }
+  // Never advertise readiness behind a memo that may hold a renderer built
+  // against a superseded generation -- that is worse than no memo, because the
+  // request path would serve it instead of rebuilding. Dropping the slot
+  // restores exactly the pre-warmup behaviour for this (CI-improbable) case.
+  resetRenderer();
+  console.warn(
+    '[playground] page renderer warmup did not stabilize; the first /page request will rebuild',
+  );
 }
 
 /** Start the playground server on the given port. Returns a handle with dispose() to stop everything. */

--- a/packages/playground/src/ssr-renderer.ts
+++ b/packages/playground/src/ssr-renderer.ts
@@ -85,7 +85,18 @@ export function isPageServerRenderers(value: unknown): value is PageServerRender
   );
 }
 
-let pageServerRendererPromise: Promise<PageServerRenderers> | null = null;
+/**
+ * Mirrors {@link ShellServerRendererLoadResult}. `usedFallback` matters to the
+ * startup warmup: a fallback RESOLVES rather than rejects, so without this flag a
+ * failed warmup build is indistinguishable from a successful one and readiness
+ * would be advertised behind a stale renderer.
+ */
+export type PageServerRendererLoadResult = {
+  renderers: PageServerRenderers;
+  usedFallback: boolean;
+};
+
+let pageServerRendererPromise: Promise<PageServerRendererLoadResult> | null = null;
 let lastGoodPageServerRenderer: PageServerRenderers | null = null;
 
 export function shellBuildSucceeded(code: string | null, usedFallback: boolean): boolean {
@@ -217,7 +228,7 @@ export function rendererWarmupAttemptDecision(
  * transient compile error during development serves the previous good renderer
  * instead of a 500.
  */
-export async function loadPageServerRenderer(): Promise<PageServerRenderers> {
+export async function loadPageServerRenderer(): Promise<PageServerRendererLoadResult> {
   if (pageServerRendererPromise !== null) return pageServerRendererPromise;
 
   pageServerRendererPromise = (async () => {
@@ -256,13 +267,16 @@ export async function loadPageServerRenderer(): Promise<PageServerRenderers> {
       if (generationAtStart === getRebuildGeneration()) {
         lastGoodPageServerRenderer = renderer;
       }
-      return renderer;
+      return { renderers: renderer, usedFallback: false };
     } catch (error) {
       console.error(
         '[playground] page server rebuild failed; serving the last-good renderer:',
         error,
       );
-      return fallbackToLastGood(lastGoodPageServerRenderer, error);
+      return {
+        renderers: fallbackToLastGood(lastGoodPageServerRenderer, error),
+        usedFallback: true,
+      };
     }
   })();
 

--- a/packages/playground/src/ssr-renderer.ts
+++ b/packages/playground/src/ssr-renderer.ts
@@ -236,7 +236,14 @@ export function rendererWarmupAttemptDecision(
  * transient compile error during development serves the previous good renderer
  * instead of a 500.
  */
-export async function loadPageServerRenderer(): Promise<PageServerRendererLoadResult> {
+/*
+ * Deliberately NOT `async`. An async wrapper returns a fresh promise that merely
+ * ADOPTS the memoized one, so a caller could never hold the identity that
+ * `resetPageServerRendererPromise(expected)` compares against -- every targeted
+ * reset would be suppressed and a rejected or last-good memo would never clear.
+ * Every `await` here lives inside the IIFE, so nothing needs the wrapper.
+ */
+export function loadPageServerRenderer(): Promise<PageServerRendererLoadResult> {
   if (pageServerRendererPromise !== null) return pageServerRendererPromise;
 
   pageServerRendererPromise = (async () => {

--- a/packages/playground/src/ssr-renderer.ts
+++ b/packages/playground/src/ssr-renderer.ts
@@ -184,7 +184,15 @@ export function resetShellRendererWarmupState(): void {
  * (unrelated) call site in `startServer`'s renderer-warmup retry loop must
  * not also reset the page-server renderer.
  */
-export function resetPageServerRendererPromise(): void {
+export function resetPageServerRendererPromise(
+  expected?: Promise<PageServerRendererLoadResult>,
+): void {
+  // A caller discarding a specific load must not clobber a NEWER one. The startup
+  // warmup can be invalidated while a concurrent `/page/:name` request has already
+  // installed a fresh promise here; nulling that unconditionally would throw away a
+  // build already in flight and force the next request to start yet another one.
+  // Passing no argument keeps the unconditional behaviour the file watcher relies on.
+  if (expected !== undefined && pageServerRendererPromise !== expected) return;
   pageServerRendererPromise = null;
 }
 


### PR DESCRIPTION
## Summary

`main-green` failed on `a5da0def` with:

```
[validate:playground] FAILED: fetch http://127.0.0.1:5555/page/access-gate
  threw: TimeoutError: The operation timed out.
```

`startServer`'s warmup prepares the **shell** renderer, and that code's own comment promises requests "must never pay the cold Svelte server compilation cost on the first navigation". That guarantee never covered `GET /page/:name`: `loadPageServerRenderer` is memoized only on its first *call*, and its single call site is the request handler itself (`playground-server.ts:440`). So `/ping` answered 200 — flipping `startupReady` — while `page-server-entry.ts` was still uncompiled, and the first page request absorbed a full uncached `Bun.build()` of that entry.

`validate-playground.ts` crawls all 209 component routes under a fixed 5s `AbortSignal.timeout` with no warmup and no retry, so `access-gate` — alphabetically first — paid the entire compile.

This warms the page renderer before `startupReady = true`, closing the gap at its source.

## Why not just raise the timeout

There is no evidence 5s is too low for a *warm* server — only that the first request was never warm. The budget is deliberately untouched.

## Failure semantics are preserved

`loadPageServerRenderer` resolves build errors against its last-good renderer, and at startup there is no last-good, so a genuine failure rejects. A memoized rejection would poison every later request, so the warmup drops the memo slot and lets the first real request retry exactly as it does today. This only moves a *successful* compile earlier; it never makes a broken build worse.

`renderFeaturedExample` is deliberately not warmed — it builds a per-component entry source and caches per component/scenario, so there is no shared bundle to warm, and its failure already degrades gracefully rather than failing the request.

## Diagnosis notes

- Not caused by the merge it surfaced on. Attempt 1 of run `33551764582` failed; attempt 2 passed on the identical commit. The warmup gap is byte-for-byte identical before and after that PR.
- Base rate over the preceding month: this signature appears **0 times** in 300 main-green runs (54 failures, all other causes).
- `validate:playground` runs only on `main`, never on pull requests — which is why this class of failure can only ever turn main red post-merge, and why it was never caught pre-merge.

## Validation

- `bun run --filter=@cinder/playground test src/playground-server.test.ts` — `playground-server.test.ts` 164 pass / 1 fail; the one failure (`/page/:name > loads package-owned component CSS for extracted Chat pages`, 5005ms) is a timeout under a local load average of ~200 from unrelated processes, not an assertion failure. Two other timeouts in `analyze.test.ts` are likewise load artifacts in files untouched by this change.
- No changeset: `@cinder/playground` is in the changesets `ignore` list.

https://claude.ai/code/session_01YZCSMnpJpoHnnw2sGrWu1E

Closes #1491 (main is red: main-green — this is the root-cause fix for that failure).
