### PR TITLE
fix(tokens): restore root declarations for component alias tokens

### DIFF
--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -105,7 +105,26 @@ export const PRETTIER_OPTIONS = {
 /** The `json` parser lives in the babel plugin; `estree` supplies its printer. */
 export const JSON_PLUGINS = [babelPlugin, estreePlugin];
 const CSS_PLUGINS = [postcssPlugin];
-const DEFERRED_COMPONENT_ALIAS_FAMILIES = new Set(['accordion-item', 'action-row']);
+/**
+ * Component families whose bare-alias tokens are NOT declared on `:root`, so both
+ * the public component property and the foundation token it aliases stay
+ * responsive to a scoped ancestor override.
+ *
+ * Deliberately EMPTY. `accordion-item` and `action-row` were deferred here and had
+ * to be restored: `fixtures/tokens-consumer/check.mjs` asserts that every token the
+ * registry advertises as `public: true` is declared in the shipped CSS, and
+ * deferring 19 public tokens broke `validate:consumer`, failing the 0.25.1 release.
+ * That gate runs only on the release path, never on pull requests, so the breakage
+ * was invisible until publish time.
+ *
+ * Before adding a family back, the registry must first be able to express that a
+ * public token is not root-declared (and `check.mjs` must honour that), or the
+ * tokens must stop being advertised as public. Deferring a `public: true` token is
+ * an observable API change -- `getComputedStyle(root).getPropertyValue(...)` returns
+ * empty -- and the registry has no way to say so today. Adding a name here without
+ * that will fail the release, not the pull request.
+ */
+const DEFERRED_COMPONENT_ALIAS_FAMILIES = new Set<string>([]);
 
 // ---------------------------------------------------------------------------
 // Corpus tree walking. Collects every `$value`-bearing node in a merged

--- a/packages/components/src/components/accordion-item/accordion-item.test.ts
+++ b/packages/components/src/components/accordion-item/accordion-item.test.ts
@@ -363,7 +363,13 @@ describe('AccordionItem', () => {
     const tokenCss = await Bun.file(
       new URL('../../styles/tokens-base.css', import.meta.url),
     ).text();
-    expect(tokenCss).not.toContain('--cinder-accordion-item-trigger-gap:');
+    // Declared on `:root` like every other public token. These aliases were briefly
+    // deferred out of `:root` so a scoped ancestor override could reach them, but that
+    // broke `validate:consumer` -- which asserts every `public: true` token is declared
+    // in the shipped CSS -- and failed the 0.25.1 release. Deferring them again requires
+    // the registry to first express "public but not root-declared"; see
+    // DEFERRED_COMPONENT_ALIAS_FAMILIES in scripts/tokens/generate.ts.
+    expect(tokenCss).toContain('--cinder-accordion-item-trigger-gap:');
     expect(css).toContain('gap: var(--cinder-accordion-item-trigger-gap,');
     expect(css).toContain('var(--cinder-accordion-item-trigger-padding-block,');
     expect(css).toContain('font-size: var(--cinder-accordion-item-trigger-font-size,');

--- a/packages/components/src/styles/tokens-base.css
+++ b/packages/components/src/styles/tokens-base.css
@@ -514,6 +514,44 @@
   --cinder-toggle-track-off-resting: light-dark(var(--cinder-border-muted), oklch(45% 0.02 245));
   /* Toggle track color in the off state on hover. Steps up from `off-resting` to be distinguishable. */
   --cinder-toggle-track-off-hover-resting: light-dark(var(--cinder-border), oklch(52% 0.02 245));
+  /* Gap between the trigger's disclosure icon and label. */
+  --cinder-accordion-item-trigger-gap: var(--cinder-space-4);
+  /* Trigger block padding. */
+  --cinder-accordion-item-trigger-padding-block: var(--cinder-space-4);
+  /* Trigger inline padding. */
+  --cinder-accordion-item-trigger-padding-inline: var(--cinder-space-5);
+  /* Trigger label font size. */
+  --cinder-accordion-item-trigger-font-size: var(--cinder-text-base);
+  /* Trigger label font weight. */
+  --cinder-accordion-item-trigger-font-weight: var(--cinder-font-semibold);
+  /* Panel content padding, block-start edge. */
+  --cinder-accordion-item-panel-inner-padding-block-start: var(--cinder-space-4);
+  /* Panel content padding, block-end edge. */
+  --cinder-accordion-item-panel-inner-padding-block-end: var(--cinder-space-5);
+  /* Panel content inline padding. */
+  --cinder-accordion-item-panel-inner-padding-inline: var(--cinder-space-5);
+  /* Panel content font size. */
+  --cinder-accordion-item-panel-font-size: var(--cinder-text-base);
+  /* Panel content line height. */
+  --cinder-accordion-item-panel-line-height: var(--cinder-leading-normal);
+  /* Row block padding (default density). */
+  --cinder-action-row-padding-block: var(--cinder-space-3);
+  /* Row inline padding (default density). */
+  --cinder-action-row-padding-inline: var(--cinder-space-4);
+  /* Grid column gap between leading/body/trailing regions. */
+  --cinder-action-row-layout-column-gap: var(--cinder-space-3);
+  /* Grid row gap between leading/body/trailing regions. */
+  --cinder-action-row-layout-row-gap: var(--cinder-space-2);
+  /* Gap between title, description, and meta lines. */
+  --cinder-action-row-body-gap: var(--cinder-space-1);
+  /* Title font size. */
+  --cinder-action-row-title-font-size: var(--cinder-text-sm);
+  /* Description font size. */
+  --cinder-action-row-description-font-size: var(--cinder-text-sm);
+  /* Meta line font size. */
+  --cinder-action-row-meta-font-size: var(--cinder-text-xs);
+  /* Gap between items in the trailing region. */
+  --cinder-action-row-trailing-gap: var(--cinder-space-2);
   /* Alert `info` tone ring/status-base color, single-consumer (alert.css); encodes the light/dark pair directly here so alert.css stays var()-only. */
   --cinder-alert-info: light-dark(oklch(45% 0.14 245), oklch(78% 0.15 245));
   /* Horizontal overlap between stacked avatars. */

--- a/packages/testing/tests/token-css-drives-styles.playwright.ts
+++ b/packages/testing/tests/token-css-drives-styles.playwright.ts
@@ -261,7 +261,23 @@ test.describe('generated token CSS drives visible styles', () => {
     expect(before).not.toBe('1px');
   });
 
-  test('a scoped foundation override reaches a deferred component alias', async ({ page }) => {
+  /**
+   * Pins the CURRENT behaviour, which is a deliberate tradeoff rather than an oversight.
+   *
+   * Component aliases are declared on `:root`, so an alias resolves against `:root`'s
+   * foundation value and a foundation override scoped to an ancestor does NOT reach it.
+   * These aliases were briefly deferred out of `:root` so that it WOULD -- and this test
+   * asserted exactly that -- but deferring them broke `validate:consumer`, which requires
+   * every `public: true` token to be declared in the shipped CSS, and failed the 0.25.1
+   * release. Restoring the declarations restores this limitation.
+   *
+   * Overriding the component property directly still works and is the supported path --
+   * see the ActionRow test above. If the deferral is reintroduced (which needs the
+   * registry to first express "public but not root-declared"), this test flips back.
+   */
+  test('a scoped foundation override does not reach a root-declared component alias', async ({
+    page,
+  }) => {
     await gotoDocumentationPage(page, '/page/accordion');
 
     const item = page
@@ -277,7 +293,15 @@ test.describe('generated token CSS drives visible styles', () => {
       (element as HTMLElement).style.setProperty('--cinder-space-4', '3px');
     });
 
-    await expect.poll(gapOf).toBe('3px');
+    // The alias already resolved against :root's --cinder-space-4, so the scoped
+    // override changes nothing here.
+    await expect.poll(gapOf).toBe(before);
     expect(before).not.toBe('3px');
+
+    // The component property itself remains overridable, which is the supported escape hatch.
+    await item.evaluate((element) => {
+      (element as HTMLElement).style.setProperty('--cinder-accordion-item-trigger-gap', '5px');
+    });
+    await expect.poll(gapOf).toBe('5px');
   });
 });

--- a/packages/testing/tests/token-css-drives-styles.playwright.ts
+++ b/packages/testing/tests/token-css-drives-styles.playwright.ts
@@ -298,8 +298,12 @@ test.describe('generated token CSS drives visible styles', () => {
     await expect.poll(gapOf).toBe(before);
     expect(before).not.toBe('3px');
 
-    // The component property itself remains overridable, which is the supported escape hatch.
-    await item.evaluate((element) => {
+    // The component property itself remains overridable, which is the supported escape
+    // hatch. Set on the PARENT, matching the ActionRow test above: `item` is located by
+    // `:not([style*="--cinder-accordion-item-trigger-gap"])`, so writing that property
+    // inline on the item makes it stop matching, and the lazy locator silently re-resolves
+    // to a different accordion item still showing the default gap.
+    await item.locator('..').evaluate((element) => {
       (element as HTMLElement).style.setProperty('--cinder-accordion-item-trigger-gap', '5px');
     });
     await expect.poll(gapOf).toBe('5px');


### PR DESCRIPTION
## Why

The **0.25.1 release failed** and npm is still serving 0.25.0.

`fixtures/tokens-consumer/check.mjs` asserts that every token the registry advertises as `public: true` is declared in the shipped CSS. PR #1484 deferred 19 of them out of `:root` — 10 `accordion-item`, 9 `action-row` — so the assertion reported 19 undeclared and the publish aborted:

```
actual:   [ '--cinder-accordion-item-trigger-gap', ... '--cinder-action-row-trailing-gap' ]
expected: []
'every public token the registry advertises is declared in the shipped CSS'
```

**`validate:consumer` runs only on the release path, never on pull requests.** #1484 passed every PR check and broke at publish time; nothing on a pull request could have caught it.

## What

Empties `DEFERRED_COMPONENT_ALIAS_FAMILIES`, restoring all 19 `:root` declarations.

Reverted rather than exempted, because deferring a `public: true` token is an observable API change — `getComputedStyle(root).getPropertyValue('--cinder-action-row-padding-block')` returns empty — and the registry has no way to express "public but not root-declared". Teaching the gate an exception would hide that from consumers instead of stating it.

The mechanism is kept but empty, with the precondition recorded in place: before a family goes back in, the registry must be able to express non-root-declared public tokens (and `check.mjs` must honour it), or the tokens must stop being advertised as public. Adding a name there without that fails the *release*, not the pull request.

## The accessibility fix is unaffected

This release exists to ship the nested-theme fix from #1484. Confirmed still intact after regeneration:

```
:root                  terminal-ansi 16
[data-theme='dark']    terminal-ansi 16
[data-theme='light']   terminal-ansi 16
```

Published 0.25.0 has 16/16/**0**, which is why all 16 ANSI slots currently fail WCAG AA (down to 1.060:1) in a light theme island nested inside a dark ancestor.

## Validation

- `validate:consumer` → `tokens-consumer — ok: 308 tokens across 4 resolved contexts, 9 source documents, 308 public properties declared` (zero undeclared; this is the assertion that failed the release). The run's remaining non-zero exit is the pre-existing `sveltekit-consumer` Vite SSR crash, which is local-only — 0.25.0 published through this same gate.
- 783 pass / 0 fail across `scripts/tokens/`, `src/styles/`, `src/test/token-introspection.test.ts`
- `tokens:check`, `components:check`, `exports:check`, `check:component-variable-registry` — all pass
- `components:generate` produced no artifact drift

https://claude.ai/code/session_01YZCSMnpJpoHnnw2sGrWu1E