### PR TITLE
ci(tokens): run the tokens-consumer fixture on every pull request

### DIFF
--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -3716,8 +3716,8 @@ async function readmeUsageExamplesSmoke(): Promise<void> {
 }
 
 /**
- * Cheap PR gate for packed-artifact consistency: the manifest/export fixture and
- * the token-registry fixture, both pure Node resolution against one shared pack.
+ * Cheap PR gate for packed-artifact consistency: the `manifest-consumer` and
+ * `tokens-consumer` fixtures, both pure Node resolution against one shared pack.
  * No browser, no SvelteKit.
  *
  * `tokens-consumer` is here because it once ran ONLY on the release path. PR

--- a/packages/components/scripts/validate-consumers.ts
+++ b/packages/components/scripts/validate-consumers.ts
@@ -3715,7 +3715,20 @@ async function readmeUsageExamplesSmoke(): Promise<void> {
   process.stdout.write('[validate-consumers] readme usage examples smoke passed.\n');
 }
 
-/** Cheap PR gate for packed manifest/export consistency; no browser or registry fixtures. */
+/**
+ * Cheap PR gate for packed-artifact consistency: the manifest/export fixture and
+ * the token-registry fixture, both pure Node resolution against one shared pack.
+ * No browser, no SvelteKit.
+ *
+ * `tokens-consumer` is here because it once ran ONLY on the release path. PR
+ * #1484 deferred 19 `public: true` component-alias tokens out of `:root`, passed
+ * every pull-request check, and then failed the 0.25.1 publish on this fixture's
+ * "every public token the registry advertises is declared in the shipped CSS"
+ * assertion -- the first moment anything ran it. The step itself costs well under
+ * a second after the pack (0.6s in that release's log); the pack is already paid
+ * for by the manifest fixture. Running it here makes that class of breakage a
+ * red pull request instead of a failed release.
+ */
 async function manifestSmoke(): Promise<void> {
   installHookProcessCleanup();
   ensureSupportedPlatform();
@@ -3726,7 +3739,10 @@ async function manifestSmoke(): Promise<void> {
   await packWorkspaceDependencyTarballs();
   await packTarball();
   await runManifestConsumerFixture();
-  process.stdout.write('[validate-consumers] manifest smoke passed.\n');
+  await runTokensConsumerFixture();
+  process.stdout.write(
+    '[validate-consumers] manifest smoke passed (manifest + tokens fixtures).\n',
+  );
 }
 
 if (import.meta.main) {


### PR DESCRIPTION
## Why

`tokens-consumer` asserts that every token the registry advertises as `public: true` is declared in the shipped CSS. It ran **only on the release path**. PR #1484 deferred 19 public component-alias tokens out of `:root`, went green through every pull-request check, and failed the 0.25.1 publish on that exact assertion — the first moment anything executed it:

```
actual:   [ '--cinder-accordion-item-trigger-gap', … '--cinder-action-row-trailing-gap' ]
expected: []
'every public token the registry advertises is declared in the shipped CSS'
```

It's the third post-merge breakage today with the same structural shape — a gate that lives only past the merge (`validate:playground` and the hydration smoke were the other two).

## What

`tokens-consumer` now runs inside `validate:consumer:manifest-smoke`, which `unit-tests.yaml`'s `static-artifact` job already executes on every pull request. The fixture is pure Node resolution against the packed tarball; the pack is already paid for by the manifest fixture. **No workflow file changes** — the existing lane that routes `packages/components/src/styles/` and `src/tokens/` changes covers it.

## Cost

0.6 seconds. From the 0.25.1 release log, step start → `ok`: `01:57:14.13` → `01:57:14.72`. The manifest fixture beside it is ~4s. `static-artifact` is 177s on a recent PR; this is noise.

## Verified

```
[validate-consumers] step: manifest-consumer (Node resolve)…
[validate-consumers] manifest-consumer OK — verified 200 components …
[validate-consumers] step: tokens-consumer (Node resolve)…
[validate-consumers] tokens-consumer — ok: 308 tokens across 4 resolved contexts, 9 source documents, 308 public properties declared across 2 stylesheet(s).
[validate-consumers] manifest smoke passed (manifest + tokens fixtures).
```

`validate-consumers.test.ts`: 51 pass / 0 fail.

## Scope, stated

Toward CIN-497's fourth acceptance criterion ("a gate that would have caught this before merge"). This PR takes the highest-value, lowest-cost piece. The hydration smoke — CIN-497's *original* failure — is 161s with a Chromium install and is deliberately not bundled here; its cost warrants its own decision about which PR lane pays it. `validate:playground` (288s) is the flaky one and is being fixed at the root in #1494 rather than promoted to PRs as-is.

No changeset: CI-only, no published package changes.

https://claude.ai/code/session_01YZCSMnpJpoHnnw2sGrWu1E