### PR TITLE
fix(components): make the artifact pipeline's prettier resolution deterministic

### DIFF
--- a/packages/components/scripts/check-promotion-readiness.ts
+++ b/packages/components/scripts/check-promotion-readiness.ts
@@ -17,6 +17,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { format, resolveConfig } from 'prettier';
+import { assertPrettierResolvesToRoot } from './lib/prettier-resolution.ts';
 
 import {
   checkPropNames,
@@ -221,6 +222,7 @@ async function runPropNamesCheck(
     }
     const depthToSrc = isExperimental ? 3 : 2;
     const generateResult = generateSchemaForComponent({ typesFilePath, componentName, depthToSrc });
+    assertPrettierResolvesToRoot();
     const prettierOptions = await resolveConfig(committedSchemaPath);
     freshSchemaJson = await format(generateResult.schemaJson, {
       ...prettierOptions,

--- a/packages/components/scripts/component-artifact-operations.test.ts
+++ b/packages/components/scripts/component-artifact-operations.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
-import { assertPrettierResolvesToRoot, formatGenerated } from './component-artifact-operations.ts';
+import { formatGenerated } from './component-artifact-operations.ts';
+import { assertPrettierResolvesToRoot } from './lib/prettier-resolution.ts';
 
 const repositoryRoot = resolve(import.meta.dirname, '../../..');
 
@@ -29,11 +30,15 @@ describe('formatGenerated prettier resolution', () => {
     const parsed: unknown = JSON.parse(
       readFileSync(join(repositoryRoot, 'node_modules', 'prettier', 'package.json'), 'utf8'),
     );
-    if (typeof parsed !== 'object' || parsed === null || !('version' in parsed)) {
-      throw new Error('root prettier package.json has no version');
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !('version' in parsed) ||
+      typeof parsed.version !== 'string'
+    ) {
+      throw new Error('root prettier package.json has no string version');
     }
-    const rootVersion = parsed.version;
-    expect(typeof rootVersion).toBe('string');
+    const rootVersion: string = parsed.version;
 
     const { version, resolvedFrom } = assertPrettierResolvesToRoot();
 

--- a/packages/components/scripts/component-artifact-operations.test.ts
+++ b/packages/components/scripts/component-artifact-operations.test.ts
@@ -26,11 +26,14 @@ describe('formatGenerated prettier resolution', () => {
    * touched `packages/components`. The pipeline must format with the root's copy.
    */
   test('resolves prettier to the version the repository root locks', () => {
-    const rootVersion = (
-      JSON.parse(
-        readFileSync(join(repositoryRoot, 'node_modules', 'prettier', 'package.json'), 'utf8'),
-      ) as { version: string }
-    ).version;
+    const parsed: unknown = JSON.parse(
+      readFileSync(join(repositoryRoot, 'node_modules', 'prettier', 'package.json'), 'utf8'),
+    );
+    if (typeof parsed !== 'object' || parsed === null || !('version' in parsed)) {
+      throw new Error('root prettier package.json has no version');
+    }
+    const rootVersion = parsed.version;
+    expect(typeof rootVersion).toBe('string');
 
     const { version, resolvedFrom } = assertPrettierResolvesToRoot();
 

--- a/packages/components/scripts/component-artifact-operations.test.ts
+++ b/packages/components/scripts/component-artifact-operations.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { assertPrettierResolvesToRoot, formatGenerated } from './component-artifact-operations.ts';
+
+const repositoryRoot = resolve(import.meta.dirname, '../../..');
+
+/**
+ * The happy path -- `formatGenerated` producing correctly formatted artifacts --
+ * is deliberately NOT asserted here. This suite runs under
+ * `--conditions browser --conditions svelte`, which resolves `prettier` to its
+ * `standalone.mjs` build: no `resolveConfig`, no parsers. The real pipeline runs
+ * under plain Bun and is gated by `components:check` in CI's `static-artifact`
+ * lane, which regenerates every artifact and diffs it against the committed
+ * copy. A formatting test that passed here would be testing a different prettier
+ * than the one that ships. What CAN be pinned here is what CIN-456 asks for:
+ * which prettier the pipeline resolves, and that failures are no longer silent.
+ */
+describe('formatGenerated prettier resolution', () => {
+  /**
+   * The regression this pins: adding a workspace member with a different
+   * `prettier` range once made bun nest a newer prettier under this package, and
+   * the artifact pipeline formatted with it while the root stayed locked on
+   * another version -- ~150 READMEs reported stale on a branch that never
+   * touched `packages/components`. The pipeline must format with the root's copy.
+   */
+  test('resolves prettier to the version the repository root locks', () => {
+    const rootVersion = (
+      JSON.parse(
+        readFileSync(join(repositoryRoot, 'node_modules', 'prettier', 'package.json'), 'utf8'),
+      ) as { version: string }
+    ).version;
+
+    const { version, resolvedFrom } = assertPrettierResolvesToRoot();
+
+    expect(version).toBe(rootVersion);
+    expect(resolvedFrom).toContain('/node_modules/prettier/');
+    // A copy nested under this package would resolve from a different tree.
+    expect(resolvedFrom).not.toContain('/packages/components/node_modules/');
+  });
+
+  /**
+   * Previously ANY failure returned `content` unchanged. Under this very harness
+   * that meant `formatGenerated` silently no-op'd -- `resolveConfig` is absent from
+   * the standalone build -- and nothing ever said so. The error must now name the
+   * file and where prettier was resolved from, whichever build is loaded.
+   */
+  test('surfaces a formatting failure naming the file and the resolved prettier', async () => {
+    const attempt = formatGenerated('export const = ;', '/generated/broken.ts');
+
+    await expect(attempt).rejects.toThrow(/failed to format \/generated\/broken\.ts/);
+    await expect(attempt).rejects.toThrow(
+      /prettier \d+\.\d+\.\d+ \(file:.*\/node_modules\/prettier\//,
+    );
+  });
+
+  test('does not return unformatted content on failure', async () => {
+    const content = 'export const = ;';
+    let result: string | undefined;
+    try {
+      result = await formatGenerated(content, '/generated/broken.ts');
+    } catch {
+      // expected
+    }
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/components/scripts/component-artifact-operations.test.ts
+++ b/packages/components/scripts/component-artifact-operations.test.ts
@@ -61,6 +61,20 @@ describe('formatGenerated prettier resolution', () => {
     await expect(attempt).rejects.toThrow(
       /prettier \d+\.\d+\.\d+ \(file:.*\/node_modules\/prettier\//,
     );
+    // The underlying error's own message is in the string, not only in `cause`,
+    // because components:check logs only `err.message` for a stage failure.
+    // (Under the test harness that underlying error is the standalone build's
+    // missing `resolveConfig`, not a parser error -- the guard on the message
+    // shape is what matters, not which failure it carried.)
+    const thrown: unknown = await attempt.catch((error: unknown) => error);
+    expect(thrown).toBeInstanceOf(Error);
+    if (!(thrown instanceof Error)) return;
+    expect(thrown.cause).toBeInstanceOf(Error);
+    if (!(thrown.cause instanceof Error)) return;
+    expect(thrown.cause.message.length).toBeGreaterThan(0);
+    expect(thrown.message).toEndWith(
+      `failed to format /generated/broken.ts: ${thrown.cause.message}`,
+    );
   });
 
   test('does not return unformatted content on failure', async () => {

--- a/packages/components/scripts/component-artifact-operations.ts
+++ b/packages/components/scripts/component-artifact-operations.ts
@@ -7,8 +7,8 @@
  * while the CLI entrypoint in `generate-component-artifacts.ts` stays thin.
  */
 
-import { existsSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
 
 import * as prettier from 'prettier';
 
@@ -46,10 +46,67 @@ const COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS = new Set([
 
 const prettierConfigurationCache = new Map<string, Promise<prettier.Options | null>>();
 
+const repositoryRoot = resolve(import.meta.dirname, '../../..');
+
+/**
+ * The generated-artifact contract ("committed artifacts match regeneration") is
+ * implicitly parameterized by whichever prettier this module happens to resolve.
+ * Nothing pins that. Adding a workspace member whose `prettier` range differed
+ * (#1425, `labs/chat-room` at `^3.8.3`) made bun nest a fresh 3.9.x under each
+ * package's own `node_modules`; this module then resolved 3.9.6 while the root
+ * stayed locked at 3.8.1, and 3.9's markdown printer moved blank lines around the
+ * `<!-- generated:variables:* -->` markers -- so `components:check` reported ~150
+ * READMEs stale on a branch that never touched `packages/components`.
+ *
+ * The invariant is not "one prettier in the lockfile" (transitives such as
+ * `@changesets/*` legitimately carry a nested 2.x) but "the artifact pipeline
+ * uses the ROOT's prettier". Compare against the version the root actually
+ * resolves rather than against a declared range, so a deliberate `bun update`
+ * at the root is not a false positive while a shadow copy nested under this
+ * package is.
+ */
+export function assertPrettierResolvesToRoot(): { version: string; resolvedFrom: string } {
+  const resolvedFrom = import.meta.resolve('prettier');
+  const rootPrettierManifest = join(repositoryRoot, 'node_modules', 'prettier', 'package.json');
+  let rootVersion: string;
+  try {
+    rootVersion = (JSON.parse(readFileSync(rootPrettierManifest, 'utf8')) as { version: string })
+      .version;
+  } catch (error) {
+    throw new Error(
+      `formatGenerated: cannot read the root prettier at ${rootPrettierManifest}; ` +
+        `the artifact pipeline must format with the root-locked prettier. ` +
+        `This module resolved prettier ${prettier.version} from ${resolvedFrom}.`,
+      { cause: error },
+    );
+  }
+  if (prettier.version !== rootVersion) {
+    throw new Error(
+      `formatGenerated: prettier resolved to ${prettier.version} from ${resolvedFrom}, ` +
+        `but the root locks ${rootVersion} (${rootPrettierManifest}). A nested copy is ` +
+        `shadowing the root's -- generated artifacts would silently track the wrong ` +
+        `formatter. Align the workspace's prettier ranges so bun dedupes to the root copy.`,
+    );
+  }
+  return { version: prettier.version, resolvedFrom };
+}
+
+let prettierResolutionChecked = false;
+
 /**
  * Run prettier over generated content using the repo's prettier configuration.
+ *
+ * Failures are NOT swallowed. An earlier version returned `content` unformatted
+ * on any error, so a formatter that failed to load -- or a version that could not
+ * parse a generated file -- produced artifacts that `components:check` flagged as
+ * drifted with no hint of the actual cause. A formatting error now names the file
+ * and where prettier was resolved from.
  */
 export async function formatGenerated(content: string, filepath: string): Promise<string> {
+  if (!prettierResolutionChecked) {
+    assertPrettierResolvesToRoot();
+    prettierResolutionChecked = true;
+  }
   try {
     const configurationDirectory = dirname(filepath);
     let optionsPromise = prettierConfigurationCache.get(configurationDirectory);
@@ -59,8 +116,12 @@ export async function formatGenerated(content: string, filepath: string): Promis
     }
     const options = await optionsPromise;
     return await prettier.format(content, { ...options, filepath });
-  } catch {
-    return content;
+  } catch (error) {
+    throw new Error(
+      `formatGenerated: prettier ${prettier.version} (${import.meta.resolve('prettier')}) ` +
+        `failed to format ${filepath}`,
+      { cause: error },
+    );
   }
 }
 

--- a/packages/components/scripts/component-artifact-operations.ts
+++ b/packages/components/scripts/component-artifact-operations.ts
@@ -65,13 +65,25 @@ const repositoryRoot = resolve(import.meta.dirname, '../../..');
  * at the root is not a false positive while a shadow copy nested under this
  * package is.
  */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** `JSON.parse` returns `any`; narrow it before trusting `.version`. */
+function readManifestVersion(manifestPath: string): string {
+  const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (!isRecord(parsed) || typeof parsed['version'] !== 'string') {
+    throw new Error(`${manifestPath} has no string "version" field`);
+  }
+  return parsed['version'];
+}
+
 export function assertPrettierResolvesToRoot(): { version: string; resolvedFrom: string } {
   const resolvedFrom = import.meta.resolve('prettier');
   const rootPrettierManifest = join(repositoryRoot, 'node_modules', 'prettier', 'package.json');
   let rootVersion: string;
   try {
-    rootVersion = (JSON.parse(readFileSync(rootPrettierManifest, 'utf8')) as { version: string })
-      .version;
+    rootVersion = readManifestVersion(rootPrettierManifest);
   } catch (error) {
     throw new Error(
       `formatGenerated: cannot read the root prettier at ${rootPrettierManifest}; ` +

--- a/packages/components/scripts/component-artifact-operations.ts
+++ b/packages/components/scripts/component-artifact-operations.ts
@@ -69,9 +69,13 @@ export async function formatGenerated(content: string, filepath: string): Promis
     const options = await optionsPromise;
     return await prettier.format(content, { ...options, filepath });
   } catch (error) {
+    // The underlying message rides in the string as well as in `cause`:
+    // `components:check` catches stage-1 failures and logs only `err.message`,
+    // so a parser error would otherwise be lost from CI output.
+    const reason = error instanceof Error ? error.message : String(error);
     throw new Error(
       `formatGenerated: prettier ${prettier.version} (${import.meta.resolve('prettier')}) ` +
-        `failed to format ${filepath}`,
+        `failed to format ${filepath}: ${reason}`,
       { cause: error },
     );
   }

--- a/packages/components/scripts/component-artifact-operations.ts
+++ b/packages/components/scripts/component-artifact-operations.ts
@@ -7,10 +7,12 @@
  * while the CLI entrypoint in `generate-component-artifacts.ts` stays thin.
  */
 
-import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 
 import * as prettier from 'prettier';
+
+import { assertPrettierResolvesToRoot } from './lib/prettier-resolution.ts';
 
 import {
   discoverComponentDirectories,
@@ -46,65 +48,6 @@ const COMPOSE_ONLY_ACCESSIBILITY_DOCUMENTATION_EXEMPTIONS = new Set([
 
 const prettierConfigurationCache = new Map<string, Promise<prettier.Options | null>>();
 
-const repositoryRoot = resolve(import.meta.dirname, '../../..');
-
-/**
- * The generated-artifact contract ("committed artifacts match regeneration") is
- * implicitly parameterized by whichever prettier this module happens to resolve.
- * Nothing pins that. Adding a workspace member whose `prettier` range differed
- * (#1425, `labs/chat-room` at `^3.8.3`) made bun nest a fresh 3.9.x under each
- * package's own `node_modules`; this module then resolved 3.9.6 while the root
- * stayed locked at 3.8.1, and 3.9's markdown printer moved blank lines around the
- * `<!-- generated:variables:* -->` markers -- so `components:check` reported ~150
- * READMEs stale on a branch that never touched `packages/components`.
- *
- * The invariant is not "one prettier in the lockfile" (transitives such as
- * `@changesets/*` legitimately carry a nested 2.x) but "the artifact pipeline
- * uses the ROOT's prettier". Compare against the version the root actually
- * resolves rather than against a declared range, so a deliberate `bun update`
- * at the root is not a false positive while a shadow copy nested under this
- * package is.
- */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
-}
-
-/** `JSON.parse` returns `any`; narrow it before trusting `.version`. */
-function readManifestVersion(manifestPath: string): string {
-  const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
-  if (!isRecord(parsed) || typeof parsed['version'] !== 'string') {
-    throw new Error(`${manifestPath} has no string "version" field`);
-  }
-  return parsed['version'];
-}
-
-export function assertPrettierResolvesToRoot(): { version: string; resolvedFrom: string } {
-  const resolvedFrom = import.meta.resolve('prettier');
-  const rootPrettierManifest = join(repositoryRoot, 'node_modules', 'prettier', 'package.json');
-  let rootVersion: string;
-  try {
-    rootVersion = readManifestVersion(rootPrettierManifest);
-  } catch (error) {
-    throw new Error(
-      `formatGenerated: cannot read the root prettier at ${rootPrettierManifest}; ` +
-        `the artifact pipeline must format with the root-locked prettier. ` +
-        `This module resolved prettier ${prettier.version} from ${resolvedFrom}.`,
-      { cause: error },
-    );
-  }
-  if (prettier.version !== rootVersion) {
-    throw new Error(
-      `formatGenerated: prettier resolved to ${prettier.version} from ${resolvedFrom}, ` +
-        `but the root locks ${rootVersion} (${rootPrettierManifest}). A nested copy is ` +
-        `shadowing the root's -- generated artifacts would silently track the wrong ` +
-        `formatter. Align the workspace's prettier ranges so bun dedupes to the root copy.`,
-    );
-  }
-  return { version: prettier.version, resolvedFrom };
-}
-
-let prettierResolutionChecked = false;
-
 /**
  * Run prettier over generated content using the repo's prettier configuration.
  *
@@ -115,10 +58,7 @@ let prettierResolutionChecked = false;
  * and where prettier was resolved from.
  */
 export async function formatGenerated(content: string, filepath: string): Promise<string> {
-  if (!prettierResolutionChecked) {
-    assertPrettierResolvesToRoot();
-    prettierResolutionChecked = true;
-  }
+  assertPrettierResolvesToRoot();
   try {
     const configurationDirectory = dirname(filepath);
     let optionsPromise = prettierConfigurationCache.get(configurationDirectory);

--- a/packages/components/scripts/generate-component-artifacts.ts
+++ b/packages/components/scripts/generate-component-artifacts.ts
@@ -37,7 +37,21 @@ async function main(): Promise<void> {
     const { buildManifest } = await import('./generate-manifest.ts');
 
     // Stage 1: per-component schema/variables/README drift check.
-    const perComponentIssues = await checkComponentArtifacts();
+    //
+    // Isolated like every later stage. `formatGenerated` no longer swallows a
+    // formatter failure (it used to return content unformatted and let the
+    // drift report imply a mismatch), so a thrown error here would otherwise
+    // abort the run before constraints/examples/manifest/agents-md report --
+    // contradicting the contract above that all stages run in check mode.
+    let perComponentIssues: Awaited<ReturnType<typeof checkComponentArtifacts>> = [];
+    let artifactsStageFailed = false;
+    try {
+      perComponentIssues = await checkComponentArtifacts();
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`components:check — artifacts stage failed: ${message}\n`);
+      artifactsStageFailed = true;
+    }
 
     // Stage 2: constraints drift check.
     let constraintIssues: DriftIssue[] = [];
@@ -144,6 +158,7 @@ async function main(): Promise<void> {
     // even when the on-disk artifacts match.
     const allIssues: string[] = [
       ...perComponentIssues.map((issue) => `${issue.component}/${issue.file} (${issue.reason})`),
+      ...(artifactsStageFailed ? ['artifacts: stage threw — see error above'] : []),
       ...constraintIssues.map(
         (issue) => `constraints: ${issue.component}/${issue.file} (${issue.reason})`,
       ),

--- a/packages/components/scripts/generate-manifest.ts
+++ b/packages/components/scripts/generate-manifest.ts
@@ -22,6 +22,7 @@ import { join } from 'node:path';
 
 import Ajv from 'ajv/dist/2020.js';
 import * as prettier from 'prettier';
+import { assertPrettierResolvesToRoot } from './lib/prettier-resolution.ts';
 
 import type { CategoryId, StatusLevel } from '../src/manifest.meta.ts';
 import { categories, overlapFamilies, statusLevels } from '../src/manifest.meta.ts';
@@ -390,6 +391,7 @@ export async function buildManifest(): Promise<Manifest> {
  * the file on commit and `manifest:check` then reports drift on the next run.
  */
 async function formatJson(content: string, filepath: string): Promise<string> {
+  assertPrettierResolvesToRoot();
   const options = await prettier.resolveConfig(filepath);
   return prettier.format(content, { ...options, filepath, parser: 'json' });
 }

--- a/packages/components/scripts/lib/prettier-resolution.ts
+++ b/packages/components/scripts/lib/prettier-resolution.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import * as prettier from 'prettier';
+
+const repositoryRoot = resolve(import.meta.dirname, '../../../..');
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/** `JSON.parse` returns `any`; narrow it before trusting `.version`. */
+function readManifestVersion(manifestPath: string): string {
+  const parsed: unknown = JSON.parse(readFileSync(manifestPath, 'utf8'));
+  if (!isRecord(parsed) || typeof parsed['version'] !== 'string') {
+    throw new Error(`${manifestPath} has no string "version" field`);
+  }
+  return parsed['version'];
+}
+
+let checked: { version: string; resolvedFrom: string } | null = null;
+
+/**
+ * Every generated-artifact pipeline under `scripts/` formats with prettier, and
+ * each one's "committed artifact matches regeneration" contract is implicitly
+ * parameterized by whichever prettier that script happens to resolve. Nothing
+ * pins it. Adding a workspace member with a different `prettier` range (#1425,
+ * `labs/chat-room` at `^3.8.3`) made bun nest a fresh 3.9.x under each package's
+ * own `node_modules`; the artifact pipeline then formatted with 3.9.6 while the
+ * root stayed locked at 3.8.1, and 3.9's markdown printer moved blank lines
+ * around the `<!-- generated:variables:* -->` markers -- so `components:check`
+ * reported ~150 READMEs stale on a branch that never touched `packages/components`
+ * (CIN-456).
+ *
+ * The invariant is not "one prettier in the lockfile" -- transitives such as
+ * `@changesets/*` legitimately carry a nested 2.x -- but "the artifact pipeline
+ * uses the ROOT's prettier". Compare against the version the root actually
+ * resolves rather than a declared range, so a deliberate `bun update` at the root
+ * is not a false positive while a shadow copy nested under this package is.
+ *
+ * Call it at every formatter entry point (manifest, agents-md, promotion
+ * readiness, tokens, component artifacts). It checks once and memoizes, so the
+ * per-call cost after the first is a null test.
+ */
+export function assertPrettierResolvesToRoot(): { version: string; resolvedFrom: string } {
+  if (checked !== null) return checked;
+  const resolvedFrom = import.meta.resolve('prettier');
+  const rootPrettierManifest = join(repositoryRoot, 'node_modules', 'prettier', 'package.json');
+  let rootVersion: string;
+  try {
+    rootVersion = readManifestVersion(rootPrettierManifest);
+  } catch (error) {
+    throw new Error(
+      `cannot read the root prettier at ${rootPrettierManifest}; generated artifacts must be ` +
+        `formatted with the root-locked prettier. This process resolved prettier ` +
+        `${prettier.version} from ${resolvedFrom}.`,
+      { cause: error },
+    );
+  }
+  if (prettier.version !== rootVersion) {
+    throw new Error(
+      `prettier resolved to ${prettier.version} from ${resolvedFrom}, but the root locks ` +
+        `${rootVersion} (${rootPrettierManifest}). A nested copy is shadowing the root's -- ` +
+        `generated artifacts would silently track the wrong formatter. Align the workspace's ` +
+        `prettier ranges so bun dedupes to the root copy.`,
+    );
+  }
+  checked = { version: prettier.version, resolvedFrom };
+  return checked;
+}

--- a/packages/components/scripts/render-agents-md.ts
+++ b/packages/components/scripts/render-agents-md.ts
@@ -19,6 +19,7 @@
 import { file, write } from 'bun';
 import { resolve } from 'node:path';
 import * as prettier from 'prettier';
+import { assertPrettierResolvesToRoot } from './lib/prettier-resolution.ts';
 import { readJsonFile } from './lib/read-json-file.ts';
 
 const PACKAGE_ROOT = resolve(import.meta.dir, '..');
@@ -220,6 +221,7 @@ async function main(): Promise<void> {
   const rendered = replaceBlock(existing, body);
   // Format with Prettier so the generated tables match the repository-wide
   // markdown style and `bun run format:check` stays green after a regenerate.
+  assertPrettierResolvesToRoot();
   const prettierConfig = (await prettier.resolveConfig(AGENTS_PATH)) ?? {};
   const next = await prettier.format(rendered, { ...prettierConfig, filepath: AGENTS_PATH });
 

--- a/packages/components/scripts/tokens/generate-artifacts.ts
+++ b/packages/components/scripts/tokens/generate-artifacts.ts
@@ -41,6 +41,7 @@ import babelPlugin from 'prettier/plugins/babel';
 import estreePlugin from 'prettier/plugins/estree';
 import markdownPlugin from 'prettier/plugins/markdown';
 import typescriptPlugin from 'prettier/plugins/typescript';
+import { assertPrettierResolvesToRoot } from '../lib/prettier-resolution.ts';
 
 import {
   buildGeneratedOutputs,
@@ -911,6 +912,7 @@ export async function renderDocTable(
     return `| ${toCodeSpan(cssProperty)} | ${value} | ${description} |`;
   });
   const raw = `${header}${rows.join('\n')}\n`;
+  assertPrettierResolvesToRoot();
   return format(raw, { ...PRETTIER_OPTIONS, parser: 'markdown', plugins: MARKDOWN_PLUGINS });
 }
 
@@ -1051,6 +1053,7 @@ export async function buildTokensDocMarkdown(
   // committed file and the generator's output can never agree: lint-staged
   // reformats on commit, `tokens:generate -- --check` regenerates without
   // that formatting, and CI reports drift on a file nobody edited.
+  assertPrettierResolvesToRoot();
   return format(rewritten, {
     ...PRETTIER_OPTIONS,
     parser: 'markdown',
@@ -1246,6 +1249,7 @@ export type ColorTokenGroup = {
 
 export const COLOR_TOKEN_GROUPS = ${groupsLiteral} as const;
 `;
+  assertPrettierResolvesToRoot();
   return format(source, { ...PRETTIER_OPTIONS, parser: 'typescript', plugins: TYPESCRIPT_PLUGINS });
 }
 
@@ -1326,6 +1330,7 @@ export const TOKEN_REGISTRY: TokenRegistry = ${serializeTokenRegistry(registry)}
 
 export default TOKEN_REGISTRY;
 `;
+  assertPrettierResolvesToRoot();
   return format(source, { ...PRETTIER_OPTIONS, parser: 'typescript', plugins: TYPESCRIPT_PLUGINS });
 }
 
@@ -1363,6 +1368,7 @@ async function buildTokenIndex(
       subpath: `@lostgradient/cinder/tokens/resolved/${name}`,
     })),
   };
+  assertPrettierResolvesToRoot();
   return format(JSON.stringify(index), {
     ...PRETTIER_OPTIONS,
     parser: 'json',
@@ -1389,6 +1395,8 @@ async function buildAllGeneratedOutputs(): Promise<Map<string, string>> {
   validateDocSections(registry);
 
   const existingDocMarkdown = await readFile(tokensDocPath, 'utf8');
+  // Guards every formatter in the Promise.all below, at a statement boundary.
+  assertPrettierResolvesToRoot();
   const [docMarkdown, registryJson, colorTokenRegistryModule, registryModule, tokenIndex] =
     await Promise.all([
       buildTokensDocMarkdown(existingDocMarkdown, baseIndex, baseResolveReferences),

--- a/packages/components/scripts/tokens/generate.ts
+++ b/packages/components/scripts/tokens/generate.ts
@@ -38,6 +38,7 @@ import { format } from 'prettier';
 import babelPlugin from 'prettier/plugins/babel';
 import estreePlugin from 'prettier/plugins/estree';
 import postcssPlugin from 'prettier/plugins/postcss';
+import { assertPrettierResolvesToRoot } from '../lib/prettier-resolution.ts';
 
 import { loadResolverDocument, loadTokenDocuments, tokenRoot } from './load.ts';
 import {
@@ -1802,6 +1803,7 @@ ${forcedSystemDarkBlock}
 ${forcedSystemLightBlock}
 `;
 
+  assertPrettierResolvesToRoot();
   return format(css, { ...PRETTIER_OPTIONS, parser: 'css', plugins: CSS_PLUGINS });
 }
 
@@ -1965,6 +1967,7 @@ export async function buildResolvedContexts(
         delete resolved[path];
       }
     }
+    assertPrettierResolvesToRoot();
     const json = await format(JSON.stringify(resolved), {
       ...PRETTIER_OPTIONS,
       parser: 'json',


### PR DESCRIPTION
## Why

The generated-artifact contract ("committed artifacts match regeneration") was implicitly parameterized by whichever `prettier` the artifact pipeline happened to resolve. Nothing pinned it.

On #1425, adding `labs/chat-room` with `prettier: ^3.8.3` made bun nest a fresh 3.9.x under each package's own `node_modules`. `formatGenerated` then formatted with **3.9.6** while the root stayed locked at **3.8.1**, and 3.9's markdown printer moves blank lines around the `<!-- generated:variables:* -->` markers — so `components:check` reported ~150 READMEs stale on a branch that never touched `packages/components`. Worse, `formatGenerated` wrapped everything in `catch { return content; }`, so a formatter that failed to load produced unformatted artifacts flagged as "drift" with no hint of the cause.

## What

**Deterministic resolution.** `formatGenerated` asserts once that the prettier it resolved is the same version the repository root resolves, and fails loudly naming both versions and the resolved path. The comparison is against the root's *installed* copy (`<root>/node_modules/prettier/package.json`) rather than a declared range: a deliberate `bun update` at the root is not a false positive, while a shadow copy nested under `packages/components` is exactly the failure. The invariant is deliberately not "one prettier in `bun.lock`" — `@changesets/apply-release-plan` and `@changesets/write` carry a legitimate nested 2.8.8 that this package never resolves, so that check would be wrong.

**No more silent failures.** A format error now surfaces naming the file and where prettier was resolved from.

## Something the swallow was hiding

Under the test harness (`--conditions browser --conditions svelte`), `prettier` resolves to `standalone.mjs`, which has no `resolveConfig`. `formatGenerated` was therefore throwing on *every* call under test conditions and silently returning content unchanged. The new tests are explicit that the happy path is gated by `components:check` under real conditions (which regenerates and diffs every artifact), not by a formatting assertion under a build that can't format.

## Verified

- `components:check` exits 0 with the assertion live — the pipeline resolves the root's 3.8.1 today.
- New `component-artifact-operations.test.ts`: 3 pass / 0 fail — root-resolution invariant, failure names the file and resolved prettier, no unformatted content on failure.
- Typecheck clean.

## Acceptance criteria (CIN-456)

- [x] Deterministic prettier resolution — `formatGenerated` asserts resolved version matches the root's, fails loudly on mismatch.
- [x] `formatGenerated` no longer swallows failures — error names file path and resolved prettier location.
- [x] Regression test pins that resolving prettier from `packages/components` yields the root-locked version.

No changeset: build-script change only, no published-artifact difference on a healthy tree.

Closes CIN-456.

https://claude.ai/code/session_01YZCSMnpJpoHnnw2sGrWu1E