### PR TITLE
test(overlays): observe data-cinder-closing before dismissal, not after

### DIFF
--- a/packages/testing/tests/overlay-exit-transition.playwright.ts
+++ b/packages/testing/tests/overlay-exit-transition.playwright.ts
@@ -1,4 +1,38 @@
-import { expect, test } from '@playwright/test';
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+/**
+ * `data-cinder-closing` exists ONLY for the duration of the real exit transition
+ * (~120ms for `--cinder-duration-fast`). Dismissing an overlay and then polling
+ * for the attribute races the transition it asserts on: under runner contention
+ * the poll's first sample can land after the transition has completed, and the
+ * assertion fails on a correctly-behaving overlay -- `element(s) not found` once
+ * it has unmounted, or `unexpected value "null"` once the attribute is gone
+ * (CIN-501; observed on PRs that touched none of this code).
+ *
+ * So the observation is armed BEFORE the dismissing action, and it is a
+ * `MutationObserver` rather than a Playwright `waitFor`: an observer records the
+ * attribute mutation the moment it happens, independent of any polling cadence,
+ * whereas `waitFor` still samples and can miss a window shorter than its
+ * interval. The observer writes a sentinel attribute onto `<html>` -- an element
+ * that outlives the overlay -- so the assertion has something stable to read
+ * even after the overlay has unmounted.
+ */
+async function armClosingObserver(target: Locator, sentinel: string): Promise<void> {
+  await target.evaluate((element, sentinelName) => {
+    document.documentElement.removeAttribute(sentinelName);
+    const observer = new MutationObserver(() => {
+      if (element.hasAttribute('data-cinder-closing')) {
+        document.documentElement.setAttribute(sentinelName, '');
+        observer.disconnect();
+      }
+    });
+    observer.observe(element, { attributes: true, attributeFilter: ['data-cinder-closing'] });
+  }, sentinel);
+}
+
+async function expectClosingObserved(page: Page, sentinel: string): Promise<void> {
+  await expect(page.locator('html')).toHaveAttribute(sentinel, '');
+}
 
 /**
  * CIN-376: every anchored overlay migrated onto the shared exit-transition
@@ -64,9 +98,10 @@ test('Popover renders data-cinder-closing during its exit transition, then unmou
   const panel = page.locator('.cinder-popover').first();
   await expect(panel).toHaveAttribute('data-cinder-position-ready', 'true');
 
+  await armClosingObserver(panel, 'data-test-popover-closing-observed');
   await trigger.click();
 
-  await expect(panel).toHaveAttribute('data-cinder-closing', '');
+  await expectClosingObserved(page, 'data-test-popover-closing-observed');
   await expect(panel).toHaveCount(0);
 });
 
@@ -103,24 +138,12 @@ test('Tooltip renders data-cinder-closing during its exit transition, then hides
   const tip = page.locator(`[id="${tooltipId}"][role="tooltip"]`).first();
   await expect(tip).toHaveAttribute('data-cinder-position-ready', 'true');
 
-  await tip.evaluate((element) => {
-    document.documentElement.removeAttribute('data-test-tooltip-closing-observed');
-    const observer = new MutationObserver(() => {
-      if (element.hasAttribute('data-cinder-closing')) {
-        document.documentElement.setAttribute('data-test-tooltip-closing-observed', '');
-        observer.disconnect();
-      }
-    });
-    observer.observe(element, {
-      attributes: true,
-      attributeFilter: ['data-cinder-closing'],
-    });
-  });
+  await armClosingObserver(tip, 'data-test-tooltip-closing-observed');
 
   // Move away to trigger the hide/close path.
   await page.mouse.move(0, 0);
 
-  await expect(page.locator('html')).toHaveAttribute('data-test-tooltip-closing-observed', '');
+  await expectClosingObserved(page, 'data-test-tooltip-closing-observed');
   await expect(tip).toBeHidden();
 });
 
@@ -140,8 +163,9 @@ test('HoverCard renders data-cinder-closing during its exit transition, then unm
   const card = page.locator('.cinder-hover-card').first();
   await expect(card).toHaveAttribute('data-cinder-position-ready', 'true');
 
+  await armClosingObserver(card, 'data-test-hover-card-closing-observed');
   await page.mouse.move(0, 0);
-  await expect(card).toHaveAttribute('data-cinder-closing', '');
+  await expectClosingObserved(page, 'data-test-hover-card-closing-observed');
 
   // The reopen-mid-close defect itself (below) is NOT exercised with this
   // basic example: its default `openDelay` (300ms) is longer than the exit
@@ -223,14 +247,15 @@ test('NavigationBar mobile panel plays its exit transition instead of snapping v
     .first();
   await expect(panel).toBeVisible();
 
-  await toggle.click();
-
   // Previously this panel used an unconditional `visibility: hidden` on
   // `[data-open='false']`, hiding it (and its exit transition) the instant
   // the toggle closed. It now stays visible/focusable through the
-  // transition, keyed off `data-cinder-closing`.
-  const closingPanel = page.locator(
-    '.cinder-navigation-bar__items[data-cinder-mobile-panel][data-cinder-closing]',
-  );
-  await expect(closingPanel).toHaveCount(1);
+  // transition, keyed off `data-cinder-closing`. `panel` is located by
+  // `[data-open="true"]`, which flips off at the same moment the closing
+  // attribute lands -- so the observer is armed on the element while that
+  // locator still resolves, and the assertion reads the sentinel rather
+  // than re-resolving a selector the closing state itself invalidates.
+  await armClosingObserver(panel, 'data-test-navigation-bar-closing-observed');
+  await toggle.click();
+  await expectClosingObserved(page, 'data-test-navigation-bar-closing-observed');
 });


### PR DESCRIPTION
## Why

`data-cinder-closing` exists only for the duration of the real exit transition (~120ms for `--cinder-duration-fast`). Three cases in `overlay-exit-transition.playwright.ts` dismissed the overlay and *then* polled for the attribute — racing the transition they assert on. Under runner contention the first poll can land after the transition has completed, and the assertion fails on a correctly-behaving overlay: `element(s) not found` once it has unmounted, or `unexpected value "null"` once the attribute is gone. Observed repeatedly on PRs that touched none of this code.

## What

Each racing assertion now arms a `MutationObserver` on the overlay **before** the dismissing action and asserts a sentinel on `<html>`, an element that outlives the overlay. An observer records the mutation the moment it happens, independent of polling cadence — a Playwright `waitFor` armed early is the right instinct but still samples and can miss a window shorter than its interval.

Shared `armClosingObserver(target, sentinel)` / `expectClosingObserved(page, sentinel)` helpers, applied to:

- **Popover** — polled after `trigger.click()`
- **HoverCard** — polled after `mouse.move(0, 0)`
- **NavigationBar** — polled `toHaveCount(1)` on a `[data-cinder-closing]` locator after `toggle.click()`

## Scope, corrected from the issue

- The **Tooltip** case was already fixed with this exact mechanism inline; it's folded into the shared helper rather than duplicated.
- The **NavigationBar** case has the identical race and wasn't listed in the issue. Included.
- The HoverCard instant-reopen sub-case already arms a `waitFor` before its pointer move — left as-is; it's asserting *attachment*, where sampling is adequate.

No sleeps, no raised timeouts, exit-transition behaviour untouched.

## Why the observer is safe by construction

- This spec runs only under the plain `chromium` project; `chromium-reduced-motion`'s `testMatch` covers two other files. Real durations apply. (Under reduced motion the transition could complete before the attribute paints and *nothing* could observe it — that path isn't exercised here.)
- `isClosing` flips true synchronously on close in `anchored-overlay-exit.svelte.ts` and clears only when `waitForTransitionCompletion` resolves, so an observer armed before dismissal always sees the attribute mutation.
- For NavigationBar, `data-open`, `data-cinder-mobile-panel`, and `data-cinder-closing` are all on one element (`navigation-bar.svelte:784–788`), so the observer armed on the `[data-open="true"]` locator is on the right node even though that locator stops matching the instant closing begins.

## Verified

```
bun run --filter=@cinder/testing test:playwright -- overlay-exit-transition --repeat-each=20
  80 passed (52.6s)
```

20/20 for each of Popover, Tooltip, HoverCard, NavigationBar.

No changeset: `@cinder/testing` is private.

Closes CIN-501.

https://claude.ai/code/session_01YZCSMnpJpoHnnw2sGrWu1E