### PR TITLE
fix(editor): resolve every src-backed subpath to src under browser and svelte

### DIFF
--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -31,6 +31,8 @@
     ".": {
       "types": "./dist/index.d.ts",
       "bun": "./src/lib/index.ts",
+      "browser": "./src/lib/index.ts",
+      "svelte": "./src/lib/index.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
@@ -120,66 +122,88 @@
     "./anchoring": {
       "types": "./dist/anchoring.d.ts",
       "bun": "./src/lib/anchoring.ts",
+      "browser": "./src/lib/anchoring.ts",
+      "svelte": "./src/lib/anchoring.ts",
       "import": "./dist/anchoring.js",
       "default": "./dist/anchoring.js"
     },
     "./comments": {
       "types": "./dist/comments/index.d.ts",
       "bun": "./src/lib/comments/index.ts",
+      "browser": "./src/lib/comments/index.ts",
+      "svelte": "./src/lib/comments/index.ts",
       "import": "./dist/comments/index.js",
       "default": "./dist/comments/index.js"
     },
     "./comments/types": {
       "types": "./dist/comments/types.d.ts",
       "bun": "./src/lib/comments/types.ts",
+      "browser": "./src/lib/comments/types.ts",
+      "svelte": "./src/lib/comments/types.ts",
       "import": "./dist/comments/types.js",
       "default": "./dist/comments/types.js"
     },
     "./export": {
       "types": "./dist/export/index.d.ts",
       "bun": "./src/lib/export/index.ts",
+      "browser": "./src/lib/export/index.ts",
+      "svelte": "./src/lib/export/index.ts",
       "import": "./dist/export/index.js",
       "default": "./dist/export/index.js"
     },
     "./export/types": {
       "types": "./dist/export/types.d.ts",
       "bun": "./src/lib/export/types.ts",
+      "browser": "./src/lib/export/types.ts",
+      "svelte": "./src/lib/export/types.ts",
       "import": "./dist/export/types.js",
       "default": "./dist/export/types.js"
     },
     "./session": {
       "types": "./dist/session/index.d.ts",
       "bun": "./src/lib/session/index.ts",
+      "browser": "./src/lib/session/index.ts",
+      "svelte": "./src/lib/session/index.ts",
       "import": "./dist/session/index.js",
       "default": "./dist/session/index.js"
     },
     "./session/types": {
       "types": "./dist/session/types.d.ts",
       "bun": "./src/lib/session/types.ts",
+      "browser": "./src/lib/session/types.ts",
+      "svelte": "./src/lib/session/types.ts",
       "import": "./dist/session/types.js",
       "default": "./dist/session/types.js"
     },
     "./shared/anchor-types": {
       "types": "./dist/shared/anchor-types.d.ts",
       "bun": "./src/lib/shared/anchor-types.ts",
+      "browser": "./src/lib/shared/anchor-types.ts",
+      "svelte": "./src/lib/shared/anchor-types.ts",
       "import": "./dist/shared/anchor-types.js",
       "default": "./dist/shared/anchor-types.js"
     },
     "./editor": {
       "types": "./dist/editor/index.d.ts",
       "bun": "./src/lib/editor/index.ts",
+      "browser": "./src/lib/editor/index.ts",
+      "svelte": "./src/lib/editor/index.ts",
       "import": "./dist/editor/index.js",
       "default": "./dist/editor/index.js"
     },
     "./editor/component-runtime": {
       "types": "./dist/editor/component-runtime.d.ts",
       "bun": "./src/lib/editor/component-runtime.ts",
+      "browser": "./src/lib/editor/component-runtime.ts",
+      "svelte": "./src/lib/editor/component-runtime.ts",
       "import": "./dist/editor/component-runtime.js",
       "default": "./dist/editor/component-runtime.js"
     },
     "./editor/test-utilities": {
       "types": "./dist/editor/test-utilities.d.ts",
       "bun": "./src/lib/editor/test-utilities.ts",
+      "browser": "./src/lib/editor/test-utilities.ts",
+      "svelte": "./src/lib/editor/test-utilities.ts",
       "import": "./dist/editor/test-utilities.js",
       "default": "./dist/editor/test-utilities.js"
     }

--- a/packages/editor/scripts/package-boundary.test.ts
+++ b/packages/editor/scripts/package-boundary.test.ts
@@ -184,6 +184,57 @@ describe('Editor package ownership boundary', () => {
     expect(published.peerDependencies).toEqual(editorManifest.peerDependencies);
   });
 
+  /**
+   * CIN-459. A subpath that resolves to `src` under Bun but to `dist` under
+   * Vite's `browser`/`svelte` conditions gives a workspace consumer two module
+   * instances of the same file -- and identity-keyed state (a ProseMirror
+   * `PluginKey`, an `instanceof`, a module-level registry) silently fails to
+   * cross that boundary. #1425 hit it for real: `anchorPluginKey` imported from
+   * `./anchor-decorations` (dist) could not read the plugin state installed by
+   * `ReviewEditor` (src). That one subpath was fixed; its siblings carried the
+   * same hazard, invisible until the next shared identity crossed it.
+   *
+   * The invariant: any export that points at `./src/` for Bun must resolve to
+   * that same source under `browser` and `svelte` too. Entries without a `bun`
+   * source condition (e.g. `./review-editor/styles`) are not part of the split
+   * and are left alone.
+   */
+  test('every src-resolving export also resolves to src under browser and svelte', () => {
+    const violations: string[] = [];
+    for (const [subpath, entry] of Object.entries(editorManifest.exports)) {
+      if (typeof entry !== 'object' || entry === null) continue;
+      const conditions = entry as Record<string, unknown>;
+      const bun = conditions['bun'];
+      if (typeof bun !== 'string' || !bun.startsWith('./src/')) continue;
+      if (conditions['browser'] !== bun || conditions['svelte'] !== bun) {
+        violations.push(
+          `${subpath}: bun=${bun} browser=${String(conditions['browser'])} svelte=${String(conditions['svelte'])}`,
+        );
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+
+  test('rewrites a src-resolving utility export to packed dist files', () => {
+    // The published artifact must stay dist-only even though the source manifest
+    // now names `./src/` under `browser`/`svelte` for utility subpaths too.
+    const published = buildPublishedManifest(editorManifest);
+    expect(published.exports['./comments']).toEqual({
+      types: './dist/comments/index.d.ts',
+      browser: './dist/comments/index.js',
+      svelte: './dist/comments/index.js',
+      import: './dist/comments/index.js',
+      default: './dist/comments/index.js',
+    });
+    expect(published.exports['.']).toEqual({
+      types: './dist/index.d.ts',
+      browser: './dist/index.js',
+      svelte: './dist/index.js',
+      import: './dist/index.js',
+      default: './dist/index.js',
+    });
+  });
+
   test('rewrites browser-aware Editor exports to packed dist files', () => {
     const published = buildPublishedManifest(editorManifest);
     const exportKeys = (entry: unknown): string[] => {

--- a/packages/editor/scripts/package-boundary.test.ts
+++ b/packages/editor/scripts/package-boundary.test.ts
@@ -206,11 +206,24 @@ describe('Editor package ownership boundary', () => {
       const conditions = entry as Record<string, unknown>;
       const bun = conditions['bun'];
       if (typeof bun !== 'string' || !bun.startsWith('./src/')) continue;
-      if (conditions['browser'] !== bun || conditions['svelte'] !== bun) {
-        violations.push(
-          `${subpath}: bun=${bun} browser=${String(conditions['browser'])} svelte=${String(conditions['svelte'])}`,
-        );
+      const keys = Object.keys(conditions);
+      const problems: string[] = [];
+      if (conditions['browser'] !== bun) problems.push(`browser=${String(conditions['browser'])}`);
+      if (conditions['svelte'] !== bun) problems.push(`svelte=${String(conditions['svelte'])}`);
+      // Conditional exports resolve to the FIRST matching key, so value equality is
+      // not enough: `browser`/`svelte` sinking below `import`/`default` would hand
+      // Vite the dist entry again while the values still matched. Pin the order.
+      const firstDistKey = Math.min(
+        ...['import', 'default'].map((k) => keys.indexOf(k)).filter((i) => i >= 0),
+      );
+      for (const sourceKey of ['bun', 'browser', 'svelte']) {
+        const at = keys.indexOf(sourceKey);
+        if (at === -1 || (Number.isFinite(firstDistKey) && at > firstDistKey)) {
+          problems.push(`${sourceKey} must precede import/default`);
+        }
       }
+      if (problems.length > 0)
+        violations.push(`${subpath} [${keys.join(', ')}]: ${problems.join('; ')}`);
     }
     expect(violations).toEqual([]);
   });


### PR DESCRIPTION
## Why

A workspace consumer — the playground, the chat-room lab, any future lab — loaded the editor's **component** subpaths (`./review-editor`, `./diff-viewer`, `./markdown-editor`) from `src` under Vite's `browser`/`svelte` conditions, but its **utility** subpaths from `dist`, because only the component entries and `./anchor-decorations` carried those conditions. That's two module instances of the same file, and identity-keyed state — a ProseMirror `PluginKey`, an `instanceof`, a module-level `WeakMap` or registry — silently fails to cross the boundary.

#1425 hit it for real: `anchorPluginKey` imported from `./anchor-decorations` (dist) couldn't read the plugin state `ReviewEditor` (src) installed, and six chat-room specs failed. That PR fixed the one subpath. Eleven siblings kept the hazard, invisible until the next shared identity crossed it. (CIN-459)

## What

Every export whose `bun` condition points under `./src/` now also names that source under `browser` and `svelte`, inserted immediately after `bun` to match the existing `./anchor-decorations` shape:

`.`, `./anchoring`, `./comments`, `./comments/types`, `./export`, `./export/types`, `./session`, `./session/types`, `./shared/anchor-types`, `./editor`, `./editor/component-runtime`, `./editor/test-utilities`

The root `.` is included deliberately — it's a pure utility barrel re-exporting exactly these subpaths, and it had the same split. `./review-editor/styles` has no `bun` source and isn't part of the split.

## The published artifact is unchanged in shape

`pack-for-publish`'s `publishedExport()` maps `browser`/`svelte` → the dist target and drops `bun`, so npm consumers keep a dist-only graph. This is the same path `./anchor-decorations` has taken through every release since #1425.

## Pinned, both halves

Two new tests in `package-boundary.test.ts`:
- **The invariant** — any export with a `./src/` `bun` entry must carry `browser` and `svelte` equal to it. Self-scoping: entries without a `bun` source are left alone.
- **The published shape** — `./comments` and `.` rewrite to dist-only with `browser`/`svelte`/`import`/`default` all on dist and no `bun`.

## Verified

Resolution from a real workspace consumer (`labs/chat-room`), the invariant in behavioral terms:

```
bun --conditions=browser --conditions=svelte -e "import.meta.resolve(...)"
  @lostgradient/editor                  -> src/lib/index.ts
  @lostgradient/editor/comments         -> src/lib/comments/index.ts
  @lostgradient/editor/session          -> src/lib/session/index.ts
  @lostgradient/editor/export           -> src/lib/export/index.ts
  @lostgradient/editor/anchoring        -> src/lib/anchoring.ts
  @lostgradient/editor/anchor-decorations -> src/lib/anchor-decorations.ts   (already src — same graph now)
  @lostgradient/editor/editor/component-runtime -> src/lib/editor/component-runtime.ts
```

And the other half — a consumer *without* Vite's conditions keeps `dist`, verified with `node` rather than `bun` (Bun applies its own `bun` condition by default, which already pointed at `src` before this change, so a `bun -e` without `--conditions` is not a control here):

```
node -e "import.meta.resolve(...)"
  @lostgradient/editor/comments           -> dist/comments/index.js
  @lostgradient/editor/anchor-decorations -> dist/anchor-decorations.js
```

Condition **order** was also re-checked on the committed manifest after lint-staged's `sort-package-json` pass: `default` remains last in every entry, and `browser`/`svelte` sit after `bun` exactly as in `./anchor-decorations`.

- `bunx turbo run test --filter=@lostgradient/editor` — **907 pass / 0 fail** (the issue's first verification command)
- Editor lint 0/0, typecheck clean

**Not run:** the issue's second verification, `labs/chat-room … playwright test src/routes/exercises/review-anchoring`. That suite is currently contended by #1488/#1489 and CIN-509 documents that concurrent runs silently adopt each other's servers, so a result from it right now wouldn't be trustworthy evidence either way. The resolution table above is the mechanism that suite would exercise.

## Out of scope, noted

The issue asks for the same audit on `@lostgradient/cinder`, `@lostgradient/chat`, and `@lostgradient/markdown`'s non-component subpaths. This PR fixes the editor — the package with the confirmed live defect — and pins its invariant; the other three are a follow-up with the same test shape.

No changeset: workspace-only resolution change; the published exports are byte-identical in shape.

Closes CIN-459.

https://claude.ai/code/session_01YZCSMnpJpoHnnw2sGrWu1E
