### PR TITLE
fix(share-card): render the value field from one Input call site

### DIFF
--- a/.changeset/share-card-single-input-call-site.md
+++ b/.changeset/share-card-single-input-call-site.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+ShareCard renders its value field from a single `Input` call site. Previously the icon-only and `labelSnippet` layouts were two separate `Input` instances, so a parent that reactively changed `actions` across that boundary tore the field down and dropped the user's focus and selection. Now the actions move between the trailing addon and the sibling row as a prop update on the same element, and focus and the selection range survive.

--- a/packages/components/src/components/share-card/share-card.svelte
+++ b/packages/components/src/components/share-card/share-card.svelte
@@ -16,6 +16,7 @@
 </script>
 
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
 
   import Check from 'lucide-svelte/icons/check';
@@ -115,6 +116,17 @@
   // the actions render OUTSIDE the field instead, as a normal full-width
   // sibling row (the pre-existing layout this redesign started from).
   const hasLabelSnippetAction = $derived(!!actions?.some((action) => !!action.labelSnippet));
+
+  // The value field's addon, typed against the `InputProps` leading/trailing
+  // union so it can be spread onto ONE `<Input>` (see the template comment).
+  // Takes the actions row as a parameter because template snippets are not in
+  // scope here.
+  type ValueFieldAddon =
+    | { trailing: Snippet; trailingInteractive: true }
+    | { trailing?: never; trailingInteractive?: never };
+  function valueFieldAddon(row: Snippet): ValueFieldAddon {
+    return hasLabelSnippetAction ? {} : { trailing: row, trailingInteractive: true };
+  }
 
   // Track which action is in the "copied" state by its key.
   let copiedKey = $state<string | null>(null);
@@ -358,49 +370,29 @@
        is present, `Input`'s trailing slot is too narrow for rich content
        (`max-inline-size: 40%`), so the actions render OUTSIDE the field as
        a normal full-width row instead of being clipped inside it. -->
-  <!-- Two `Input` arms rather than one call site with the addon applied conditionally.
-       Switching arms tears the value field down — two `<Input>` instances are two
-       native elements — so a parent reactively updating `actions` across the
-       `labelSnippet` boundary drops the user's focus and selection.
-
-       `Input` itself no longer recreates its `<input>` when an addon appears or
-       disappears (CIN-500: the control wrapper is always rendered), so a single call
-       site WOULD now preserve the element. The remaining obstacle is typing: a
-       conditional spread (`{...cond ? {} : { trailing, trailingInteractive }}`) does
-       not typecheck against `InputProps`' leading/trailing union under
-       `exactOptionalPropertyTypes`, because the conditional's type is widened before
-       the spread. A spread of a `$derived` object whose type is already narrowed to
-       the union does typecheck (CIN-500's fixture does exactly that). Collapsing to
-       that form is tracked as CIN-512. -->
+  <!-- One `Input` call site. `Input` keeps its native element when an addon
+       appears or disappears (CIN-500), so moving the actions between the trailing
+       addon and the sibling row is a prop update on the same instance, and a parent
+       reactively changing `actions` across the `labelSnippet` boundary no longer
+       drops the user's focus and selection in the value field. The addon is built by
+       `valueFieldAddon`, whose return type is already narrowed to the `InputProps`
+       leading/trailing union; a conditional spread written inline would widen
+       `trailing` to optional first and fail `exactOptionalPropertyTypes`. -->
+  <Input
+    id={valueFieldId}
+    {value}
+    readonly
+    variant="code"
+    class="cinder-share-card__value"
+    title={value}
+    aria-label={valueRegionLabel}
+    inputAttachment={valueFieldAttachment}
+    oncopy={handleFieldCopy}
+    onfocus={(event) => event.currentTarget.select()}
+    {...valueFieldAddon(actionsRow)}
+  />
   {#if hasLabelSnippetAction}
-    <Input
-      id={valueFieldId}
-      {value}
-      readonly
-      variant="code"
-      class="cinder-share-card__value"
-      title={value}
-      aria-label={valueRegionLabel}
-      inputAttachment={valueFieldAttachment}
-      oncopy={handleFieldCopy}
-      onfocus={(event) => event.currentTarget.select()}
-    />
     {@render actionsRow()}
-  {:else}
-    <Input
-      id={valueFieldId}
-      {value}
-      readonly
-      variant="code"
-      class="cinder-share-card__value"
-      title={value}
-      aria-label={valueRegionLabel}
-      inputAttachment={valueFieldAttachment}
-      oncopy={handleFieldCopy}
-      onfocus={(event) => event.currentTarget.select()}
-      trailing={actionsRow}
-      trailingInteractive
-    />
   {/if}
 </div>
 

--- a/packages/components/src/components/share-card/share-card.test.ts
+++ b/packages/components/src/components/share-card/share-card.test.ts
@@ -449,19 +449,12 @@ describe('ShareCard Input composition', () => {
 
   test('the value field presents identically in both action layouts', () => {
     // `labelSnippet` presence decides whether the actions ride inside `Input`'s trailing
-    // addon or render as a sibling row, and those are two separate `Input` invocations.
-    // A review rightly flagged that switching arms tears the value field down, dropping
-    // focus and selection on a presentation-only change.
-    //
-    // `Input` itself now keeps its `<input>` when an addon appears or disappears
-    // (CIN-500), so one call site with a union-narrowed `$derived` spread would preserve
-    // the element; a conditional spread inside the attribute still does not typecheck
-    // under `exactOptionalPropertyTypes`. Collapsing the arms is tracked as CIN-512.
-    //
-    // What is worth guarding is that the two arms cannot DRIFT: the field must present
-    // the same contract either way. Asserted on the rendered result rather than by
-    // regex-parsing the source, so a reformat or refactor cannot fail it without an
-    // actual behavioural change.
+    // addon or render as a sibling row. That used to be two separate `Input` arms,
+    // which tore the value field down on a presentation-only change; it is one call
+    // site now (CIN-512), and the test below pins the element's identity across the
+    // boundary. This one keeps guarding that the field presents the same contract in
+    // both layouts, asserted on the rendered result rather than by regex-parsing the
+    // source, so a reformat or refactor cannot fail it without a behavioural change.
     const richLabel = createRawSnippet(() => ({ render: () => '<span>Copy it</span>' }));
     const value = 'https://example.com/a/b/c';
 
@@ -501,6 +494,50 @@ describe('ShareCard Input composition', () => {
     // Sanity-check the contract is not vacuously empty on both sides.
     expect(compactContract.value).toBe(value);
     expect(compactContract.readOnly).toBe(true);
+  });
+
+  test('the value field keeps its native element when actions cross the labelSnippet boundary', async () => {
+    // A parent that reactively changes `actions` so that a `labelSnippet` appears or
+    // disappears moves the actions between the trailing addon and the sibling row.
+    // With one `Input` call site and Input keeping its element across an addon
+    // toggle (CIN-500), that is a prop update on the same element: focus and the
+    // selection range survive. Exactly one field is asserted alongside identity
+    // because happy-dom can leave a torn-down `{#if}` arm's nodes connected, and
+    // identity alone would then pass against the stale node.
+    const richLabel = createRawSnippet(() => ({ render: () => '<span>Copy it</span>' }));
+    const value = 'https://example.com/a/b/c';
+    const compactActions = [{ key: 'copy', label: 'Copy', copyValue: value }];
+    const richActions = [{ key: 'copy', label: 'Copy', labelSnippet: richLabel, copyValue: value }];
+
+    const { container, rerender } = render(ShareCard, { value, actions: compactActions });
+    const field = () => container.querySelectorAll<HTMLInputElement>('.cinder-share-card__value');
+    expect(field()).toHaveLength(1);
+    const before = field()[0]!;
+    before.focus();
+    before.setSelectionRange(8, 19);
+    expect(document.activeElement).toBe(before);
+    expect(
+      container.querySelector('.cinder-input-group__trailing .cinder-share-card__actions'),
+    ).not.toBeNull();
+
+    await rerender({ actions: richActions });
+    expect(field()).toHaveLength(1);
+    expect(field()[0]).toBe(before);
+    expect(document.activeElement).toBe(before);
+    expect(before.selectionStart).toBe(8);
+    expect(before.selectionEnd).toBe(19);
+    expect(container.querySelector('.cinder-input-group')).toBeNull();
+    expect(container.querySelector('.cinder-share-card__actions')?.parentElement).toBe(
+      container.querySelector<HTMLElement>('.cinder-share-card'),
+    );
+
+    await rerender({ actions: compactActions });
+    expect(field()).toHaveLength(1);
+    expect(field()[0]).toBe(before);
+    expect(document.activeElement).toBe(before);
+    expect(
+      container.querySelector('.cinder-input-group__trailing .cinder-share-card__actions'),
+    ).not.toBeNull();
   });
 
   test('both action layouts render exactly one value field, in the right place', () => {

--- a/packages/components/src/components/share-card/share-card.test.ts
+++ b/packages/components/src/components/share-card/share-card.test.ts
@@ -535,6 +535,8 @@ describe('ShareCard Input composition', () => {
     expect(field()).toHaveLength(1);
     expect(field()[0]).toBe(before);
     expect(document.activeElement).toBe(before);
+    expect(before.selectionStart).toBe(8);
+    expect(before.selectionEnd).toBe(19);
     expect(
       container.querySelector('.cinder-input-group__trailing .cinder-share-card__actions'),
     ).not.toBeNull();


### PR DESCRIPTION
Closes CIN-512

## What was wrong

`share-card.svelte` rendered its value field as two separate `<Input>` invocations in `{#if hasLabelSnippetAction}` arms — one with `trailing={actionsRow} trailingInteractive`, one without (the actions then render as a sibling row). Two instances are two native elements, so a parent that reactively changed `actions` across the `labelSnippet` boundary tore the value field down and dropped the user's focus and selection. The file's comment recorded two reasons the arms were not collapsed: a conditional spread did not typecheck against `InputProps`' leading/trailing union, and `Input` itself recreated the element anyway. CIN-500 (#1502) removed the second and showed the first is narrower than stated.

## What changed

- **`share-card.svelte`** — one `<Input>`. The addon comes from `valueFieldAddon(actionsRow)`, a script function whose return type is already narrowed to the union (`{ trailing: Snippet; trailingInteractive: true } | { trailing?: never; trailingInteractive?: never }`), so the spread typechecks under `exactOptionalPropertyTypes` with no type assertion (`no-unsafe-type-assertion` is enforced). It takes the actions row as a parameter because template snippets are not in scope in the instance script. `{#if hasLabelSnippetAction}{@render actionsRow()}{/if}` renders the sibling row. The "two arms" comments are gone.
- **`share-card.test.ts`** — the "presents identically in both action layouts" test stays as the contract guard with its comment rewritten; a new test holds the value field across `rerender({ actions })` in both directions and asserts identity, exactly one field (happy-dom can leave a torn-down `{#if}` arm's nodes connected, so identity alone can pass against a stale node), focus, the `8–19` selection range, and where the actions row lands in each layout.
- Patch changeset for `@lostgradient/cinder`.

## Verification

- **Real browser** (Chromium, Vite-served ShareCard toggling `actions` between icon-only and `labelSnippet`): the same tagged value field survives compact → rich → compact, focus stays on it, the selection `8–19` is intact, and the actions row moves from `.cinder-input-group__trailing` to the card root and back.
- ShareCard suite 40/40; full package unit suite 11,849 pass, 0 fail.
- lint, `lint:invariants`, typecheck, `components:check` green.
- Docs page (`/page/share-card`) pixel-compared against the post-CIN-500 capture: 2 differing pixels, all at the playground sidebar filter's rounded corners (`20,57 … 21,92`), the established same-tree render noise; both layouts unchanged.

https://claude.ai/code/session_01YZCSMnpJpoHnnw2sGrWu1E
