### PR TITLE
fix(editor): guard the Cinder peer range against the planned release, like Chat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -178,7 +178,7 @@
         "typescript": "^5.9.0",
       },
       "peerDependencies": {
-        "@lostgradient/cinder": "^0.25.0",
+        "@lostgradient/cinder": "^0.26.0",
         "@lostgradient/markdown": "^0.4.0",
         "@milkdown/ctx": "^7.17.3",
         "@milkdown/kit": "^7.17.3",

--- a/packages/chat/scripts/package-boundary.test.ts
+++ b/packages/chat/scripts/package-boundary.test.ts
@@ -102,6 +102,10 @@ describe('Chat package ownership boundary', () => {
     ]);
   });
 
+  // Editor's guard checks the same thing against the same target (CIN-510). The two
+  // deliberately agree: a guard that checks the CURRENT version cannot see a pending
+  // minor about to exclude itself, and having one of each meant no single peer-range
+  // value satisfied both while a minor was pending.
   test('keeps Chat’s Cinder peer range covering the planned Cinder release', () => {
     const cinderPeerRange = chatManifest.peerDependencies?.['@lostgradient/cinder'];
     expect(

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -260,7 +260,7 @@
     "typescript": "^5.9.0"
   },
   "peerDependencies": {
-    "@lostgradient/cinder": "^0.25.0",
+    "@lostgradient/cinder": "^0.26.0",
     "@lostgradient/markdown": "^0.4.0",
     "@milkdown/ctx": "^7.17.3",
     "@milkdown/kit": "^7.17.3",

--- a/packages/editor/scripts/package-boundary.test.ts
+++ b/packages/editor/scripts/package-boundary.test.ts
@@ -1,3 +1,4 @@
+import getReleasePlan from '@changesets/get-release-plan';
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
 
@@ -20,6 +21,20 @@ const markdownManifest = JSON.parse(
   await Bun.file(join(workspaceRoot, 'packages', 'markdown', 'package.json')).text(),
 ) as PackageManifest;
 const editorReadme = await Bun.file(join(packageRoot, 'README.md')).text();
+
+/**
+ * The Cinder version this repository is about to publish, not the one already
+ * published. Mirrors Chat's guard deliberately: checking the CURRENT version lets
+ * a pending minor ship a peer range that excludes the very Cinder released beside
+ * it, which is exactly how Markdown 0.1.0 -> 0.2.0 shipped past a stale `^0.1.0`
+ * (see the comment on Chat's Markdown guard). `reconcile-internal-peers.ts` still
+ * rewrites both ranges at `changeset:version` time; this makes the intent visible
+ * in the pull request that introduces the minor rather than only at release.
+ */
+const releasePlan = await getReleasePlan(workspaceRoot);
+const plannedCinderVersion =
+  releasePlan.releases.find((release) => release.name === '@lostgradient/cinder')?.newVersion ??
+  cinderManifest.version;
 
 describe('Editor package ownership boundary', () => {
   test('keeps component tests serial without isolating the Svelte preload plugin', () => {
@@ -116,7 +131,7 @@ describe('Editor package ownership boundary', () => {
     ]);
   });
 
-  test('keeps Editor’s Cinder peer range covering the current Cinder version', () => {
+  test('keeps Editor’s Cinder peer range covering the planned Cinder release', () => {
     const cinderPeerRange = editorManifest.peerDependencies?.['@lostgradient/cinder'];
     expect(
       cinderPeerRange,
@@ -126,8 +141,8 @@ describe('Editor package ownership boundary', () => {
 
     expect(cinderPeerRange).toMatch(/^\^\d+\.\d+\.\d+$/u);
     expect(
-      Bun.semver.satisfies(cinderManifest.version, cinderPeerRange),
-      'Editor’s Cinder peer range must cover the current Cinder version.',
+      Bun.semver.satisfies(plannedCinderVersion, cinderPeerRange),
+      'Editor’s Cinder peer range must cover the planned Cinder release.',
     ).toBe(true);
   });
 


### PR DESCRIPTION
Closes CIN-510.

## Problem

Chat and Editor both guard their `@lostgradient/cinder` peer range, but against **different targets**:

- **Chat** asserted the range covers the **planned** release, from the changeset release plan.
- **Editor** asserted it covers the **current** published version.

While a Cinder minor is pending, those demands are mutually exclusive. With Cinder at 0.25.x and 0.26.0 planned, Chat requires `^0.26.0` while Editor rejects it — `^0.25.0` excludes the planned release, `^0.26.0` excludes the published one. No single value satisfied both, so the established convention of widening the range in the feature pull request (precedent: #1472) could not be followed without turning one guard red.

Found the hard way in [#1496](https://github.com/stevekinney/cinder/pull/1496), where widening both together turned a green Chat guard into a red Editor guard and cost three CI cycles.

## Direction, and why this one

Editor moves to the **planned** release rather than Chat relaxing to **current**, because the planned-release check is the one that caught a real defect. The comment above Chat's Markdown guard records it: Markdown went 0.1.0 → 0.2.0 while Chat still declared `^0.1.0`, excluding the Markdown released beside it, and nothing caught it. Relaxing Chat would discard a check earned by a shipped bug.

`packages/editor/package.json` moves to `^0.26.0` accordingly. That is the exact widening reverted in `5c2b5ff39` during #1496 — correct once the guard's target is fixed, incorrect before it, which is why the two changes have to land together rather than in either order.

## This does not replace release-time reconciliation

`reconcile-internal-peers.ts` still rewrites both ranges to the generated version during `changeset:version`, so this is idempotent with the release path. What changes is that the intent becomes visible in the pull request that introduces the minor, rather than only at release time.

Both files now carry a comment stating that the two guards deliberately agree, so the next reader doesn't have to rediscover why.

## Verification

Checked in **both** lifecycle states, not just the current one:

- With the pending Cinder minor present: `packages/chat` 11 pass, `packages/editor` 11 pass — on a single peer-range value.
- In a simulated post-release state (changesets consumed, Cinder at 0.26.0): both still pass. This mattered because the acceptance criteria required it and it is not implied by the first check.

`check:changeset-prerelease-bumps` and `typecheck` both exit 0. `bun.lock` regenerated for the manifest change — one line.

## Scope

Two `package-boundary.test.ts` files, `packages/editor/package.json`, and the lockfile. No production source changes.

https://claude.ai/code/session_01BicogfzUyxNrcZZumwGJSp