### PR TITLE
fix(input): share one declaration of the invalid-hover border

### DIFF
--- a/.changeset/input-invalid-border-recipe.md
+++ b/.changeset/input-invalid-border-recipe.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/cinder': patch
+---
+
+Share one declaration of the Input's invalid-hover border between the input, its host wrapper, and the group. The three surfaces that can paint that edge each derived it separately, so they could drift apart, and the duplication pushed the file past its raw-color allowance.

--- a/packages/components/src/components/input/input.css
+++ b/packages/components/src/components/input/input.css
@@ -6,6 +6,22 @@
  * INPUT
  * ======================================== */
 
+  /* One recipe for the invalid border's hover step, shared by the three
+   * surfaces that can paint that edge: the bare input, the host wrapper that
+   * takes ownership when an addon appears, and the group. Deriving it three
+   * times over is what pushed this file past its raw-color allowance, and a
+   * single declaration keeps the three in step by construction — they are the
+   * same edge, and a divergence between them would be a bug rather than a
+   * choice.
+   */
+  .cinder-input,
+  .cinder-input-host,
+  .cinder-input-group {
+    --_cinder-input-invalid-border-hover: oklch(
+      from var(--cinder-status-danger-solid) calc(l - 0.06) c h
+    );
+  }
+
   /* ----------------------------------------
  * Field wrapper
  * ---------------------------------------- */
@@ -168,7 +184,7 @@
 
   @media (hover: hover) {
     .cinder-input[aria-invalid='true']:hover:not(:disabled) {
-      border-color: oklch(from var(--cinder-status-danger-solid) calc(l - 0.06) c h);
+      border-color: var(--_cinder-input-invalid-border-hover);
     }
   }
 
@@ -230,7 +246,7 @@
   }
   @media (hover: hover) {
     .cinder-input-host[data-invalid]:hover:not([data-disabled]) {
-      border-color: oklch(from var(--cinder-status-danger-solid) calc(l - 0.06) c h);
+      border-color: var(--_cinder-input-invalid-border-hover);
     }
   }
   .cinder-input-host[data-disabled] {
@@ -340,7 +356,7 @@
   }
   @media (hover: hover) {
     .cinder-input-group--invalid:hover:not(.cinder-input-group--disabled) {
-      border-color: oklch(from var(--cinder-status-danger-solid) calc(l - 0.06) c h);
+      border-color: var(--_cinder-input-invalid-border-hover);
     }
   }
 

--- a/packages/components/src/components/input/input.test.ts
+++ b/packages/components/src/components/input/input.test.ts
@@ -719,7 +719,13 @@ describe('Input group (leading/trailing addons)', () => {
       /\.cinder-input-host:hover:not\(\[data-disabled\]\)\s*\{[^}]*border-color:\s*var\(--cinder-border-strong\);/,
     );
     expect(css).toMatch(
-      /\.cinder-input-host\[data-invalid\]:hover:not\(\[data-disabled\]\)\s*\{[^}]*border-color:\s*oklch\(from var\(--cinder-status-danger-solid\) calc\(l - 0\.06\) c h\);/,
+      /\.cinder-input-host\[data-invalid\]:hover:not\(\[data-disabled\]\)\s*\{[^}]*border-color:\s*var\(--_cinder-input-invalid-border-hover\);/,
+    );
+    // The three surfaces that can paint that edge share one declaration of it,
+    // so they cannot drift apart: the bare input, the host that takes over when
+    // an addon appears, and the group.
+    expect(css).toMatch(
+      /\.cinder-input,\s*\.cinder-input-host,\s*\.cinder-input-group\s*\{[^}]*--_cinder-input-invalid-border-hover:\s*oklch\(\s*from var\(--cinder-status-danger-solid\) calc\(l - 0\.06\) c h\s*\);/,
     );
     // And the reverse direction: the grouped input drops its border with
     // `border-style`, not the `border` shorthand, so its computed border-color


### PR DESCRIPTION
Closes CIN-524. `main` has been red since 2026-09-04.

## What was failing

`main-green` → **Source audits (cinder)** → `colors:audit`:

```
NEW raw-color migration debt (not in baseline):
  src/components/input/input.css [oklch]: found 3, allowed 2
```

Total migration debt was already *below* baseline (26 against 38), so this was the per-file allowance, not an overall regression.

## Root cause

Three identical declarations of the same derived colour — the invalid border, one step darker on hover — one for each surface that can paint that edge:

```css
border-color: oklch(from var(--cinder-status-danger-solid) calc(l - 0.06) c h);
```

`.cinder-input[aria-invalid='true']:hover`, `.cinder-input-host[data-invalid]:hover`, and `.cinder-input-group--invalid:hover`. The third arrived with #1502, which gave the host its own invalid-hover rule so the group's border-colour transition would not start from `currentcolor` when an addon appears — correct behaviour, but it made the file's third copy of the derivation.

## Fix

One declaration, shared by the three selectors:

```css
.cinder-input,
.cinder-input-host,
.cinder-input-group {
  --_cinder-input-invalid-border-hover: oklch(
    from var(--cinder-status-danger-solid) calc(l - 0.06) c h
  );
}
```

This is the first of the three remedies the audit itself names, and it is the right one here: the three surfaces are *the same edge*, so a divergence between them would be a bug rather than a choice, and the shared declaration makes that true by construction. The private-property convention (`--_cinder-input-*`) is the one the file already uses for `--_cinder-input-ring`.

The computed value is unchanged — same derivation, same input token — so nothing renders differently. Neither the allowance nor the baseline was touched.

## Verification

- `colors:audit` exits 0; migration debt drops 26 → 24.
- `bun run test -- src/components/input` — 89 pass.
- Prettier, lint, and `typecheck` clean.

`input.test.ts` pinned the literal `oklch(...)` in the host's hover rule, so that assertion moved to the variable — and gained a second one that pins the shared declaration itself, which is the stronger claim: the three surfaces cannot drift apart.
