### PR TITLE
ci: stop a failed artifact upload from failing a green Playwright lane

### DIFF
--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -429,9 +429,12 @@ jobs:
       - name: Upload Playwright HTML report
         if: failure()
         uses: actions/upload-artifact@v7
-        # Diagnostics, never a verdict: whether the artifact service accepts a
-        # zip must not decide what this job reports about the code under test.
-        # A 403 on finalize was failing lanes whose tests had all passed.
+        # Diagnostics, never a verdict — this applies to every upload in this
+        # workflow, including the ones that only run after a failure. Whether
+        # the artifact service accepts a zip must not change what the job
+        # reports about the code under test, in either direction: a 403 on
+        # finalize was turning green lanes red, and on a step like this one it
+        # would bury the failure the report was collected to explain.
         continue-on-error: true
         with:
           name: playwright-report-${{ matrix.shard }}
@@ -632,6 +635,12 @@ jobs:
       - name: Download blob reports
         if: "always() && needs.playwright-lane.result != 'skipped'"
         uses: actions/download-artifact@v8
+        # The same reachable state one step earlier: with uploads best-effort,
+        # a run where no shard uploaded a blob matches no artifact, and the
+        # download fails before the merge guard below ever sees the empty
+        # directory. Tolerated here so the aggregate does not inherit the very
+        # false red this change removes from the lanes.
+        continue-on-error: true
         with:
           pattern: playwright-blob-*
           path: packages/testing/blob-reports

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -429,8 +429,9 @@ jobs:
       - name: Upload Playwright HTML report
         if: failure()
         uses: actions/upload-artifact@v7
-        # Diagnostics, never a verdict: a 403 from the artifact service must not
-        # fail a lane whose tests passed, and with it the required check.
+        # Diagnostics, never a verdict: whether the artifact service accepts a
+        # zip must not decide what this job reports about the code under test.
+        # A 403 on finalize was failing lanes whose tests had all passed.
         continue-on-error: true
         with:
           name: playwright-report-${{ matrix.shard }}
@@ -637,7 +638,19 @@ jobs:
           merge-multiple: true
       - name: Merge sharded report
         if: "always() && needs.playwright-lane.result != 'skipped'"
-        run: bunx playwright merge-reports --reporter html packages/testing/blob-reports
+        # Uploads are best-effort, so "no blobs at all" is now a reachable
+        # state — an artifact-service outage produces it. Merging nothing is
+        # not a failure of the code under test, and failing here would just
+        # move the false red from the lanes to the aggregate. A merge that
+        # fails with blobs present still fails the job.
+        run: |
+          set -euo pipefail
+          BLOBS=packages/testing/blob-reports
+          if [ -d "$BLOBS" ] && find "$BLOBS" -type f -print -quit | grep -q .; then
+            bunx playwright merge-reports --reporter html "$BLOBS"
+          else
+            echo 'No blob reports were uploaded; skipping the merged report.' | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Merge sharded visual reports
         if: "always() && needs.playwright-visual.result != 'skipped' && github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'report'"
         uses: actions/download-artifact@v8

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -429,6 +429,9 @@ jobs:
       - name: Upload Playwright HTML report
         if: failure()
         uses: actions/upload-artifact@v7
+        # Diagnostics, never a verdict: a 403 from the artifact service must not
+        # fail a lane whose tests passed, and with it the required check.
+        continue-on-error: true
         with:
           name: playwright-report-${{ matrix.shard }}
           path: packages/testing/playwright-report
@@ -438,6 +441,7 @@ jobs:
       - name: Upload Playwright blob report
         if: always()
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: playwright-blob-${{ matrix.shard }}
           path: packages/testing/blob-report
@@ -447,6 +451,7 @@ jobs:
       - name: Upload axe JSON results
         if: always()
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: axe-results-${{ matrix.shard }}
           path: packages/testing/test-results/axe
@@ -456,6 +461,7 @@ jobs:
       - name: Upload axe summary
         if: always()
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: axe-summary-${{ matrix.shard }}
           path: packages/testing/test-results/axe-summary.json
@@ -468,6 +474,7 @@ jobs:
         # 7-day retention bounds the storage cost.
         if: always()
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: screenshots-${{ matrix.shard }}
           path: packages/testing/screenshots
@@ -509,6 +516,7 @@ jobs:
         env:
           CINDER_VISUAL_DIFF: ${{ github.event.inputs.mode || 'off' }}
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: visual-report
           path: packages/testing/test-results/visual-report.json
@@ -572,6 +580,7 @@ jobs:
       - name: Upload visual report
         if: always() && env.CINDER_VISUAL_DIFF == 'report'
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: visual-report-${{ matrix.shard }}
           path: packages/testing/test-results/visual-report.json
@@ -580,6 +589,7 @@ jobs:
       - name: Upload visual failure diagnostics
         if: always()
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: playwright-visual-diagnostics-${{ matrix.shard }}
           path: |
@@ -645,6 +655,7 @@ jobs:
       - name: Upload merged report
         if: "always() && needs.playwright-lane.result != 'skipped'"
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: playwright-report-merged
           path: playwright-report
@@ -653,6 +664,7 @@ jobs:
       - name: Upload merged visual report
         if: "always() && needs.playwright-visual.result != 'skipped' && github.event_name == 'workflow_dispatch' && github.event.inputs.mode == 'report'"
         uses: actions/upload-artifact@v7
+        continue-on-error: true
         with:
           name: visual-report
           path: packages/testing/visual-report.json

--- a/.github/workflows/browser-tests.yaml
+++ b/.github/workflows/browser-tests.yaml
@@ -645,9 +645,8 @@ jobs:
         # fails with blobs present still fails the job.
         run: |
           set -euo pipefail
-          BLOBS=packages/testing/blob-reports
-          if [ -d "$BLOBS" ] && find "$BLOBS" -type f -print -quit | grep -q .; then
-            bunx playwright merge-reports --reporter html "$BLOBS"
+          if find packages/testing/blob-reports -type f -print -quit 2>/dev/null | grep -q .; then
+            bunx playwright merge-reports --reporter html packages/testing/blob-reports
           else
             echo 'No blob reports were uploaded; skipping the merged report.' | tee -a "$GITHUB_STEP_SUMMARY"
           fi

--- a/packages/components/scripts/check-pipeline-coverage.test.ts
+++ b/packages/components/scripts/check-pipeline-coverage.test.ts
@@ -121,6 +121,12 @@ describe('Turbo input topology', () => {
     expect(browserWorkflow).toContain(
       'bunx playwright merge-reports --reporter html packages/testing/blob-reports',
     );
+    // The merge is skipped when no shard uploaded a blob — a reachable state
+    // now that the diagnostic uploads are best-effort — so that an artifact
+    // outage cannot fail the aggregate on behalf of code that passed.
+    expect(browserWorkflow).toContain(
+      "echo 'No blob reports were uploaded; skipping the merged report.'",
+    );
     expect(mainWorkflow).toContain("github.event_name == 'schedule'");
     expect(mainWorkflow).toContain("github.event.inputs.force_audit == 'true'");
     expect(turboConfiguration.tasks['@lostgradient/cinder#test']?.inputs).toContain(


### PR DESCRIPTION
Closes CIN-525.

## What happened

`playwright-lane (1, 8)` on #1513 ran every test successfully:

```
Running 68 tests using 1 worker, shard 1 of 8
68 passed (1.2m)
```

and the job went red anyway, nine times over:

```
##[error]Failed to FinalizeArtifact: Received non-retryable error:
Failed request: (403) Forbidden: Error from intermediary with HTTP status code 403 "Forbidden"
```

The aggregate required check then fails by construction, because it reads the job result rather than the test result:

```sh
if [ "$RELEVANT" = true ]; then [ "$LANES" = success ] || exit 1; fi
```

So a branch was blocked from merging because GitHub's blob storage declined to finalize a zip.

## The change

`continue-on-error: true` on the ten `upload-artifact` steps in this workflow.

Every one of them is a diagnostic — the HTML report, the blob report, the axe JSON and summary, screenshots, the visual reports, the merged report. I checked that nothing downstream depends on them before doing this:

- **Report merging tolerates gaps.** `download-artifact` with `pattern:` + `merge-multiple:` takes whatever shards exist, and `merge-reports` renders what it is given.
- **The axe gate is not artifact-driven.** `runAxe()` / `evaluateAxeGate()` are called per component test and fail that test directly, in every mode — the workflow's own comment says so, and nothing reads `axe-summary-*` or `axe-results-*` back.
- **The verdict still comes from the tests.** The gate keys off `needs.playwright-lane.result`, which a real test failure still turns red. Losing an artifact now costs an incomplete report, which is what it should cost.

## What this does not fix

Two other CI problems are in flight and deliberately not folded in:

- CIN-523 — the playground harness's own instability (warm-up exceeding its 240s budget, the server exiting mid-shard, and hydration mismatches leaving pages non-interactive). That one may be hiding a real bug and needs a diagnosis, not a config change.
- CIN-524 — `main` has been red on `colors:audit` since 2026-09-04; #1513 fixes it and is waiting behind this.

## Worth measuring separately

Each lane uploads a ~36 MB screenshots artifact (`Received 36712717 of 36712717`) on `always()`, across 16 functional lanes and 8 visual shards — on the order of 600 MB per run, on every pull request, at 7- to 30-day retention. That volume is a plausible trigger for the intermediary's 403, but trimming it is a decision about which diagnostics are worth keeping, so it is not bundled into a fix whose point is to stop false reds.
