### PR TITLE
fix(testing): pin the container's Bun to the version this workspace pins

### DIFF
--- a/packages/testing/Dockerfile
+++ b/packages/testing/Dockerfile
@@ -3,6 +3,12 @@ FROM mcr.microsoft.com/playwright:v${PLAYWRIGHT_VERSION}-jammy
 
 ARG PLAYWRIGHT_VERSION
 
+# The workspace's own `packageManager` pin, passed in by the build. Installing
+# whatever bun.sh serves at build time let the container run a Bun the
+# repository never pinned, which is invisible until a Bun release changes
+# behaviour — and then it reads as the branch under test being broken.
+ARG BUN_VERSION
+
 ENV PLAYWRIGHT_DOCKER=1
 ENV CINDER_PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION}
 ENV DEBIAN_FRONTEND=noninteractive
@@ -10,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && rm -rf /var/lib/apt/lists/* \
-    && curl -fsSL https://bun.sh/install | bash \
+    && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
     && ln -sf /root/.bun/bin/bun /usr/local/bin/bun \
     && ln -sf /root/.bun/bin/bun /usr/local/bin/bunx
 

--- a/packages/testing/Dockerfile
+++ b/packages/testing/Dockerfile
@@ -13,7 +13,12 @@ ENV PLAYWRIGHT_DOCKER=1
 ENV CINDER_PLAYWRIGHT_VERSION=${PLAYWRIGHT_VERSION}
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update \
+# Fail the build rather than fall back to "latest": an image that silently
+# installs an unpinned Bun is exactly the drift this argument exists to stop,
+# and a manual `docker build` without it would reintroduce it quietly.
+RUN test -n "${BUN_VERSION}" \
+    || { echo 'BUN_VERSION build-arg is required (see readPinnedBunVersion)' >&2; exit 1; } \
+    && apt-get update \
     && apt-get install -y --no-install-recommends unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \

--- a/packages/testing/scripts/pinned-bun-version.test.ts
+++ b/packages/testing/scripts/pinned-bun-version.test.ts
@@ -32,6 +32,14 @@ describe('the container runs the Bun this workspace pins', () => {
     expect(dockerfile).toMatch(/bun\.sh\/install \| bash -s "bun-v\$\{BUN_VERSION\}"/);
   });
 
+  it('refuses to build without the version rather than falling back to latest', () => {
+    // A manual `docker build` with no build-arg would otherwise reintroduce
+    // the drift quietly, which is the whole failure this pins down.
+    const dockerfile = readFileSync(resolve(testingPackageRoot, 'Dockerfile'), 'utf8');
+    expect(dockerfile).toMatch(/test -n "\$\{BUN_VERSION\}"/);
+    expect(dockerfile).toMatch(/BUN_VERSION build-arg is required/);
+  });
+
   it('is the same Bun every workflow job installs', () => {
     const workflow = readFileSync(
       resolve(workspaceRoot, '.github/workflows/browser-tests.yaml'),

--- a/packages/testing/scripts/pinned-bun-version.test.ts
+++ b/packages/testing/scripts/pinned-bun-version.test.ts
@@ -19,8 +19,9 @@ function readWorkspaceManifest(): { packageManager?: string } {
 describe('the container runs the Bun this workspace pins', () => {
   it('reads the exact version from `packageManager`', () => {
     const { packageManager } = readWorkspaceManifest();
-    expect(packageManager).toBeDefined();
-    expect(readPinnedBunVersion()).toBe(packageManager?.replace('bun@', ''));
+    if (packageManager === undefined)
+      throw new Error('the workspace package.json must declare packageManager');
+    expect(readPinnedBunVersion()).toBe(packageManager.replace('bun@', ''));
   });
 
   it('installs that exact version in the image rather than whatever bun.sh serves', () => {

--- a/packages/testing/scripts/pinned-bun-version.test.ts
+++ b/packages/testing/scripts/pinned-bun-version.test.ts
@@ -18,9 +18,9 @@ function readWorkspaceManifest(): { packageManager?: string } {
 
 describe('the container runs the Bun this workspace pins', () => {
   it('reads the exact version from `packageManager`', () => {
-    expect(readPinnedBunVersion()).toBe(
-      readWorkspaceManifest().packageManager?.replace('bun@', ''),
-    );
+    const { packageManager } = readWorkspaceManifest();
+    expect(packageManager).toBeDefined();
+    expect(readPinnedBunVersion()).toBe(packageManager?.replace('bun@', ''));
   });
 
   it('installs that exact version in the image rather than whatever bun.sh serves', () => {

--- a/packages/testing/scripts/pinned-bun-version.test.ts
+++ b/packages/testing/scripts/pinned-bun-version.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { readPinnedBunVersion } from './update-snapshots-docker.ts';
+
+const testingPackageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const workspaceRoot = resolve(testingPackageRoot, '../..');
+
+function readWorkspaceManifest(): { packageManager?: string } {
+  const parsed: unknown = JSON.parse(readFileSync(resolve(workspaceRoot, 'package.json'), 'utf8'));
+  if (typeof parsed !== 'object' || parsed === null)
+    throw new Error('workspace manifest is not an object');
+  const packageManager = (parsed as Record<string, unknown>)['packageManager'];
+  return typeof packageManager === 'string' ? { packageManager } : {};
+}
+
+describe('the container runs the Bun this workspace pins', () => {
+  it('reads the exact version from `packageManager`', () => {
+    expect(readPinnedBunVersion()).toBe(
+      readWorkspaceManifest().packageManager?.replace('bun@', ''),
+    );
+  });
+
+  it('installs that exact version in the image rather than whatever bun.sh serves', () => {
+    // The install line took no version at all, so an image built today ran a
+    // Bun the repository never pinned — the failure mode this guards.
+    const dockerfile = readFileSync(resolve(testingPackageRoot, 'Dockerfile'), 'utf8');
+    expect(dockerfile).toMatch(/ARG BUN_VERSION/);
+    expect(dockerfile).toMatch(/bun\.sh\/install \| bash -s "bun-v\$\{BUN_VERSION\}"/);
+  });
+
+  it('is the same Bun every workflow job installs', () => {
+    const workflow = readFileSync(
+      resolve(workspaceRoot, '.github/workflows/browser-tests.yaml'),
+      'utf8',
+    );
+    const pinned = workflow.match(/^\s*BUN_VERSION:\s*(\S+)\s*$/m)?.[1];
+    expect(pinned).toBe(readPinnedBunVersion());
+  });
+});

--- a/packages/testing/scripts/update-snapshots-docker.ts
+++ b/packages/testing/scripts/update-snapshots-docker.ts
@@ -34,10 +34,14 @@ export function readPinnedPlaywrightVersion(): string {
 export function readPinnedBunVersion(): string {
   const raw = readFileSync(resolvePath(repoRoot, 'package.json'), 'utf8');
   const parsed: unknown = JSON.parse(raw);
-  const pinned =
+  const field =
     typeof parsed === 'object' && parsed !== null
       ? (parsed as PackageManifest).packageManager
       : undefined;
+  // Checked rather than assumed: a `packageManager` that is present but not a
+  // string would make `.match` throw a TypeError, replacing the explicit
+  // message below with something a reader has to decode.
+  const pinned = typeof field === 'string' ? field : undefined;
   const match = pinned?.match(/^bun@(\d+\.\d+\.\d+)$/);
   if (!match?.[1]) {
     throw new Error(

--- a/packages/testing/scripts/update-snapshots-docker.ts
+++ b/packages/testing/scripts/update-snapshots-docker.ts
@@ -8,7 +8,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolvePath(here, '..');
 const repoRoot = resolvePath(packageRoot, '../..');
 
-type PackageManifest = { devDependencies?: Record<string, string> };
+type PackageManifest = { devDependencies?: Record<string, string>; packageManager?: string };
 
 export function readPinnedPlaywrightVersion(): string {
   const raw = readFileSync(resolvePath(packageRoot, 'package.json'), 'utf8');
@@ -20,6 +20,31 @@ export function readPinnedPlaywrightVersion(): string {
     );
   }
   return pinned;
+}
+
+/**
+ * The Bun the container must run, taken from the workspace's own
+ * `packageManager` pin so the image cannot drift away from the host.
+ *
+ * It drifted: the image installed whatever `https://bun.sh/install` served at
+ * build time, so a container built today ran a Bun the repository never
+ * pinned, while every other job used the pinned one. That is invisible until
+ * a Bun release changes behaviour, and then it looks like the branch broke.
+ */
+export function readPinnedBunVersion(): string {
+  const raw = readFileSync(resolvePath(repoRoot, 'package.json'), 'utf8');
+  const parsed: unknown = JSON.parse(raw);
+  const pinned =
+    typeof parsed === 'object' && parsed !== null
+      ? (parsed as PackageManifest).packageManager
+      : undefined;
+  const match = pinned?.match(/^bun@(\d+\.\d+\.\d+)$/);
+  if (!match?.[1]) {
+    throw new Error(
+      `packageManager must pin an exact Bun version (bun@x.y.z) in the workspace package.json; got ${pinned ?? 'undefined'}`,
+    );
+  }
+  return match[1];
 }
 
 export function run(
@@ -240,6 +265,8 @@ export async function buildPlaywrightDockerImage(
       'build',
       '--build-arg',
       `PLAYWRIGHT_VERSION=${playwrightVersion}`,
+      '--build-arg',
+      `BUN_VERSION=${readPinnedBunVersion()}`,
       '-t',
       imageTag,
       '-f',


### PR DESCRIPTION
Refs CIN-523. This is what is currently making every pull request red, including the two fixes queued behind it (#1513, #1514).

## The evidence

Nothing has merged to `main` since #1510 on 2026-09-04, and its run was fully green — all eight visual shards included. Today the same code fails, and the failures split cleanly along one line:

| Job | Where it runs | Result |
| --- | --- | --- |
| `playwright-lane (1, 8)` | host | `68 passed (1.2m)` |
| `playwright-visual shard 8` | **docker** | `42 failed`, `160 passed` |

Every one of the 42 is the same thing:

```
Error: checkbox-group diagnostics
+   "%c[svelte] hydration_mismatch
+ %cHydration failed because the initial UI does not match what was rendered on the server
```

The whole documentation suite passes on the host: `bun run test:playwright -- tests/playground-documentation.playwright.ts` → **69 passed**.

## The cause

`packages/testing/Dockerfile` installed Bun unpinned:

```dockerfile
curl -fsSL https://bun.sh/install | bash
```

The workspace pins `bun@1.4.0` in `packageManager`, and every workflow job installs `BUN_VERSION: 1.4.0` — but the container took whatever bun.sh served at image-build time. The image is rebuilt on every run, so the version silently tracks upstream.

The timeline matches:

| When | What |
| --- | --- |
| 2026-09-04 07:31Z | #1510 merges, all eight visual shards green |
| 2026-09-04 08:39Z | Bun **1.4.1** published |
| 2026-09-05 06:01Z | Bun **1.4.2** published |
| 2026-09-08 | Same code, docker shards fail with hydration mismatches |

So the container has been running a Bun the repository never pinned, and the playground's SSR output stopped agreeing with what the client hydrates. The host lanes were never affected because they use the pinned Bun — which is exactly why the failure looked like it belonged to whichever branch happened to be in the queue.

## The fix

The Dockerfile takes `ARG BUN_VERSION` and installs that exact version; the build passes it from the workspace's own `packageManager` pin, so the container cannot drift from the host again:

```dockerfile
curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}"
```

`readPinnedBunVersion()` reads `packageManager` and rejects anything that is not an exact `bun@x.y.z`, mirroring how `readPinnedPlaywrightVersion()` already refuses a caret or tilde range.

Three guard tests (`scripts/pinned-bun-version.test.ts`) pin the three things that must stay true: the version comes from `packageManager`, the Dockerfile installs *that* version rather than the latest, and it equals the `BUN_VERSION` the workflow jobs install. Reverting the Dockerfile fails the second one.

## How this gets confirmed

I cannot run the container locally (no Docker on this machine), so the hypothesis is confirmed by **this pull request's own visual shards going green** — same code as the failing runs, one line of Dockerfile different. If they fail, the diagnosis is wrong and the failing shard's log is the next thing to read, not this change.

## Noted, not fixed

`update-snapshots-docker.ts` carries three pre-existing lint findings under the strict config (two `no-shadow` on `repoRoot` parameters, one `no-unsafe-type-assertion` in `readPinnedPlaywrightVersion`). CI does not lint this file, so they are not gating, and renaming parameters in exported helpers is churn this urgent fix does not need. Flagging rather than silently carrying them.

Separately: the base image is `mcr.microsoft.com/playwright:v1.60.0-jammy`, a mutable tag. The Playwright *version* is pinned but the image contents are not, so the same class of drift can arrive through the browser. Worth a digest pin, in its own change with its own verification.
