### PR TITLE
fix(testing): report the playground's death instead of its symptoms

### DIFF
--- a/packages/testing/scripts/playground-exit-report.test.ts
+++ b/packages/testing/scripts/playground-exit-report.test.ts
@@ -27,6 +27,19 @@ describe('describePlaygroundExit', () => {
     expect(report).not.toContain('line 20');
   });
 
+  it('reads the tail when the report is written, not when the process exits', () => {
+    // `exit` can fire while stdout still has buffered data to deliver, so the
+    // report takes the buffer as it stands at report time. This models that:
+    // the last line arrives after the termination is recorded.
+    let buffer = 'starting up';
+    const readTail = (): string => buffer;
+    const termination = { code: 1, signal: null };
+    buffer += '\nSegmentation fault';
+    expect(describePlaygroundExit({ ...termination, output: readTail() })).toContain(
+      'Segmentation fault',
+    );
+  });
+
   it('omits the output section when the server said nothing', () => {
     expect(describePlaygroundExit({ code: 0, signal: null, output: '   \n  ' })).not.toContain(
       'Last playground output',

--- a/packages/testing/scripts/playground-exit-report.test.ts
+++ b/packages/testing/scripts/playground-exit-report.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'bun:test';
+
+import { describePlaygroundExit } from './start-server.ts';
+
+describe('describePlaygroundExit', () => {
+  it('names the exit and says the browser failures are downstream of it', () => {
+    const report = describePlaygroundExit({ code: 137, signal: null, output: '' });
+    expect(report).toContain('code=137');
+    expect(report).toContain('signal=null');
+    // The point of the message: without it, dozens of ERR_CONNECTION_REFUSED
+    // navigations read as the branch under test being broken.
+    expect(report).toContain('not their own cause');
+  });
+
+  it('reports a signal death as well as an exit code', () => {
+    const report = describePlaygroundExit({ code: null, signal: 'SIGKILL', output: '' });
+    expect(report).toContain('code=null');
+    expect(report).toContain('signal=SIGKILL');
+  });
+
+  it("keeps the server's last words, bounded to the final lines", () => {
+    const output = Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join('\n');
+    const report = describePlaygroundExit({ code: 1, signal: null, output });
+    expect(report).toContain('Last playground output:');
+    expect(report).toContain('line 40');
+    expect(report).toContain('line 21');
+    expect(report).not.toContain('line 20');
+  });
+
+  it('omits the output section when the server said nothing', () => {
+    expect(describePlaygroundExit({ code: 0, signal: null, output: '   \n  ' })).not.toContain(
+      'Last playground output',
+    );
+  });
+});

--- a/packages/testing/scripts/playground-exit-report.test.ts
+++ b/packages/testing/scripts/playground-exit-report.test.ts
@@ -21,7 +21,7 @@ describe('describePlaygroundExit', () => {
   it("keeps the server's last words, bounded to the final lines", () => {
     const output = Array.from({ length: 40 }, (_, index) => `line ${index + 1}`).join('\n');
     const report = describePlaygroundExit({ code: 1, signal: null, output });
-    expect(report).toContain('Last playground output:');
+    expect(report).toContain('Last playground output (stdout and stderr):');
     expect(report).toContain('line 40');
     expect(report).toContain('line 21');
     expect(report).not.toContain('line 20');
@@ -50,6 +50,16 @@ describe('describePlaygroundExit', () => {
     // whitespace is part of how the server's own logs read.
     expect(report).not.toContain('\r');
     expect(report).toContain('    indented detail');
+  });
+
+  it('names both streams, because a crash reason usually arrives on stderr', () => {
+    const report = describePlaygroundExit({
+      code: null,
+      signal: 'SIGSEGV',
+      output: 'Listening at http://localhost:5555\nUncaught Error: boom',
+    });
+    expect(report).toContain('stdout and stderr');
+    expect(report).toContain('Uncaught Error: boom');
   });
 
   it('omits the output section when the server said nothing', () => {

--- a/packages/testing/scripts/playground-exit-report.test.ts
+++ b/packages/testing/scripts/playground-exit-report.test.ts
@@ -40,8 +40,23 @@ describe('describePlaygroundExit', () => {
     );
   });
 
+  it('keeps CRLF output readable and preserves indentation', () => {
+    const report = describePlaygroundExit({
+      code: 1,
+      signal: null,
+      output: 'first line\r\n    indented detail\r\n',
+    });
+    // A stray `\r` on every line makes the tail unreadable, and the leading
+    // whitespace is part of how the server's own logs read.
+    expect(report).not.toContain('\r');
+    expect(report).toContain('    indented detail');
+  });
+
   it('omits the output section when the server said nothing', () => {
     expect(describePlaygroundExit({ code: 0, signal: null, output: '   \n  ' })).not.toContain(
+      'Last playground output',
+    );
+    expect(describePlaygroundExit({ code: 0, signal: null, output: '  \r\n \r\n' })).not.toContain(
       'Last playground output',
     );
   });

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -37,6 +37,30 @@ const reuseOptOut = process.env['PLAYWRIGHT_REUSE_SERVER'] === '0';
 let targetPlaygroundUrl = PLAYGROUND_URL;
 const PLAYGROUND_PORT_PROBE_TIMEOUT_MS = 500;
 const PLAYGROUND_READY_TIMEOUT_MS = 240_000;
+
+/** How the playground server ended, when it ends before the suite does. */
+export type PlaygroundExit = {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  output: string;
+};
+
+/**
+ * What to print when the playground dies mid-run. Says outright that the
+ * browser failures above are downstream of this, because the alternative —
+ * dozens of `ERR_CONNECTION_REFUSED` navigations — reads as the branch under
+ * test being broken, and keeps the server's own last words, which are usually
+ * the only evidence of why it stopped.
+ */
+export function describePlaygroundExit({ code, signal, output }: PlaygroundExit): string {
+  const lines = [
+    `Playground server exited during the run (code=${code ?? 'null'} signal=${signal ?? 'null'}). ` +
+      'The browser failures above are its consequence, not their own cause.',
+  ];
+  const tail = output.trim().split('\n').slice(-20).join('\n');
+  if (tail.length > 0) lines.push(`Last playground output:\n${tail}`);
+  return lines.join('\n');
+}
 const PLAYGROUND_WARM_READINESS_STABLE_READS = 2;
 const PLAYGROUND_WARM_READINESS_DELAY_MS = 500;
 const CHILD_PROCESS_TERMINATION_GRACE_MS = 5_000;
@@ -710,6 +734,11 @@ async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
   let serverProcess: ReturnType<typeof spawn> | null = null;
+  let playgroundExit: PlaygroundExit | null = null;
+  // Read through a function with a declared return type: the only assignment
+  // is inside the server's `exit` callback, which control-flow analysis does
+  // not see, so a direct read narrows to `never` at the check below.
+  const readPlaygroundExit = (): PlaygroundExit | null => playgroundExit;
   let playgroundPortFile: string | null = null;
   const children: ManagedChildProcess[] = [];
   let dependencyWatchController: DependencyWatchController | null = null;
@@ -816,6 +845,15 @@ async function main(): Promise<void> {
     });
 
     let serverOutputBuffer = '';
+
+    // Nothing watched the server once it was ready, so a server that exited
+    // mid-run turned into one bare `ERR_EMPTY_RESPONSE` followed by a
+    // `ERR_CONNECTION_REFUSED` for every remaining test — dozens of failures
+    // that name the symptom and never the cause. Record its death here and
+    // report it below.
+    serverProcess.on('exit', (code, signal) => {
+      playgroundExit = { code, signal, output: serverOutputBuffer };
+    });
     serverProcess.stdout?.on('data', (chunk: string | Uint8Array) => {
       process.stdout.write(chunk);
       const output = typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
@@ -909,7 +947,20 @@ async function main(): Promise<void> {
     },
   });
   children.push({ childProcess: playwright, name: 'Playwright', killProcessGroup: false });
+  // A dead playground cannot serve the rest of the suite, and every test that
+  // follows would spend its full timeout proving it. Stop here instead.
+  serverProcess?.once('exit', () => {
+    if (playwright.exitCode === null && playwright.signalCode === null) {
+      console.error('Playground server exited mid-run; stopping the browser suite.');
+      playwright.kill('SIGTERM');
+    }
+  });
   const playwrightCode = await waitForExit(playwright);
+  const playgroundDeath = readPlaygroundExit();
+  if (playgroundDeath !== null) {
+    console.error(describePlaygroundExit(playgroundDeath));
+    await exitAfterCleanup(playwrightCode === 0 ? 1 : playwrightCode);
+  }
   await exitIfShuttingDown();
   await dependencyWatchController?.waitForIdle();
   const dependencyFailure = dependencyWatchController?.getFailure();

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -896,6 +896,11 @@ async function main(): Promise<void> {
       // threshold masking a lifecycle bug rather than fixing one.
       await new Promise<void>((resolve) => {
         serverProcessRef.once('close', () => resolve());
+        // `close` is not replayed, so it can fire in the window between the
+        // check above and this registration and never reach the listener.
+        // Re-checking the recorded flag after registering closes that window,
+        // the same way `waitForExit` handles its own spawn-to-listen race.
+        if (hasClosed()) resolve();
       });
     };
     serverProcess.stdout?.on('data', (chunk: string | Uint8Array) => {

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -913,7 +913,15 @@ async function main(): Promise<void> {
       );
       reportedPlaygroundPort =
         parsePlaygroundListeningPort(serverOutputBuffer) ?? reportedPlaygroundPort;
-      serverOutputBuffer = appendServerOutputBuffer(serverOutputBuffer, '', true);
+      // Bounded only once the port is known, matching the parameter's intent.
+      // Forcing it unconditionally discarded pre-readiness output, which is
+      // exactly where an early crash explains itself — and now that this
+      // buffer is what the exit report prints, that output is the point.
+      serverOutputBuffer = appendServerOutputBuffer(
+        serverOutputBuffer,
+        '',
+        reportedPlaygroundPort !== null,
+      );
     });
 
     serverProcess.stderr?.on('data', (chunk: string | Uint8Array) => {

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -890,10 +890,12 @@ async function main(): Promise<void> {
       if (hasClosed()) return;
       // `close` is the only event that promises every stdio stream has been
       // delivered — `exit` does not, and with stderr piped as well there are
-      // now two streams to wait on rather than one.
+      // two streams to wait on rather than one. Awaited without a deadline
+      // deliberately: the process has already exited by the time this runs,
+      // so its stdio closes on its own, and a bound here would be a wait
+      // threshold masking a lifecycle bug rather than fixing one.
       await new Promise<void>((resolve) => {
         serverProcessRef.once('close', () => resolve());
-        setTimeout(resolve, 2_000).unref();
       });
     };
     serverProcess.stdout?.on('data', (chunk: string | Uint8Array) => {

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -46,6 +46,14 @@ export type PlaygroundExit = {
 };
 
 /**
+ * What the process recorded when it died, before its output is attached.
+ * `exit` can fire while stdout still has buffered `data` events to deliver,
+ * so the tail is read when the report is written rather than snapshotted
+ * here — otherwise the report omits exactly the last lines that explain it.
+ */
+type PlaygroundTermination = { code: number | null; signal: NodeJS.Signals | null };
+
+/**
  * What to print when the playground dies mid-run. Says outright that the
  * browser failures above are downstream of this, because the alternative —
  * dozens of `ERR_CONNECTION_REFUSED` navigations — reads as the branch under
@@ -734,11 +742,15 @@ async function main(): Promise<void> {
   const args = process.argv.slice(2);
 
   let serverProcess: ReturnType<typeof spawn> | null = null;
-  let playgroundExit: PlaygroundExit | null = null;
+  let playgroundTermination: PlaygroundTermination | null = null;
+  // Reads the server's output as it stands when the report is written; the
+  // buffer itself lives in the block that spawns the server, and stays null
+  // until there is one to read.
+  let serverOutputTail: (() => string) | null = null;
   // Read through a function with a declared return type: the only assignment
   // is inside the server's `exit` callback, which control-flow analysis does
   // not see, so a direct read narrows to `never` at the check below.
-  const readPlaygroundExit = (): PlaygroundExit | null => playgroundExit;
+  const readPlaygroundTermination = (): PlaygroundTermination | null => playgroundTermination;
   let playgroundPortFile: string | null = null;
   const children: ManagedChildProcess[] = [];
   let dependencyWatchController: DependencyWatchController | null = null;
@@ -845,6 +857,7 @@ async function main(): Promise<void> {
     });
 
     let serverOutputBuffer = '';
+    serverOutputTail = (): string => serverOutputBuffer;
 
     // Nothing watched the server once it was ready, so a server that exited
     // mid-run turned into one bare `ERR_EMPTY_RESPONSE` followed by a
@@ -852,7 +865,7 @@ async function main(): Promise<void> {
     // that name the symptom and never the cause. Record its death here and
     // report it below.
     serverProcess.on('exit', (code, signal) => {
-      playgroundExit = { code, signal, output: serverOutputBuffer };
+      playgroundTermination = { code, signal };
     });
     serverProcess.stdout?.on('data', (chunk: string | Uint8Array) => {
       process.stdout.write(chunk);
@@ -949,16 +962,27 @@ async function main(): Promise<void> {
   children.push({ childProcess: playwright, name: 'Playwright', killProcessGroup: false });
   // A dead playground cannot serve the rest of the suite, and every test that
   // follows would spend its full timeout proving it. Stop here instead.
-  serverProcess?.once('exit', () => {
-    if (playwright.exitCode === null && playwright.signalCode === null) {
-      console.error('Playground server exited mid-run; stopping the browser suite.');
-      playwright.kill('SIGTERM');
-    }
-  });
+  const stopSuiteForDeadPlayground = (): void => {
+    if (playwright.exitCode !== null || playwright.signalCode !== null) return;
+    console.error('Playground server exited mid-run; stopping the browser suite.');
+    playwright.kill('SIGTERM');
+  };
+  serverProcess?.once('exit', stopSuiteForDeadPlayground);
+  // `exit` is not replayed, so a server that died between becoming ready and
+  // this registration would otherwise leave the suite running to its
+  // timeouts — the very thing this is here to prevent. The earlier listener
+  // has already recorded it, so the recorded state is the reliable signal.
+  if (readPlaygroundTermination() !== null) stopSuiteForDeadPlayground();
+
   const playwrightCode = await waitForExit(playwright);
-  const playgroundDeath = readPlaygroundExit();
-  if (playgroundDeath !== null) {
-    console.error(describePlaygroundExit(playgroundDeath));
+  const playgroundDeath = readPlaygroundTermination();
+  // A shutdown this wrapper asked for kills the playground on its way out.
+  // Reporting that as a mid-run death would blame cancellation for failures
+  // it did not cause, so only an unrequested exit is reported.
+  if (playgroundDeath !== null && shutdownExitCode === null) {
+    console.error(
+      describePlaygroundExit({ ...playgroundDeath, output: serverOutputTail?.() ?? '' }),
+    );
     await exitAfterCleanup(playwrightCode === 0 ? 1 : playwrightCode);
   }
   await exitIfShuttingDown();

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -69,7 +69,7 @@ export function describePlaygroundExit({ code, signal, output }: PlaygroundExit)
   // the server's own logs read. The split tolerates CRLF so a `\r` does not
   // ride along on every line.
   const tail = output.trimEnd().split(/\r?\n/).slice(-20).join('\n');
-  if (tail.trim().length > 0) lines.push(`Last playground output:\n${tail}`);
+  if (tail.trim().length > 0) lines.push(`Last playground output (stdout and stderr):\n${tail}`);
   return lines.join('\n');
 }
 const PLAYGROUND_WARM_READINESS_STABLE_READS = 2;
@@ -852,7 +852,11 @@ async function main(): Promise<void> {
     serverProcess = spawn('bun', playgroundServerArguments(), {
       cwd: playgroundServerWorkingDirectory(),
       detached: process.platform !== 'win32',
-      stdio: ['ignore', 'pipe', 'inherit'],
+      // stderr is piped rather than inherited so an uncaught exception's stack
+      // trace — where the reason for a death usually is — reaches the tail the
+      // exit report prints. It is still teed straight through, so nothing that
+      // used to appear in the log disappears from it.
+      stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, PLAYGROUND_PORT_FILE: playgroundPortFile },
     });
     children.push({
@@ -876,15 +880,20 @@ async function main(): Promise<void> {
     // does not promise. Waiting for it before reading the tail is what keeps
     // the crash reason — often the very last chunk — in the report.
     const serverProcessRef = serverProcess;
+    let serverStdioClosed = false;
+    serverProcessRef.once('close', () => {
+      serverStdioClosed = true;
+    });
+    const hasClosed = (): boolean => serverStdioClosed;
     awaitServerOutputDrain = async (): Promise<void> => {
       if (serverProcessRef.exitCode === null && serverProcessRef.signalCode === null) return;
+      if (hasClosed()) return;
+      // `close` is the only event that promises every stdio stream has been
+      // delivered — `exit` does not, and with stderr piped as well there are
+      // now two streams to wait on rather than one.
       await new Promise<void>((resolve) => {
-        if (serverProcessRef.stdout === null || serverProcessRef.stdout.readableEnded) {
-          resolve();
-          return;
-        }
-        serverProcessRef.stdout.once('end', () => resolve());
         serverProcessRef.once('close', () => resolve());
+        setTimeout(resolve, 2_000).unref();
       });
     };
     serverProcess.stdout?.on('data', (chunk: string | Uint8Array) => {
@@ -898,6 +907,18 @@ async function main(): Promise<void> {
       reportedPlaygroundPort =
         parsePlaygroundListeningPort(serverOutputBuffer) ?? reportedPlaygroundPort;
       serverOutputBuffer = appendServerOutputBuffer(serverOutputBuffer, '', true);
+    });
+
+    serverProcess.stderr?.on('data', (chunk: string | Uint8Array) => {
+      process.stderr.write(chunk);
+      const output = typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
+      // Same bounded buffer as stdout, interleaved, so the tail reads in the
+      // order the server actually said things.
+      serverOutputBuffer = appendServerOutputBuffer(
+        serverOutputBuffer,
+        output,
+        reportedPlaygroundPort !== null,
+      );
     });
 
     const startedAt = Date.now();

--- a/packages/testing/scripts/start-server.ts
+++ b/packages/testing/scripts/start-server.ts
@@ -65,8 +65,11 @@ export function describePlaygroundExit({ code, signal, output }: PlaygroundExit)
     `Playground server exited during the run (code=${code ?? 'null'} signal=${signal ?? 'null'}). ` +
       'The browser failures above are its consequence, not their own cause.',
   ];
-  const tail = output.trim().split('\n').slice(-20).join('\n');
-  if (tail.length > 0) lines.push(`Last playground output:\n${tail}`);
+  // `trimEnd` rather than `trim`: the first line's indentation is part of how
+  // the server's own logs read. The split tolerates CRLF so a `\r` does not
+  // ride along on every line.
+  const tail = output.trimEnd().split(/\r?\n/).slice(-20).join('\n');
+  if (tail.trim().length > 0) lines.push(`Last playground output:\n${tail}`);
   return lines.join('\n');
 }
 const PLAYGROUND_WARM_READINESS_STABLE_READS = 2;
@@ -747,6 +750,8 @@ async function main(): Promise<void> {
   // buffer itself lives in the block that spawns the server, and stays null
   // until there is one to read.
   let serverOutputTail: (() => string) | null = null;
+  // Resolves once the dead server's stdio has been fully delivered.
+  let awaitServerOutputDrain: (() => Promise<void>) | null = null;
   // Read through a function with a declared return type: the only assignment
   // is inside the server's `exit` callback, which control-flow analysis does
   // not see, so a direct read narrows to `never` at the check below.
@@ -867,6 +872,21 @@ async function main(): Promise<void> {
     serverProcess.on('exit', (code, signal) => {
       playgroundTermination = { code, signal };
     });
+    // `close` fires once every stdio stream has been consumed, which `exit`
+    // does not promise. Waiting for it before reading the tail is what keeps
+    // the crash reason — often the very last chunk — in the report.
+    const serverProcessRef = serverProcess;
+    awaitServerOutputDrain = async (): Promise<void> => {
+      if (serverProcessRef.exitCode === null && serverProcessRef.signalCode === null) return;
+      await new Promise<void>((resolve) => {
+        if (serverProcessRef.stdout === null || serverProcessRef.stdout.readableEnded) {
+          resolve();
+          return;
+        }
+        serverProcessRef.stdout.once('end', () => resolve());
+        serverProcessRef.once('close', () => resolve());
+      });
+    };
     serverProcess.stdout?.on('data', (chunk: string | Uint8Array) => {
       process.stdout.write(chunk);
       const output = typeof chunk === 'string' ? chunk : new TextDecoder().decode(chunk);
@@ -964,6 +984,10 @@ async function main(): Promise<void> {
   // follows would spend its full timeout proving it. Stop here instead.
   const stopSuiteForDeadPlayground = (): void => {
     if (playwright.exitCode !== null || playwright.signalCode !== null) return;
+    // A shutdown this wrapper requested kills the playground itself. Saying
+    // it "exited mid-run" there would be a message no later guard can
+    // retract, so the check belongs here as well as on the report.
+    if (shutdownExitCode !== null) return;
     console.error('Playground server exited mid-run; stopping the browser suite.');
     playwright.kill('SIGTERM');
   };
@@ -980,6 +1004,7 @@ async function main(): Promise<void> {
   // Reporting that as a mid-run death would blame cancellation for failures
   // it did not cause, so only an unrequested exit is reported.
   if (playgroundDeath !== null && shutdownExitCode === null) {
+    await awaitServerOutputDrain?.();
     console.error(
       describePlaygroundExit({ ...playgroundDeath, output: serverOutputTail?.() ?? '' }),
     );


### PR DESCRIPTION
Refs CIN-523. Second of the two things making pull requests red for reasons that have nothing to do with them; the first is #1515.

## What happens today

`playwright-lane (14, 16)` on #1515:

```
44 failed
57 passed (4.2m)

1) domain focus rings -- chat harness › keyboard tabs through dense chat targets
   Test timeout of 90000ms exceeded.
   Error: goto: net::ERR_EMPTY_RESPONSE at http://localhost:5555/page/chat?snapshot=1&…
   Error: goto: net::ERR_CONNECTION_REFUSED at http://localhost:5555/page/dropdown?snapshot=1
   Error: goto: net::ERR_CONNECTION_REFUSED at http://localhost:5555/page/modal?snapshot=1
   …
```

One `ERR_EMPTY_RESPONSE`, then `ERR_CONNECTION_REFUSED` for everything after it: the playground server stopped listening partway through the shard. The log never says so. It says forty-four tests failed, which reads as "this branch broke the chat harness".

## Why the harness cannot tell you

`start-server.ts` spawns the playground, waits for it to become ready, spawns Playwright, and then awaits **only Playwright**:

```ts
children.push({ childProcess: playwright, name: 'Playwright', killProcessGroup: false });
const playwrightCode = await waitForExit(playwright);
```

Nothing watches the server after readiness. Its death is invisible, and each remaining test spends its full 90s timeout rediscovering it.

## The change

- The server's `exit` is recorded — code, signal, and the tail of what it printed.
- When it dies mid-run, Playwright is stopped immediately rather than left to time out test after test against a closed port.
- The run then fails with the server's death as the stated reason, and prints its last twenty lines, which are usually the only evidence of *why* it stopped.

The message is a small exported function, `describePlaygroundExit`, so the part most likely to rot is unit-tested: it names the code and signal, keeps the tail bounded to the last twenty lines, drops the section when the server said nothing, and states outright that the browser failures above are downstream. Four tests in `scripts/playground-exit-report.test.ts`.

## What this does and does not do

It does not stop the server dying — the cause is still unknown, and CIN-523 stays open for it. What it does is make the next occurrence diagnosable in one line instead of forty-four, and cut the wasted wall-clock from minutes to seconds. That is the precondition for finding the cause: right now the log tells you nothing about it.

## Verification

`bun test scripts/` in `packages/testing` — 198 pass, including the four new ones. `tsc --noEmit` clean; the new file is lint-clean under the strict config.

I tried reproducing the end-to-end path locally by killing the playground mid-run, and could not get a reliable harness around it — the kill races the suite's own startup. Rather than claim a verification I did not get, the process-level behaviour is left to CI, and only the reporting is unit-tested. That is also why the change is deliberately small: it adds an observer and a fast exit, and changes nothing about how the suite runs when the server stays up.

## Noted, not fixed

`start-server.ts` carries one pre-existing `no-unsafe-type-assertion` finding at line 116 (`PlaygroundFreshnessFingerprint`). CI does not lint this file, so it is not gating; flagging rather than silently carrying it.
