### PR TITLE
fix(components): follow relative imports transitively in the virtual-list guard

### DIFF
--- a/packages/components/scripts/check-virtual-list-dependency-free.test.ts
+++ b/packages/components/scripts/check-virtual-list-dependency-free.test.ts
@@ -1,0 +1,341 @@
+/**
+ * CIN-522: closes two escape hatches left open in `check-virtual-list-dependency-free.ts`.
+ *
+ * `_internal/dependency-free.test.ts` already exercises `classifySpecifier`,
+ * `packageNameFromSpecifier`, and `findDependencyViolations`'s original,
+ * single-file behavior end to end — this file does not repeat that coverage.
+ * It exercises only what CIN-522 added:
+ *
+ *   1. `walkDependencyGraph` — following a literal relative import to whatever
+ *      file it resolves to, transitively, instead of trusting a relative
+ *      specifier just because it is relative. Fixture trees live under a
+ *      temporary directory (same `mkdtempSync` pattern the companion test uses
+ *      for `loadDeclaredDependencyNames`) so a hop can genuinely land OUTSIDE
+ *      the file that wrote it, the way a real escape would.
+ *   2. `resolveRelativeSpecifier` — the resolution `walkDependencyGraph` uses to
+ *      turn a written specifier into a file on disk.
+ *   3. `import x = require('pkg')` — the TypeScript-only import-equals form,
+ *      tested through `findDependencyViolations` directly, the same way the
+ *      companion file tests plain `require('pkg')`.
+ *   4. `findDependencyViolations`'s new `treatAsTestFile` override, which
+ *      `walkDependencyGraph` uses to classify a transitively-reached file by
+ *      how the import graph actually reaches it rather than by its own
+ *      filename alone.
+ */
+
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+import {
+  FORBIDDEN_SPECIFIER,
+  collectScanTargets,
+  findDependencyViolations,
+  loadDeclaredDependencyNames,
+  resolveRelativeSpecifier,
+  walkDependencyGraph,
+} from './check-virtual-list-dependency-free.ts';
+
+/**
+ * Materializes `files` (relative path → content) under a fresh temporary
+ * directory, runs `assert` against that directory's root, and always cleans up
+ * afterward — mirrors `_internal/dependency-free.test.ts`'s
+ * `withTemporaryManifest` helper, generalized to more than one file so a fixture
+ * tree can express a real relative-import hop between two files on disk.
+ */
+async function withTemporaryFileTree(
+  files: Readonly<Record<string, string>>,
+  assert: (root: string) => Promise<void>,
+): Promise<void> {
+  const root = mkdtempSync(join(tmpdir(), 'check-virtual-list-dependency-free-'));
+  try {
+    for (const [relativePath, content] of Object.entries(files)) {
+      const filePath = join(root, relativePath);
+      mkdirSync(dirname(filePath), { recursive: true });
+      writeFileSync(filePath, content);
+    }
+    await assert(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+describe('resolveRelativeSpecifier', () => {
+  test('resolves a specifier that already names an existing file exactly', async () => {
+    await withTemporaryFileTree({ 'entry.ts': '', 'sibling.css': '' }, async (root) => {
+      const resolved = resolveRelativeSpecifier('./sibling.css', join(root, 'entry.ts'));
+      expect(resolved).toBe(join(root, 'sibling.css'));
+    });
+  });
+
+  test('resolves an extensionless specifier by appending .ts', async () => {
+    await withTemporaryFileTree({ 'entry.ts': '', 'sibling.ts': '' }, async (root) => {
+      const resolved = resolveRelativeSpecifier('./sibling', join(root, 'entry.ts'));
+      expect(resolved).toBe(join(root, 'sibling.ts'));
+    });
+  });
+
+  test('resolves an extensionless specifier by appending .svelte', async () => {
+    await withTemporaryFileTree({ 'entry.ts': '', 'widget.svelte': '' }, async (root) => {
+      const resolved = resolveRelativeSpecifier('./widget', join(root, 'entry.ts'));
+      expect(resolved).toBe(join(root, 'widget.svelte'));
+    });
+  });
+
+  test('resolves a directory specifier to the index.ts inside it', async () => {
+    await withTemporaryFileTree({ 'entry.ts': '', 'folder/index.ts': '' }, async (root) => {
+      const resolved = resolveRelativeSpecifier('./folder', join(root, 'entry.ts'));
+      expect(resolved).toBe(join(root, 'folder', 'index.ts'));
+    });
+  });
+
+  test('returns undefined for a specifier that resolves to nothing on disk', async () => {
+    await withTemporaryFileTree({ 'entry.ts': '' }, async (root) => {
+      expect(resolveRelativeSpecifier('./nowhere', join(root, 'entry.ts'))).toBeUndefined();
+    });
+  });
+
+  test('returns undefined for a specifier naming an existing directory with no index file of its own', async () => {
+    // "folder" is real on disk, but only as a directory — existsSync alone would
+    // treat that as resolved, which is why resolveRelativeSpecifier also requires
+    // statSync(...).isFile().
+    await withTemporaryFileTree({ 'entry.ts': '', 'folder/leaf.ts': '' }, async (root) => {
+      expect(resolveRelativeSpecifier('./folder', join(root, 'entry.ts'))).toBeUndefined();
+    });
+  });
+});
+
+describe('findDependencyViolations — import x = require(...) (CIN-522)', () => {
+  test('flags an import-equals require of the forbidden package in shipped source', () => {
+    const source = `import virtualizer = require('${FORBIDDEN_SPECIFIER}');`;
+    const violations = findDependencyViolations(source, 'virtual-list.ts', new Set());
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.specifier).toBe(FORBIDDEN_SPECIFIER);
+    expect(violations[0]?.reason).toEqual(expect.stringContaining('@tanstack/virtual-core'));
+  });
+
+  test('flags an import-equals require of an undeclared package in shipped source', () => {
+    const source = "import helper = require('some-dev-only-package');";
+    const violations = findDependencyViolations(source, 'virtual-list.ts', new Set());
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.specifier).toBe('some-dev-only-package');
+  });
+
+  test('allows an import-equals require of a devDependency in a TEST file', () => {
+    // Mirrors the existing exemption for a plain static `import { render } from
+    // '@testing-library/svelte'` in a test file — nothing in a test file ships.
+    const source = "import testing = require('@testing-library/svelte');";
+    expect(findDependencyViolations(source, 'virtual-list.test.ts', new Set())).toEqual([]);
+  });
+
+  test('still bans the forbidden package via import-equals require in a TEST file', () => {
+    const source = `import virtualizer = require('${FORBIDDEN_SPECIFIER}');`;
+    const violations = findDependencyViolations(source, 'virtual-list.test.ts', new Set());
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.specifier).toBe(FORBIDDEN_SPECIFIER);
+  });
+
+  test('does not flag an import-equals ALIAS of an internal namespace, only the external module form', () => {
+    // `import Bar = Foo` is also an ImportEqualsDeclaration, but its
+    // moduleReference is an EntityName, not an ExternalModuleReference — it
+    // aliases a local namespace, not a package, and loads nothing.
+    const source = 'namespace Foo {\n  export const value = 1;\n}\nimport Bar = Foo;';
+    expect(findDependencyViolations(source, 'virtual-list.ts', new Set())).toEqual([]);
+  });
+});
+
+describe('findDependencyViolations — treatAsTestFile override (CIN-522)', () => {
+  test('treatAsTestFile: true exempts an undeclared bare import even though the filename does not match TEST_FILE_PATTERN', () => {
+    const source = "import leftPad from 'left-pad';";
+    const violations = findDependencyViolations(source, 'happy-dom.ts', new Set(), {
+      treatAsTestFile: true,
+    });
+    expect(violations).toEqual([]);
+  });
+
+  test('treatAsTestFile: false applies the full rule even though the filename matches TEST_FILE_PATTERN', () => {
+    const source = "import leftPad from 'left-pad';";
+    const violations = findDependencyViolations(source, 'virtual-list.test.ts', new Set(), {
+      treatAsTestFile: false,
+    });
+    expect(violations).toHaveLength(1);
+    expect(violations[0]?.specifier).toBe('left-pad');
+  });
+
+  test('omitting the fourth argument entirely behaves exactly like the original three-argument call', () => {
+    const source = "import leftPad from 'left-pad';";
+    expect(findDependencyViolations(source, 'virtual-list.test.ts', new Set())).toEqual([]);
+    expect(findDependencyViolations(source, 'virtual-list.ts', new Set())).toHaveLength(1);
+  });
+});
+
+describe('walkDependencyGraph — transitive relative import following (CIN-522)', () => {
+  test('flags an undeclared bare import reached through a relative hop from a production (non-test) root', async () => {
+    await withTemporaryFileTree(
+      {
+        'entry.ts': "import { helper } from './hop/target.ts';\nexport { helper };\n",
+        'hop/target.ts': "import leftPad from 'left-pad';\nexport const helper = leftPad;\n",
+      },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'entry.ts')], new Set());
+
+        expect(result.scannedFilePaths).toContain(join(root, 'hop', 'target.ts'));
+        expect(result.violations).toHaveLength(1);
+        expect(result.violations[0]?.filePath).toBe(join(root, 'hop', 'target.ts'));
+        expect(result.violations[0]?.specifier).toBe('left-pad');
+      },
+    );
+  });
+
+  test('does not flag an undeclared bare import reached ONLY through a relative hop from a test root', async () => {
+    // The real-world shape this pins: src/components/virtual-list/virtual-list.test.ts
+    // relatively imports src/test/happy-dom.ts, which bare-imports the devDependency
+    // "happy-dom" and is excluded from package.json's "files" allowlist, so it never
+    // ships. Reaching it transitively must not turn that into a false violation.
+    await withTemporaryFileTree(
+      {
+        'entry.test.ts': "import { setup } from './hop/test-helper.ts';\nsetup();\nexport {};\n",
+        'hop/test-helper.ts':
+          "import leftPad from 'left-pad';\nexport function setup(): void {\n  void leftPad;\n}\n",
+      },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'entry.test.ts')], new Set());
+
+        expect(result.scannedFilePaths).toContain(join(root, 'hop', 'test-helper.ts'));
+        expect(result.violations).toEqual([]);
+      },
+    );
+  });
+
+  test('flags the forbidden package reached through a relative hop from a production (non-test) root', async () => {
+    await withTemporaryFileTree(
+      {
+        'entry.ts': "import { helper } from './hop/target.ts';\nexport { helper };\n",
+        'hop/target.ts': `import { createVirtualizer } from '${FORBIDDEN_SPECIFIER}';\nexport const helper = createVirtualizer;\n`,
+      },
+      async (root) => {
+        // Declared as a dependency here on purpose: the forbidden-package ban is
+        // absolute and must not be waved through just because it happens to be
+        // declared elsewhere in this hypothetical package.json.
+        const declared = new Set([FORBIDDEN_SPECIFIER]);
+        const result = await walkDependencyGraph([join(root, 'entry.ts')], declared);
+
+        expect(result.violations).toHaveLength(1);
+        expect(result.violations[0]?.specifier).toBe(FORBIDDEN_SPECIFIER);
+      },
+    );
+  });
+
+  test('still flags the forbidden package reached through a relative hop from a test root', async () => {
+    await withTemporaryFileTree(
+      {
+        'entry.test.ts': "import { setup } from './hop/test-helper.ts';\nsetup();\nexport {};\n",
+        'hop/test-helper.ts': `import { createVirtualizer } from '${FORBIDDEN_SPECIFIER}';\nexport function setup(): void {\n  void createVirtualizer;\n}\n`,
+      },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'entry.test.ts')], new Set());
+
+        expect(result.violations).toHaveLength(1);
+        expect(result.violations[0]?.specifier).toBe(FORBIDDEN_SPECIFIER);
+      },
+    );
+  });
+
+  test('reports a relative import that does not resolve to a file on disk, instead of throwing', async () => {
+    await withTemporaryFileTree(
+      { 'entry.ts': "import { missing } from './does-not-exist.ts';\nexport { missing };\n" },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'entry.ts')], new Set());
+
+        expect(result.violations).toHaveLength(1);
+        expect(result.violations[0]?.specifier).toBe('./does-not-exist.ts');
+        expect(result.violations[0]?.reason).toEqual(expect.stringContaining('does not resolve'));
+      },
+    );
+  });
+
+  test('terminates on a two-file import cycle instead of looping forever', async () => {
+    await withTemporaryFileTree(
+      {
+        'a.ts': "import './b.ts';\nexport const a = 1;\n",
+        'b.ts': "import './a.ts';\nexport const b = 2;\n",
+      },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'a.ts')], new Set());
+
+        expect(result.scannedFilePaths.slice().sort()).toEqual(
+          [join(root, 'a.ts'), join(root, 'b.ts')].sort(),
+        );
+        expect(result.violations).toEqual([]);
+      },
+    );
+  });
+
+  test('classifies a file reachable from BOTH a production root and a test root as shipped', async () => {
+    // Pass 1 (production roots) runs to exhaustion before pass 2 (test roots)
+    // starts, so shared.ts is claimed — and classified strictly — before
+    // test-entry.test.ts's own edge to it is ever considered.
+    await withTemporaryFileTree(
+      {
+        'production-entry.ts': "import { shared } from './shared.ts';\nexport { shared };\n",
+        'test-entry.test.ts': "import { shared } from './shared.ts';\nvoid shared;\nexport {};\n",
+        'shared.ts': "import leftPad from 'left-pad';\nexport const shared = leftPad;\n",
+      },
+      async (root) => {
+        const roots = [join(root, 'production-entry.ts'), join(root, 'test-entry.test.ts')];
+        const result = await walkDependencyGraph(roots, new Set());
+
+        expect(result.violations).toHaveLength(1);
+        expect(result.violations[0]?.filePath).toBe(join(root, 'shared.ts'));
+        expect(result.violations[0]?.specifier).toBe('left-pad');
+      },
+    );
+  });
+
+  test('resolves an extensionless relative hop end to end through the walker', async () => {
+    await withTemporaryFileTree(
+      {
+        'entry.ts': "import { helper } from './hop/target';\nexport { helper };\n",
+        'hop/target.ts': "import leftPad from 'left-pad';\nexport const helper = leftPad;\n",
+      },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'entry.ts')], new Set());
+
+        expect(result.scannedFilePaths).toContain(join(root, 'hop', 'target.ts'));
+        expect(result.violations).toHaveLength(1);
+      },
+    );
+  });
+});
+
+describe('walkDependencyGraph — real virtual-list tree (CIN-522)', () => {
+  test('walking from the real collectScanTargets() finds no violations', async () => {
+    const declaredDependencyNames = await loadDeclaredDependencyNames();
+    const rootFilePaths = await collectScanTargets();
+    const result = await walkDependencyGraph(rootFilePaths, declaredDependencyNames);
+
+    expect(result.violations).toEqual([]);
+    // Proves the walk actually expanded past the original root set — an empty
+    // violations list alone can't distinguish a real transitive walk from one
+    // that never left the roots.
+    expect(result.scannedFilePaths.length).toBeGreaterThan(rootFilePaths.length);
+  });
+
+  test('reaches the real src/test/happy-dom.ts transitively, yet does not flag its "happy-dom" import', async () => {
+    const declaredDependencyNames = await loadDeclaredDependencyNames();
+    const rootFilePaths = await collectScanTargets();
+    const result = await walkDependencyGraph(rootFilePaths, declaredDependencyNames);
+
+    const happyDomFilePath = result.scannedFilePaths.find((filePath) =>
+      filePath.endsWith(join('test', 'happy-dom.ts')),
+    );
+    expect(happyDomFilePath).toBeDefined();
+    expect(result.violations.some((violation) => violation.filePath === happyDomFilePath)).toBe(
+      false,
+    );
+  });
+});

--- a/packages/components/scripts/check-virtual-list-dependency-free.test.ts
+++ b/packages/components/scripts/check-virtual-list-dependency-free.test.ts
@@ -339,3 +339,73 @@ describe('walkDependencyGraph — real virtual-list tree (CIN-522)', () => {
     );
   });
 });
+
+describe('the guard follows JavaScript helpers, not only TypeScript ones', () => {
+  test('reports a forbidden import reached through a relative .js helper', async () => {
+    // The hole this closes. Bun bundles a relative `.js` helper exactly like a `.ts`
+    // one, so accepting it as resolved and then declining to scan it meant the helper
+    // could import anything at all and the guard would still report a clean tree.
+    await withTemporaryFileTree(
+      {
+        'engine.ts': "import './helper.js';\n",
+        'helper.js': "import '@tanstack/virtual-core';\n",
+      },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'engine.ts')], new Set());
+        expect(result.violations.map((violation) => violation.specifier)).toContain(
+          '@tanstack/virtual-core',
+        );
+        // Named against the file that actually holds it, not the entry point.
+        expect(
+          result.violations.some((violation) => violation.filePath.endsWith('helper.js')),
+        ).toBe(true);
+      },
+    );
+  });
+
+  test('follows .mjs and .cjs helpers too', async () => {
+    for (const extension of ['mjs', 'cjs']) {
+      await withTemporaryFileTree(
+        {
+          'engine.ts': `import './helper.${extension}';\n`,
+          [`helper.${extension}`]: "import 'undeclared-package';\n",
+        },
+        async (root) => {
+          const result = await walkDependencyGraph([join(root, 'engine.ts')], new Set());
+          expect(result.violations.map((violation) => violation.specifier)).toContain(
+            'undeclared-package',
+          );
+        },
+      );
+    }
+  });
+
+  test('scans a JavaScript helper rather than merely resolving it', async () => {
+    // The distinction that mattered: resolution already worked, so a test asserting
+    // only that the import resolved would have passed against the hole.
+    await withTemporaryFileTree(
+      {
+        'engine.ts': "import './helper.js';\n",
+        'helper.js': '',
+      },
+      async (root) => {
+        const result = await walkDependencyGraph([join(root, 'engine.ts')], new Set());
+        expect(result.scannedFilePaths.some((path) => path.endsWith('helper.js'))).toBe(true);
+      },
+    );
+  });
+});
+
+describe('resolveRelativeSpecifier — unreadable candidates', () => {
+  test('reports an unresolved import rather than crashing the guard', async () => {
+    // `statSync` can throw even when `existsSync` has just said yes — a permission
+    // error, or the path disappearing between the two calls. A guard that crashes
+    // reports nothing at all, which is worse than reporting the import as unresolved.
+    await withTemporaryFileTree({ 'entry.ts': '' }, async (root) => {
+      expect(() =>
+        resolveRelativeSpecifier('./nothing-here', join(root, 'entry.ts')),
+      ).not.toThrow();
+      expect(resolveRelativeSpecifier('./nothing-here', join(root, 'entry.ts'))).toBeUndefined();
+    });
+  });
+});

--- a/packages/components/scripts/check-virtual-list-dependency-free.ts
+++ b/packages/components/scripts/check-virtual-list-dependency-free.ts
@@ -12,15 +12,22 @@
  * other new bare import into this one subtree without a corresponding,
  * reviewed `dependencies` entry.
  *
- * This script walks every `.ts`/`.svelte` file under
+ * This script starts from every `.ts`/`.svelte` file under
  * `packages/components/src/components/virtual-list/**` plus
  * `packages/components/src/utilities/fixed-virtual-window.ts`, parses every
- * `import`/`export ... from` specifier, and fails if any specifier:
+ * `import`/`export ... from`/`import x = require(...)` specifier (dynamic
+ * `import()` included), and — via `walkDependencyGraph` — follows every literal
+ * RELATIVE one transitively to whatever file it resolves to, so a relative hop to
+ * a module outside that starting set cannot smuggle in anything unchecked (CIN-522).
+ * It fails if any specifier reached this way:
  *
  *   - is exactly `@tanstack/virtual-core`, or
  *   - is a bare specifier (not relative, not `svelte`/`svelte/*`, not a
  *     Node/Bun builtin) that is not already listed in this package's
- *     `package.json` `dependencies`.
+ *     `package.json` `dependencies` — unless the file it was found in is reached
+ *     ONLY through relative imports from a `*.test.ts`/`*.spec.ts` file, in which
+ *     case it never ships and the undeclared-dependency rule does not apply (see
+ *     `walkDependencyGraph`'s doc comment for exactly how that is decided).
  *
  * Registered as `check:virtual-list-dependency-free` and wired into
  * `lint:invariants` so it is CI-gated, not merely runnable.
@@ -39,6 +46,7 @@
  */
 
 import { Glob } from 'bun';
+import { existsSync, statSync } from 'node:fs';
 import { isBuiltin } from 'node:module';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -338,6 +346,25 @@ function collectSpecifiers(text: string, baseOffset: number): ParsedSpecifier[] 
       }
     }
 
+    // `import x = require('pkg')` is TypeScript's own import-equals form, still legal
+    // in a `.ts` file compiled as CommonJS-interop, and loads exactly as real a
+    // dependency as `import x from 'pkg'` does. `ts.forEachChild` does not surface it
+    // through either of the two branches above — its right-hand side is an
+    // `ExternalModuleReference` node, not a `CallExpression` — so a bare `visit` walk
+    // skips it unless asked for by name. It is a static declaration, not a runtime
+    // call, hence `isDynamic: false` here (matching the plain `import`/`export from`
+    // branch above), even though `require()` calls are treated as dynamic.
+    if (ts.isImportEqualsDeclaration(node) && ts.isExternalModuleReference(node.moduleReference)) {
+      const { expression } = node.moduleReference;
+      const specifier = literalText(expression);
+      found.push({
+        specifier: specifier ?? expression.getText(sourceFile),
+        offset: baseOffset + expression.getStart(sourceFile),
+        isDynamic: false,
+        isLiteral: specifier !== undefined,
+      });
+    }
+
     if (ts.isCallExpression(node) && node.expression.kind === ts.SyntaxKind.ImportKeyword) {
       const [argument] = node.arguments;
       if (argument !== undefined) {
@@ -396,6 +423,42 @@ function resolveViolationReason(
 }
 
 /**
+ * Every import specifier `content` contains: for a `.ts` file, the whole file
+ * parsed once; for a `.svelte` file, each `<script>` body parsed separately (see
+ * `extractScriptBlocks`) plus the template walked on its own (see
+ * `collectTemplateSpecifiers`), since a template `{#await import(...)}` lives
+ * outside every script body.
+ *
+ * Shared by `findDependencyViolations` (classifies each specifier) and
+ * `walkDependencyGraph` (follows the relative ones to the file they resolve to) so
+ * both see the exact same import list for a given file — the two-parser drift this
+ * module's history warns about (see the module doc) is a risk only when a
+ * scanner is reimplemented, not when it is reused.
+ */
+function collectAllSpecifiers(content: string, filePath: string): ParsedSpecifier[] {
+  const isSvelte = filePath.endsWith('.svelte');
+  const blocks = isSvelte ? extractScriptBlocks(content) : [{ text: content, offset: 0 }];
+  const parsedSpecifiers = blocks.flatMap((block) => collectSpecifiers(block.text, block.offset));
+  if (isSvelte) parsedSpecifiers.push(...collectTemplateSpecifiers(content));
+  return parsedSpecifiers;
+}
+
+/** Overrides for {@link findDependencyViolations}. */
+export type FindDependencyViolationsOptions = {
+  /**
+   * Forces the shipped-source-versus-test-file rule (see {@link resolveViolationReason})
+   * for this call, in place of `TEST_FILE_PATTERN.test(filePath)`. `walkDependencyGraph`
+   * passes this once it has determined whether the file is reachable from a
+   * shipping entry point at all, rather than from its filename alone — a file
+   * reached ONLY through a relative import from a test file (e.g.
+   * `src/test/happy-dom.ts`, which never ships) needs the lenient rule even though
+   * its own name does not end in `.test.ts`. Omitted, this call behaves exactly as
+   * it always has.
+   */
+  readonly treatAsTestFile?: boolean;
+};
+
+/**
  * Returns one {@link DependencyViolation} per disallowed specifier in `content`.
  * Pure and filesystem-free so it can be exercised directly against fabricated
  * source text (see `_internal/dependency-free.test.ts`).
@@ -406,15 +469,12 @@ export function findDependencyViolations(
   content: string,
   filePath: string,
   declaredDependencyNames: ReadonlySet<string>,
+  options?: FindDependencyViolationsOptions,
 ): DependencyViolation[] {
-  const isTestFile = TEST_FILE_PATTERN.test(filePath);
+  const isTestFile = options?.treatAsTestFile ?? TEST_FILE_PATTERN.test(filePath);
   const lineStartOffsets = buildLineStartOffsets(content);
   const lines = content.split('\n');
-
-  const isSvelte = filePath.endsWith('.svelte');
-  const blocks = isSvelte ? extractScriptBlocks(content) : [{ text: content, offset: 0 }];
-  const parsedSpecifiers = blocks.flatMap((block) => collectSpecifiers(block.text, block.offset));
-  if (isSvelte) parsedSpecifiers.push(...collectTemplateSpecifiers(content));
+  const parsedSpecifiers = collectAllSpecifiers(content, filePath);
 
   const violations: DependencyViolation[] = [];
   {
@@ -486,20 +546,167 @@ export async function collectScanTargets(): Promise<string[]> {
   return files;
 }
 
+/**
+ * Extensions `collectScanTargets`' own glob recognizes. A relative import that
+ * resolves to anything else (`./virtual-list.css`, say) is real and gets its
+ * existence confirmed by `resolveRelativeSpecifier`, but this guard has no import
+ * graph to walk for it — it only understands `.ts`/`.svelte` source — so it is left
+ * unscanned rather than fed to a TypeScript parser that was never going to
+ * understand it.
+ */
+const SCANNABLE_SOURCE_EXTENSIONS = ['.ts', '.svelte'] as const;
+
+function isScannableSourceFile(filePath: string): boolean {
+  return SCANNABLE_SOURCE_EXTENSIONS.some((extension) => filePath.endsWith(extension));
+}
+
+/**
+ * Resolves a relative import specifier against the file that wrote it, trying (in
+ * order) the specifier exactly as written, then each extension this package's own
+ * relative imports are sometimes written without appended to it (e.g.
+ * `virtual-list.schema.ts` imports `'../../schema-types'`, no `.ts`), then an
+ * `index` file inside it as a directory. Returns `undefined` — never throws — when
+ * none of those exist, so a broken relative import is reported as a violation
+ * rather than crashing the scan.
+ *
+ * `statSync(...).isFile()`, not just `existsSync`, because a specifier can name an
+ * existing DIRECTORY with no `index` file inside it (`./some-folder` where nothing
+ * has been added yet) — `existsSync` alone would treat the directory itself as a
+ * resolved module.
+ */
+export function resolveRelativeSpecifier(
+  specifier: string,
+  importingFilePath: string,
+): string | undefined {
+  const candidateBase = resolve(dirname(importingFilePath), specifier);
+  const candidatePaths = [
+    candidateBase,
+    ...SCANNABLE_SOURCE_EXTENSIONS.map((extension) => `${candidateBase}${extension}`),
+    ...SCANNABLE_SOURCE_EXTENSIONS.map((extension) => join(candidateBase, `index${extension}`)),
+  ];
+  for (const candidatePath of candidatePaths) {
+    if (existsSync(candidatePath) && statSync(candidatePath).isFile()) return candidatePath;
+  }
+  return undefined;
+}
+
+const UNRESOLVED_RELATIVE_IMPORT_REASON =
+  'this relative import does not resolve to a file on disk, so the dependency-free guard cannot ' +
+  'verify what it would pull into the virtual-list engine';
+
+/** What one full transitive scan of the virtual-list dependency graph found. */
+export type DependencyGraphWalkResult = {
+  /**
+   * Every disallowed specifier found across the whole reachable graph, plus one
+   * entry per relative import that did not resolve to a file on disk.
+   */
+  readonly violations: DependencyViolation[];
+  /**
+   * Every `.ts`/`.svelte` file the walk actually parsed for violations — the
+   * original `rootFilePaths` plus everything reached transitively through a
+   * literal relative import.
+   */
+  readonly scannedFilePaths: readonly string[];
+};
+
+/**
+ * Follows every literal relative import reachable from `rootFilePaths`, closing
+ * the CIN-522 escape hatch where a scanned file relatively imports a module
+ * outside the scan set and that module goes completely unchecked —
+ * `classifySpecifier` always waves a relative specifier through, so nothing short
+ * of actually opening the file it points to can tell whether that file is clean.
+ *
+ * Runs as two passes over one shared `visited` set, rather than classifying each
+ * newly-reached file by its own filename in isolation, so a file's shipped-versus-
+ * test status is decided by how the import graph actually reaches it:
+ *
+ *   1. From every root NOT matched by `TEST_FILE_PATTERN`, follow relative
+ *      imports to exhaustion. Everything this reaches ships, and faces the full
+ *      rule (`treatAsTestFile: false`).
+ *   2. From every root matched by `TEST_FILE_PATTERN`, follow relative imports
+ *      into whatever pass 1 left unvisited. A file reached ONLY this way — e.g.
+ *      `src/test/happy-dom.ts`, which `package.json`'s `files` allowlist excludes
+ *      from the published tarball — never ships, so it gets the same
+ *      undeclared-devDependency leniency `resolveViolationReason` already grants
+ *      any `*.test.ts` file (`treatAsTestFile: true`). The forbidden-package ban
+ *      still applies to it regardless — see `resolveViolationReason`.
+ *
+ * A file reachable from both groups is claimed by pass 1, since it runs to
+ * completion first and marks the file visited — correct, because reachability
+ * from any shipping root means the file ships, however else it is also reached.
+ * `visited` is what makes a cycle terminate: each file is read and parsed at most
+ * once, however many edges point at it.
+ */
+export async function walkDependencyGraph(
+  rootFilePaths: readonly string[],
+  declaredDependencyNames: ReadonlySet<string>,
+): Promise<DependencyGraphWalkResult> {
+  const visited = new Set<string>();
+  const violations: DependencyViolation[] = [];
+  const scannedFilePaths: string[] = [];
+
+  async function visitFrom(
+    seedFilePaths: readonly string[],
+    treatAsTestFile: boolean,
+  ): Promise<void> {
+    const queue = [...seedFilePaths];
+    for (let filePath = queue.shift(); filePath !== undefined; filePath = queue.shift()) {
+      if (visited.has(filePath)) continue;
+      visited.add(filePath);
+      if (!isScannableSourceFile(filePath)) continue;
+
+      const content = await Bun.file(filePath).text();
+      scannedFilePaths.push(filePath);
+      violations.push(
+        ...findDependencyViolations(content, filePath, declaredDependencyNames, {
+          treatAsTestFile,
+        }),
+      );
+
+      const lineStartOffsets = buildLineStartOffsets(content);
+      const lines = content.split('\n');
+      for (const parsed of collectAllSpecifiers(content, filePath)) {
+        if (!parsed.isLiteral || !isRelativeSpecifier(parsed.specifier)) continue;
+        const resolvedPath = resolveRelativeSpecifier(parsed.specifier, filePath);
+        if (resolvedPath === undefined) {
+          const lineNumber = lineNumberForOffset(lineStartOffsets, parsed.offset);
+          violations.push({
+            filePath,
+            lineNumber,
+            specifier: parsed.specifier,
+            line: (lines[lineNumber - 1] ?? '').trim(),
+            reason: UNRESOLVED_RELATIVE_IMPORT_REASON,
+          });
+          continue;
+        }
+        if (!visited.has(resolvedPath)) queue.push(resolvedPath);
+      }
+    }
+  }
+
+  const testRootFilePaths = rootFilePaths.filter((filePath) => TEST_FILE_PATTERN.test(filePath));
+  const productionRootFilePaths = rootFilePaths.filter(
+    (filePath) => !TEST_FILE_PATTERN.test(filePath),
+  );
+
+  await visitFrom(productionRootFilePaths, false);
+  await visitFrom(testRootFilePaths, true);
+
+  return { violations, scannedFilePaths };
+}
+
 async function main(): Promise<void> {
   const declaredDependencyNames = await loadDeclaredDependencyNames();
-  const files = await collectScanTargets();
-
-  const violations: DependencyViolation[] = [];
-  for (const filePath of files) {
-    const content = await Bun.file(filePath).text();
-    violations.push(...findDependencyViolations(content, filePath, declaredDependencyNames));
-  }
+  const rootFilePaths = await collectScanTargets();
+  const { violations, scannedFilePaths } = await walkDependencyGraph(
+    rootFilePaths,
+    declaredDependencyNames,
+  );
 
   if (violations.length === 0) {
     process.stdout.write(
-      `check-virtual-list-dependency-free — OK (${files.length} files, no @tanstack/virtual-core ` +
-        'or undeclared bare imports).\n',
+      `check-virtual-list-dependency-free — OK (${scannedFilePaths.length} files, no ` +
+        '@tanstack/virtual-core or undeclared bare imports).\n',
     );
     return;
   }

--- a/packages/components/scripts/check-virtual-list-dependency-free.ts
+++ b/packages/components/scripts/check-virtual-list-dependency-free.ts
@@ -554,7 +554,15 @@ export async function collectScanTargets(): Promise<string[]> {
  * unscanned rather than fed to a TypeScript parser that was never going to
  * understand it.
  */
-const SCANNABLE_SOURCE_EXTENSIONS = ['.ts', '.svelte'] as const;
+/**
+ * Extensions a relative import can resolve to, and that this guard can read.
+ *
+ * The JavaScript ones matter as much as the TypeScript: Bun bundles a relative `.js`,
+ * `.mjs`, or `.cjs` helper exactly like a `.ts` one, so accepting those as resolved and
+ * then declining to scan them left a hole the size of the whole guard — the helper could
+ * import `@tanstack/virtual-core` or an undeclared package and nothing would report it.
+ */
+const SCANNABLE_SOURCE_EXTENSIONS = ['.ts', '.tsx', '.svelte', '.js', '.mjs', '.cjs'] as const;
 
 function isScannableSourceFile(filePath: string): boolean {
   return SCANNABLE_SOURCE_EXTENSIONS.some((extension) => filePath.endsWith(extension));
@@ -585,7 +593,15 @@ export function resolveRelativeSpecifier(
     ...SCANNABLE_SOURCE_EXTENSIONS.map((extension) => join(candidateBase, `index${extension}`)),
   ];
   for (const candidatePath of candidatePaths) {
-    if (existsSync(candidatePath) && statSync(candidatePath).isFile()) return candidatePath;
+    // `statSync` can throw even when `existsSync` just said yes — a permission error, or
+    // the path disappearing between the two calls. A guard that crashes reports nothing
+    // at all, which is strictly worse than reporting the import as unresolved, so a
+    // candidate that cannot be inspected is simply not a match.
+    try {
+      if (existsSync(candidatePath) && statSync(candidatePath).isFile()) return candidatePath;
+    } catch {
+      continue;
+    }
   }
   return undefined;
 }
@@ -649,8 +665,12 @@ export async function walkDependencyGraph(
     seedFilePaths: readonly string[],
     treatAsTestFile: boolean,
   ): Promise<void> {
+    // Walked with a moving index rather than `shift()`, which reindexes the whole array
+    // on every step and makes the traversal quadratic as the graph grows. Paths pushed
+    // while walking are picked up by the same loop, so the order is unchanged.
     const queue = [...seedFilePaths];
-    for (let filePath = queue.shift(); filePath !== undefined; filePath = queue.shift()) {
+    for (let queueIndex = 0; queueIndex < queue.length; queueIndex += 1) {
+      const filePath = queue[queueIndex]!;
       if (visited.has(filePath)) continue;
       visited.add(filePath);
       if (!isScannableSourceFile(filePath)) continue;


### PR DESCRIPTION
**Stacked on #1518** — base branch is `virtual-list-sticky-smooth-and-semantics`. Review the top commit only.

Two ways to reach `@tanstack/virtual-core` past the guard remained open.

## Relative imports were accepted without being followed

A relative specifier was classified as uninteresting and never followed, while the scan set covered only `virtual-list/**` plus `fixed-virtual-window.ts`. So a scanned file could import a relative module just outside that set, and that module could import anything at all — completely unchecked.

The scan now resolves relative specifiers against the importing file and walks them transitively, tracking visited files so a cycle terminates, and reporting a specifier that resolves to nothing rather than crashing.

## `import x = require('y')` was invisible

`ImportEqualsDeclaration` with an external module reference is a real import the AST walk never looked at.

## Confirmed, not assumed

I verified the transitive detection against a temporary fixture rather than trusting the report: a file under `virtual-list/_internal/` importing a module in `utilities/` that in turn imports `@tanstack/virtual-core`. The guard exited 0 on that shape before this change; it now exits 1 and names the file actually holding the forbidden import. Fixtures removed, guard re-confirmed clean on the real tree.

## Validation

- guard on the real tree — exits 0
- `bun test scripts/check-virtual-list-dependency-free.test.ts` — 24 pass
- `lint:invariants`, `typecheck`, `lint` — all exit 0

Closes CIN-522

https://claude.ai/code/session_01BicogfzUyxNrcZZumwGJSp