### PR TITLE
fix(chat-room): adopt the Operative abort fix so Stop closes the upstream stream

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
         "@lostgradient/cinder": "workspace:*",
         "@lostgradient/editor": "workspace:*",
         "@lostgradient/markdown": "workspace:*",
-        "@lostgradient/operative": "0.8.0",
+        "@lostgradient/operative": "0.10.0",
         "@milkdown/ctx": "^7.17.3",
         "@milkdown/kit": "^7.17.3",
         "@milkdown/prose": "^7.17.3",
@@ -495,9 +495,9 @@
 
     "@lostgradient/markdown": ["@lostgradient/markdown@workspace:packages/markdown"],
 
-    "@lostgradient/operative": ["@lostgradient/operative@0.8.0", "", { "dependencies": { "@lostgradient/weft": "^0.20.0", "armorer": "^2.1.0", "conversationalist": "^1.1.0" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.50.0", "@google/genai": ">=2.19.0", "@opentelemetry/api": "^1.9.1", "openai": ">=4.0.0", "zod": "^4.4.3" }, "optionalPeers": ["@anthropic-ai/sdk", "@google/genai", "@opentelemetry/api", "openai"] }, "sha512-KIUfKBPYpNU6p2bpxogJxYkkqGV+w+P9ij8H3F7C8aCt5BwgA4Ga3wvtHUIIMTUFXNPxVxhlyU5buPWSnqaf/Q=="],
+    "@lostgradient/operative": ["@lostgradient/operative@0.10.0", "", { "dependencies": { "@lostgradient/weft": "^0.23.1", "armorer": "^2.3.0", "conversationalist": "^1.1.0" }, "peerDependencies": { "@anthropic-ai/sdk": ">=0.50.0", "@google/genai": ">=2.19.0", "@opentelemetry/api": "^1.9.1", "openai": ">=4.0.0", "zod": "^4.4.3" }, "optionalPeers": ["@anthropic-ai/sdk", "@google/genai", "@opentelemetry/api", "openai"] }, "sha512-67guQvIT3TWMFvir4XonM05zGEV2DI2k7j7eTDBZVOfakf+MuPRAhsylZxZOIsCkxrFQ3YID136T/CpghoM7qw=="],
 
-    "@lostgradient/weft": ["@lostgradient/weft@0.20.0", "", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "zod": "^4.3.6" }, "optionalDependencies": { "@valibot/to-json-schema": "^1.7.0" }, "peerDependencies": { "@libsql/client": "^0.17.2", "@lostgradient/weft-console": "^0.1.0", "@neondatabase/serverless": "^1.1.0", "@opentelemetry/api": "^1.0.0", "better-sqlite3": "^12.8.0", "lmdb": "^3.5.2", "pg": "^8.11.0" }, "optionalPeers": ["@libsql/client", "@lostgradient/weft-console", "@neondatabase/serverless", "@opentelemetry/api", "better-sqlite3", "lmdb", "pg"], "bin": { "weft": "dist/cli-main.js", "weft-mcp": "dist/mcp/cli.js" } }, "sha512-eiUnJOZOhYZISPRgxg5WGDSc1N8lX7z07py+cf7hkNrGimQUDw3X9EvIZJnbMKIdZlLh4HJTFWzwXw0AAM+WpQ=="],
+    "@lostgradient/weft": ["@lostgradient/weft@0.23.1", "", { "dependencies": { "@msgpack/msgpack": "^3.1.3", "zod": "^4.3.6" }, "optionalDependencies": { "@valibot/to-json-schema": "^1.7.0" }, "peerDependencies": { "@libsql/client": "^0.17.2", "@lostgradient/weft-ui": "^0.1.0", "@neondatabase/serverless": "^1.1.0", "@opentelemetry/api": "^1.0.0", "better-sqlite3": "^12.8.0", "lmdb": "^3.5.2", "pg": "^8.11.0" }, "optionalPeers": ["@libsql/client", "@lostgradient/weft-ui", "@neondatabase/serverless", "@opentelemetry/api", "better-sqlite3", "lmdb", "pg"], "bin": { "weft": "dist/cli-main.js", "weft-mcp": "dist/mcp/cli.js" } }, "sha512-DDdAc30CEzk+RzFw79n5olewnvO62oQDKVxUk9qzhkDiCM1V+sa/ieaknLIiDMAusyB5Xe2zLYt/dzrlKd+6uQ=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "^7.5.5", "@types/node": "^12.7.1", "find-up": "^4.1.0", "fs-extra": "^8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
@@ -879,7 +879,7 @@
 
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
-    "armorer": ["armorer@2.1.0", "", { "peerDependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "@openai/agents": "^0.14.3 || ^0.15.0", "@opentelemetry/api": "^1.9.1", "zod": "^4.4.3" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@openai/agents"] }, "sha512-eJRUbYwriEheDV7cxiBVMoFsMDhHdnD+3FQBQukzvjSQl3T2aCu+vy4wcTZNN4a0cHgUNYWaQ8NHrkJ3wS59hw=="],
+    "armorer": ["armorer@2.4.0", "", { "peerDependencies": { "@modelcontextprotocol/sdk": "^1.30.0", "@openai/agents": "^0.14.3 || ^0.15.0", "@opentelemetry/api": "^1.9.1", "zod": "^4.4.3" }, "optionalPeers": ["@modelcontextprotocol/sdk", "@openai/agents"] }, "sha512-N4vgbsh/nets3hNpi6c5/s+z70r2LAGyaxJGpBTguHf8GsOsS5R0j0ELizW0tEuBM7avhgRbR5ZWOgO98f4tnw=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
@@ -961,7 +961,7 @@
 
     "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
 
-    "conversationalist": ["conversationalist@1.1.0", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.116.0", "zod": "^4.4.3" }, "optionalPeers": ["@anthropic-ai/sdk"] }, "sha512-G6iNvSCmgR1E+RcPky871NtIwA2AS89mpmX5j6QALRI6gvigbuPmUYTsNFV1vvAaK4Q58P+d6uPjvTMlCOTW9g=="],
+    "conversationalist": ["conversationalist@1.2.0", "", { "dependencies": { "gray-matter": "^4.0.3" }, "peerDependencies": { "@anthropic-ai/sdk": "^0.116.0", "zod": "^4.4.3" }, "optionalPeers": ["@anthropic-ai/sdk"] }, "sha512-2/r2RYZzM7JLoh0cfDInzK9aY2cHqUW5Xr88n+K4vFKDUZVuhLk0jS9c8PhENoTRTakpt15YNgIyuarHKNZ3Ww=="],
 
     "cookie": ["cookie@0.6.0", "", {}, "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw=="],
 

--- a/labs/chat-room/package.json
+++ b/labs/chat-room/package.json
@@ -27,7 +27,7 @@
 		"@lostgradient/cinder": "workspace:*",
 		"@lostgradient/editor": "workspace:*",
 		"@lostgradient/markdown": "workspace:*",
-		"@lostgradient/operative": "0.8.0",
+		"@lostgradient/operative": "0.10.0",
 		"@milkdown/ctx": "^7.17.3",
 		"@milkdown/kit": "^7.17.3",
 		"@milkdown/prose": "^7.17.3",

--- a/labs/chat-room/src/routes/api/chat/chat-agent.test.ts
+++ b/labs/chat-room/src/routes/api/chat/chat-agent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
 	AgentRunError,
 	AbortAgentRunError,
-	StandardSchemaValidationError,
+	OutputValidationError,
 	createAgent,
 	stopWhen,
 	type AgentRun,
@@ -519,19 +519,37 @@ describe('classifyChatRunFailure', () => {
 	});
 
 	// Pins CIN-434's confirmed fact: output-validation failures are an
-	// `AgentRunError` with `kind: 'output'`, `code: 'INVALID_OUTPUT'` — there is
-	// no separate `OutputValidationError`. `StandardSchemaValidationError` is
-	// the concrete class Operative throws for this (from `AgentRun.output()` /
-	// `.unwrap()`, not from `run.result()` — see the doc comment on
-	// `classifyChatRunFailure`), so constructing one directly here exercises
-	// the real shape rather than a hand-rolled stand-in.
-	test('maps a StandardSchemaValidationError to kind: "output", code: "INVALID_OUTPUT"', () => {
-		const error = new StandardSchemaValidationError([{ message: 'expected an object' }]);
+	// `AgentRunError` with `kind: 'output'`, `code: 'INVALID_OUTPUT'`.
+	// `OutputValidationError` is the concrete class Operative throws for this
+	// (from `AgentRun.output()` / `.unwrap()`, not from `run.result()` — see
+	// the doc comment on `classifyChatRunFailure`), so constructing one
+	// directly here exercises the real shape rather than a hand-rolled
+	// stand-in. It replaced `StandardSchemaValidationError`, which 0.10.0
+	// removed with no alias.
+	test('maps an OutputValidationError to kind: "output", code: "INVALID_OUTPUT"', () => {
+		const error = new OutputValidationError(new Error('expected an object'));
 		const envelope = classifyChatRunFailure(error, 'error');
 		expect(envelope.ok).toBe(false);
 		if (envelope.ok) throw new Error('unreachable');
 		expect(envelope.error.kind).toBe('output');
 		expect(envelope.error.code).toBe('INVALID_OUTPUT');
+	});
+
+	// Operative's code union grows on its own schedule; the chat wire's does
+	// not. `decodeChatStreamEvent` rejects a frame whose code it does not know,
+	// so a code that reached the wire verbatim would take the entire terminal
+	// frame down with it and the client would see no failure at all. Reverting
+	// `toChatWireErrorCode` to pass `error.code` through fails this test.
+	test('reports an Operative code the chat wire does not admit as UNKNOWN', () => {
+		const error = new AgentRunError('no such agent handle', {
+			kind: 'generate',
+			code: 'INVALID_AGENT_HANDLE'
+		});
+		const envelope = classifyChatRunFailure(error, 'error');
+		expect(envelope.ok).toBe(false);
+		if (envelope.ok) throw new Error('unreachable');
+		expect(envelope.error.code).toBe('UNKNOWN');
+		expect(envelope.error.message).toBe('no such agent handle');
 	});
 
 	// The route branches on `error.kind === 'abort'` to choose between closing

--- a/labs/chat-room/src/routes/api/chat/chat-agent.ts
+++ b/labs/chat-room/src/routes/api/chat/chat-agent.ts
@@ -25,7 +25,6 @@ import {
 	createAgent,
 	stopWhen,
 	type AgentRun,
-	type AgentRunErrorCode,
 	type AgentRunErrorKind,
 	type AnyToolbox,
 	type ConversationHistory,
@@ -109,8 +108,41 @@ export type ChatRunEnvelope =
 	| {
 			ok: false;
 			status: string;
-			error: { kind: AgentRunErrorKind; code: AgentRunErrorCode; message: string };
+			error: { kind: AgentRunErrorKind; code: ChatSerializedRunError['code']; message: string };
 	  };
+
+/**
+ * Every error code `@lostgradient/chat`'s wire contract admits, as a total
+ * record so this list cannot silently fall behind that union: adding a member
+ * to it makes this object fail to typecheck for the missing key.
+ *
+ * The narrowing exists because the two unions grow independently. Operative's
+ * `AgentRunErrorCode` gained `INVALID_AGENT_HANDLE` in 0.9.0, and
+ * `decodeChatStreamEvent` REJECTS a frame carrying a code it does not know —
+ * so forwarding a new Operative code verbatim does not deliver an unfamiliar
+ * error, it drops the whole terminal frame and the client sees nothing at all.
+ * Reporting `UNKNOWN`, which the wire does know, keeps the failure visible.
+ * Admitting a new code into the contract is a `packages/chat` decision with a
+ * published release behind it, not something a lab widens on its own.
+ */
+const CHAT_WIRE_ERROR_CODES: Record<ChatSerializedRunError['code'], true> = {
+	INVALID_EXPORT: true,
+	LOAD_FAILED: true,
+	ABORTED: true,
+	BUDGET_EXCEEDED: true,
+	ELICITATION_DENIED: true,
+	INVALID_OUTPUT: true,
+	MAXIMUM_STEPS: true,
+	TRIPWIRE: true,
+	UNKNOWN: true
+};
+
+/** Projects an Operative error code onto the codes the chat wire accepts. */
+export function toChatWireErrorCode(code: string): ChatSerializedRunError['code'] {
+	return Object.hasOwn(CHAT_WIRE_ERROR_CODES, code)
+		? (code as ChatSerializedRunError['code'])
+		: 'UNKNOWN';
+}
 
 /**
  * Stops the loop the instant a step produces ANY tool call, approval-gated
@@ -271,7 +303,11 @@ export function classifyChatRunFailure(
 		return {
 			ok: false,
 			status: error.kind === 'abort' ? 'aborted' : fallbackStatus,
-			error: { kind: error.kind, code: error.code, message: error.message }
+			error: {
+				kind: error.kind,
+				code: toChatWireErrorCode(error.code),
+				message: error.message
+			}
 		};
 	}
 

--- a/labs/chat-room/src/routes/api/chat/chat-agent.ts
+++ b/labs/chat-room/src/routes/api/chat/chat-agent.ts
@@ -288,7 +288,8 @@ export function startChatRun(agent: StandaloneAgent, conversation: ConversationH
  *
  * Exported so `chat-agent.test.ts` can pin the `AgentRunError` shapes
  * `@lostgradient/operative` documents directly — most usefully
- * `StandardSchemaValidationError` (`kind: 'output'`, `code: 'INVALID_OUTPUT'`),
+ * `OutputValidationError` (`kind: 'output'`, `code: 'INVALID_OUTPUT'`; it replaced
+ * `StandardSchemaValidationError`, which 0.10.0 removed with no alias),
  * which this route never triggers live: `createChatAgent` sets no `output`
  * schema, and even an agent that does only ever raises it from
  * `AgentRun.output()`/`.unwrap()`, not from `run.result()` — confirmed

--- a/labs/chat-room/src/routes/page.svelte.e2e.ts
+++ b/labs/chat-room/src/routes/page.svelte.e2e.ts
@@ -645,6 +645,18 @@ test.describe('production streaming path', () => {
 		await expect(log).toContainText(HOLD_PARTIAL_TEXT);
 		await expect(page.getByTestId('demo-error')).toBeEmpty();
 
+		// Keeping the partial text is only half a correct stop. The other half is
+		// upstream: the fixture is still holding an open response for this marker
+		// until the socket closes, so the gate clearing is the proof that the
+		// abort travelled all the way to the provider request instead of stopping
+		// at the browser. `gate` resolves `disconnected` on that close and drops
+		// the marker, so the poll clears without anyone releasing it.
+		await expect.poll(() => fixtureGateHeld(marker)).toBe(false);
+
+		// And nothing is left to release — a `true` here would mean the gate
+		// outlived the abort and this spec merely raced it.
+		expect(await releaseFixtureGate(marker)).toBe(false);
+
 		// The server-side half of the same stop. A dead preview server refuses the
 		// connection and this throws rather than returning a failing response, so
 		// read a rejection here as the crash described above and not as a routing
@@ -682,18 +694,17 @@ test.describe('production streaming path', () => {
 		await expect(page.getByTestId('demo-error')).toBeEmpty();
 		await expect(log.getByRole('article')).toHaveCount(1);
 
-		// The abort SHOULD reach the fixture — SvelteKit cancels the ndjson
-		// stream, the route aborts the run, Operative aborts the upstream
-		// request, the fixture's `gate` sees the socket close — and CIN-513 adds
-		// `await expect.poll(() => fixtureGateHeld(marker)).toBe(false)` here.
-		// Today it does not: Operative 0.8.0's Anthropic provider puts the abort
-		// signal in the request BODY instead of the SDK's `RequestOptions`
-		// (AB-189), so the upstream request stays parked. Read the probe for the
-		// trace, then release the gate so the leaked run can unwind instead of
-		// outliving the test.
-		const heldAfterAbort = await fixtureGateHeld(marker);
-		expect(typeof heldAfterAbort).toBe('boolean');
-		await releaseFixtureGate(marker);
+		// The abort reaches the fixture: SvelteKit cancels the ndjson stream, the
+		// route aborts the run, Operative aborts the upstream request, and the
+		// fixture's `gate` sees the socket close and drops the marker. Under
+		// Operative 0.8.0 this stayed held forever — its Anthropic provider put
+		// the abort signal in the request BODY instead of the SDK's
+		// `RequestOptions`, so the upstream request was never cancelled (AB-189).
+		await expect.poll(() => fixtureGateHeld(marker)).toBe(false);
+
+		// Nothing left to release. A `true` here would mean the gate was still
+		// parked and the poll above had merely raced it.
+		expect(await releaseFixtureGate(marker)).toBe(false);
 
 		const alive = await page.request.get('/');
 		expect(alive.ok()).toBe(true);


### PR DESCRIPTION
## The defect

Clicking **Stop generating** cancelled the browser stream and the route called `run.abort()`, but the request to Anthropic stayed open until the model finished on its own — a billed, leaked upstream request per stop, with `run.result()` parked on the server until then.

The cause was upstream, filed as AB-189: `@lostgradient/operative@0.8.0`'s Anthropic provider passed the abort signal as a **body parameter**, which `@anthropic-ai/sdk` ignores, instead of as the SDK's `RequestOptions`.

## The change

Pins `@lostgradient/operative` to **0.10.0** — the release carrying that fix (shipped in 0.9.0) plus the same defect's cure in the OpenAI provider (AB-238).

Not 0.11.0. It needs a newer `armorer` than this workspace pins: its `AnyToolbox` gains `issueGrant`/`revokeGrant`/`listGrants`, which the lab's toolbox does not satisfy, producing four extra type errors that have nothing to do with aborting a run. That adoption wants its own change.

## The assertion the specs could only describe before

Both cancel specs now assert the *upstream* half of the stop. The scaffolding for it — the read-only `GET /__fixture/held?marker=` probe and the `fixtureGateHeld` helper — already shipped with CIN-436; only the assertion was missing, because it could not pass:

```ts
await expect.poll(() => fixtureGateHeld(marker)).toBe(false);
expect(await releaseFixtureGate(marker)).toBe(false);
```

The gate clearing on its own is the proof that the abort travelled all the way to the provider request instead of stopping at the browser: `gate()` resolves `disconnected` on the socket close and drops the marker. The second line rules out a race — a `true` there would mean the gate outlived the abort and the poll merely beat it.

**Proven against the old pin first.** On 0.8.0 both specs fail on the poll, with the gate still held:

```
Expected: false
Received: true
Timeout 5000ms exceeded while waiting on the predicate
> 703 | await expect.poll(() => fixtureGateHeld(marker)).toBe(false);
```

On 0.10.0 both pass.

## Two adjustments the version brings with it

`StandardSchemaValidationError` was removed with no alias, so the classification test constructs the `OutputValidationError` that replaced it.

Operative's `AgentRunErrorCode` gained `INVALID_AGENT_HANDLE`, which `@lostgradient/chat`'s wire union does not admit. This matters more than a type error: `decodeChatStreamEvent` **rejects** a frame carrying a code it does not know, so forwarding a new Operative code verbatim would not deliver an unfamiliar error — it would drop the entire terminal frame and show the client nothing at all. The route now projects an unrecognized code onto `UNKNOWN`, which the wire does know, through a `Record<ChatSerializedRunError['code'], true>` that fails to typecheck if the wire union grows and this list does not follow. A new test pins the behavior and fails if the code is passed through verbatim.

Admitting a new code into that union is a `packages/chat` decision with a published release behind it, not one a lab makes on its own — same boundary the existing `stopWhen` comment in this file draws.

## Validation

From `labs/chat-room`:

- `bun run lint` — clean
- `bun run check` — 2598 files, 0 errors, 0 warnings
- `bun run test:unit` — 49 pass, 0 fail
- `bun run test:playwright` — **926 pass, 0 fail** (13.4m)

`test:live-operative` needs a real Anthropic credential and cannot run here; it remains for a human to run against the live API.