### PR TITLE
fix(chat): agree counted strings with their count

### DIFF
--- a/.changeset/agree-counted-strings-with-count.md
+++ b/.changeset/agree-counted-strings-with-count.md
@@ -1,0 +1,5 @@
+---
+'@lostgradient/chat': patch
+---
+
+Agree five counted strings with their count, so a count of one no longer reads as a plural. The tool-call group's heading now says `Called 1 tool` rather than `Called 1 tools`, its list is named `1 consecutive tool call`, the status region a live region reads says `1 message in conversation`, and the reasoning estimate says `(1 token)`. Three of the five are screen-reader surfaces, and a single tool call is the ordinary case for a subagent delegation rather than an edge case.

--- a/packages/chat/src/lib/components/chat/container/chat-status-announcer.svelte
+++ b/packages/chat/src/lib/components/chat/container/chat-status-announcer.svelte
@@ -26,7 +26,7 @@
 
 <!-- Screen reader status -->
 <div id={statusId} class="cinder-sr-only">
-  {messageCount} messages in conversation
+  {messageCount === 1 ? '1 message' : `${messageCount} messages`} in conversation
 </div>
 
 <!-- Screen reader announcements (polite — does not interrupt current reading) -->

--- a/packages/chat/src/lib/components/chat/container/chat-status-announcer.test.ts
+++ b/packages/chat/src/lib/components/chat/container/chat-status-announcer.test.ts
@@ -32,6 +32,17 @@ describe('ChatStatusAnnouncer', () => {
     expect(status?.textContent).toContain('5 messages in conversation');
   });
 
+  test('the status region says "1 message" for a single message', () => {
+    // A live-region sibling reads this out, so "1 messages in conversation"
+    // was audible rather than merely untidy.
+    const { container } = render(ChatStatusAnnouncer, {
+      props: { statusId: 'chat-status', messageCount: 1, announcerMessage: '' },
+    });
+    const status = container.querySelector('#chat-status');
+    expect(status?.textContent).toContain('1 message in conversation');
+    expect(status?.textContent).not.toContain('1 messages');
+  });
+
   test('the polite region carries the announcer message', () => {
     const { container } = render(ChatStatusAnnouncer, {
       props: {

--- a/packages/chat/src/lib/components/chat/message/chat-message-tool-rendering.test.ts
+++ b/packages/chat/src/lib/components/chat/message/chat-message-tool-rendering.test.ts
@@ -171,6 +171,53 @@ describe('ChatMessage — tool-call rendering', () => {
     expect(container.textContent).toContain('Network unavailable');
   });
 
+  describe('counted strings agree with the count', () => {
+    // A single delegation is the ordinary case for a subagent tool, not an
+    // edge case — it is what `/exercises/multi-agent` renders — and the
+    // heading is in the document outline while the list label is an
+    // accessible name, so both are read aloud. Both used to say "1 tools" /
+    // "1 consecutive tool calls".
+    const pair: ToolCallPair = { call: { id: 'only', name: 'lookup', arguments: {} } };
+    const second: ToolCallPair = { call: { id: 'other', name: 'fetch', arguments: {} } };
+    const describeToolCall = (): ToolCallPresentation => ({
+      verb: 'Checking',
+      tense: 'present',
+      detail: 'records',
+      kind: 'search',
+    });
+
+    test('says "1 tool" for one pair and "2 tools" for two', () => {
+      const one = render(ToolCallTimeline, {
+        props: { pairs: [pair], messageId: 'count-one', describeToolCall },
+      });
+      expect(one.container.querySelector('h3')?.textContent).toContain('Called 1 tool');
+      // Not merely "contains 1 tool" — that is also true of "1 tools".
+      expect(one.container.querySelector('h3')?.textContent).not.toContain('1 tools');
+      cleanup();
+
+      const two = render(ToolCallTimeline, {
+        props: { pairs: [pair, second], messageId: 'count-two', describeToolCall },
+      });
+      expect(two.container.querySelector('h3')?.textContent).toContain('Called 2 tools');
+    });
+
+    test('names the list "1 consecutive tool call" for one pair', () => {
+      const one = render(ToolCallTimeline, {
+        props: { pairs: [pair], messageId: 'label-one', describeToolCall },
+      });
+      const list = one.container.querySelector('[role="list"]');
+      expect(list?.getAttribute('aria-label')).toBe('1 consecutive tool call');
+      cleanup();
+
+      const two = render(ToolCallTimeline, {
+        props: { pairs: [pair, second], messageId: 'label-two', describeToolCall },
+      });
+      expect(two.container.querySelector('[role="list"]')?.getAttribute('aria-label')).toBe(
+        '2 consecutive tool calls',
+      );
+    });
+  });
+
   test('namespaces grouped disclosure ids across separate timelines', async () => {
     const pair: ToolCallPair = { call: { id: 'reused', name: 'lookup', arguments: {} } };
     const describeToolCall = (): ToolCallPresentation => ({

--- a/packages/chat/src/lib/components/chat/message/parts/reasoning-part.svelte
+++ b/packages/chat/src/lib/components/chat/message/parts/reasoning-part.svelte
@@ -22,7 +22,9 @@
   // Approximate token count — 1 token ≈ 4 characters (rough heuristic for display).
   const approximateTokenCount = $derived(Math.round(part.content.length / 4));
   const tokenDisplay = $derived(
-    approximateTokenCount > 0 ? ` (${approximateTokenCount.toLocaleString()} tokens)` : '',
+    approximateTokenCount > 0
+      ? ` (${approximateTokenCount.toLocaleString()} ${approximateTokenCount === 1 ? 'token' : 'tokens'})`
+      : '',
   );
 
   // The polite "Reasoning complete." announcement fires ONLY on a streaming

--- a/packages/chat/src/lib/components/chat/message/parts/reasoning-part.test.ts
+++ b/packages/chat/src/lib/components/chat/message/parts/reasoning-part.test.ts
@@ -249,6 +249,18 @@ describe('ReasoningPart — token count display', () => {
     const label = container.querySelector('.chat-reasoning-label');
     // Should contain the approximate token count (10)
     expect(label?.textContent).toContain('10');
+    expect(label?.textContent).toContain('tokens');
+  });
+
+  test('says "1 token" when the estimate rounds to one', () => {
+    // 4 chars → 1 token, at the heuristic's own boundary. Reachable in
+    // practice: a reasoning block that has streamed only its first few
+    // characters passes through this count.
+    const part = makePart({ content: 'a'.repeat(4) });
+    const { container } = render(ReasoningPart, { props: { part } });
+    const label = container.querySelector('.chat-reasoning-label');
+    expect(label?.textContent).toContain('(1 token)');
+    expect(label?.textContent).not.toContain('1 tokens');
   });
 });
 

--- a/packages/chat/src/lib/components/chat/message/tool-call-timeline.svelte
+++ b/packages/chat/src/lib/components/chat/message/tool-call-timeline.svelte
@@ -67,6 +67,14 @@
   );
   const completedCount = $derived(steps.filter((step) => step.status === 'succeeded').length);
   const hasActivityPresentations = $derived(activityPresentations.some(Boolean));
+
+  // Derived ONCE and used by both arms of the `hasActivityPresentations`
+  // branch below, which previously wrote the same sentence twice. Fixing the
+  // plural in one arm and not the other is exactly the drift that produced
+  // "1 consecutive tool calls" here in the first place.
+  const callsLabel = $derived(
+    `${pairs.length} consecutive tool ${pairs.length === 1 ? 'call' : 'calls'}`,
+  );
   const expandedCalls = new SvelteSet<string>();
 
   function toggleCall(occurrenceKey: string): void {
@@ -83,14 +91,12 @@
   tabindex="-1"
 >
   <h3 id={headingId}>
-    Called {pairs.length} tools{completedCount ? `, ${completedCount} complete` : ''}
+    Called {pairs.length === 1 ? '1 tool' : `${pairs.length} tools`}{completedCount
+      ? `, ${completedCount} complete`
+      : ''}
   </h3>
   {#if hasActivityPresentations}
-    <div
-      class="presented-tool-calls"
-      role="list"
-      aria-label={`${pairs.length} consecutive tool calls`}
-    >
+    <div class="presented-tool-calls" role="list" aria-label={callsLabel}>
       {#each pairs as pair, index (`${index}:${pair.call.id}`)}
         <div role="listitem">
           <ToolCallGroup
@@ -105,7 +111,7 @@
       {/each}
     </div>
   {:else}
-    <RunStepTimeline {steps} label={`${pairs.length} consecutive tool calls`} />
+    <RunStepTimeline {steps} label={callsLabel} />
   {/if}
 </section>
 


### PR DESCRIPTION
Closes CIN-611.

Five strings in `@lostgradient/chat` interpolated a number in front of an unconditionally plural noun, so a count of 1 rendered ungrammatically. Three of the five are screen-reader surfaces, which is what makes this worth fixing rather than tolerating.

| Site | Before | After |
| --- | --- | --- |
| `tool-call-timeline.svelte` `<h3>` | `Called 1 tools, 1 complete` | `Called 1 tool, 1 complete` |
| `tool-call-timeline.svelte` list `aria-label` | `1 consecutive tool calls` | `1 consecutive tool call` |
| `tool-call-timeline.svelte` `RunStepTimeline` label | `1 consecutive tool calls` | `1 consecutive tool call` |
| `chat-status-announcer.svelte` status region | `1 messages in conversation` | `1 message in conversation` |
| `reasoning-part.svelte` token estimate | `(1 tokens)` | `(1 token)` |

The heading is in the document outline and reachable by heading navigation; the status region is read by a live region.

## How it was found

Rendering `/exercises/multi-agent` in the chat-room lab, which makes exactly one delegation and so hits the singular case every time. A single tool call is the ordinary case for a subagent tool, not an edge case.

## Not a new convention

`chat-conversation-list.svelte:44` already writes:

```ts
summary.messageCount === 1 ? '1 message' : \`\${summary.messageCount} messages\`
```

This matches that form. No pluralization helper, no i18n layer — the delivery boundary is `packages/chat` and five conditionals.

Each site is written as a **single expression** rather than `{count}` followed by a separate `{noun}`. The multi-line form inserts whitespace text nodes, which breaks existing assertions that match the full sentence (`'5 messages in conversation'`).

## One deduplication

The list `aria-label` and the `RunStepTimeline` label were the same sentence written twice, in the two arms of one `{#if}`. That duplication is exactly how one of them came to be fixed and the other not — my own first pass fixed one and missed the other. They now derive from a single \`callsLabel\`.

## Tests

Four new assertions, each covering a count of 1 **and** a count that is not 1, and each asserting the *absence* of the plural form too — \`toContain('1 tool')\` is also satisfied by \`'1 tools'\`.

Proven load-bearing by reverting the three components and re-running:

- reverted: **1332 pass, 4 fail** — all four new tests, no others
- restored: **1336 pass, 0 fail**

## Validation

\`\`\`
bun run --filter @lostgradient/chat lint       # 0
bun run --filter @lostgradient/chat typecheck  # 0
bun run --filter @lostgradient/chat test       # 1336 pass, 0 fail
bun run --filter @lostgradient/chat validate   # 0
\`\`\`

Note: CIN-611's description named a `check` script for this package; it does not exist. The real gates are `typecheck` and `validate`, and the issue has been corrected.

https://claude.ai/code/session_01RKLn1mLTUgVjSN38WRtA19