### PR TITLE
fix(chat-room): agree three lab assertions with Chat's corrected tool heading

### DIFF
--- a/labs/chat-room/src/routes/api/chat/approval-flow.e2e.ts
+++ b/labs/chat-room/src/routes/api/chat/approval-flow.e2e.ts
@@ -245,7 +245,7 @@ test('denying reaches a terminal state without resuming', async ({ page }, testI
 	await expect(chat.locator('.tool-call-group')).toHaveCount(0);
 	await expect(chat.getByRole('button', { name: 'Approve' })).toHaveCount(0);
 	await expect(chat.getByRole('button', { name: 'Reject' })).toHaveCount(0);
-	const settled = chat.getByRole('region', { name: 'Called 1 tools' });
+	const settled = chat.getByRole('region', { name: 'Called 1 tool' });
 	await expect(settled).toContainText('remember_note');
 	await expect(settled).toContainText('Failed');
 	await expect(page.getByTestId('demo-error')).toBeEmpty();

--- a/labs/chat-room/src/routes/exercises/multi-agent/multi-agent.e2e.ts
+++ b/labs/chat-room/src/routes/exercises/multi-agent/multi-agent.e2e.ts
@@ -145,9 +145,16 @@ test("the delegation renders as a tool-activity entry in Chat's transcript", asy
 
 	// ONE call, and it completed. The heading counts both, so a call left
 	// unpaired with its result — which renders the same row — says "Called 1
-	// tools" with no completion clause.
+	// tool" with no completion clause.
+	//
+	// `tool`, singular. This asserted "Called 1 tools" when it was written,
+	// because that is what Chat rendered: the count was interpolated in front
+	// of a hardcoded plural (CIN-611). A spec pinning an exact user-visible
+	// string will pin whatever the string currently is, bug included, which is
+	// how the wrong text ended up asserted in the first place — and is worth
+	// remembering the next time one of these is written from observed output.
 	await expect(timeline).toHaveAttribute('data-cinder-tool-call-count', '1');
-	await expect(timeline.getByRole('heading')).toHaveText('Called 1 tools, 1 complete');
+	await expect(timeline.getByRole('heading')).toHaveText('Called 1 tool, 1 complete');
 
 	// Named, and reported as succeeded.
 	await expect(timeline.locator('.cinder-run-step-timeline__label')).toHaveText(

--- a/labs/chat-room/src/routes/page.svelte.e2e.ts
+++ b/labs/chat-room/src/routes/page.svelte.e2e.ts
@@ -394,7 +394,7 @@ test.describe('production streaming path', () => {
 		// Verification alone would leave the transcript pending: the tool has to
 		// have actually run on resume, the client has to have swapped the result
 		// in, and the follow-up turn has to have fired.
-		await expect(chat.getByRole('region', { name: 'Called 1 tools, 1 complete' })).toBeVisible();
+		await expect(chat.getByRole('region', { name: 'Called 1 tool, 1 complete' })).toBeVisible();
 		await expect(page.getByRole('log', { name: 'Messages' })).toContainText(
 			APPROVAL_FOLLOW_UP_TEXT
 		);


### PR DESCRIPTION
**`main` is red right now, and no CI job is reporting it.** This makes it green.

## What broke

#1538 (CIN-611) corrected `@lostgradient/chat` to render `Called 1 tool, 1 complete` instead of the ungrammatical `Called 1 tools`. Three lab specs assert the old string:

| Spec | Assertion |
| --- | --- |
| `exercises/multi-agent/multi-agent.e2e.ts:150` | `toHaveText('Called 1 tools, 1 complete')` |
| `page.svelte.e2e.ts:397` | `getByRole('region', { name: 'Called 1 tools, 1 complete' })` |
| `api/chat/approval-flow.e2e.ts:248` | `getByRole('region', { name: 'Called 1 tools' })` |

They pinned the bug, because they were written from observed output while the bug was live. I've left a comment at the multi-agent site saying so — a spec that pins an exact user-visible string pins whatever that string currently is, wrong text included, and that's worth flagging for the next person writing one from a screenshot.

## Why nothing caught it — filed as CIN-612

`labs-chat-room.yaml` gates its `validate` job (lint, check, unit tests, **and the entire Playwright matrix**) behind a `scope` job that sets `lab_changed=true` only for a diff touching `labs/chat-room/**` or the workflow file. `packages/chat/**` triggers the workflow but only reaches `client-styles`.

The run on #1538's head `bec74f5cd` records it exactly:

```
client-styles  completed/success
scope          completed/success
validate       completed/skipped
```

**The same gate applies to the `push` event on `main`**, and #1538's merge diff is still `packages/chat` only — so the breakage would not have surfaced on `main` either. It would have sat until the next person touched the lab and inherited three unexplained failures.

The workflow's own comment says a Chat-only PR is "covered by `client-styles` alone". That's true for stylesheet survival (CIN-514), which is what that job checks. It is not true for rendered text, accessible names, or DOM structure — all three of which the lab asserts against Chat's output. CIN-612 covers closing that; this PR only unbreaks `main`.

## Verification

From a clean checkout of `main` plus this change:

- The three specs **fail** before the change and **pass** after.
- `page.svelte.e2e.ts` + `approval-flow.e2e.ts` + multi-agent together: **27 passed**.
- `bun run lint` → 0, `bun run check` → `0 ERRORS 0 WARNINGS`, `bun run test:unit` → 58 pass / 0 fail.

Found while rebasing #1533 onto the new `main` — the rebase surfaced it, not CI.

https://claude.ai/code/session_01RKLn1mLTUgVjSN38WRtA19