### PR TITLE
test(chat-room): prove a reloaded conversation renders its history from the server

### DIFF
--- a/labs/chat-room/playwright.config.ts
+++ b/labs/chat-room/playwright.config.ts
@@ -45,6 +45,14 @@ const CROSS_ENGINE_SHARDS = [
 		// added to `server-owned-streaming` in this branch.
 		//
 		// Measured, not estimated: moving these five gives 54/61/62/51/50.
+		//
+		// SINCE UPDATED — `server-owned-streaming` gained the reload-history
+		// spec, putting the counts at 54/62/62/51/50. Two shards now sit exactly
+		// at the ceiling and there is no headroom in either: the next test added
+		// to `webkit-2` or `webkit-3` takes one of them to 63, past the point
+		// where a WebKit worker stops accepting navigation. Whoever adds it
+		// moves a spec to `webkit-5` (50) or `webkit-4` (51) rather than
+		// re-measuring afterwards and discovering the shard already broke.
 		'**/approval-flow.e2e.ts'
 	],
 	[

--- a/labs/chat-room/src/routes/server-owned/server-owned-streaming.e2e.ts
+++ b/labs/chat-room/src/routes/server-owned/server-owned-streaming.e2e.ts
@@ -532,3 +532,63 @@ test('a failed create leaves focus on the button that failed', async ({ page }) 
 	);
 	expect(focused).toBe('server-owned-create');
 });
+
+test('a reloaded conversation renders its full history from the session store', async ({
+	page,
+	request
+}) => {
+	// THE claim the whole variant exists to make: a reload renders history
+	// because the server has it, not because the browser kept anything. Until
+	// now that claim was made by the route's shape and by prose — the existing
+	// reload spec reloads the LIST, not a conversation.
+	//
+	// Seeded through the API rather than by streaming turns: this is about what
+	// survives a reload, so a deterministic transcript is the point and a real
+	// model turn would only add nondeterminism to the thing under test.
+	const title = uniqueTitle('Reload');
+	const created = await request.post('/api/server-owned/conversations', { data: { title } });
+	expect(created.status()).toBe(201);
+	const { conversation } = (await created.json()) as { conversation: { id: string } };
+
+	// SEVERAL turns, in order. A single turn cannot distinguish "history
+	// survived" from "the last turn survived", and ordering is half of what a
+	// transcript is.
+	const turns = [
+		'First thing the user said',
+		'Second thing the user said',
+		'Third thing the user said'
+	];
+	for (const text of turns) {
+		const appended = await request.post(
+			`/api/server-owned/conversations/${conversation.id}/turns`,
+			{ data: { text } }
+		);
+		expect(appended.status()).toBe(201);
+	}
+
+	await gotoHydrated(page, `/server-owned/${conversation.id}`);
+	const log = page.getByRole('log', { name: 'Messages' });
+	for (const text of turns) await expect(log).toContainText(text);
+
+	// The reload. Nothing in the browser carries across it.
+	await page.reload();
+	await expect(page.getByRole('heading', { name: title })).toBeVisible();
+
+	// EVERY turn, and in order. Asserting only that the text is present would
+	// pass on a transcript that came back shuffled, which is a different bug
+	// wearing the same symptom.
+	for (const text of turns) await expect(log).toContainText(text);
+
+	const rendered = await log.innerText();
+	const positions = turns.map((text) => rendered.indexOf(text));
+	expect(positions.every((at) => at >= 0)).toBe(true);
+	expect([...positions].sort((a, b) => a - b)).toEqual(positions);
+
+	// And it came from the SERVER, not from anything the browser replayed —
+	// the navigation response already carries the turns, which is the
+	// distinction from the canonical browser-owned exemplar.
+	const document = await request.get(`/server-owned/${conversation.id}`);
+	expect(document.status()).toBe(200);
+	const html = await document.text();
+	for (const text of turns) expect(html).toContain(text);
+});


### PR DESCRIPTION
Closes CIN-444.

## Four of five criteria were already delivered

CIN-443 built the route family, and most of this issue came with it. Measured against the merged branch rather than estimated — the evidence is on the issue:

| Criterion | State |
| --- | --- |
| Persists through the public session store, no Bureau | delivered by CIN-443 |
| `grep -rn "@lostgradient/bureau" src/ package.json` → zero | delivered, re-verified here |
| Conversation list driven by the host-owned index | delivered by CIN-443 |
| Browser-owned variant provably untouched | re-verified: this branch's diff on `page.svelte.e2e.ts` is empty |
| **A spec reloads the page and asserts the session resumes with full history** | **this PR** |

## The gap, and why it mattered

There *was* a reload spec — it reloads the **list**. Nothing reloaded a conversation. So the claim the entire variant exists to demonstrate, that a reload renders history because the server has it, rested on the route's shape and on prose.

## Deliberately stricter than the criterion

- **Several turns, not one.** A single turn cannot distinguish "history survived" from "the last turn survived".
- **Order, not just presence.** Asserting the text is there would pass on a transcript that came back shuffled — a different bug wearing the same symptom.
- **The navigation response carries the turns**, checked directly with `request.get`. This is the real distinction from the canonical browser-owned exemplar: not "the page shows history after a reload" but "the server sent it". A client replaying from somewhere else would satisfy the weaker claim and miss the point.

Seeded through the API rather than by streaming a real turn: this tests what survives a reload, so a deterministic transcript is the point and a model turn would only add nondeterminism to the thing under test.

## Proven load-bearing

Making the loader return an empty conversation turns it red:

```
Expected substring: "First thing the user said"
Received string:    " No messages yet   "
```

## It passed, and that is worth stating

The scope assessment on CIN-444 predicted this spec might arrive red, given CIN-608 (a failed turn is indistinguishable after reload) and CIN-609 (a second tab omits turns another tab persisted). **It passes.**

Those two defects are real but narrower than "reload loses history" — they concern a *failed* turn's presentation and *cross-tab* visibility, neither of which this criterion covers. They stay open on their own tickets rather than being folded in here.

## Shard ceiling — read before adding a test to this spec

Re-measured, as `playwright.config.ts` requires when this spec gains a test: **54/62/62/51/50**.

Not over the ceiling, but **no headroom left**. Two shards now sit exactly at 62, so the next test added to `webkit-2` or `webkit-3` takes one to 63 — past the point where a long-lived WebKit process stops accepting navigation. Recorded at the placement note so the next person rebalances *first*, which is how a shard reached 66 on the previous PR.

## Verification

```
bun run lint                 # 0
bun run check                # 0 ERRORS 0 WARNINGS
bun run test:unit            # 0
bun run test:unit-inventory  # 0
bun run build                # 0
bunx playwright test src/routes/server-owned src/routes/page.svelte.e2e.ts --project=chromium   # 27 passed
```

https://claude.ai/code/session_01RKLn1mLTUgVjSN38WRtA19