### PR TITLE
fix(chat): stop the composer-popover caret tests serializing the DOM on every poll

### DIFF
--- a/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.test.ts
+++ b/packages/chat/src/lib/components/chat-composer-popover/chat-composer-popover.test.ts
@@ -57,6 +57,26 @@ function queryListbox(): HTMLElement | null {
   return document.body.querySelector('[role="listbox"]');
 }
 
+/**
+ * Waits for the listbox to leave the DOM.
+ *
+ * The assertion is on a BOOLEAN rather than on the element, and that is the whole
+ * point of the helper. `expect(element).toBeNull()` builds its failure message by
+ * serializing the element, and under happy-dom one failed assertion costs roughly
+ * 2.2 seconds — measured, not estimated. Two failed polls put the caret tests within
+ * 136ms of the 5000ms per-test timeout, which failed pull requests that had nothing
+ * to do with Chat, since `packages/chat` shares the `package` job.
+ *
+ * It compounds, too. The formatting is synchronous, so it starves the macrotask the
+ * component's caret sync is queued on — the condition cannot become true until the
+ * formatting finishes, which guarantees the next poll fails and pays again.
+ *
+ * Same claim, same strength: the listbox is gone. Only the failure message is cheap.
+ */
+async function waitForListboxToClose(): Promise<void> {
+  await waitFor(() => expect(queryListbox() === null).toBe(true));
+}
+
 async function typeComposer(value: string): Promise<HTMLTextAreaElement> {
   const composer = getComposer();
   composer.value = value;
@@ -290,7 +310,7 @@ describe('ChatComposerPopover', () => {
     expect(selected[0]?.query).toBe('');
     expect(selected[0]?.trigger).toBe('/');
     expect(selected[0]?.range).toEqual({ start: 0, end: 1 });
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(document.activeElement).toBe(composer);
   });
 
@@ -315,7 +335,7 @@ describe('ChatComposerPopover', () => {
     expect(tabEvent.defaultPrevented).toBe(true);
     expect(selected).toHaveLength(1);
     expect(selected[0]?.item.value).toBe('help');
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(document.activeElement).toBe(composer);
   });
 
@@ -326,7 +346,7 @@ describe('ChatComposerPopover', () => {
     await waitFor(() => expect(queryListbox()).not.toBeNull());
     await fireEvent.keyDown(composer, { key: 'Enter' });
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(composer.value).toBe('/stop');
     expect(composer.getAttribute('aria-expanded')).toBe('false');
   });
@@ -338,7 +358,7 @@ describe('ChatComposerPopover', () => {
     await waitFor(() => expect(queryListbox()).not.toBeNull());
     await fireEvent.keyDown(composer, { key: 'Enter' });
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(composer.value).toBe('/stop');
     expect(composer.getAttribute('aria-expanded')).toBe('false');
   });
@@ -372,7 +392,7 @@ describe('ChatComposerPopover', () => {
     );
     await tick();
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(composer.getAttribute('aria-expanded')).toBe('false');
     expect(composer.getAttribute('aria-controls')).toBeNull();
     expect(composer.getAttribute('aria-activedescendant')).toBeNull();
@@ -389,7 +409,7 @@ describe('ChatComposerPopover', () => {
 
     await typeComposer('hello');
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(onDismissed).toHaveBeenCalledTimes(1);
     expect(composer.getAttribute('aria-expanded')).toBe('false');
     expect(composer.getAttribute('aria-controls')).toBeNull();
@@ -409,7 +429,7 @@ describe('ChatComposerPopover', () => {
 
     await fireEvent.pointerDown(outside);
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(onDismissed).toHaveBeenCalledTimes(1);
     expect(composer.getAttribute('aria-expanded')).toBe('false');
     expect(composer.getAttribute('aria-controls')).toBeNull();
@@ -432,7 +452,7 @@ describe('ChatComposerPopover', () => {
     composer.dispatchEvent(arrowLeft);
     composer.setSelectionRange(2, 2);
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(onDismissed).toHaveBeenCalledTimes(1);
     expect(composer.getAttribute('aria-expanded')).toBe('false');
     expect(composer.getAttribute('aria-controls')).toBeNull();
@@ -474,7 +494,7 @@ describe('ChatComposerPopover', () => {
 
     await waitFor(() => expect(submittedMessages).toHaveLength(1));
     expect(submittedMessages[0]).toMatchObject({ content: '/zzzz' });
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(composer.getAttribute('aria-expanded')).toBe('false');
   });
 
@@ -500,7 +520,7 @@ describe('ChatComposerPopover', () => {
     composer.setSelectionRange(2, 2);
     await fireEvent.pointerUp(composer);
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(onDismissed).toHaveBeenCalledTimes(1);
     expect(composer.getAttribute('aria-expanded')).toBe('false');
     expect(composer.getAttribute('aria-controls')).toBeNull();
@@ -518,7 +538,7 @@ describe('ChatComposerPopover', () => {
     await fireEvent.blur(composer, { relatedTarget: outside });
     outside.focus();
 
-    await waitFor(() => expect(queryListbox()).toBeNull());
+    await waitForListboxToClose();
     expect(onDismissed).toHaveBeenCalledTimes(1);
     expect(document.activeElement).toBe(outside);
     expect(composer.getAttribute('aria-expanded')).toBe('false');


### PR DESCRIPTION
Two tests in `chat-composer-popover.test.ts` sat within 136ms of the 5000ms per-test timeout and failed pull requests that had nothing to do with Chat, since `packages/chat` shares the `package` job of `unit-tests.yaml`.

## The runtime was not the component

Measured by phase rather than guessed at:

```
[phase] render: 17ms
[phase] type + input: 16ms
[phase] waitFor open: 1ms
[phase] dispatch + setSelectionRange: 1ms
[phase] waitFor dismiss: 4203ms
```

And hand-polling on a short macrotask instead of `waitFor` showed the component itself is finished almost immediately:

```
[diag] listbox left the DOM after 11ms of hand polling
[diag] waitFor then returned in 0ms
```

## The cause is the assertion's failure message

`expect(element).toBeNull()` builds its message by serializing the element, and under happy-dom **one failed assertion costs about 2.2 seconds**:

```
[H] one failed element assertion: 2204ms
```

Two failed polls make the 4.2. Swapping the assertion for one whose failure carries a boolean is the whole difference:

```
[E] element-bearing failure: 4270ms
[F] boolean failure: 2ms
[G] bare Error: 2ms
```

## Why it lands so near the limit rather than merely being slow

The formatting is synchronous, so it starves the macrotask the component's caret sync is queued on. A plain `setTimeout(0)` queued at the same moment ran **4190ms** later:

```
[diag] waitFor callback attempts: 3
[diag] first attempt that saw null: 4192ms
[diag] a plain setTimeout(0) queued alongside ran at: 4190ms
```

So the condition cannot become true until the formatting finishes, which guarantees the next poll fails and pays again. Yielding one macrotask before waiting — letting that sync run — takes 3ms:

```
[C] macrotask then waitFor: 3ms
```

That feedback loop is why the interval is irrelevant (`interval: 1` measured 4380ms) and why the runtime sits just under the limit instead of anywhere in particular.

## The fix

One helper, used by all eleven disappearance waits in the file so the next one added does not reintroduce it:

```ts
async function waitForListboxToClose(): Promise<void> {
  await waitFor(() => expect(queryListbox() === null).toBe(true));
}
```

Same claim, same strength — the listbox is gone. Only the failure message is cheap. The comment records the measurement so the assertion does not get "tidied" back.

## Results

| | before | after |
| --- | --- | --- |
| pointer caret test | 4.77s | 610ms |
| caret-only test | 4.59s | 599ms |
| whole file | 4.77s | 611–671ms |
| `packages/chat` suite | 29.0s | 22.2s |

- 20 consecutive runs of the file: 0 failures, 611–671ms
- `packages/chat` suite: 1336 tests passing
- `check:timeout-increases` exits 0 — no timeout raised anywhere, which the ticket requires explicitly

## Boundary

`packages/chat`, one test file. No component change: the component's `setTimeout(0)` caret sync is correct, since a native caret-moving keypress does not update the selection until after its default action.

One instance of the same shape remains outside this ticket's boundary, at `chat/chat.test.ts:798`. It is fast today only because its condition is already true on the first poll, so it never pays the formatting — worth converting when that file is next touched.

Closes CIN-521

https://claude.ai/code/session_01BicogfzUyxNrcZZumwGJSp
